### PR TITLE
fix: sync fixes from first-tree-context migration

### DIFF
--- a/.context-tree/examples/claude-code/README.md
+++ b/.context-tree/examples/claude-code/README.md
@@ -13,23 +13,3 @@ cp .context-tree/examples/claude-code/settings.json .claude/settings.json
 
 The `SessionStart` hook runs `.context-tree/scripts/inject-tree-context.sh` when a Claude Code session begins. This injects the root `NODE.md` content as additional context, giving the agent an overview of the tree structure before any task.
 
-## Customization
-
-You can add additional hooks alongside the framework hook. For example, to also inject custom instructions:
-
-```json
-{
-  "hooks": {
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": ".context-tree/scripts/inject-tree-context.sh"
-          }
-        ]
-      }
-    ]
-  }
-}
-```

--- a/.context-tree/workflows/validate.yml
+++ b/.context-tree/workflows/validate.yml
@@ -16,4 +16,4 @@ jobs:
           node-version: "22"
 
       - name: Validate tree
-        run: npx context-tree verify
+        run: npx -p first-tree context-tree verify


### PR DESCRIPTION
## Summary

- **Remove misleading Customization section** from Claude Code example — was identical to the basic setup, not an actual customization
- **Fix validate workflow** — `npx context-tree verify` fails because npx can't resolve a bin name that differs from the package name; use `npx -p first-tree context-tree verify`

Discovered during first-tree-context migration (agent-team-foundation/first-tree-context#65).

## Test plan

- [ ] `npx -p first-tree context-tree verify` works in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)