### PR TITLE
fix: progress tracking, template fix, and agent instructions

### DIFF
--- a/.context-tree/templates/members-domain.md.template
+++ b/.context-tree/templates/members-domain.md.template
@@ -1,0 +1,45 @@
+---
+title: Members
+owners: []
+---
+
+# Members
+
+Member definitions, work scope, and personal node specifications.
+
+Members are **humans and AI agents**. Both are first-class participants in the organization — they own nodes, make decisions, and collaborate through the tree.
+
+---
+
+## Joining
+
+1. Create a personal directory under `members/` with a `NODE.md` (e.g., `members/alice/NODE.md`)
+2. Follow the required personal node format — CI will reject PRs with missing fields
+3. Be assigned as owner of relevant domain nodes
+
+---
+
+## Personal Node Format
+
+Each member is a **directory** under `members/` containing a `NODE.md`. Required frontmatter fields:
+
+```yaml
+---
+title: "<display name>"
+owners: [<github-username>]
+type: "<human | personal_assistant | autonomous_agent>"
+role: "<role in the organization>"
+domains:
+  - "<high-level domain or direction>"
+---
+```
+
+See `.context-tree/templates/member-node.md.template` for a full scaffold.
+
+---
+
+## Principles
+
+**Keep your node fresh.** Your personal node is how other members understand you. Stale information leads to poor decisions.
+
+**Trust the tree.** Communicate through the tree, not around it.

--- a/context_tree_cli/init.py
+++ b/context_tree_cli/init.py
@@ -19,7 +19,7 @@ FRAMEWORK_DIR = ".context-tree"
 TEMPLATE_MAP = [
     ("root-node.md.template", "NODE.md"),
     ("agent.md.template", "AGENT.md"),
-    ("member-node.md.template", "members/NODE.md"),
+    ("members-domain.md.template", "members/NODE.md"),
 ]
 
 

--- a/context_tree_cli/init.py
+++ b/context_tree_cli/init.py
@@ -101,6 +101,15 @@ def _format_task_list(groups: list[dict]) -> str:
     lines.append("- [ ] `validate_nodes.py` passes with no errors")
     lines.append("- [ ] At least one member node exists")
     lines.append("")
+    lines.append("---")
+    lines.append("")
+    lines.append(
+        "**Important:** As you complete each task, check it off in"
+        " `.context-tree/progress.md` by changing `- [ ]` to `- [x]`."
+        " Run `context-tree verify` when done — it will fail if any"
+        " items remain unchecked."
+    )
+    lines.append("")
     return "\n".join(lines)
 
 

--- a/context_tree_cli/upgrade.py
+++ b/context_tree_cli/upgrade.py
@@ -31,6 +31,13 @@ def _get_upstream_version(repo: Repo) -> str | None:
     return result.stdout.strip()
 
 
+def _write_progress(repo: Repo, content: str) -> None:
+    """Write the upgrade task list to .context-tree/progress.md."""
+    progress_path = repo.root / ".context-tree" / "progress.md"
+    progress_path.parent.mkdir(parents=True, exist_ok=True)
+    progress_path.write_text(content)
+
+
 def run_upgrade() -> int:
     repo = Repo()
 
@@ -46,15 +53,17 @@ def run_upgrade() -> int:
 
     # Check for upstream remote
     if not repo.has_upstream_remote():
-        print("# Context Tree Upgrade\n")
-        print("## Setup")
-        print(
+        lines = [
+            "# Context Tree Upgrade\n",
+            "## Setup",
             f"- [ ] Add upstream remote:"
-            f" `git remote add context-tree-upstream {SEED_TREE_URL}`"
-        )
-        print(
-            "- [ ] Then run `context-tree upgrade` again to check for updates"
-        )
+            f" `git remote add context-tree-upstream {SEED_TREE_URL}`",
+            "- [ ] Then run `context-tree upgrade` again to check for updates",
+        ]
+        output = "\n".join(lines)
+        print(output)
+        _write_progress(repo, output + "\n")
+        print(f"\nProgress file written to .context-tree/progress.md")
         return 0
 
     # Fetch upstream version
@@ -67,32 +76,43 @@ def run_upgrade() -> int:
         print(f"Already up to date (v{local_version}).")
         return 0
 
-    print(f"# Context Tree Upgrade — v{local_version} -> v{upstream_version}\n")
-
-    print("## Framework")
-    print(
+    lines = [
+        f"# Context Tree Upgrade — v{local_version} -> v{upstream_version}\n",
+        "## Framework",
         "- [ ] Pull latest from upstream:"
         " `git fetch context-tree-upstream"
-        " && git merge context-tree-upstream/main`"
-    )
-    print(
+        " && git merge context-tree-upstream/main`",
         "- [ ] Resolve any conflicts in `.context-tree/`"
-        " (framework files should generally take upstream version)"
-    )
-    print()
+        " (framework files should generally take upstream version)",
+        "",
+    ]
 
     # Check AGENT.md
     if repo.has_agent_md_markers():
-        print("## Agent Instructions")
-        print(
+        lines.extend([
+            "## Agent Instructions",
             "- [ ] Check if AGENT.md framework section needs updating"
-            " — compare content between markers to the new template"
-        )
-        print()
+            " — compare content between markers to the new template",
+            "",
+        ])
 
-    print("## Verification")
-    print(f"- [ ] `.context-tree/VERSION` reads `{upstream_version}`")
-    print("- [ ] `validate_nodes.py` passes")
-    print("- [ ] AGENT.md framework section matches upstream")
-    print()
+    lines.extend([
+        "## Verification",
+        f"- [ ] `.context-tree/VERSION` reads `{upstream_version}`",
+        "- [ ] `validate_nodes.py` passes",
+        "- [ ] AGENT.md framework section matches upstream",
+        "",
+        "---",
+        "",
+        "**Important:** As you complete each task, check it off in"
+        " `.context-tree/progress.md` by changing `- [ ]` to `- [x]`."
+        " Run `context-tree verify` when done — it will fail if any"
+        " items remain unchecked.",
+        "",
+    ])
+
+    output = "\n".join(lines)
+    print(output)
+    _write_progress(repo, output)
+    print(f"Progress file written to .context-tree/progress.md")
     return 0

--- a/context_tree_cli/verify.py
+++ b/context_tree_cli/verify.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 
 from context_tree_cli.repo import Repo
+
+UNCHECKED_RE = re.compile(r"^- \[ \] (.+)$", re.MULTILINE)
 
 
 def _check(label: str, passed: bool) -> bool:
@@ -15,11 +18,35 @@ def _check(label: str, passed: bool) -> bool:
     return passed
 
 
+def _check_progress(repo: Repo) -> list[str]:
+    """Read progress.md and return any unchecked items."""
+    text = repo.read_file(".context-tree/progress.md")
+    if text is None:
+        return []
+    return UNCHECKED_RE.findall(text)
+
+
 def run_verify() -> int:
     repo = Repo()
     all_passed = True
 
     print("Context Tree Verification\n")
+
+    # --- Progress file check ---
+    unchecked = _check_progress(repo)
+    if unchecked:
+        print("  Unchecked items in .context-tree/progress.md:\n")
+        for item in unchecked:
+            print(f"    - [ ] {item}")
+        print()
+        print(
+            "  Verify each step above and check it off in progress.md"
+            " before running verify again.\n"
+        )
+        all_passed = False
+
+    # --- Deterministic checks ---
+    print("  Checks:\n")
 
     # 1. Framework exists
     all_passed &= _check(

--- a/tests/test_cli_verify.py
+++ b/tests/test_cli_verify.py
@@ -7,7 +7,7 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-from context_tree_cli.verify import _check, run_verify
+from context_tree_cli.verify import _check, _check_progress, run_verify
 from context_tree_cli.repo import Repo
 
 
@@ -27,6 +27,41 @@ class TestCheck:
         out = capsys.readouterr().out
         assert "FAIL" in out
         assert "my check" in out
+
+
+# ---------------------------------------------------------------------------
+# _check_progress
+# ---------------------------------------------------------------------------
+
+class TestCheckProgress:
+    def test_no_progress_file(self, tmp_path: Path) -> None:
+        repo = Repo(root=tmp_path)
+        assert _check_progress(repo) == []
+
+    def test_all_checked(self, tmp_path: Path) -> None:
+        ct = tmp_path / ".context-tree"
+        ct.mkdir()
+        (ct / "progress.md").write_text(
+            "# Progress\n- [x] Task one\n- [x] Task two\n"
+        )
+        repo = Repo(root=tmp_path)
+        assert _check_progress(repo) == []
+
+    def test_some_unchecked(self, tmp_path: Path) -> None:
+        ct = tmp_path / ".context-tree"
+        ct.mkdir()
+        (ct / "progress.md").write_text(
+            "# Progress\n- [x] Done task\n- [ ] Pending task\n- [ ] Another pending\n"
+        )
+        repo = Repo(root=tmp_path)
+        assert _check_progress(repo) == ["Pending task", "Another pending"]
+
+    def test_empty_progress(self, tmp_path: Path) -> None:
+        ct = tmp_path / ".context-tree"
+        ct.mkdir()
+        (ct / "progress.md").write_text("")
+        repo = Repo(root=tmp_path)
+        assert _check_progress(repo) == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Fix members template mapping** — `init` was using `member-node.md.template` (individual member scaffold) as `members/NODE.md` (domain index). Added `members-domain.md.template` for the domain index.
- **Verify checks progress.md** — `verify` now reads `.context-tree/progress.md` and fails if any items remain unchecked. The agent is responsible for checking off completed items.
- **Init/upgrade instruct agent** — Both commands now append instructions telling the agent to check off items in `progress.md` and run `verify` when done. Upgrade also writes to `progress.md` (previously only printed to stdout).

## The progress loop

1. `init`/`upgrade` generates task list → writes to `progress.md` → tells agent to check items off
2. Agent works through tasks → edits `progress.md` changing `- [ ]` to `- [x]`
3. `verify` fails if any unchecked items remain + runs deterministic checks

## Test plan

- [x] 115 tests pass
- [x] `context-tree init` includes progress instruction in output
- [x] `context-tree verify` reports unchecked progress items
- [x] Members domain template renders correctly (tested on nanogpt-tree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)