### PR TITLE
feat: move codeowners to framework, wire up member validation

### DIFF
--- a/.context-tree/generate-codeowners.ts
+++ b/.context-tree/generate-codeowners.ts
@@ -205,7 +205,7 @@ export function generate(
       return 0;
     }
     console.log(
-      "CODEOWNERS is out-of-date. Run: npx context-tree codeowners",
+      "CODEOWNERS is out-of-date. Run: npx tsx .context-tree/generate-codeowners.ts",
     );
     return 1;
   }
@@ -214,4 +214,11 @@ export function generate(
   writeFileSync(codeownersFile, content);
   console.log(`Wrote ${relative(treeRoot, codeownersFile)}`);
   return 0;
+}
+
+const isDirectRun =
+  process.argv[1]?.endsWith("generate-codeowners.ts") ||
+  process.argv[1]?.endsWith("generate-codeowners.js");
+if (isDirectRun) {
+  process.exit(generate(process.cwd()));
 }

--- a/.context-tree/workflows/codeowners.yml
+++ b/.context-tree/workflows/codeowners.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: "22"
 
-      - run: npx context-tree codeowners
+      - run: npx tsx .context-tree/generate-codeowners.ts
 
       - name: Commit if changed
         run: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-tree",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "CLI tools for Context Tree — the living source of truth for your organization.",
   "type": "module",
   "bin": {

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -1,4 +1,5 @@
 import { Repo } from "./repo.js";
+import { runValidateMembers } from "./validators/members.js";
 import { runValidateNodes } from "./validators/nodes.js";
 
 const UNCHECKED_RE = /^- \[ \] (.+)$/gm;
@@ -79,11 +80,9 @@ export function runVerify(repo?: Repo, nodeValidator?: NodeValidator): number {
   const { exitCode } = validate(r.root);
   allPassed = check("Node validation passes", exitCode === 0) && allPassed;
 
-  // 5. At least one member node exists
-  allPassed = check(
-    "At least one member node exists under members/",
-    r.memberCount() > 0,
-  ) && allPassed;
+  // 5. Member validation
+  const members = runValidateMembers(r.root);
+  allPassed = check("Member validation passes", members.exitCode === 0) && allPassed;
 
   console.log();
   if (allPassed) {

--- a/tests/generate-codeowners.test.ts
+++ b/tests/generate-codeowners.test.ts
@@ -6,7 +6,7 @@ import {
   resolveNodeOwners,
   collectEntries,
   formatOwners,
-} from "../src/validators/codeowners.js";
+} from "../.context-tree/generate-codeowners.js";
 import { useTmpDir } from "./helpers.js";
 
 function write(root: string, relPath: string, content: string): string {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -64,6 +64,6 @@ export function makeMembers(root: string, count = 1): void {
   for (let i = 0; i < count; i++) {
     const d = join(membersDir, `member-${i}`);
     mkdirSync(d);
-    writeFileSync(join(d, "NODE.md"), `---\ntitle: Member ${i}\n---\n`);
+    writeFileSync(join(d, "NODE.md"), `---\ntitle: Member ${i}\nowners: [member-${i}]\ntype: human\nrole: Engineer\ndomains:\n  - engineering\n---\n`);
   }
 }


### PR DESCRIPTION
## Summary

- **Move codeowners validator to `.context-tree/`** — `src/validators/codeowners.ts` was exported but unused by the CLI. Moved to `.context-tree/generate-codeowners.ts` so it ships with the portable framework to downstream repos. Added `main()` entry point for direct execution via `npx tsx`.
- **Wire up member validation in `verify`** — `context-tree verify` now calls `runValidateMembers` (checks type, role, domains fields), replacing the shallow "at least one member exists" check.
- **Update codeowners workflow template** — Changed `npx context-tree codeowners` (non-existent command) to `npx tsx .context-tree/generate-codeowners.ts`.

Prerequisite for migrating first-tree-context to use the first-tree framework.

## Test plan

- [x] All 131 tests pass (`pnpm test`)
- [ ] Verify `context-tree verify` runs correctly against a downstream context tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)