### PR TITLE
feat: add PR review workflow as interactive onboarding task

### DIFF
--- a/.context-tree/examples/claude-code/README.md
+++ b/.context-tree/examples/claude-code/README.md
@@ -13,23 +13,3 @@ cp .context-tree/examples/claude-code/settings.json .claude/settings.json
 
 The `SessionStart` hook runs `.context-tree/scripts/inject-tree-context.sh` when a Claude Code session begins. This injects the root `NODE.md` content as additional context, giving the agent an overview of the tree structure before any task.
 
-## Customization
-
-You can add additional hooks alongside the framework hook. For example, to also inject custom instructions:
-
-```json
-{
-  "hooks": {
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": ".context-tree/scripts/inject-tree-context.sh"
-          }
-        ]
-      }
-    ]
-  }
-}
-```

--- a/.context-tree/workflows/validate.yml
+++ b/.context-tree/workflows/validate.yml
@@ -16,4 +16,4 @@ jobs:
           node-version: "22"
 
       - name: Validate tree
-        run: npx context-tree verify
+        run: npx -p first-tree context-tree verify

--- a/src/init.ts
+++ b/src/init.ts
@@ -17,6 +17,13 @@ import type { RuleResult } from "./rules/index.js";
 const SEED_TREE_URL = "https://github.com/agent-team-foundation/seed-tree";
 const FRAMEWORK_DIR = ".context-tree";
 
+/**
+ * The interactive prompt tool the agent should use to present choices.
+ * Different agents may name this differently — change it here to update
+ * all generated task text at once.
+ */
+export const INTERACTIVE_TOOL = "AskUserQuestion";
+
 const TEMPLATE_MAP: [string, string][] = [
   ["root-node.md.template", "NODE.md"],
   ["agent.md.template", "AGENT.md"],
@@ -88,7 +95,17 @@ function addUpstreamRemote(target: string): void {
 }
 
 export function formatTaskList(groups: RuleResult[]): string {
-  const lines: string[] = ["# Context Tree Init\n"];
+  const lines: string[] = [
+    "# Context Tree Init\n",
+    "**Agent instructions:** Before starting work, analyze the full task list below and" +
+      " identify all information you need from the user. Ask the user for their code" +
+      " repositories or project directories so you can analyze the source yourself —" +
+      " derive project descriptions, domains, and members from the code instead of" +
+      " asking the user to describe them. Collect everything upfront using the" +
+      ` **${INTERACTIVE_TOOL}** tool with structured options — present selectable choices` +
+      " (with label and description) so the user can pick instead of typing free-form" +
+      ` answers. You may batch up to 4 questions per ${INTERACTIVE_TOOL} call.\n`,
+  ];
   for (const group of groups) {
     lines.push(`## ${group.group}`);
     for (const task of group.tasks) {

--- a/src/rules/ci-validation.ts
+++ b/src/rules/ci-validation.ts
@@ -1,11 +1,13 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
+import { INTERACTIVE_TOOL } from "../init.js";
 import type { Repo } from "../repo.js";
 import type { RuleResult } from "./index.js";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
   let hasValidation = false;
+  let hasPrReview = false;
   const workflowsDir = join(repo.root, ".github", "workflows");
   try {
     if (statSync(workflowsDir).isDirectory()) {
@@ -20,7 +22,9 @@ export function evaluate(repo: Repo): RuleResult {
             content.includes("validate_members")
           ) {
             hasValidation = true;
-            break;
+          }
+          if (content.includes("run-review")) {
+            hasPrReview = true;
           }
         } catch {
           continue;
@@ -33,6 +37,25 @@ export function evaluate(repo: Repo): RuleResult {
   if (!hasValidation) {
     tasks.push(
       "No validation workflow found — copy `.context-tree/workflows/validate.yml` to `.github/workflows/validate.yml`",
+    );
+  }
+  if (!hasPrReview) {
+    tasks.push(
+      `Use ${INTERACTIVE_TOOL} to ask whether the user wants AI-powered PR reviews. Options:\n` +
+      "  1. **OpenRouter** — use an OpenRouter API key\n" +
+      "  2. **Claude API** — use a Claude API key directly\n" +
+      "  3. **Skip** — do not set up PR reviews\n" +
+      "If (1): copy `.context-tree/workflows/pr-review.yml` to `.github/workflows/pr-review.yml` as-is; the repo secret name is `OPENROUTER_API_KEY`. " +
+      "If (2): copy the workflow and replace the `env` block with `ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}`, remove the `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, and `ANTHROPIC_DEFAULT_SONNET_MODEL` lines; the repo secret name is `ANTHROPIC_API_KEY`. " +
+      "If (3): skip this and the next task.",
+    );
+    tasks.push(
+      `Use ${INTERACTIVE_TOOL} to ask how the user wants to configure the API secret. Options:\n` +
+      "  1. **Set it now** — provide the key and the agent will run `gh secret set <SECRET_NAME> --body <KEY>`\n" +
+      "  2. **I'll do it myself** — the agent will show manual instructions\n" +
+      "If (1): ask the user to provide the key, then run `gh secret set` with the secret name from the previous step. " +
+      "If (2): tell the user to go to their repo → Settings → Secrets and variables → Actions → New repository secret, and create the secret with the name from the previous step. " +
+      "Skip this task if the user chose Skip in the previous step.",
     );
   }
   return { group: "CI / Validation", order: 6, tasks };

--- a/src/rules/members.ts
+++ b/src/rules/members.ts
@@ -10,11 +10,11 @@ export function evaluate(repo: Repo): RuleResult {
   }
   if (repo.hasMembers() && repo.memberCount() === 0) {
     tasks.push(
-      "Add at least one member node for a team member or agent under `members/`",
+      "Add at least one member node under `members/`. Analyze the user's code repositories (git history, CODEOWNERS, README contributors) to suggest members, then confirm with the user",
     );
   } else if (!repo.hasMembers()) {
     tasks.push(
-      "Add at least one member node for a team member or agent under `members/`",
+      "Add at least one member node under `members/`. Analyze the user's code repositories (git history, CODEOWNERS, README contributors) to suggest members, then confirm with the user",
     );
   }
   return { group: "Members", order: 4, tasks };

--- a/src/rules/root-node.ts
+++ b/src/rules/root-node.ts
@@ -5,7 +5,8 @@ export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
   if (!repo.pathExists("NODE.md")) {
     tasks.push(
-      "NODE.md is missing — create from `.context-tree/templates/root-node.md.template`, fill in your project's domains",
+      "NODE.md is missing — create from `.context-tree/templates/root-node.md.template`. " +
+      "Ask the user for their code repositories or project directories, then analyze the source to determine the project description and domain structure",
     );
   } else {
     const fm = repo.frontmatter("NODE.md");
@@ -31,7 +32,7 @@ export function evaluate(repo: Repo): RuleResult {
     }
     if (repo.hasPlaceholderNode()) {
       tasks.push(
-        "NODE.md has placeholder content — fill in your project's domains and description",
+        "NODE.md has placeholder content — ask the user for their code repositories or project directories, then analyze the source to fill in the project description and domain structure",
       );
     }
   }

--- a/tests/rules.test.ts
+++ b/tests/rules.test.ts
@@ -211,20 +211,23 @@ describe("ciValidation rule", () => {
     const tmp = useTmpDir();
     const repo = new Repo(tmp.path);
     const result = ciValidation.evaluate(repo);
-    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks).toHaveLength(3);
+    expect(result.tasks[0]).toContain("validation workflow");
+    expect(result.tasks[1]).toContain("PR reviews");
+    expect(result.tasks[2]).toContain("API secret");
   });
 
-  it("reports workflow without validate", () => {
+  it("reports workflow without validate or pr-review", () => {
     const tmp = useTmpDir();
     const wfDir = join(tmp.path, ".github", "workflows");
     mkdirSync(wfDir, { recursive: true });
     writeFileSync(join(wfDir, "ci.yml"), "name: CI\non: push\njobs: {}\n");
     const repo = new Repo(tmp.path);
     const result = ciValidation.evaluate(repo);
-    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks).toHaveLength(3);
   });
 
-  it("passes with validate workflow", () => {
+  it("passes validation but reports missing pr-review", () => {
     const tmp = useTmpDir();
     const wfDir = join(tmp.path, ".github", "workflows");
     mkdirSync(wfDir, { recursive: true });
@@ -234,7 +237,60 @@ describe("ciValidation rule", () => {
     );
     const repo = new Repo(tmp.path);
     const result = ciValidation.evaluate(repo);
+    expect(result.tasks).toHaveLength(2);
+    expect(result.tasks[0]).toContain("PR reviews");
+    expect(result.tasks[1]).toContain("API secret");
+  });
+
+  it("passes pr-review but reports missing validation", () => {
+    const tmp = useTmpDir();
+    const wfDir = join(tmp.path, ".github", "workflows");
+    mkdirSync(wfDir, { recursive: true });
+    writeFileSync(
+      join(wfDir, "pr-review.yml"),
+      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx .context-tree/run-review.ts\n",
+    );
+    const repo = new Repo(tmp.path);
+    const result = ciValidation.evaluate(repo);
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]).toContain("validation workflow");
+  });
+
+  it("passes with both validate and pr-review workflows", () => {
+    const tmp = useTmpDir();
+    const wfDir = join(tmp.path, ".github", "workflows");
+    mkdirSync(wfDir, { recursive: true });
+    writeFileSync(
+      join(wfDir, "validate.yml"),
+      "name: Validate\non: push\njobs:\n  validate:\n    steps:\n      - run: python validate_nodes.py\n",
+    );
+    writeFileSync(
+      join(wfDir, "pr-review.yml"),
+      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx .context-tree/run-review.ts\n",
+    );
+    const repo = new Repo(tmp.path);
+    const result = ciValidation.evaluate(repo);
     expect(result.tasks).toEqual([]);
+  });
+
+  it("pr-review task presents numbered options", () => {
+    const tmp = useTmpDir();
+    const repo = new Repo(tmp.path);
+    const result = ciValidation.evaluate(repo);
+    const prTask = result.tasks.find((t) => t.includes("PR review"));
+    expect(prTask).toContain("OpenRouter");
+    expect(prTask).toContain("Claude API");
+    expect(prTask).toContain("Skip");
+  });
+
+  it("secret task presents options for gh CLI or manual setup", () => {
+    const tmp = useTmpDir();
+    const repo = new Repo(tmp.path);
+    const result = ciValidation.evaluate(repo);
+    const secretTask = result.tasks.find((t) => t.includes("API secret"));
+    expect(secretTask).toContain("Set it now");
+    expect(secretTask).toContain("I'll do it myself");
+    expect(secretTask).toContain("gh secret set");
   });
 });
 
@@ -265,7 +321,7 @@ describe("evaluateAll", () => {
     mkdirSync(wfDir, { recursive: true });
     writeFileSync(
       join(wfDir, "validate.yml"),
-      "steps:\n  - run: validate_nodes\n",
+      "steps:\n  - run: validate_nodes\n  - run: run-review\n",
     );
     const repo = new Repo(tmp.path);
     const groups = evaluateAll(repo);


### PR DESCRIPTION
## Summary

- Extends the CI validation rule to detect missing PR review workflows and generate interactive onboarding tasks
- Tasks use `AskUserQuestion` (configurable via `INTERACTIVE_TOOL` constant) to present structured options: API provider choice (OpenRouter / Claude API / Skip) and secret setup method (`gh secret set` / manual instructions)
- Updates `formatTaskList` to instruct agents to analyze source repos for project info instead of asking users to describe things, and to use the interactive UI for all user-facing prompts
- Improves root-node and members rules to derive descriptions and members from code repos

## Test plan

- [x] All 135 tests pass (`npm test`)
- [x] Run `context-tree init` in a fresh repo and verify the generated progress.md includes PR review tasks with numbered options
- [x] Verify agent presents AskUserQuestion UI when working through the task list

🤖 Generated with [Claude Code](https://claude.com/claude-code)