### PR TITLE
feat: eval harness for context-tree impact measurement

### DIFF
--- a/evals/cases/nanobot-example.yaml
+++ b/evals/cases/nanobot-example.yaml
@@ -1,0 +1,32 @@
+# Eval case: ExecTool regex bug — Windows drive-root paths bypass workspace guard.
+# Based on: https://github.com/HKUDS/nanobot/pull/2683
+# Issue: https://github.com/HKUDS/nanobot/issues/2671
+
+id: nanobot-exectool-regex
+source: custom
+repo: HKUDS/nanobot
+commit_sha: "ddc9fc4fd286025aebaab5fb3f2f032a18ed2478"
+task: |
+  Fix a bug in ExecTool._extract_absolute_paths (nanobot/agent/tools/shell.py).
+
+  The regex for extracting Windows absolute paths uses `+` quantifier:
+    r"[A-Za-z]:\\[^\s\"'|><;]+"
+
+  This requires at least one character after the backslash, so bare Windows
+  drive-root paths like `E:\` are never extracted. This means commands like
+  `dir E:\` bypass the workspace safety guard when restrict_to_workspace=True.
+
+  Fix the regex so that `E:\` (nothing after the backslash) is correctly
+  extracted and blocked by the safety guard.
+
+  Write tests to verify:
+  1. _extract_absolute_paths("dir E:\\") returns ["E:\\"]
+  2. _guard_command("dir E:\\", "E:\\workspace") returns an error when
+     restrict_to_workspace=True
+setup: |
+  uv venv .venv --quiet
+  uv pip install -e ".[dev]" --quiet --python .venv/bin/python
+verification: fixtures/nanobot-example/verify.sh
+difficulty: easy
+timeout_ms: 300000
+max_turns: 20

--- a/evals/context-tree-eval.test.ts
+++ b/evals/context-tree-eval.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Context Tree eval test suite.
+ *
+ * Gated by EVALS=1 environment variable.
+ * Run with: EVALS=1 pnpm run eval
+ *
+ * Conditions are configured via env vars:
+ *   EVALS_CONDITIONS='baseline'                    — baseline only
+ *   EVALS_CONDITIONS='baseline,cli-v0.0.3:aaa111'  — baseline + tree version
+ *
+ * Format: label or label:tree_sha (comma-separated)
+ */
+
+import { describe, test, afterAll } from 'vitest';
+import type { EvalCondition, AgentConfig, ContextTreeConfig } from '#evals/helpers/types.js';
+import { loadCases } from '#evals/helpers/case-loader.js';
+import { runTrial } from '#evals/helpers/condition-runner.js';
+import { EvalCollector } from '#evals/helpers/eval-store.js';
+
+const evalsEnabled = !!process.env.EVALS;
+
+import { parseConditions } from '#evals/helpers/parse-conditions.js';
+
+const conditions = parseConditions(process.env.EVALS_CONDITIONS || 'baseline');
+const trialCount = parseInt(process.env.EVALS_TRIALS || '1', 10);
+
+const agent: AgentConfig = {
+  cli: (process.env.EVALS_CLI as AgentConfig['cli']) || 'claude-code',
+  model: process.env.EVALS_MODEL || 'claude-sonnet-4-6',
+};
+
+const treeConfig: ContextTreeConfig | undefined = process.env.EVALS_TREE_REPO
+  ? { repo: process.env.EVALS_TREE_REPO }
+  : undefined;
+
+const caseFilter = process.env.EVALS_CASES
+  ? process.env.EVALS_CASES.split(',').map(s => s.trim())
+  : undefined;
+
+const describeEval = evalsEnabled ? describe : describe.skip;
+
+describeEval('context-tree eval', () => {
+  const collector = new EvalCollector({ model: agent.model, cli: agent.cli });
+
+  let cases: ReturnType<typeof loadCases>;
+  try {
+    cases = loadCases({ ids: caseFilter });
+  } catch (err: any) {
+    process.stderr.write(`⚠ ${err.message}\n`);
+    cases = [];
+  }
+
+  afterAll(async () => {
+    if (collector) {
+      await collector.finalize();
+    }
+  });
+
+  for (const evalCase of cases) {
+    describe(evalCase.id, () => {
+      for (const condition of conditions) {
+        for (let trial = 1; trial <= trialCount; trial++) {
+          const testName = trialCount > 1
+            ? `${condition.label} (trial ${trial})`
+            : condition.label;
+
+          test(testName, async () => {
+            const result = await runTrial(evalCase, condition, trial, agent, treeConfig);
+            collector.addTrial(result);
+          }, evalCase.timeout_ms || 600_000);
+        }
+      }
+    });
+  }
+});

--- a/evals/fixtures/nanobot-example/verify.sh
+++ b/evals/fixtures/nanobot-example/verify.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Verification for nanobot-exectool-regex eval case.
+#
+# Tests that the ExecTool regex fix was applied correctly.
+# The bug: regex uses `+` quantifier which requires >=1 char after `\`,
+# so bare `E:\` is missed. Fix: change `+` to `*`.
+
+set -euo pipefail
+
+cd "${SANDBOX_DIR:-.}"
+
+python3 << 'PYEOF'
+import re, json
+
+passed = 0
+total = 2
+
+with open("nanobot/agent/tools/shell.py") as f:
+    source = f.read()
+
+# Find the win_paths line and extract the regex pattern between r" and "
+match = re.search(r'win_paths\s*=\s*re\.findall\(r"(.+?)",\s*command\)', source)
+if not match:
+    print("FAIL: Could not find win_paths regex in shell.py")
+    print(json.dumps({"passed": 0, "total": total}))
+    exit(0)
+
+raw_pattern = match.group(1)
+
+# Test 1: The pattern must use * (not +) so bare drive roots are matched.
+# The key part is: [^\s"'|><;]* (with * allowing zero characters after \)
+# We test this by running the regex against "dir E:\"
+#
+# Since the pattern is inside r"...", we need to reconstruct it.
+# The source has: [A-Za-z]:\\[^\s\"'|><;]* (with \" being a literal quote in the r-string)
+# In Python, inside r"...", \" is the two chars \ and "... but actually it just escapes the quote.
+# The actual regex pattern as Python sees it is: [A-Za-z]:\[^\s"'|><;]*
+#
+# Simplest check: does the pattern end with * or + before the closing?
+if raw_pattern.endswith("*"):
+    passed += 1
+    print("PASS: regex uses * quantifier (matches zero-length suffix)")
+elif raw_pattern.endswith("+"):
+    print("FAIL: regex still uses + quantifier (misses bare drive roots like E:\\)")
+else:
+    # The agent may have rewritten the regex differently — test empirically
+    print(f"INFO: unexpected pattern ending: ...{raw_pattern[-10:]}")
+    # Try to compile and test it
+    try:
+        # Reconstruct: the \" in source means literal " in the regex
+        test_pattern = raw_pattern.replace('\\"', '"')
+        paths = re.findall(test_pattern, "dir E:\\")
+        if paths and "E:\\" in paths:
+            passed += 1
+            print("PASS: regex captures E:\\ (alternative fix)")
+        else:
+            print(f"FAIL: regex does not capture E:\\ (result: {paths!r})")
+    except re.error as e:
+        print(f"FAIL: regex compilation error: {e}")
+
+# Test 2: Verify the regex still captures full paths (no regression)
+try:
+    test_pattern = raw_pattern.replace('\\"', '"')
+    paths = re.findall(test_pattern, "dir C:\\Users\\foo\\bar.txt")
+    if paths and any("C:\\" in p for p in paths):
+        passed += 1
+        print(f"PASS: regex captures full path ({paths})")
+    else:
+        print(f"FAIL: regex does not capture full Windows path (result: {paths!r})")
+except re.error as e:
+    print(f"FAIL: regex compilation error: {e}")
+
+print(json.dumps({"passed": passed, "total": total}))
+PYEOF

--- a/evals/helpers/case-loader.ts
+++ b/evals/helpers/case-loader.ts
@@ -1,0 +1,106 @@
+/**
+ * Load eval case definitions from YAML files in evals/cases/.
+ *
+ * Supports two YAML formats:
+ *   Single-repo:  repo + commit_sha + setup (top-level fields)
+ *   Multi-repo:   repos[] array with per-repo fields (P1/P2)
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import type { EvalCase, RepoRef } from '#evals/helpers/types.js';
+
+function parseRepos(data: any, filePath: string): RepoRef[] {
+  // Multi-repo format: repos[]
+  if (Array.isArray(data.repos)) {
+    for (const [i, r] of data.repos.entries()) {
+      if (!r.repo || !r.commit_sha) {
+        throw new Error(`repos[${i}] missing repo or commit_sha in ${filePath}`);
+      }
+    }
+    return data.repos.map((r: any) => ({
+      repo: r.repo,
+      commit_sha: r.commit_sha,
+      path: r.path,
+      setup: r.setup,
+    }));
+  }
+
+  // Single-repo format: repo + commit_sha at top level
+  if (!data.repo || !data.commit_sha) {
+    throw new Error(`Missing repo or commit_sha in ${filePath}`);
+  }
+  return [{
+    repo: data.repo,
+    commit_sha: data.commit_sha,
+    setup: data.setup,
+  }];
+}
+
+function validateCase(data: any, filePath: string): EvalCase {
+  for (const field of ['id', 'source', 'task', 'verification'] as const) {
+    if (!data[field]) {
+      throw new Error(`Missing required field '${field}' in ${filePath}`);
+    }
+  }
+
+  if (!['custom', 'swebench'].includes(data.source)) {
+    throw new Error(`Invalid source '${data.source}' in ${filePath}. Must be 'custom' or 'swebench'.`);
+  }
+
+  if (!['easy', 'medium', 'hard'].includes(data.difficulty || 'medium')) {
+    throw new Error(`Invalid difficulty '${data.difficulty}' in ${filePath}.`);
+  }
+
+  const repos = parseRepos(data, filePath);
+
+  return {
+    id: data.id,
+    source: data.source,
+    repos,
+    task: data.task,
+    golden_pr: data.golden_pr,
+    verification: data.verification,
+    difficulty: data.difficulty || 'medium',
+    timeout_ms: data.timeout_ms,
+    max_turns: data.max_turns,
+  };
+}
+
+export function loadCases(options?: {
+  ids?: string[];
+  casesDir?: string;
+}): EvalCase[] {
+  const casesDir = options?.casesDir || path.resolve(import.meta.dirname, '..', 'cases');
+  const ids = options?.ids;
+
+  if (!fs.existsSync(casesDir)) {
+    throw new Error(`Cases directory not found: ${casesDir}`);
+  }
+
+  const files = fs.readdirSync(casesDir)
+    .filter(f => f.endsWith('.yaml') || f.endsWith('.yml'))
+    .filter(f => !f.startsWith('_'))
+    .sort();
+
+  const cases: EvalCase[] = [];
+  for (const file of files) {
+    const filePath = path.join(casesDir, file);
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const data = parseYaml(content);
+    const evalCase = validateCase(data, filePath);
+
+    if (ids && !ids.includes(evalCase.id)) continue;
+    cases.push(evalCase);
+  }
+
+  if (cases.length === 0) {
+    const msg = ids
+      ? `No eval cases found matching ids: ${ids.join(', ')}`
+      : `No eval cases found in ${casesDir}`;
+    throw new Error(msg);
+  }
+
+  return cases;
+}

--- a/evals/helpers/condition-runner.ts
+++ b/evals/helpers/condition-runner.ts
@@ -1,0 +1,186 @@
+/**
+ * Condition runner: orchestrates a single eval trial.
+ *
+ * For a given (case, condition, trial), it:
+ * 1. Creates a sandbox (cloned repo at the target commit)
+ * 2. Constructs the appropriate prompt per condition
+ * 3. Runs the agent session
+ * 4. Executes verification tests
+ * 5. Returns a TrialResult
+ */
+
+import { execSync } from 'node:child_process';
+import * as path from 'node:path';
+import type { EvalCase, EvalCondition, AgentConfig, TrialResult, ContextTreeConfig } from '#evals/helpers/types.js';
+import { createSandbox } from '#evals/helpers/repo-sandbox.js';
+import { runSession } from '#evals/helpers/session-runner.js';
+
+// --- Prompt construction ---
+
+function buildPrompt(evalCase: EvalCase, condition: EvalCondition): string {
+  const parts: string[] = [];
+
+  // Base task
+  parts.push(`You are working in a code repository. Your task:\n\n${evalCase.task}`);
+
+  // If the condition has a tree, tell the agent about it
+  if (condition.tree_sha) {
+    parts.push(
+      '\n\n## Context Tree',
+      'This repository contains a context tree — a structured knowledge base in NODE.md files.',
+      'Before starting, read the root NODE.md to understand the project structure and domains.',
+      'Follow soft_links in frontmatter to discover related context.',
+      'Use the context tree to understand architecture, conventions, and cross-domain relationships.',
+    );
+  }
+
+  parts.push(
+    '\n\n## Instructions',
+    'Make the minimal changes needed to complete the task.',
+    'Do not refactor unrelated code or add unnecessary features.',
+  );
+
+  return parts.join('\n');
+}
+
+// --- Verification ---
+
+interface VerificationResult {
+  passed: boolean;
+  tests_total: number;
+  tests_passed: number;
+  error?: string;
+}
+
+function runVerification(
+  sandboxDir: string,
+  verificationPath: string,
+  evalsRoot: string,
+): VerificationResult {
+  const absVerification = path.resolve(evalsRoot, verificationPath);
+
+  try {
+    const output = execSync(`bash ${JSON.stringify(absVerification)}`, {
+      cwd: sandboxDir,
+      stdio: 'pipe',
+      timeout: 120_000,
+      env: { ...process.env, SANDBOX_DIR: sandboxDir },
+    }).toString();
+
+    // Try to parse structured output: { "passed": N, "total": M }
+    try {
+      const result = JSON.parse(output.trim());
+      if (typeof result.passed === 'number' && typeof result.total === 'number') {
+        return {
+          passed: result.passed === result.total,
+          tests_total: result.total,
+          tests_passed: result.passed,
+        };
+      }
+    } catch { /* not structured — treat as pass */ }
+
+    return { passed: true, tests_total: 1, tests_passed: 1 };
+  } catch (err: any) {
+    // Try to parse structured output from failed run
+    const output = err.stdout?.toString() || '';
+    try {
+      const result = JSON.parse(output.trim());
+      if (typeof result.passed === 'number' && typeof result.total === 'number') {
+        return {
+          passed: false,
+          tests_total: result.total,
+          tests_passed: result.passed,
+          error: err.message,
+        };
+      }
+    } catch { /* not structured */ }
+
+    return {
+      passed: false,
+      tests_total: 1,
+      tests_passed: 0,
+      error: err.message?.slice(0, 500),
+    };
+  }
+}
+
+// --- Main trial runner ---
+
+export async function runTrial(
+  evalCase: EvalCase,
+  condition: EvalCondition,
+  trial: number,
+  agent: AgentConfig,
+  treeConfig?: ContextTreeConfig,
+): Promise<TrialResult> {
+  const evalsRoot = path.resolve(import.meta.dirname, '..');
+  const testName = `${evalCase.id}/${condition.label}/trial-${trial}`;
+  process.stderr.write(`\n▶ ${testName} (${agent.cli}/${agent.model})\n`);
+
+  const sandbox = await createSandbox(evalCase, condition, treeConfig);
+
+  try {
+    // Run agent session
+    const prompt = buildPrompt(evalCase, condition);
+    const session = await runSession({
+      prompt,
+      workingDirectory: sandbox.dir,
+      agent,
+      maxTurns: evalCase.max_turns || 30,
+      timeout: evalCase.timeout_ms || 300_000,
+      testName,
+    });
+
+    // Run verification
+    process.stderr.write(`  Running verification...\n`);
+    const verification = runVerification(sandbox.dir, evalCase.verification, evalsRoot);
+
+    const status = verification.passed ? '✓ PASS' : '✗ FAIL';
+    process.stderr.write(`  ${status} (${verification.tests_passed}/${verification.tests_total})\n`);
+
+    return {
+      case_id: evalCase.id,
+      condition: condition.label,
+      trial,
+      passed: verification.passed,
+      tests_total: verification.tests_total,
+      tests_passed: verification.tests_passed,
+      input_tokens: session.costEstimate.inputTokens,
+      output_tokens: session.costEstimate.outputTokens,
+      cache_creation_tokens: session.costEstimate.cacheCreationTokens,
+      cache_read_tokens: session.costEstimate.cacheReadTokens,
+      api_calls: session.toolCalls.length,
+      wall_clock_ms: session.duration,
+      cost_usd: session.costEstimate.estimatedCost,
+      exit_reason: session.exitReason,
+      transcript: session.transcript,
+      model: session.model,
+      cli: agent.cli,
+      error: verification.error,
+    };
+  } catch (err: any) {
+    process.stderr.write(`  ✗ ERROR: ${err.message}\n`);
+    return {
+      case_id: evalCase.id,
+      condition: condition.label,
+      trial,
+      passed: false,
+      tests_total: 0,
+      tests_passed: 0,
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_creation_tokens: 0,
+      cache_read_tokens: 0,
+      api_calls: 0,
+      wall_clock_ms: Date.now(),
+      cost_usd: 0,
+      exit_reason: 'error',
+      transcript: [],
+      model: agent.model,
+      cli: agent.cli,
+      error: err.message?.slice(0, 500),
+    };
+  } finally {
+    sandbox.cleanup();
+  }
+}

--- a/evals/helpers/eval-store.ts
+++ b/evals/helpers/eval-store.ts
@@ -1,0 +1,150 @@
+/**
+ * Eval result persistence.
+ *
+ * EvalCollector accumulates trial results, writes them to
+ * ~/.context-tree/evals/{branch}-{timestamp}.json with crash-safe
+ * partial saves, and prints a summary table on finalize.
+ *
+ * Adapted from gstack's eval-store.ts.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { spawnSync } from 'node:child_process';
+import type { TrialResult, EvalRun } from '#evals/helpers/types.js';
+
+const SCHEMA_VERSION = 1;
+const EVAL_DIR = path.join(os.homedir(), '.context-tree', 'evals');
+
+function getGitInfo(): { branch: string; sha: string } {
+  try {
+    const branch = spawnSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { stdio: 'pipe', timeout: 5000 });
+    const sha = spawnSync('git', ['rev-parse', '--short', 'HEAD'], { stdio: 'pipe', timeout: 5000 });
+    return {
+      branch: branch.stdout?.toString().trim() || 'unknown',
+      sha: sha.stdout?.toString().trim() || 'unknown',
+    };
+  } catch {
+    return { branch: 'unknown', sha: 'unknown' };
+  }
+}
+
+export class EvalCollector {
+  private trials: TrialResult[] = [];
+  private finalized = false;
+  private evalDir: string;
+  private createdAt = Date.now();
+  private model: string;
+  private cli: string;
+  private conditions: Set<string> = new Set();
+
+  constructor(options: { model: string; cli: string; evalDir?: string }) {
+    this.model = options.model;
+    this.cli = options.cli;
+    this.evalDir = options.evalDir || EVAL_DIR;
+  }
+
+  addTrial(trial: TrialResult): void {
+    this.trials.push(trial);
+    this.conditions.add(trial.condition);
+    this.savePartial();
+  }
+
+  /** Atomic partial save after each trial. Non-fatal on error. */
+  private savePartial(): void {
+    try {
+      const run = this.buildRun(true);
+      fs.mkdirSync(this.evalDir, { recursive: true });
+      const partialPath = path.join(this.evalDir, '_partial-eval.json');
+      const tmp = partialPath + '.tmp';
+      fs.writeFileSync(tmp, JSON.stringify(run, null, 2) + '\n');
+      fs.renameSync(tmp, partialPath);
+    } catch { /* non-fatal */ }
+  }
+
+  async finalize(): Promise<string> {
+    if (this.finalized) return '';
+    this.finalized = true;
+
+    const run = this.buildRun(false);
+
+    // Write final file
+    fs.mkdirSync(this.evalDir, { recursive: true });
+    const dateStr = run.timestamp.replace(/[:.]/g, '').replace('T', '-').slice(0, 15);
+    const safeBranch = run.branch.replace(/[^a-zA-Z0-9._-]/g, '-');
+    const filename = `${safeBranch}-${dateStr}.json`;
+    const filepath = path.join(this.evalDir, filename);
+    fs.writeFileSync(filepath, JSON.stringify(run, null, 2) + '\n');
+
+    // Clean up partial file
+    try { fs.unlinkSync(path.join(this.evalDir, '_partial-eval.json')); } catch { /* ignore */ }
+
+    this.printSummary(run, filepath);
+    return filepath;
+  }
+
+  private buildRun(partial: boolean): EvalRun & { _partial?: boolean } {
+    const git = getGitInfo();
+    const totalCost = this.trials.reduce((s, t) => s + t.cost_usd, 0);
+    const totalDuration = this.trials.reduce((s, t) => s + t.wall_clock_ms, 0);
+
+    return {
+      schema_version: SCHEMA_VERSION,
+      timestamp: new Date().toISOString(),
+      git_sha: git.sha,
+      branch: git.branch,
+      hostname: os.hostname(),
+      model: this.model,
+      cli: this.cli,
+      conditions: [...this.conditions],
+      trials: this.trials,
+      total_cost_usd: Math.round(totalCost * 100) / 100,
+      total_duration_ms: totalDuration,
+      wall_clock_ms: Date.now() - this.createdAt,
+      ...(partial ? { _partial: true } : {}),
+    };
+  }
+
+  private printSummary(run: EvalRun, filepath: string): void {
+    const lines: string[] = [];
+    lines.push('');
+    lines.push(`Eval Results — ${run.cli}/${run.model} @ ${run.branch} (${run.git_sha})`);
+    lines.push('═'.repeat(75));
+
+    // Group by condition
+    const byCondition = new Map<string, TrialResult[]>();
+    for (const t of this.trials) {
+      const list = byCondition.get(t.condition) || [];
+      list.push(t);
+      byCondition.set(t.condition, list);
+    }
+
+    for (const [condition, trials] of byCondition) {
+      const passed = trials.filter(t => t.passed).length;
+      const totalCost = trials.reduce((s, t) => s + t.cost_usd, 0);
+      lines.push(`\n  ${condition} (${passed}/${trials.length} passed, $${totalCost.toFixed(2)})`);
+      lines.push('  ' + '─'.repeat(71));
+
+      for (const t of trials) {
+        const status = t.passed ? ' PASS ' : ' FAIL ';
+        const cost = `$${t.cost_usd.toFixed(2)}`;
+        const dur = `${Math.round(t.wall_clock_ms / 1000)}s`;
+        const inTok = Math.round(t.input_tokens / 1000);
+        const outTok = Math.round(t.output_tokens / 1000);
+        const tokens = `${inTok}k in/${outTok}k out`;
+        const name = t.case_id.length > 30
+          ? t.case_id.slice(0, 27) + '...'
+          : t.case_id.padEnd(30);
+        lines.push(`    ${name}  ${status}  ${cost.padStart(7)}  ${dur.padStart(5)}  ${tokens.padStart(8)}`);
+      }
+    }
+
+    lines.push('\n' + '═'.repeat(75));
+    const totalPassed = this.trials.filter(t => t.passed).length;
+    lines.push(`  Total: ${totalPassed}/${this.trials.length} passed  $${run.total_cost_usd.toFixed(2)}  ${Math.round(run.wall_clock_ms / 1000)}s wall`);
+    lines.push(`  Saved: ${filepath}`);
+
+    process.stderr.write(lines.join('\n') + '\n');
+  }
+}

--- a/evals/helpers/parse-conditions.ts
+++ b/evals/helpers/parse-conditions.ts
@@ -1,0 +1,22 @@
+/**
+ * Parse condition strings from env var format.
+ *
+ * Format: "baseline,cli-v0.0.3:aaa111,human-curated:ccc333"
+ * Each entry is either "label" (no tree) or "label:tree_sha".
+ */
+
+import type { EvalCondition } from '#evals/helpers/types.js';
+
+export function parseConditions(env: string): EvalCondition[] {
+  return env.split(',').map(s => {
+    const trimmed = s.trim();
+    const colonIdx = trimmed.indexOf(':');
+    if (colonIdx === -1) {
+      return { label: trimmed };
+    }
+    return {
+      label: trimmed.slice(0, colonIdx),
+      tree_sha: trimmed.slice(colonIdx + 1),
+    };
+  });
+}

--- a/evals/helpers/repo-sandbox.ts
+++ b/evals/helpers/repo-sandbox.ts
@@ -1,0 +1,122 @@
+/**
+ * Repo sandbox: create isolated working directories for eval trials.
+ *
+ * Clones one or more repos into a tmpdir at specific commits.
+ * If the condition specifies a context tree (tree_sha), clones the
+ * tree repo and overlays it into the sandbox.
+ *
+ * Single-repo layout:   /tmp/ct-eval-xxx/  (repo cloned at root)
+ * Multi-repo layout:    /tmp/ct-eval-xxx/backend/
+ *                       /tmp/ct-eval-xxx/web/
+ *                       /tmp/ct-eval-xxx/mobile/
+ */
+
+import { execSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import type { EvalCase, EvalCondition, ContextTreeConfig, RepoRef } from '#evals/helpers/types.js';
+
+export interface Sandbox {
+  dir: string;
+  cleanup: () => void;
+}
+
+function cloneRepo(ref: RepoRef, targetDir: string): void {
+  const isLocal = !ref.repo.includes('/') || fs.existsSync(ref.repo);
+  const cloneUrl = isLocal ? ref.repo : `https://github.com/${ref.repo}.git`;
+
+  process.stderr.write(`  Cloning ${ref.repo} @ ${ref.commit_sha.slice(0, 8)}...\n`);
+  execSync(
+    `git clone --quiet --no-checkout ${JSON.stringify(cloneUrl)} ${JSON.stringify(targetDir)}`,
+    { stdio: 'pipe', timeout: 120_000 },
+  );
+  execSync(
+    `git checkout --quiet ${ref.commit_sha}`,
+    { cwd: targetDir, stdio: 'pipe', timeout: 30_000 },
+  );
+
+  if (ref.setup) {
+    process.stderr.write(`  Running setup for ${ref.repo}...\n`);
+    execSync(ref.setup, {
+      cwd: targetDir,
+      stdio: 'pipe',
+      timeout: 300_000,
+      shell: '/bin/bash',
+    });
+  }
+}
+
+/** Derive the default subdirectory name from a repo slug. */
+function defaultPath(repo: string): string {
+  return repo.split('/').pop() || repo;
+}
+
+export async function createSandbox(
+  evalCase: EvalCase,
+  condition: EvalCondition,
+  treeConfig?: ContextTreeConfig,
+): Promise<Sandbox> {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `ct-eval-${evalCase.id}-`));
+  const isMultiRepo = evalCase.repos.length > 1;
+
+  try {
+    if (isMultiRepo) {
+      // Multi-repo: each repo gets its own subdirectory
+      for (const ref of evalCase.repos) {
+        const subdir = ref.path || defaultPath(ref.repo);
+        const targetDir = path.join(tmpDir, subdir);
+        cloneRepo(ref, targetDir);
+      }
+    } else {
+      // Single-repo: clone directly into tmpDir
+      const ref = evalCase.repos[0];
+      cloneRepo(ref, tmpDir);
+    }
+
+    // Inject context tree if the condition specifies one
+    if (condition.tree_sha && treeConfig) {
+      const treeUrl = `https://github.com/${treeConfig.repo}.git`;
+      const treeTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ct-eval-tree-'));
+
+      try {
+        // Derive branch name from primary repo
+        const primaryRepo = evalCase.repos[0];
+        const repoName = defaultPath(primaryRepo.repo);
+        const branch = `${repoName}/${primaryRepo.commit_sha.slice(0, 8)}`;
+
+        process.stderr.write(`  Cloning context tree @ ${condition.tree_sha.slice(0, 8)} (${condition.label})...\n`);
+        execSync(
+          `git clone --quiet --branch ${JSON.stringify(branch)} ${JSON.stringify(treeUrl)} ${JSON.stringify(treeTmp)}`,
+          { stdio: 'pipe', timeout: 60_000 },
+        );
+        execSync(
+          `git checkout --quiet ${condition.tree_sha}`,
+          { cwd: treeTmp, stdio: 'pipe', timeout: 10_000 },
+        );
+
+        // Overlay tree files into sandbox root (skip .git)
+        const entries = fs.readdirSync(treeTmp);
+        for (const entry of entries) {
+          if (entry === '.git') continue;
+          const src = path.join(treeTmp, entry);
+          const dest = path.join(tmpDir, entry);
+          execSync(`cp -a ${JSON.stringify(src)} ${JSON.stringify(dest)}`, { stdio: 'ignore' });
+        }
+        process.stderr.write(`  Injected context tree (${condition.label}).\n`);
+      } finally {
+        try { fs.rmSync(treeTmp, { recursive: true, force: true }); } catch { /* ignore */ }
+      }
+    }
+  } catch (err) {
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    throw err;
+  }
+
+  return {
+    dir: tmpDir,
+    cleanup: () => {
+      try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    },
+  };
+}

--- a/evals/helpers/session-runner.ts
+++ b/evals/helpers/session-runner.ts
@@ -1,0 +1,287 @@
+/**
+ * Agent CLI subprocess runner for eval testing.
+ *
+ * Spawns an agent CLI (claude, codex, gemini) as an independent process,
+ * streams NDJSON output, and returns structured results.
+ *
+ * Adapted from gstack's session-runner.ts (Bun → Node.js).
+ */
+
+import { spawn } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import type { AgentConfig, SessionResult, CostEstimate } from '#evals/helpers/types.js';
+
+// --- NDJSON parser (pure, no I/O) ---
+
+export interface ParsedNDJSON {
+  transcript: any[];
+  resultLine: any | null;
+  turnCount: number;
+  toolCallCount: number;
+  toolCalls: Array<{ tool: string; input: any; output: string }>;
+}
+
+export function parseNDJSON(lines: string[]): ParsedNDJSON {
+  const transcript: any[] = [];
+  let resultLine: any = null;
+  let turnCount = 0;
+  let toolCallCount = 0;
+  const toolCalls: ParsedNDJSON['toolCalls'] = [];
+
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    try {
+      const event = JSON.parse(line);
+      transcript.push(event);
+
+      if (event.type === 'assistant') {
+        turnCount++;
+        const content = event.message?.content || [];
+        for (const item of content) {
+          if (item.type === 'tool_use') {
+            toolCallCount++;
+            toolCalls.push({
+              tool: item.name || 'unknown',
+              input: item.input || {},
+              output: '',
+            });
+          }
+        }
+      }
+
+      if (event.type === 'result') resultLine = event;
+    } catch { /* skip malformed lines */ }
+  }
+
+  return { transcript, resultLine, turnCount, toolCallCount, toolCalls };
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max) + '…' : s;
+}
+
+// --- CLI adapter ---
+
+function buildCommand(agent: AgentConfig, maxTurns: number): { cmd: string; args: string[] } {
+  switch (agent.cli) {
+    case 'claude-code':
+      return {
+        cmd: 'claude',
+        args: [
+          '-p',
+          '--model', agent.model,
+          '--output-format', 'stream-json',
+          '--verbose',
+          '--dangerously-skip-permissions',
+          '--max-turns', String(maxTurns),
+        ],
+      };
+    case 'codex':
+      return {
+        cmd: 'codex',
+        args: [
+          'exec',
+          '--model', agent.model,
+          '--dangerously-auto-approve',
+        ],
+      };
+    case 'gemini':
+      return {
+        cmd: 'gemini',
+        args: [
+          '-p',
+          '--model', agent.model,
+          '--sandbox=false',
+        ],
+      };
+    default:
+      throw new Error(`Unknown CLI: ${agent.cli}`);
+  }
+}
+
+// --- Main runner ---
+
+export async function runSession(options: {
+  prompt: string;
+  workingDirectory: string;
+  agent: AgentConfig;
+  maxTurns?: number;
+  timeout?: number;
+  testName?: string;
+}): Promise<SessionResult> {
+  const {
+    prompt,
+    workingDirectory,
+    agent,
+    maxTurns = 30,
+    timeout = 300_000,
+    testName,
+  } = options;
+
+  const startTime = Date.now();
+
+  // Write prompt to temp file to avoid shell escaping issues
+  const promptFile = path.join(
+    os.tmpdir(),
+    `.eval-prompt-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  fs.writeFileSync(promptFile, prompt);
+
+  const { cmd, args } = buildCommand(agent, maxTurns);
+
+  // If a .venv exists in the working directory, prepend it to PATH
+  // so the agent's python/pip commands use the sandboxed environment.
+  const env = { ...process.env };
+  const venvBin = path.join(workingDirectory, '.venv', 'bin');
+  if (fs.existsSync(venvBin)) {
+    env.PATH = `${venvBin}:${env.PATH}`;
+    env.VIRTUAL_ENV = path.join(workingDirectory, '.venv');
+  }
+
+  // Spawn: cat promptfile | <cli> <args>
+  const shellCmd = `cat "${promptFile}" | ${cmd} ${args.map(a => `"${a}"`).join(' ')}`;
+  const proc = spawn('sh', ['-c', shellCmd], {
+    cwd: workingDirectory,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env,
+  });
+
+  let timedOut = false;
+  const timeoutId = setTimeout(() => {
+    timedOut = true;
+    proc.kill('SIGTERM');
+  }, timeout);
+
+  // Stream NDJSON from stdout
+  const collectedLines: string[] = [];
+  let liveTurnCount = 0;
+  let liveToolCount = 0;
+  let firstResponseMs = 0;
+  let lastToolTime = 0;
+  let maxInterTurnMs = 0;
+  let buf = '';
+
+  const stdoutDone = new Promise<void>((resolve) => {
+    proc.stdout.on('data', (chunk: Buffer) => {
+      buf += chunk.toString();
+      const lines = buf.split('\n');
+      buf = lines.pop() || '';
+
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        collectedLines.push(line);
+
+        try {
+          const event = JSON.parse(line);
+          if (event.type === 'assistant') {
+            liveTurnCount++;
+            const content = event.message?.content || [];
+            for (const item of content) {
+              if (item.type === 'tool_use') {
+                liveToolCount++;
+                const now = Date.now();
+                const elapsed = Math.round((now - startTime) / 1000);
+
+                if (firstResponseMs === 0) firstResponseMs = now - startTime;
+                if (lastToolTime > 0) {
+                  const interTurn = now - lastToolTime;
+                  if (interTurn > maxInterTurnMs) maxInterTurnMs = interTurn;
+                }
+                lastToolTime = now;
+
+                const progressLine = `  [${elapsed}s] turn ${liveTurnCount} tool #${liveToolCount}: ${item.name}(${truncate(JSON.stringify(item.input || {}), 80)})\n`;
+                process.stderr.write(progressLine);
+              }
+            }
+          }
+        } catch { /* skip — parseNDJSON handles later */ }
+      }
+    });
+
+    proc.stdout.on('end', resolve);
+  });
+
+  // Collect stderr
+  let stderr = '';
+  proc.stderr.on('data', (chunk: Buffer) => {
+    stderr += chunk.toString();
+  });
+
+  // Wait for process exit
+  const exitCode = await new Promise<number | null>((resolve) => {
+    proc.on('close', (code) => resolve(code));
+  });
+  await stdoutDone;
+  clearTimeout(timeoutId);
+
+  // Flush remaining buffer
+  if (buf.trim()) {
+    collectedLines.push(buf);
+  }
+
+  // Clean up prompt file
+  try { fs.unlinkSync(promptFile); } catch { /* non-fatal */ }
+
+  // Determine exit reason
+  let exitReason: string;
+  if (timedOut) {
+    exitReason = 'timeout';
+  } else if (exitCode === 0) {
+    exitReason = 'success';
+  } else {
+    exitReason = `exit_code_${exitCode}`;
+  }
+
+  const duration = Date.now() - startTime;
+  const parsed = parseNDJSON(collectedLines);
+  const { transcript, resultLine, toolCalls } = parsed;
+
+  // Refine exit reason from result line (Claude Code specific)
+  if (resultLine) {
+    if (resultLine.is_error) {
+      exitReason = 'error_api';
+    } else if (resultLine.subtype === 'success') {
+      exitReason = 'success';
+    } else if (resultLine.subtype) {
+      exitReason = resultLine.subtype;
+    }
+  }
+
+  // Extract cost from result line
+  const turnsUsed = resultLine?.num_turns || 0;
+  const estimatedCost = resultLine?.total_cost_usd || 0;
+  const usage = resultLine?.usage || {};
+  const inputTokens = (usage.input_tokens || 0)
+    + (usage.cache_creation_input_tokens || 0)
+    + (usage.cache_read_input_tokens || 0);
+  const outputTokens = usage.output_tokens || 0;
+  const cacheCreationTokens = usage.cache_creation_input_tokens || 0;
+  const cacheReadTokens = usage.cache_read_input_tokens || 0;
+
+  const costEstimate: CostEstimate = {
+    inputTokens,
+    outputTokens,
+    cacheCreationTokens,
+    cacheReadTokens,
+    estimatedCost: Math.round(estimatedCost * 100) / 100,
+    turnsUsed,
+  };
+
+  if (testName && (exitReason !== 'success')) {
+    process.stderr.write(`  ⚠ ${testName}: exit_reason=${exitReason}, turns=${liveTurnCount}, tools=${liveToolCount}\n`);
+  }
+
+  return {
+    toolCalls,
+    exitReason,
+    duration,
+    output: resultLine?.result || '',
+    costEstimate,
+    transcript,
+    model: agent.model,
+    firstResponseMs,
+    maxInterTurnMs,
+  };
+}

--- a/evals/helpers/types.ts
+++ b/evals/helpers/types.ts
@@ -1,0 +1,106 @@
+/**
+ * Core types for the context-tree eval harness.
+ */
+
+/** A single repo to clone into the sandbox. */
+export interface RepoRef {
+  repo: string;
+  commit_sha: string;
+  path?: string;     // subdirectory name in sandbox (defaults to repo name)
+  setup?: string;    // per-repo setup commands (run in repo's directory)
+}
+
+/** Test case loaded from YAML — the problem to solve. */
+export interface EvalCase {
+  id: string;
+  source: 'custom' | 'swebench';
+  repos: RepoRef[];  // one or more repos
+  task: string;
+  golden_pr?: string;
+  verification: string;
+  difficulty: 'easy' | 'medium' | 'hard';
+  timeout_ms?: number;
+  max_turns?: number;
+}
+
+/**
+ * Condition — what tools/context the agent gets.
+ * Baseline has no tree. Tree conditions reference a commit in the context tree repo.
+ */
+export interface EvalCondition {
+  label: string;
+  tree_sha?: string;
+}
+
+/** Global config for how to find context trees. */
+export interface ContextTreeConfig {
+  repo: string;       // e.g. "agent-team-foundation/eval-context-trees"
+}
+
+export interface AgentConfig {
+  cli: 'claude-code' | 'codex' | 'gemini';
+  model: string;
+}
+
+export interface CostEstimate {
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
+  estimatedCost: number;
+  turnsUsed: number;
+}
+
+export interface SessionResult {
+  toolCalls: Array<{ tool: string; input: any; output: string }>;
+  exitReason: string;
+  duration: number;
+  output: string;
+  costEstimate: CostEstimate;
+  transcript: any[];
+  model: string;
+  firstResponseMs: number;
+  maxInterTurnMs: number;
+}
+
+export interface TrialResult {
+  case_id: string;
+  condition: string;
+  trial: number;
+
+  // Correctness
+  passed: boolean;
+  tests_total: number;
+  tests_passed: number;
+
+  // Efficiency
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_tokens: number;
+  cache_read_tokens: number;
+  api_calls: number;
+  wall_clock_ms: number;
+  cost_usd: number;
+
+  // Diagnostics
+  exit_reason: string;
+  transcript: any[];
+  model: string;
+  cli: string;
+  error?: string;
+}
+
+export interface EvalRun {
+  schema_version: number;
+  timestamp: string;
+  git_sha: string;
+  branch: string;
+  hostname: string;
+  model: string;
+  cli: string;
+  conditions: string[];
+  trials: TrialResult[];
+  total_cost_usd: number;
+  total_duration_ms: number;
+  wall_clock_ms: number;
+}

--- a/evals/tests/eval-helpers.test.ts
+++ b/evals/tests/eval-helpers.test.ts
@@ -1,0 +1,441 @@
+/**
+ * Unit tests for eval harness helpers.
+ *
+ * Tests pure functions and data loading — no subprocess spawning.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { parseNDJSON } from '#evals/helpers/session-runner.js';
+import { loadCases } from '#evals/helpers/case-loader.js';
+import { parseConditions } from '#evals/helpers/parse-conditions.js';
+import { EvalCollector } from '#evals/helpers/eval-store.js';
+
+// --- Temp dir helper ---
+
+let tmpDirs: string[] = [];
+
+function useTmpDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'eval-test-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs) {
+    try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+  tmpDirs = [];
+});
+
+function writeCase(dir: string, filename: string, content: string): void {
+  writeFileSync(join(dir, filename), content);
+}
+
+// --- parseNDJSON ---
+
+describe('parseNDJSON', () => {
+  it('parses empty input', () => {
+    const result = parseNDJSON([]);
+    expect(result.transcript).toEqual([]);
+    expect(result.resultLine).toBeNull();
+    expect(result.turnCount).toBe(0);
+    expect(result.toolCallCount).toBe(0);
+    expect(result.toolCalls).toEqual([]);
+  });
+
+  it('skips blank lines', () => {
+    const result = parseNDJSON(['', '  ', '\t']);
+    expect(result.transcript).toEqual([]);
+  });
+
+  it('skips malformed JSON', () => {
+    const result = parseNDJSON(['not json', '{ broken']);
+    expect(result.transcript).toEqual([]);
+  });
+
+  it('counts turns from assistant events', () => {
+    const lines = [
+      JSON.stringify({ type: 'assistant', message: { content: [] } }),
+      JSON.stringify({ type: 'assistant', message: { content: [] } }),
+      JSON.stringify({ type: 'assistant', message: { content: [] } }),
+    ];
+    const result = parseNDJSON(lines);
+    expect(result.turnCount).toBe(3);
+    expect(result.toolCallCount).toBe(0);
+  });
+
+  it('extracts tool calls from assistant events', () => {
+    const lines = [
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          content: [
+            { type: 'tool_use', name: 'Read', input: { file_path: '/foo.ts' } },
+            { type: 'text', text: 'hello' },
+            { type: 'tool_use', name: 'Edit', input: { file_path: '/bar.ts' } },
+          ],
+        },
+      }),
+    ];
+    const result = parseNDJSON(lines);
+    expect(result.turnCount).toBe(1);
+    expect(result.toolCallCount).toBe(2);
+    expect(result.toolCalls).toEqual([
+      { tool: 'Read', input: { file_path: '/foo.ts' }, output: '' },
+      { tool: 'Edit', input: { file_path: '/bar.ts' }, output: '' },
+    ]);
+  });
+
+  it('captures result line', () => {
+    const lines = [
+      JSON.stringify({ type: 'assistant', message: { content: [] } }),
+      JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        total_cost_usd: 0.15,
+        num_turns: 5,
+        usage: {
+          input_tokens: 100,
+          output_tokens: 200,
+          cache_read_input_tokens: 5000,
+          cache_creation_input_tokens: 1000,
+        },
+      }),
+    ];
+    const result = parseNDJSON(lines);
+    expect(result.resultLine).not.toBeNull();
+    expect(result.resultLine.type).toBe('result');
+    expect(result.resultLine.total_cost_usd).toBe(0.15);
+    expect(result.resultLine.usage.input_tokens).toBe(100);
+    expect(result.resultLine.usage.cache_read_input_tokens).toBe(5000);
+  });
+
+  it('handles tool_use with missing name', () => {
+    const lines = [
+      JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use' }] },
+      }),
+    ];
+    const result = parseNDJSON(lines);
+    expect(result.toolCalls[0].tool).toBe('unknown');
+  });
+});
+
+// --- parseConditions ---
+
+describe('parseConditions', () => {
+  it('parses baseline only', () => {
+    const conditions = parseConditions('baseline');
+    expect(conditions).toEqual([{ label: 'baseline' }]);
+  });
+
+  it('parses multiple conditions with tree SHAs', () => {
+    const conditions = parseConditions('baseline,cli-v1:aaa111,human:bbb222');
+    expect(conditions).toEqual([
+      { label: 'baseline' },
+      { label: 'cli-v1', tree_sha: 'aaa111' },
+      { label: 'human', tree_sha: 'bbb222' },
+    ]);
+  });
+
+  it('trims whitespace', () => {
+    const conditions = parseConditions(' baseline , cli-v1:aaa111 ');
+    expect(conditions).toEqual([
+      { label: 'baseline' },
+      { label: 'cli-v1', tree_sha: 'aaa111' },
+    ]);
+  });
+
+  it('handles SHA with colons (long SHA)', () => {
+    // Only the first colon splits label from SHA
+    const conditions = parseConditions('test:abc:def');
+    expect(conditions).toEqual([
+      { label: 'test', tree_sha: 'abc:def' },
+    ]);
+  });
+});
+
+// --- loadCases ---
+
+describe('loadCases', () => {
+  it('loads a single-repo case from YAML', () => {
+    const dir = useTmpDir();
+    writeCase(dir, 'test.yaml', `
+id: test-case
+source: custom
+repo: org/repo
+commit_sha: "abc123"
+task: "Fix the bug"
+verification: verify.sh
+difficulty: easy
+`);
+
+    const cases = loadCases({ casesDir: dir });
+    expect(cases).toHaveLength(1);
+    expect(cases[0].id).toBe('test-case');
+    expect(cases[0].repos).toEqual([
+      { repo: 'org/repo', commit_sha: 'abc123', setup: undefined },
+    ]);
+  });
+
+  it('loads a multi-repo case from YAML', () => {
+    const dir = useTmpDir();
+    writeCase(dir, 'multi.yaml', `
+id: multi-case
+source: custom
+repos:
+  - repo: org/backend
+    commit_sha: "aaa111"
+    path: backend
+    setup: "pip install -e ."
+  - repo: org/frontend
+    commit_sha: "bbb222"
+    path: web
+task: "Fix the flow"
+verification: verify.sh
+difficulty: hard
+`);
+
+    const cases = loadCases({ casesDir: dir });
+    expect(cases).toHaveLength(1);
+    expect(cases[0].repos).toHaveLength(2);
+    expect(cases[0].repos[0]).toEqual({
+      repo: 'org/backend',
+      commit_sha: 'aaa111',
+      path: 'backend',
+      setup: 'pip install -e .',
+    });
+    expect(cases[0].repos[1]).toEqual({
+      repo: 'org/frontend',
+      commit_sha: 'bbb222',
+      path: 'web',
+      setup: undefined,
+    });
+  });
+
+  it('skips files starting with _', () => {
+    const dir = useTmpDir();
+    writeCase(dir, '_example.yaml', `
+id: example
+source: custom
+repo: org/repo
+commit_sha: "abc"
+task: "example"
+verification: verify.sh
+`);
+
+    expect(() => loadCases({ casesDir: dir })).toThrow('No eval cases found');
+  });
+
+  it('filters by case id', () => {
+    const dir = useTmpDir();
+    writeCase(dir, 'a.yaml', `
+id: case-a
+source: custom
+repo: org/a
+commit_sha: "aaa"
+task: "task a"
+verification: verify.sh
+`);
+    writeCase(dir, 'b.yaml', `
+id: case-b
+source: custom
+repo: org/b
+commit_sha: "bbb"
+task: "task b"
+verification: verify.sh
+`);
+
+    const cases = loadCases({ casesDir: dir, ids: ['case-b'] });
+    expect(cases).toHaveLength(1);
+    expect(cases[0].id).toBe('case-b');
+  });
+
+  it('throws on missing required fields', () => {
+    const dir = useTmpDir();
+    writeCase(dir, 'bad.yaml', `
+id: bad-case
+source: custom
+task: "no repo"
+verification: verify.sh
+`);
+
+    expect(() => loadCases({ casesDir: dir })).toThrow('Missing repo or commit_sha');
+  });
+
+  it('throws on invalid source', () => {
+    const dir = useTmpDir();
+    writeCase(dir, 'bad.yaml', `
+id: bad-case
+source: invalid
+repo: org/repo
+commit_sha: "abc"
+task: "test"
+verification: verify.sh
+`);
+
+    expect(() => loadCases({ casesDir: dir })).toThrow("Invalid source");
+  });
+
+  it('throws on missing cases directory', () => {
+    expect(() => loadCases({ casesDir: '/nonexistent' })).toThrow('Cases directory not found');
+  });
+
+  it('defaults difficulty to medium', () => {
+    const dir = useTmpDir();
+    writeCase(dir, 'test.yaml', `
+id: test
+source: custom
+repo: org/repo
+commit_sha: "abc"
+task: "test"
+verification: verify.sh
+`);
+
+    const cases = loadCases({ casesDir: dir });
+    expect(cases[0].difficulty).toBe('medium');
+  });
+
+  it('preserves optional fields', () => {
+    const dir = useTmpDir();
+    writeCase(dir, 'test.yaml', `
+id: test
+source: custom
+repo: org/repo
+commit_sha: "abc"
+task: "test"
+verification: verify.sh
+golden_pr: golden.patch
+timeout_ms: 120000
+max_turns: 10
+`);
+
+    const cases = loadCases({ casesDir: dir });
+    expect(cases[0].golden_pr).toBe('golden.patch');
+    expect(cases[0].timeout_ms).toBe(120000);
+    expect(cases[0].max_turns).toBe(10);
+  });
+});
+
+// --- EvalCollector ---
+
+describe('EvalCollector', () => {
+  it('accumulates trials and finalizes', async () => {
+    const evalDir = useTmpDir();
+    const collector = new EvalCollector({
+      model: 'test-model',
+      cli: 'claude-code',
+      evalDir,
+    });
+
+    collector.addTrial({
+      case_id: 'test-case',
+      condition: 'baseline',
+      trial: 1,
+      passed: true,
+      tests_total: 2,
+      tests_passed: 2,
+      input_tokens: 1000,
+      output_tokens: 200,
+      cache_creation_tokens: 500,
+      cache_read_tokens: 300,
+      api_calls: 5,
+      wall_clock_ms: 10000,
+      cost_usd: 0.05,
+      exit_reason: 'success',
+      transcript: [],
+      model: 'test-model',
+      cli: 'claude-code',
+    });
+
+    collector.addTrial({
+      case_id: 'test-case',
+      condition: 'cli-v1',
+      trial: 1,
+      passed: false,
+      tests_total: 2,
+      tests_passed: 1,
+      input_tokens: 2000,
+      output_tokens: 400,
+      cache_creation_tokens: 1000,
+      cache_read_tokens: 600,
+      api_calls: 8,
+      wall_clock_ms: 20000,
+      cost_usd: 0.10,
+      exit_reason: 'success',
+      transcript: [],
+      model: 'test-model',
+      cli: 'claude-code',
+    });
+
+    const filepath = await collector.finalize();
+    expect(filepath).toContain('.json');
+
+    // Read the output file
+    const { readFileSync } = await import('node:fs');
+    const data = JSON.parse(readFileSync(filepath, 'utf-8'));
+
+    expect(data.schema_version).toBe(1);
+    expect(data.model).toBe('test-model');
+    expect(data.cli).toBe('claude-code');
+    expect(data.trials).toHaveLength(2);
+    expect(data.total_cost_usd).toBe(0.15);
+    expect(data.conditions).toEqual(expect.arrayContaining(['baseline', 'cli-v1']));
+  });
+
+  it('writes partial file after each trial', () => {
+    const evalDir = useTmpDir();
+    const collector = new EvalCollector({
+      model: 'test-model',
+      cli: 'claude-code',
+      evalDir,
+    });
+
+    collector.addTrial({
+      case_id: 'test',
+      condition: 'baseline',
+      trial: 1,
+      passed: true,
+      tests_total: 1,
+      tests_passed: 1,
+      input_tokens: 100,
+      output_tokens: 50,
+      cache_creation_tokens: 0,
+      cache_read_tokens: 0,
+      api_calls: 1,
+      wall_clock_ms: 5000,
+      cost_usd: 0.01,
+      exit_reason: 'success',
+      transcript: [],
+      model: 'test-model',
+      cli: 'claude-code',
+    });
+
+    const { existsSync, readFileSync } = require('node:fs');
+    const partialPath = join(evalDir, '_partial-eval.json');
+    expect(existsSync(partialPath)).toBe(true);
+
+    const partial = JSON.parse(readFileSync(partialPath, 'utf-8'));
+    expect(partial._partial).toBe(true);
+    expect(partial.trials).toHaveLength(1);
+  });
+
+  it('finalize is idempotent', async () => {
+    const evalDir = useTmpDir();
+    const collector = new EvalCollector({
+      model: 'test-model',
+      cli: 'claude-code',
+      evalDir,
+    });
+
+    const path1 = await collector.finalize();
+    const path2 = await collector.finalize();
+    expect(path1).not.toBe('');
+    expect(path2).toBe('');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-tree",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "CLI tools for Context Tree — the living source of truth for your organization.",
   "type": "module",
   "bin": {
@@ -8,6 +8,7 @@
   },
   "imports": {
     "#src/*.js": "./src/*.ts",
+    "#evals/*.js": "./evals/*.ts",
     "#docs/*": "./docs/*"
   },
   "files": [
@@ -17,6 +18,7 @@
     "build": "tsdown",
     "prepack": "pnpm build",
     "test": "vitest run",
+    "eval": "vitest run --config vitest.eval.config.ts",
     "typecheck": "tsc --noEmit"
   },
   "packageManager": "pnpm@10.25.0",
@@ -25,6 +27,7 @@
     "@types/node": "^25.5.0",
     "tsdown": "^0.12.0",
     "typescript": "^5.8.0",
-    "vitest": "^3.2.0"
+    "vitest": "^3.2.0",
+    "yaml": "^2.8.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,10 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.0
-        version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)
+        version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3)
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
 
 packages:
 
@@ -835,6 +838,11 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
 snapshots:
 
   '@babel/generator@7.29.1':
@@ -1129,13 +1137,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1))':
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -1433,13 +1441,13 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  vite-node@3.2.4(@types/node@25.5.0)(jiti@2.6.1):
+  vite-node@3.2.4(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -1454,7 +1462,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1):
+  vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.4)
@@ -1466,12 +1474,13 @@ snapshots:
       '@types/node': 25.5.0
       fsevents: 2.3.3
       jiti: 2.6.1
+      yaml: 2.8.3
 
-  vitest@3.2.4(@types/node@25.5.0)(jiti@2.6.1):
+  vitest@3.2.4(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -1489,8 +1498,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)
-      vite-node: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.5.0
@@ -1512,3 +1521,5 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  yaml@2.8.3: {}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,6 @@ export default defineConfig({
     },
   ],
   test: {
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.ts", "evals/tests/**/*.test.ts"],
   },
 });

--- a/vitest.eval.config.ts
+++ b/vitest.eval.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['evals/context-tree-eval.test.ts'],
+    testTimeout: 600_000,    // 10 min per test (agent runs are slow)
+    hookTimeout: 30_000,
+    pool: 'forks',           // Process isolation for subprocess spawning
+  },
+});


### PR DESCRIPTION
## Summary

- Eval pipeline comparing agent performance with/without context trees
- Spawns agent CLI as subprocess, parses NDJSON stream, runs verification tests
- Supports multiple conditions (baseline + N tree versions), agents (Claude/Codex/Gemini), and trials
- First test case: nanobot ExecTool regex fix (PR HKUDS/nanobot#2683)
- 23 unit tests for eval helpers, all passing alongside existing 149 tests

## Architecture

```
case × condition × agent × trial
 │        │          │       │
 │        │          │       └─ repeat for statistical confidence
 │        │          └─ claude-code / codex / gemini + model
 │        └─ baseline (no tree) or label:tree_sha
 └─ YAML definition: repo, commit, task, verification
```

## Key files

| File | Purpose |
|------|---------|
| `evals/helpers/types.ts` | Core interfaces (EvalCase, RepoRef, EvalCondition, TrialResult) |
| `evals/helpers/session-runner.ts` | Spawns agent CLI, streams NDJSON, extracts tokens/cost |
| `evals/helpers/repo-sandbox.ts` | Clones repo(s) at commit, injects context tree, runs setup |
| `evals/helpers/condition-runner.ts` | Orchestrates trial: prompt → session → verification |
| `evals/helpers/eval-store.ts` | Crash-safe result persistence, summary tables |
| `evals/helpers/case-loader.ts` | YAML loader, supports single + multi-repo cases |
| `evals/context-tree-eval.test.ts` | Vitest e2e test, gated by `EVALS=1` |
| `evals/tests/eval-helpers.test.ts` | 23 unit tests for helpers |

## Usage

```bash
# Baseline only
EVALS=1 EVALS_CONDITIONS=baseline pnpm run eval

# Baseline vs tree version
EVALS=1 EVALS_CONDITIONS='baseline,cli-v1:aaa111' \
  EVALS_TREE_REPO=org/eval-trees pnpm run eval
```

## Test plan

- [x] `pnpm test` passes (172/172 — 149 existing + 23 new)
- [x] `pnpm run eval` skips when `EVALS` not set
- [x] `EVALS=1 EVALS_CONDITIONS=baseline pnpm run eval` completes nanobot case (PASS, ~$0.12, ~40s)
- [x] Results written to `~/.context-tree/evals/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)