### PR TITLE
feat: add first-tree CLI framework skill

### DIFF
--- a/.codex/skills/first-tree-cli-framework/SKILL.md
+++ b/.codex/skills/first-tree-cli-framework/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: first-tree-cli-framework
+description: Work on the `first-tree` CLI repo and its shipped `.context-tree` framework. Use when Codex needs to modify or validate `context-tree` commands (`init`, `verify`, `upgrade`, `help onboarding`), update `.context-tree/` templates/workflows/scripts/docs, maintain validator or rule logic around `NODE.md`, `AGENT.md`, `members/`, `owners`, `soft_links`, `progress.md`, or `CODEOWNERS`, or understand the full Context Tree maintenance model implemented in this repo.
+---
+
+# First Tree CLI Framework
+
+## Overview
+
+Use this skill when the task lives inside the `first-tree` repository or depends on the exact behavior of the framework that `first-tree` ships to user repos. Treat the repo as two coupled products: the CLI under `src/` and the framework payload under `.context-tree/`.
+
+## Non-Negotiables
+
+- Treat `first-tree` as the template source and CLI, not as a Context Tree repo itself.
+- Preserve the contract that the CLI is a harness for agents: it scaffolds, prints task lists, and validates state; it does not replace human approval or perform all maintenance automatically.
+- Keep `.context-tree/` generic. Anything in that directory can be copied into user repos by `context-tree init`.
+- Keep decision knowledge in the tree and execution detail in source systems. Re-check this boundary in `references/context-tree-maintenance-principles.md` whenever a change makes it blurry.
+
+## Quick Start
+
+1. Read `../../../AGENTS.md` and `../../../README.md`.
+2. Read `references/context-tree-maintenance-principles.md` for the operating model.
+3. Read `references/context-tree-source-map.md` to locate the exact source files for the task.
+4. Use `./scripts/run-local-cli.sh <command>` from this skill directory when you need repo-local CLI behavior. The script builds the local CLI and runs `node dist/cli.js ...` from the repo root.
+5. After edits, run the smallest relevant check first, then the default repo checks: `pnpm typecheck`, `pnpm test`, `pnpm build`.
+
+## Command Workflow
+
+- Run `./scripts/run-local-cli.sh --help` to confirm top-level usage.
+- Run `./scripts/run-local-cli.sh help onboarding` to inspect the onboarding document wired through `src/onboarding.ts`.
+- Run `./scripts/run-local-cli.sh init` to exercise framework copy, template rendering, upstream remote setup, and progress generation.
+- Run `./scripts/run-local-cli.sh verify` to exercise progress checks plus node/member validation.
+- Run `./scripts/run-local-cli.sh upgrade` to exercise upstream version comparison and upgrade task generation.
+- Prefer the local runner while editing this repo. Use a published/global `context-tree` binary only when the task is explicitly about consumer-side usage outside the repo.
+
+## Task Playbooks
+
+### CLI, Rules, and Validators
+
+- Inspect the command module in `src/` and the paired test file in `tests/`.
+- If a change alters generated task text, also review `src/rules/*.ts`, `.context-tree/templates/`, and the onboarding docs the task text points at.
+- If a change alters validation behavior, inspect both `src/validators/*.ts` and any workflow or template content that teaches users how to satisfy those checks.
+
+### Framework Payload
+
+- Read `.context-tree/principles.md`, `.context-tree/ownership-and-naming.md`, templates, workflows, and helper scripts before editing.
+- Remember that framework edits affect every repo initialized or upgraded from `first-tree`.
+- Keep workflow files, helper scripts, rule text, and docs aligned. If one changes and the others still teach the old behavior, treat that as an incomplete change.
+
+### Tree-Model Questions
+
+- Start with `references/context-tree-maintenance-principles.md`.
+- Follow the authoritative file links from `references/context-tree-source-map.md` instead of relying on memory.
+- If philosophy and implementation disagree, diagnose the mismatch explicitly and then align docs to code or code to docs before stopping.
+
+## Validation
+
+- Default repo checks: `pnpm typecheck`, `pnpm test`, `pnpm build`
+- Targeted CLI smoke checks:
+  - `./scripts/run-local-cli.sh --version`
+  - `./scripts/run-local-cli.sh help onboarding`
+  - `./scripts/run-local-cli.sh --help`
+- When changing `.context-tree/generate-codeowners.ts`, cover inheritance, additive leaf owners, and wildcard handling in tests.
+- When changing validators, cover hard errors plus warnings/infos where applicable.
+
+## References
+
+- `references/context-tree-maintenance-principles.md`: the maintenance philosophy, ownership model, member model, and validation invariants.
+- `references/context-tree-source-map.md`: the authoritative file-by-file map for CLI commands, rules, validators, templates, workflows, and helper scripts.

--- a/.codex/skills/first-tree-cli-framework/agents/openai.yaml
+++ b/.codex/skills/first-tree-cli-framework/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "First Tree CLI"
+  short_description: "Work on the first-tree CLI and Context Tree framework"
+  default_prompt: "Use $first-tree-cli-framework to work on the first-tree CLI or maintain its .context-tree framework."

--- a/.codex/skills/first-tree-cli-framework/references/context-tree-maintenance-principles.md
+++ b/.codex/skills/first-tree-cli-framework/references/context-tree-maintenance-principles.md
@@ -1,0 +1,189 @@
+# Context Tree Maintenance Principles
+
+## Table Of Contents
+
+- Product boundary
+- Command model
+- Decision model
+- Organization model
+- Ownership model
+- Member model
+- Validation invariants
+- Upgrade and workflow model
+- Common failure modes
+
+## Product Boundary
+
+All paths below are relative to the `first-tree` repo root.
+
+- `first-tree` is the template source and CLI for Context Tree. It is not a tree repo itself.
+- `.context-tree/` is the shipped framework payload. `context-tree init` copies it into a user repo and renders top-level scaffolding from templates.
+- `src/` is the CLI implementation that decides how users see onboarding, tasks, verification, and upgrade prompts.
+
+Read these first when the boundary is unclear:
+
+- `AGENTS.md`
+- `README.md`
+- `src/cli.ts`
+- `src/init.ts`
+
+## Command Model
+
+- `context-tree init`:
+  - requires a git repo
+  - clones `https://github.com/agent-team-foundation/seed-tree`
+  - copies `.context-tree/`
+  - renders `NODE.md`, `AGENT.md`, and `members/NODE.md` from templates when missing
+  - adds `context-tree-upstream`
+  - prints onboarding text
+  - writes `.context-tree/progress.md`
+- `context-tree verify`:
+  - fails when unchecked items remain in `.context-tree/progress.md`
+  - checks framework presence
+  - checks root `NODE.md` frontmatter
+  - checks `AGENT.md` framework markers
+  - runs node validation
+  - runs member validation
+- `context-tree upgrade`:
+  - requires an existing `.context-tree/`
+  - fetches upstream `.context-tree/VERSION` from `context-tree-upstream/main`
+  - writes an upgrade-specific `.context-tree/progress.md`
+  - tells the user to resolve framework conflicts, then re-run `context-tree verify`
+- `context-tree help onboarding` prints `docs/onboarding.md` through `src/onboarding.ts`.
+
+Authoritative sources:
+
+- `src/cli.ts`
+- `src/init.ts`
+- `src/verify.ts`
+- `src/upgrade.ts`
+- `src/onboarding.ts`
+
+## Decision Model
+
+The tree stores information an agent needs to decide on an approach, not the execution detail required to carry it out.
+
+Keep these ideas intact:
+
+- The tree is the living source of truth, not a historical snapshot.
+- If source systems contradict the tree, treat that as a tree bug and fix the tree before proceeding.
+- Agents should read the tree before deciding and ask after every task whether the tree now needs updating.
+- Cross-domain relationships, rationale, and non-obvious constraints belong in the tree.
+- Function signatures, route inventories, database schemas, and other execution-level details stay in source systems unless they are themselves decision-critical.
+
+Authoritative sources:
+
+- `.context-tree/principles.md`
+- `docs/about.md`
+- `docs/onboarding.md`
+- `.context-tree/templates/agent.md.template`
+
+## Organization Model
+
+- Organize domains by concern, not by code repo, team boundary, or org chart.
+- Start flat. Create subdomains when a domain can no longer be scanned quickly.
+- Root `NODE.md` is the domain map. It must list every top-level domain that actually exists.
+- `NODE.md` files explain the domain, its boundaries, and which deeper nodes matter.
+- Leaf files capture specific decisions or designs under the domain.
+- `soft_links` connect related domains without turning the tree into a full graph.
+
+Authoritative sources:
+
+- `.context-tree/principles.md`
+- `docs/onboarding.md`
+- `.context-tree/templates/root-node.md.template`
+- `src/validators/nodes.ts`
+
+## Ownership Model
+
+- Every folder in a tree must contain `NODE.md`.
+- Every node must declare an `owners` field in frontmatter.
+- `owners: []` inherits from the nearest parent `NODE.md`.
+- `owners: [*]` means anyone can approve that node or folder, but wildcard cannot be mixed with usernames.
+- Folder `NODE.md` ownership is the folder-level authority.
+- Leaf owners are additive; they do not remove authority from the folder `NODE.md` owners.
+- When a child folder declares its own owners, it overrides the parent folder for that child subtree.
+
+Authoritative sources:
+
+- `.context-tree/ownership-and-naming.md`
+- `src/validators/nodes.ts`
+- `.context-tree/generate-codeowners.ts`
+
+## Member Model
+
+- `members/` is mandatory for a real tree and must have `members/NODE.md`.
+- Every member is a directory that contains `NODE.md`, not a standalone markdown file.
+- Required frontmatter fields for member nodes:
+  - `title`
+  - `owners`
+  - `type`
+  - `role`
+  - `domains`
+- Valid `type` values are exactly:
+  - `human`
+  - `personal_assistant`
+  - `autonomous_agent`
+- `domains` must contain at least one entry.
+- Nested members are allowed.
+- Member directory names must be unique across the full `members/` subtree.
+- `delegate_mention`, when present, must point to an existing member directory whose type is `personal_assistant`.
+
+Authoritative sources:
+
+- `.context-tree/templates/members-domain.md.template`
+- `.context-tree/templates/member-node.md.template`
+- `src/validators/members.ts`
+
+## Validation Invariants
+
+These are the non-obvious checks that shape correct tree maintenance:
+
+- Missing frontmatter is an error.
+- Missing `owners` is an error.
+- Invalid GitHub usernames in `owners` are an error.
+- `soft_links` must resolve to a real node or directory-with-`NODE.md`.
+- Every non-hidden directory in the tree must contain `NODE.md`.
+- A top-level domain directory that exists but is not listed in root `NODE.md` is an error.
+- A domain listed in root `NODE.md` but missing on disk is an error.
+- A leaf file that exists but is not mentioned in its folder `NODE.md` is a warning, not an error.
+- A soft link without a reverse reference is an info-level finding, not an error.
+- Very short node bodies are warnings.
+- Frontmatter title mismatches against the first heading are warnings.
+- `context-tree verify` also treats unchecked progress items as failures, even before node/member validation runs.
+
+Authoritative sources:
+
+- `src/verify.ts`
+- `src/validators/nodes.ts`
+- `src/validators/members.ts`
+
+## Upgrade And Workflow Model
+
+- The upgrade path is framework-centric: compare local `.context-tree/VERSION` with upstream and guide the user through reconciling framework files.
+- `AGENT.md` has framework markers and a user-editable section after them. Upgrades should preserve the custom section while checking whether the framework block changed.
+- `.context-tree/workflows/validate.yml` is the baseline CI validation workflow.
+- `.context-tree/workflows/pr-review.yml` is optional and is set up only if the user opts into AI PR review.
+- `.context-tree/workflows/codeowners.yml` auto-generates `.github/CODEOWNERS` from tree ownership on PRs.
+- `.context-tree/generate-codeowners.ts` resolves inherited owners, additive leaf owners, and wildcard exclusions.
+- `.context-tree/scripts/inject-tree-context.sh` and `.context-tree/examples/claude-code/` show how agent integrations preload root context.
+
+Authoritative sources:
+
+- `src/upgrade.ts`
+- `src/rules/ci-validation.ts`
+- `.context-tree/workflows/validate.yml`
+- `.context-tree/workflows/pr-review.yml`
+- `.context-tree/workflows/codeowners.yml`
+- `.context-tree/generate-codeowners.ts`
+- `.context-tree/scripts/inject-tree-context.sh`
+- `.context-tree/examples/claude-code/README.md`
+
+## Common Failure Modes
+
+- Treating `first-tree` as if it were itself a tree repo and forgetting that `.context-tree/` is shipped content.
+- Putting organization-specific content into `.context-tree/`.
+- Changing validator behavior without updating task text, docs, templates, or tests that teach the same rule.
+- Adding execution details to the tree model instead of keeping the tree focused on decisions and relationships.
+- Forgetting that `progress.md` is part of verification semantics, not just a human note file.
+- Changing ownership behavior without checking `generate-codeowners.ts`.

--- a/.codex/skills/first-tree-cli-framework/references/context-tree-source-map.md
+++ b/.codex/skills/first-tree-cli-framework/references/context-tree-source-map.md
@@ -1,0 +1,120 @@
+# Context Tree Source Map
+
+## Table Of Contents
+
+- Read first
+- CLI entrypoints
+- Init and upgrade flow
+- Rule modules
+- Validators
+- Framework payload
+- Tests
+- Command reference
+
+## Read First
+
+These files establish the product boundary and should be read before deeper changes:
+
+| Path | Why it matters |
+| --- | --- |
+| `AGENTS.md` | Repo-specific expectations for working on the CLI and framework |
+| `README.md` | User-facing command overview and framework shape |
+| `docs/about.md` | High-level Context Tree problem statement and promise |
+| `docs/onboarding.md` | The onboarding narrative emitted by `help onboarding` and `init` |
+
+## CLI Entrypoints
+
+| Path | Purpose |
+| --- | --- |
+| `src/cli.ts` | Top-level command dispatch and usage text |
+| `src/onboarding.ts` | Emits the onboarding markdown |
+| `src/repo.ts` | Repo inspection helpers, marker checks, and path probing |
+
+## Init And Upgrade Flow
+
+| Path | Purpose |
+| --- | --- |
+| `src/init.ts` | Clones upstream framework, copies `.context-tree/`, renders templates, writes `progress.md` |
+| `src/upgrade.ts` | Checks upstream version, writes upgrade tasks, and defines the upgrade contract |
+| `src/verify.ts` | Progress gating plus node/member validation entrypoint |
+
+Read these together when changing user-visible behavior for `init`, `verify`, or `upgrade`.
+
+## Rule Modules
+
+These files control which task groups appear in `progress.md` after `init`.
+
+| Path | Purpose |
+| --- | --- |
+| `src/rules/framework.ts` | Detect missing framework |
+| `src/rules/root-node.ts` | Detect missing or placeholder root `NODE.md` |
+| `src/rules/agent-instructions.ts` | Detect missing `AGENT.md` or missing custom instructions |
+| `src/rules/members.ts` | Detect missing members structure |
+| `src/rules/agent-integration.ts` | Detect missing agent session integration |
+| `src/rules/ci-validation.ts` | Detect missing validation, PR review, and CODEOWNERS workflows |
+| `src/rules/populate-tree.ts` | Emit the deep-population workflow for the tree |
+| `src/rules/index.ts` | Rule ordering and aggregation |
+
+## Validators
+
+| Path | Purpose |
+| --- | --- |
+| `src/validators/nodes.ts` | Validates frontmatter, owners, `soft_links`, folder structure, root domain sync, reciprocity, body length, title-heading consistency |
+| `src/validators/members.ts` | Validates member node schema, nested member layout, name uniqueness, and `delegate_mention` integrity |
+
+When changing validation behavior, inspect both validator files and the tests that prove the expected severity.
+
+## Framework Payload
+
+These files are copied into user repos or referenced by rule output:
+
+| Path | Purpose |
+| --- | --- |
+| `.context-tree/principles.md` | Core decision model and examples |
+| `.context-tree/ownership-and-naming.md` | Ownership and naming contract |
+| `.context-tree/templates/root-node.md.template` | Root tree scaffold |
+| `.context-tree/templates/agent.md.template` | Framework section for `AGENT.md` |
+| `.context-tree/templates/members-domain.md.template` | `members/NODE.md` scaffold |
+| `.context-tree/templates/member-node.md.template` | Member node scaffold |
+| `.context-tree/workflows/validate.yml` | Validation workflow template |
+| `.context-tree/workflows/pr-review.yml` | Optional AI PR review workflow |
+| `.context-tree/workflows/codeowners.yml` | CODEOWNERS generation workflow |
+| `.context-tree/generate-codeowners.ts` | CODEOWNERS generator with inheritance logic |
+| `.context-tree/run-review.ts` | Review runner used by the PR review workflow |
+| `.context-tree/scripts/inject-tree-context.sh` | Session-start root context injection |
+| `.context-tree/examples/claude-code/README.md` | Claude Code integration instructions |
+
+## Tests
+
+Touch the paired tests whenever behavior changes:
+
+| Path | Coverage |
+| --- | --- |
+| `tests/init.test.ts` | `init` flow and `progress.md` writing |
+| `tests/verify.test.ts` | verification flow and progress handling |
+| `tests/rules.test.ts` | init task generation |
+| `tests/validate-nodes.test.ts` | node validator behavior |
+| `tests/validate-members.test.ts` | member validator behavior |
+| `tests/generate-codeowners.test.ts` | ownership resolution and CODEOWNERS generation |
+| `tests/run-review.test.ts` | review runner behavior |
+| `tests/repo.test.ts` | repo helper parsing behavior |
+
+## Command Reference
+
+Use these commands from the repo root unless the task explicitly needs something else:
+
+```bash
+pnpm typecheck
+pnpm test
+pnpm build
+```
+
+Use these commands from the skill directory for local CLI smoke tests:
+
+```bash
+./scripts/run-local-cli.sh --help
+./scripts/run-local-cli.sh --version
+./scripts/run-local-cli.sh help onboarding
+```
+
+If a change touches user-facing CLI behavior, run both the repo checks and at least one CLI smoke test.

--- a/.codex/skills/first-tree-cli-framework/scripts/run-local-cli.sh
+++ b/.codex/skills/first-tree-cli-framework/scripts/run-local-cli.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${SKILL_DIR}/../../.." && pwd)"
+
+cd "${REPO_ROOT}"
+
+pnpm build >/dev/null
+node dist/cli.js "$@"

--- a/AGENT.md
+++ b/AGENT.md
@@ -24,6 +24,10 @@ This repo is the **template source and CLI** for Context Tree. It is NOT a conte
 2. Read `.context-tree/principles.md` — the core ideas that Context Tree is built on
 3. Read `.context-tree/ownership-and-naming.md` — how nodes and ownership work
 
+## Repo-Local Skill
+
+- Use `.codex/skills/first-tree-cli-framework/SKILL.md` when working on `src/cli.ts`, `src/init.ts`, `src/verify.ts`, `src/upgrade.ts`, `.context-tree/`, or any task that needs the exact Context Tree maintenance model implemented in this repo. The skill includes a local CLI runner plus references for rules, validators, templates, workflows, and framework philosophy.
+
 ## Rules
 
 - **Framework files** (`.context-tree/`) must stay generic — no org-specific content. These get copied to every user's tree.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,10 @@ This repo is the **template source and CLI** for Context Tree. It is NOT a conte
 2. Read `.context-tree/principles.md` — the core ideas that Context Tree is built on
 3. Read `.context-tree/ownership-and-naming.md` — how nodes and ownership work
 
+## Repo-Local Skill
+
+- Use `.codex/skills/first-tree-cli-framework/SKILL.md` when working on `src/cli.ts`, `src/init.ts`, `src/verify.ts`, `src/upgrade.ts`, `.context-tree/`, or any task that needs the exact Context Tree maintenance model implemented in this repo. The skill includes a local CLI runner plus references for rules, validators, templates, workflows, and framework philosophy.
+
 ## Rules
 
 - **Framework files** (`.context-tree/`) must stay generic — no org-specific content. These get copied to every user's tree.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,10 @@ This repo is the **template source and CLI** for Context Tree. It is NOT a conte
 2. Read `.context-tree/principles.md` — the core ideas that Context Tree is built on
 3. Read `.context-tree/ownership-and-naming.md` — how nodes and ownership work
 
+## Repo-Local Skill
+
+- Use `.codex/skills/first-tree-cli-framework/SKILL.md` when working on `src/cli.ts`, `src/init.ts`, `src/verify.ts`, `src/upgrade.ts`, `.context-tree/`, or any task that needs the exact Context Tree maintenance model implemented in this repo. The skill includes a local CLI runner plus references for rules, validators, templates, workflows, and framework philosophy.
+
 ## Rules
 
 - **Framework files** (`.context-tree/`) must stay generic — no org-specific content. These get copied to every user's tree.


### PR DESCRIPTION
## Summary
- add a repo-local  skill under 
- capture the Context Tree maintenance model in dedicated reference docs so agents can work from the repo's actual rules and philosophy
- add a local CLI wrapper and point AGENT/AGENTS/CLAUDE guidance at the new skill

## Validation
- pnpm install
- pnpm typecheck
- pnpm test
- pnpm build
- ./.codex/skills/first-tree-cli-framework/scripts/run-local-cli.sh --version
- ./.codex/skills/first-tree-cli-framework/scripts/run-local-cli.sh help onboarding
