### PR TITLE
feat: recursive member validation with name uniqueness and delegate_mention checks

### DIFF
--- a/src/repo.ts
+++ b/src/repo.ts
@@ -113,19 +113,21 @@ export class Repo {
       return 0;
     }
     let count = 0;
-    for (const entry of readdirSync(membersDir)) {
-      const childPath = join(membersDir, entry);
-      try {
-        if (
-          statSync(childPath).isDirectory() &&
-          existsSync(join(childPath, "NODE.md"))
-        ) {
+    const walk = (dir: string): void => {
+      for (const entry of readdirSync(dir)) {
+        const childPath = join(dir, entry);
+        try {
+          if (!statSync(childPath).isDirectory()) continue;
+        } catch {
+          continue;
+        }
+        if (existsSync(join(childPath, "NODE.md"))) {
           count++;
         }
-      } catch {
-        // skip unreadable entries
+        walk(childPath);
       }
-    }
+    };
+    walk(membersDir);
     return count;
   }
 

--- a/src/validators/members.ts
+++ b/src/validators/members.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { join, relative } from "node:path";
+import { basename, join, relative } from "node:path";
 
 const FRONTMATTER_RE = /^---\s*\n(.*?)\n---/s;
 const VALID_TYPES = new Set(["human", "personal_assistant", "autonomous_agent"]);
@@ -100,6 +100,14 @@ export function validateMember(
   return errors;
 }
 
+/** Info collected per member for cross-validation. */
+type MemberInfo = {
+  name: string;
+  relPath: string;
+  type: string | null;
+  delegateMention: string | null;
+};
+
 export function runValidateMembers(treeRoot: string): {
   exitCode: number;
   errors: string[];
@@ -113,30 +121,85 @@ export function runValidateMembers(treeRoot: string): {
   const allErrors: string[] = [];
   let memberCount = 0;
 
-  for (const child of readdirSync(membersDir).sort()) {
-    const childPath = join(membersDir, child);
+  // Collected for cross-validation (name uniqueness + delegate_mention)
+  const nameOccurrences = new Map<string, string[]>();
+  const members: MemberInfo[] = [];
 
-    // Reject stray .md files
-    try {
-      const stat = statSync(childPath);
-      if (stat.isFile() && child.endsWith(".md") && child !== "NODE.md") {
-        allErrors.push(
-          `${rel(childPath, treeRoot)}: member must be a directory with NODE.md, not a standalone file — use members/${child.replace(/\.md$/, "")}/NODE.md instead`,
-        );
+  function walk(dir: string): void {
+    for (const child of readdirSync(dir).sort()) {
+      const childPath = join(dir, child);
+
+      // Reject stray .md files
+      try {
+        const stat = statSync(childPath);
+        if (stat.isFile() && child.endsWith(".md") && child !== "NODE.md") {
+          allErrors.push(
+            `${rel(childPath, treeRoot)}: member must be a directory with NODE.md, not a standalone file — use ${rel(dir, treeRoot)}/${child.replace(/\.md$/, "")}/NODE.md instead`,
+          );
+          continue;
+        }
+        if (!stat.isDirectory()) continue;
+      } catch {
         continue;
       }
-      if (!stat.isDirectory()) continue;
-    } catch {
-      continue;
-    }
 
-    const nodePath = join(childPath, "NODE.md");
-    if (!existsSync(nodePath)) {
-      allErrors.push(`${rel(childPath, treeRoot)}/: directory exists but missing NODE.md`);
-      continue;
+      // Track directory name occurrences for uniqueness check
+      const relPath = relative(membersDir, childPath);
+      const occurrences = nameOccurrences.get(child) ?? [];
+      occurrences.push(relPath);
+      nameOccurrences.set(child, occurrences);
+
+      const nodePath = join(childPath, "NODE.md");
+      if (!existsSync(nodePath)) {
+        allErrors.push(`${rel(childPath, treeRoot)}/: directory exists but missing NODE.md`);
+        walk(childPath);
+        continue;
+      }
+
+      memberCount++;
+      allErrors.push(...validateMember(nodePath, treeRoot));
+
+      // Collect info for cross-validation
+      const fm = parseFrontmatter(nodePath);
+      if (fm) {
+        members.push({
+          name: child,
+          relPath,
+          type: extractScalar(fm, "type"),
+          delegateMention: extractScalar(fm, "delegate_mention"),
+        });
+      }
+
+      // Recurse into subdirectories
+      walk(childPath);
     }
-    memberCount++;
-    allErrors.push(...validateMember(nodePath, treeRoot));
+  }
+
+  walk(membersDir);
+
+  // Cross-validation: directory name uniqueness
+  for (const [name, paths] of nameOccurrences) {
+    if (paths.length > 1) {
+      allErrors.push(
+        `Duplicate member directory name '${name}' found at: ${paths.map((p) => `members/${p}`).join(", ")} — directory names must be unique across all levels under members/`,
+      );
+    }
+  }
+
+  // Cross-validation: delegate_mention references
+  const memberByName = new Map(members.map((m) => [m.name, m]));
+  for (const member of members) {
+    if (!member.delegateMention) continue;
+    const target = memberByName.get(member.delegateMention);
+    if (!target) {
+      allErrors.push(
+        `members/${member.relPath}/NODE.md: delegate_mention '${member.delegateMention}' references non-existent member — the target must be a directory under members/`,
+      );
+    } else if (target.type !== "personal_assistant") {
+      allErrors.push(
+        `members/${member.relPath}/NODE.md: delegate_mention '${member.delegateMention}' must reference a member with type 'personal_assistant', but '${target.name}' has type '${target.type}'`,
+      );
+    }
   }
 
   if (allErrors.length > 0) {

--- a/tests/validate-members.test.ts
+++ b/tests/validate-members.test.ts
@@ -5,6 +5,7 @@ import {
   extractScalar,
   extractList,
   validateMember,
+  runValidateMembers,
 } from "#src/validators/members.js";
 import { useTmpDir } from "./helpers.js";
 
@@ -23,6 +24,16 @@ role: Engineer
 domains: [engineering]
 ---
 # Alice
+`;
+
+const VALID_ASSISTANT = `---
+title: Alice Assistant
+owners: [alice]
+type: personal_assistant
+role: Assistant
+domains: [engineering]
+---
+# Alice Assistant
 `;
 
 // --- validateMember ---
@@ -64,6 +75,115 @@ describe("validateMember", () => {
     const p = write(tmp.path, "members/alice/NODE.md", content);
     const errors = validateMember(p, tmp.path);
     expect(errors.some((e) => e.includes("domains"))).toBe(true);
+  });
+});
+
+// --- runValidateMembers: recursive scanning ---
+
+describe("runValidateMembers", () => {
+  it("validates nested members recursively", () => {
+    const tmp = useTmpDir();
+    write(tmp.path, "members/NODE.md", "---\ntitle: Members\n---\n");
+    write(tmp.path, "members/alice/NODE.md", VALID_MEMBER);
+    write(tmp.path, "members/team-a/NODE.md", `---\ntitle: Team A\nowners: [lead]\ntype: autonomous_agent\nrole: Team Lead\ndomains: [engineering]\n---\n`);
+    write(tmp.path, "members/team-a/bot-1/NODE.md", `---\ntitle: Bot 1\nowners: [lead]\ntype: autonomous_agent\nrole: Worker\ndomains: [engineering]\n---\n`);
+
+    const result = runValidateMembers(tmp.path);
+    expect(result.exitCode).toBe(0);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("detects duplicate directory names across levels", () => {
+    const tmp = useTmpDir();
+    write(tmp.path, "members/NODE.md", "---\ntitle: Members\n---\n");
+    write(tmp.path, "members/alice/NODE.md", VALID_MEMBER);
+    // Same name "alice" nested under team-a
+    write(tmp.path, "members/team-a/NODE.md", `---\ntitle: Team A\nowners: [lead]\ntype: autonomous_agent\nrole: Lead\ndomains: [eng]\n---\n`);
+    write(tmp.path, "members/team-a/alice/NODE.md", `---\ntitle: Alice Clone\nowners: [alice2]\ntype: human\nrole: Eng\ndomains: [eng]\n---\n`);
+
+    const result = runValidateMembers(tmp.path);
+    expect(result.exitCode).toBe(1);
+    expect(result.errors.some((e) => e.includes("Duplicate member directory name 'alice'"))).toBe(true);
+  });
+
+  it("reports missing NODE.md in nested directories", () => {
+    const tmp = useTmpDir();
+    write(tmp.path, "members/NODE.md", "---\ntitle: Members\n---\n");
+    write(tmp.path, "members/alice/NODE.md", VALID_MEMBER);
+    // Create directory without NODE.md
+    mkdirSync(join(tmp.path, "members/team-a/orphan"), { recursive: true });
+    write(tmp.path, "members/team-a/NODE.md", `---\ntitle: Team A\nowners: [lead]\ntype: autonomous_agent\nrole: Lead\ndomains: [eng]\n---\n`);
+
+    const result = runValidateMembers(tmp.path);
+    expect(result.exitCode).toBe(1);
+    expect(result.errors.some((e) => e.includes("orphan") && e.includes("missing NODE.md"))).toBe(true);
+  });
+
+  it("validates deeply nested members (3+ levels)", () => {
+    const tmp = useTmpDir();
+    write(tmp.path, "members/NODE.md", "---\ntitle: Members\n---\n");
+    write(tmp.path, "members/org/NODE.md", `---\ntitle: Org\nowners: [admin]\ntype: autonomous_agent\nrole: Org\ndomains: [all]\n---\n`);
+    write(tmp.path, "members/org/team-a/NODE.md", `---\ntitle: Team A\nowners: [lead]\ntype: autonomous_agent\nrole: Lead\ndomains: [eng]\n---\n`);
+    write(tmp.path, "members/org/team-a/bot-1/NODE.md", `---\ntitle: Bot 1\nowners: [lead]\ntype: autonomous_agent\nrole: Worker\ndomains: [eng]\n---\n`);
+
+    const result = runValidateMembers(tmp.path);
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+// --- runValidateMembers: delegate_mention cross-validation ---
+
+describe("runValidateMembers delegate_mention", () => {
+  it("accepts valid delegate_mention to personal_assistant", () => {
+    const tmp = useTmpDir();
+    write(tmp.path, "members/NODE.md", "---\ntitle: Members\n---\n");
+    write(tmp.path, "members/alice/NODE.md", `---\ntitle: Alice\nowners: [alice]\ntype: human\nrole: Eng\ndomains: [eng]\ndelegate_mention: alice-assistant\n---\n`);
+    write(tmp.path, "members/alice-assistant/NODE.md", VALID_ASSISTANT);
+
+    const result = runValidateMembers(tmp.path);
+    expect(result.exitCode).toBe(0);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("rejects delegate_mention to non-existent member", () => {
+    const tmp = useTmpDir();
+    write(tmp.path, "members/NODE.md", "---\ntitle: Members\n---\n");
+    write(tmp.path, "members/alice/NODE.md", `---\ntitle: Alice\nowners: [alice]\ntype: human\nrole: Eng\ndomains: [eng]\ndelegate_mention: ghost\n---\n`);
+
+    const result = runValidateMembers(tmp.path);
+    expect(result.exitCode).toBe(1);
+    expect(result.errors.some((e) => e.includes("delegate_mention 'ghost'") && e.includes("non-existent"))).toBe(true);
+  });
+
+  it("rejects delegate_mention to non-personal_assistant member", () => {
+    const tmp = useTmpDir();
+    write(tmp.path, "members/NODE.md", "---\ntitle: Members\n---\n");
+    write(tmp.path, "members/alice/NODE.md", `---\ntitle: Alice\nowners: [alice]\ntype: human\nrole: Eng\ndomains: [eng]\ndelegate_mention: bob\n---\n`);
+    write(tmp.path, "members/bob/NODE.md", `---\ntitle: Bob\nowners: [bob]\ntype: human\nrole: Eng\ndomains: [eng]\n---\n`);
+
+    const result = runValidateMembers(tmp.path);
+    expect(result.exitCode).toBe(1);
+    expect(result.errors.some((e) => e.includes("delegate_mention 'bob'") && e.includes("personal_assistant"))).toBe(true);
+  });
+
+  it("accepts delegate_mention to nested personal_assistant", () => {
+    const tmp = useTmpDir();
+    write(tmp.path, "members/NODE.md", "---\ntitle: Members\n---\n");
+    write(tmp.path, "members/alice/NODE.md", `---\ntitle: Alice\nowners: [alice]\ntype: human\nrole: Eng\ndomains: [eng]\ndelegate_mention: helper\n---\n`);
+    write(tmp.path, "members/bots/NODE.md", `---\ntitle: Bots\nowners: [admin]\ntype: autonomous_agent\nrole: Group\ndomains: [infra]\n---\n`);
+    write(tmp.path, "members/bots/helper/NODE.md", `---\ntitle: Helper\nowners: [admin]\ntype: personal_assistant\nrole: Assistant\ndomains: [eng]\n---\n`);
+
+    const result = runValidateMembers(tmp.path);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("allows member without delegate_mention", () => {
+    const tmp = useTmpDir();
+    write(tmp.path, "members/NODE.md", "---\ntitle: Members\n---\n");
+    write(tmp.path, "members/alice/NODE.md", VALID_MEMBER);
+
+    const result = runValidateMembers(tmp.path);
+    expect(result.exitCode).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary
- `runValidateMembers()` now recursively scans all subdirectories under `members/`, not just first-level children
- `memberCount()` in `Repo` class also counts nested members recursively
- **Directory name uniqueness**: enforced across all levels under `members/` — duplicate names at different depths are rejected
- **`delegate_mention` cross-validation**: if present, the target must exist under `members/` and have `type: personal_assistant`
- 10 new tests covering nested members, duplicate detection, deep nesting, and delegate_mention scenarios

## Context
Prepares the validation side for supporting hierarchical agent structures in Context Tree. The companion PR in first-tree-hub (recursive sync) depends on these validation guarantees.

## Test plan
- [x] All 145 existing + new tests pass (`vitest run`)
- [ ] Verify `context-tree verify` works on a repo with nested `members/` structure
- [ ] Verify duplicate directory names across levels are correctly rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)