### PR TITLE
feat: add populate tree rule to init flow

### DIFF
--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -4,6 +4,7 @@ import * as agentIntegration from "#src/rules/agent-integration.js";
 import * as ciValidation from "#src/rules/ci-validation.js";
 import * as framework from "#src/rules/framework.js";
 import * as members from "#src/rules/members.js";
+import * as populateTree from "#src/rules/populate-tree.js";
 import * as rootNode from "#src/rules/root-node.js";
 
 export interface RuleResult {
@@ -23,6 +24,7 @@ const ALL_RULES: Rule[] = [
   members,
   agentIntegration,
   ciValidation,
+  populateTree,
 ];
 
 export function evaluateAll(repo: Repo): RuleResult[] {
@@ -36,4 +38,4 @@ export function evaluateAll(repo: Repo): RuleResult[] {
   return results.sort((a, b) => a.order - b.order);
 }
 
-export { framework, rootNode, agentInstructions, members, agentIntegration, ciValidation };
+export { framework, rootNode, agentInstructions, members, agentIntegration, ciValidation, populateTree };

--- a/src/rules/populate-tree.ts
+++ b/src/rules/populate-tree.ts
@@ -1,0 +1,36 @@
+import type { Repo } from "#src/repo.js";
+import type { RuleResult } from "#src/rules/index.js";
+import { INTERACTIVE_TOOL } from "#src/init.js";
+
+export function evaluate(repo: Repo): RuleResult {
+  const tasks: string[] = [];
+
+  tasks.push(
+    `Ask the user whether they want to populate the full context tree now using the **${INTERACTIVE_TOOL}** tool. ` +
+      "Present two options: (1) **Yes — populate the full tree**: the agent will analyze source repositories, " +
+      "create sub-domains, and populate NODE.md files for each domain and sub-domain; " +
+      "(2) **No — I'll do it later**: skip deep population and finish init with just the top-level structure. " +
+      "If the user selects No, check off all remaining items in this section and move on.",
+  );
+
+  tasks.push(
+    "If the user selected Yes: analyze the codebase (and any additional repositories the user provides) to identify " +
+      "logical sub-domains within each top-level domain. For each sub-domain, create a directory with a NODE.md " +
+      "containing proper frontmatter (title, owners) and a description of the sub-domain's purpose, boundaries, " +
+      "and key decisions. Create deeper sub-domains when a domain is large enough to warrant further decomposition.",
+  );
+
+  tasks.push(
+    "Use **sub-tasks** (TaskCreate) to parallelize the population work — create one sub-task per top-level domain " +
+      "so each domain can be populated concurrently. Each sub-task should: read the relevant source code, identify " +
+      "sub-domains, create NODE.md files, and establish soft_links between related domains.",
+  );
+
+  tasks.push(
+    "After all domains are populated, update the root NODE.md to list every top-level domain with a one-line " +
+      "description. Ensure all NODE.md files pass `context-tree verify` — valid frontmatter, no placeholders, " +
+      "and soft_links that resolve correctly.",
+  );
+
+  return { group: "Populate Tree", order: 7, tasks };
+}

--- a/tests/rules.test.ts
+++ b/tests/rules.test.ts
@@ -10,6 +10,7 @@ import {
   members,
   agentIntegration,
   ciValidation,
+  populateTree,
 } from "#src/rules/index.js";
 import {
   useTmpDir,
@@ -319,6 +320,34 @@ describe("ciValidation rule", () => {
   });
 });
 
+// --- populateTree rule ---
+
+describe("populateTree rule", () => {
+  it("always produces tasks", () => {
+    const tmp = useTmpDir();
+    const repo = new Repo(tmp.path);
+    const result = populateTree.evaluate(repo);
+    expect(result.group).toBe("Populate Tree");
+    expect(result.order).toBe(7);
+    expect(result.tasks.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("first task asks user whether to populate", () => {
+    const tmp = useTmpDir();
+    const repo = new Repo(tmp.path);
+    const result = populateTree.evaluate(repo);
+    expect(result.tasks[0]).toContain("Yes");
+    expect(result.tasks[0]).toContain("No");
+  });
+
+  it("includes sub-task parallelization instruction", () => {
+    const tmp = useTmpDir();
+    const repo = new Repo(tmp.path);
+    const result = populateTree.evaluate(repo);
+    expect(result.tasks.some((t) => t.includes("sub-task") || t.includes("TaskCreate"))).toBe(true);
+  });
+});
+
 // --- evaluateAll ---
 
 describe("evaluateAll", () => {
@@ -353,5 +382,12 @@ describe("evaluateAll", () => {
     for (const g of groups) {
       expect(g.tasks.length).toBeGreaterThan(0);
     }
+  });
+
+  it("includes populate tree group", () => {
+    const tmp = useTmpDir();
+    const repo = new Repo(tmp.path);
+    const groups = evaluateAll(repo);
+    expect(groups.some((g) => g.group === "Populate Tree")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Adds a new "Populate Tree" rule (order 7) to the default `context-tree init` task list
- The first task asks the user whether they want full tree population via `AskUserQuestion` — if they decline, remaining items are skipped
- If accepted, the agent analyzes source repos, creates sub-domains with NODE.md files, and uses sub-tasks (`TaskCreate`) to parallelize work across top-level domains
- Includes 4 new tests for the populate-tree rule

## Test plan
- [x] All 149 existing tests pass
- [ ] Run `context-tree init` and verify the "Populate Tree" section appears in the generated task list
- [ ] Verify the agent presents Yes/No options and handles both paths correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)