### PR TITLE
fix: add CODEOWNERS workflow detection and fix untracked file commit

### DIFF
--- a/.context-tree/workflows/codeowners.yml
+++ b/.context-tree/workflows/codeowners.yml
@@ -23,9 +23,9 @@ jobs:
 
       - name: Commit if changed
         run: |
-          git diff --quiet .github/CODEOWNERS && exit 0
+          git add .github/CODEOWNERS
+          git diff --cached --quiet .github/CODEOWNERS && exit 0
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .github/CODEOWNERS
           git commit -m "chore: update CODEOWNERS from tree ownership"
           git push

--- a/src/rules/ci-validation.ts
+++ b/src/rules/ci-validation.ts
@@ -8,6 +8,7 @@ export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
   let hasValidation = false;
   let hasPrReview = false;
+  let hasCodeowners = false;
   const workflowsDir = join(repo.root, ".github", "workflows");
   try {
     if (statSync(workflowsDir).isDirectory()) {
@@ -25,6 +26,9 @@ export function evaluate(repo: Repo): RuleResult {
           }
           if (content.includes("run-review")) {
             hasPrReview = true;
+          }
+          if (content.includes("generate-codeowners")) {
+            hasCodeowners = true;
           }
         } catch {
           continue;
@@ -56,6 +60,11 @@ export function evaluate(repo: Repo): RuleResult {
       "If (1): ask the user to provide the key, then run `gh secret set` with the secret name from the previous step. " +
       "If (2): tell the user to go to their repo → Settings → Secrets and variables → Actions → New repository secret, and create the secret with the name from the previous step. " +
       "Skip this task if the user chose Skip in the previous step.",
+    );
+  }
+  if (!hasCodeowners) {
+    tasks.push(
+      "No CODEOWNERS workflow found — copy `.context-tree/workflows/codeowners.yml` to `.github/workflows/codeowners.yml` to auto-generate CODEOWNERS from tree ownership on every PR.",
     );
   }
   return { group: "CI / Validation", order: 6, tasks };

--- a/tests/rules.test.ts
+++ b/tests/rules.test.ts
@@ -211,10 +211,11 @@ describe("ciValidation rule", () => {
     const tmp = useTmpDir();
     const repo = new Repo(tmp.path);
     const result = ciValidation.evaluate(repo);
-    expect(result.tasks).toHaveLength(3);
+    expect(result.tasks).toHaveLength(4);
     expect(result.tasks[0]).toContain("validation workflow");
     expect(result.tasks[1]).toContain("PR reviews");
     expect(result.tasks[2]).toContain("API secret");
+    expect(result.tasks[3]).toContain("CODEOWNERS");
   });
 
   it("reports workflow without validate or pr-review", () => {
@@ -224,10 +225,10 @@ describe("ciValidation rule", () => {
     writeFileSync(join(wfDir, "ci.yml"), "name: CI\non: push\njobs: {}\n");
     const repo = new Repo(tmp.path);
     const result = ciValidation.evaluate(repo);
-    expect(result.tasks).toHaveLength(3);
+    expect(result.tasks).toHaveLength(4);
   });
 
-  it("passes validation but reports missing pr-review", () => {
+  it("passes validation but reports missing pr-review and codeowners", () => {
     const tmp = useTmpDir();
     const wfDir = join(tmp.path, ".github", "workflows");
     mkdirSync(wfDir, { recursive: true });
@@ -237,15 +238,35 @@ describe("ciValidation rule", () => {
     );
     const repo = new Repo(tmp.path);
     const result = ciValidation.evaluate(repo);
-    expect(result.tasks).toHaveLength(2);
+    expect(result.tasks).toHaveLength(3);
     expect(result.tasks[0]).toContain("PR reviews");
     expect(result.tasks[1]).toContain("API secret");
+    expect(result.tasks[2]).toContain("CODEOWNERS");
   });
 
-  it("passes pr-review but reports missing validation", () => {
+  it("passes pr-review but reports missing validation and codeowners", () => {
     const tmp = useTmpDir();
     const wfDir = join(tmp.path, ".github", "workflows");
     mkdirSync(wfDir, { recursive: true });
+    writeFileSync(
+      join(wfDir, "pr-review.yml"),
+      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx .context-tree/run-review.ts\n",
+    );
+    const repo = new Repo(tmp.path);
+    const result = ciValidation.evaluate(repo);
+    expect(result.tasks).toHaveLength(2);
+    expect(result.tasks[0]).toContain("validation workflow");
+    expect(result.tasks[1]).toContain("CODEOWNERS");
+  });
+
+  it("passes with validate and pr-review but reports missing codeowners", () => {
+    const tmp = useTmpDir();
+    const wfDir = join(tmp.path, ".github", "workflows");
+    mkdirSync(wfDir, { recursive: true });
+    writeFileSync(
+      join(wfDir, "validate.yml"),
+      "name: Validate\non: push\njobs:\n  validate:\n    steps:\n      - run: python validate_nodes.py\n",
+    );
     writeFileSync(
       join(wfDir, "pr-review.yml"),
       "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx .context-tree/run-review.ts\n",
@@ -253,10 +274,10 @@ describe("ciValidation rule", () => {
     const repo = new Repo(tmp.path);
     const result = ciValidation.evaluate(repo);
     expect(result.tasks).toHaveLength(1);
-    expect(result.tasks[0]).toContain("validation workflow");
+    expect(result.tasks[0]).toContain("CODEOWNERS");
   });
 
-  it("passes with both validate and pr-review workflows", () => {
+  it("passes with all three workflows", () => {
     const tmp = useTmpDir();
     const wfDir = join(tmp.path, ".github", "workflows");
     mkdirSync(wfDir, { recursive: true });
@@ -267,6 +288,10 @@ describe("ciValidation rule", () => {
     writeFileSync(
       join(wfDir, "pr-review.yml"),
       "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx .context-tree/run-review.ts\n",
+    );
+    writeFileSync(
+      join(wfDir, "codeowners.yml"),
+      "name: Update CODEOWNERS\non: pull_request\njobs:\n  update:\n    steps:\n      - run: npx tsx .context-tree/generate-codeowners.ts\n",
     );
     const repo = new Repo(tmp.path);
     const result = ciValidation.evaluate(repo);
@@ -321,7 +346,7 @@ describe("evaluateAll", () => {
     mkdirSync(wfDir, { recursive: true });
     writeFileSync(
       join(wfDir, "validate.yml"),
-      "steps:\n  - run: validate_nodes\n  - run: run-review\n",
+      "steps:\n  - run: validate_nodes\n  - run: run-review\n  - run: generate-codeowners\n",
     );
     const repo = new Repo(tmp.path);
     const groups = evaluateAll(repo);


### PR DESCRIPTION
## Summary
- CI validation rule now detects CODEOWNERS workflow (`generate-codeowners` in workflow content) and prompts setup during `context-tree init`
- Fix workflow template: `git diff --quiet` only checks tracked files, so a newly generated CODEOWNERS was silently skipped. Now stages first with `git add`, then uses `git diff --cached --quiet` to catch both new and modified files

## Test plan
- [x] All 136 tests pass (`pnpm test`)
- [x] Typecheck passes (`pnpm typecheck`)
- [x] Run `context-tree init` on a repo without CODEOWNERS workflow — verify the task appears in the checklist
- [x] Run `context-tree init` on a repo with CODEOWNERS workflow — verify no task appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)