### PR TITLE
refactor: use Node.js subpath imports instead of relative paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "bin": {
     "context-tree": "./dist/cli.js"
   },
+  "imports": {
+    "#src/*.js": "./src/*.ts",
+    "#docs/*": "./docs/*"
+  },
   "files": [
     "dist"
   ],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,7 @@ async function runHelp(args: string[]): Promise<number> {
 
   switch (topic) {
     case "onboarding": {
-      const { runOnboarding } = await import("./onboarding.js");
+      const { runOnboarding } = await import("#src/onboarding.js");
       return runOnboarding();
     }
     default:
@@ -52,15 +52,15 @@ async function main(): Promise<number> {
 
   switch (command) {
     case "init": {
-      const { runInit } = await import("./init.js");
+      const { runInit } = await import("#src/init.js");
       return runInit();
     }
     case "verify": {
-      const { runVerify } = await import("./verify.js");
+      const { runVerify } = await import("#src/verify.js");
       return runVerify();
     }
     case "upgrade": {
-      const { runUpgrade } = await import("./upgrade.js");
+      const { runUpgrade } = await import("#src/upgrade.js");
       return runUpgrade();
     }
     case "help":

--- a/src/init.ts
+++ b/src/init.ts
@@ -10,10 +10,10 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
-import { Repo } from "./repo.js";
-import { ONBOARDING_TEXT } from "./onboarding.js";
-import { evaluateAll } from "./rules/index.js";
-import type { RuleResult } from "./rules/index.js";
+import { Repo } from "#src/repo.js";
+import { ONBOARDING_TEXT } from "#src/onboarding.js";
+import { evaluateAll } from "#src/rules/index.js";
+import type { RuleResult } from "#src/rules/index.js";
 
 const SEED_TREE_URL = "https://github.com/agent-team-foundation/seed-tree";
 const FRAMEWORK_DIR = ".context-tree";

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -1,4 +1,4 @@
-import ONBOARDING_TEXT from "../docs/onboarding.md";
+import ONBOARDING_TEXT from "#docs/onboarding.md";
 
 export { ONBOARDING_TEXT };
 

--- a/src/rules/agent-instructions.ts
+++ b/src/rules/agent-instructions.ts
@@ -1,6 +1,6 @@
-import { FRAMEWORK_END_MARKER } from "../repo.js";
-import type { Repo } from "../repo.js";
-import type { RuleResult } from "./index.js";
+import { FRAMEWORK_END_MARKER } from "#src/repo.js";
+import type { Repo } from "#src/repo.js";
+import type { RuleResult } from "#src/rules/index.js";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];

--- a/src/rules/agent-integration.ts
+++ b/src/rules/agent-integration.ts
@@ -1,5 +1,5 @@
-import type { Repo } from "../repo.js";
-import type { RuleResult } from "./index.js";
+import type { Repo } from "#src/repo.js";
+import type { RuleResult } from "#src/rules/index.js";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];

--- a/src/rules/ci-validation.ts
+++ b/src/rules/ci-validation.ts
@@ -1,8 +1,8 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
-import { INTERACTIVE_TOOL } from "../init.js";
-import type { Repo } from "../repo.js";
-import type { RuleResult } from "./index.js";
+import { INTERACTIVE_TOOL } from "#src/init.js";
+import type { Repo } from "#src/repo.js";
+import type { RuleResult } from "#src/rules/index.js";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];

--- a/src/rules/framework.ts
+++ b/src/rules/framework.ts
@@ -1,5 +1,5 @@
-import type { Repo } from "../repo.js";
-import type { RuleResult } from "./index.js";
+import type { Repo } from "#src/repo.js";
+import type { RuleResult } from "#src/rules/index.js";
 
 const SEED_TREE_URL = "https://github.com/agent-team-foundation/seed-tree";
 

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,10 +1,10 @@
-import type { Repo } from "../repo.js";
-import * as agentInstructions from "./agent-instructions.js";
-import * as agentIntegration from "./agent-integration.js";
-import * as ciValidation from "./ci-validation.js";
-import * as framework from "./framework.js";
-import * as members from "./members.js";
-import * as rootNode from "./root-node.js";
+import type { Repo } from "#src/repo.js";
+import * as agentInstructions from "#src/rules/agent-instructions.js";
+import * as agentIntegration from "#src/rules/agent-integration.js";
+import * as ciValidation from "#src/rules/ci-validation.js";
+import * as framework from "#src/rules/framework.js";
+import * as members from "#src/rules/members.js";
+import * as rootNode from "#src/rules/root-node.js";
 
 export interface RuleResult {
   group: string;

--- a/src/rules/members.ts
+++ b/src/rules/members.ts
@@ -1,5 +1,5 @@
-import type { Repo } from "../repo.js";
-import type { RuleResult } from "./index.js";
+import type { Repo } from "#src/repo.js";
+import type { RuleResult } from "#src/rules/index.js";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];

--- a/src/rules/root-node.ts
+++ b/src/rules/root-node.ts
@@ -1,5 +1,5 @@
-import type { Repo } from "../repo.js";
-import type { RuleResult } from "./index.js";
+import type { Repo } from "#src/repo.js";
+import type { RuleResult } from "#src/rules/index.js";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];

--- a/src/upgrade.ts
+++ b/src/upgrade.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { Repo } from "./repo.js";
+import { Repo } from "#src/repo.js";
 
 const SEED_TREE_URL = "https://github.com/agent-team-foundation/seed-tree";
 

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -1,6 +1,6 @@
-import { Repo } from "./repo.js";
-import { runValidateMembers } from "./validators/members.js";
-import { runValidateNodes } from "./validators/nodes.js";
+import { Repo } from "#src/repo.js";
+import { runValidateMembers } from "#src/validators/members.js";
+import { runValidateNodes } from "#src/validators/nodes.js";
 
 const UNCHECKED_RE = /^- \[ \] (.+)$/gm;
 

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -1,8 +1,8 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { formatTaskList, writeProgress, runInit } from "../src/init.js";
-import { Repo } from "../src/repo.js";
+import { formatTaskList, writeProgress, runInit } from "#src/init.js";
+import { Repo } from "#src/repo.js";
 import { useTmpDir, makeFramework } from "./helpers.js";
 
 // --- formatTaskList ---

--- a/tests/repo.test.ts
+++ b/tests/repo.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { Repo } from "../src/repo.js";
+import { Repo } from "#src/repo.js";
 import { useTmpDir } from "./helpers.js";
 
 // --- pathExists ---

--- a/tests/rules.test.ts
+++ b/tests/rules.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { Repo } from "../src/repo.js";
+import { Repo } from "#src/repo.js";
 import {
   evaluateAll,
   framework,
@@ -10,7 +10,7 @@ import {
   members,
   agentIntegration,
   ciValidation,
-} from "../src/rules/index.js";
+} from "#src/rules/index.js";
 import {
   useTmpDir,
   makeFramework,

--- a/tests/validate-members.test.ts
+++ b/tests/validate-members.test.ts
@@ -5,7 +5,7 @@ import {
   extractScalar,
   extractList,
   validateMember,
-} from "../src/validators/members.js";
+} from "#src/validators/members.js";
 import { useTmpDir } from "./helpers.js";
 
 function write(root: string, relPath: string, content: string): string {

--- a/tests/validate-nodes.test.ts
+++ b/tests/validate-nodes.test.ts
@@ -10,7 +10,7 @@ import {
   validateEmptyNodes,
   validateTitleMismatch,
   setTreeRoot,
-} from "../src/validators/nodes.js";
+} from "#src/validators/nodes.js";
 import { useTmpDir } from "./helpers.js";
 
 function write(root: string, relPath: string, content: string): string {

--- a/tests/verify.test.ts
+++ b/tests/verify.test.ts
@@ -1,8 +1,8 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { check, checkProgress, runVerify } from "../src/verify.js";
-import { Repo } from "../src/repo.js";
+import { check, checkProgress, runVerify } from "#src/verify.js";
+import { Repo } from "#src/repo.js";
 import { useTmpDir, makeFramework, makeNode, makeAgentMd, makeMembers } from "./helpers.js";
 
 // --- check ---


### PR DESCRIPTION
## Summary
- Replace all `../` and `./` relative imports with `#src/` and `#docs/` subpath imports
- Add `imports` field to `package.json` mapping `#src/*.js` → `./src/*.ts` and `#docs/*` → `./docs/*`
- TypeScript resolves these via `moduleResolution: "Node16"` reading `package.json#imports`

## Test plan
- [x] All 136 tests pass (`pnpm test`)
- [x] Typecheck passes (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)