### PR TITLE
fix: align first-tree skill naming and install docs

### DIFF
--- a/.agents/skills/first-tree-cli-framework/references/context-tree-maintenance-principles.md
+++ b/.agents/skills/first-tree-cli-framework/references/context-tree-maintenance-principles.md
@@ -31,7 +31,7 @@ Read these first when the boundary is unclear:
 
 - `context-tree init`:
   - requires a git repo
-  - clones `https://github.com/agent-team-foundation/seed-tree`
+  - clones `https://github.com/agent-team-foundation/first-tree`
   - copies `.context-tree/`
   - renders `NODE.md`, `AGENT.md`, and `members/NODE.md` from templates when missing
   - adds `context-tree-upstream`

--- a/.agents/skills/first-tree-cli-framework/references/portable-quickstart.md
+++ b/.agents/skills/first-tree-cli-framework/references/portable-quickstart.md
@@ -11,7 +11,7 @@ This skill is meant to keep working even after the `skills/first-tree-cli-framew
 Snapshot source:
 
 - live repo: `agent-team-foundation/first-tree`
-- snapshot base commit when this portable copy was refreshed: `50f157ac815ab1d1cd94eddb113ea7b0b3ae1df9`
+- snapshot base commit when this portable copy was refreshed: `7654fa51341659cf24ab2b03bc1b066f881919ed`
 
 ## If You Have A Live `first-tree` Checkout
 
@@ -27,25 +27,33 @@ The script will detect the repo root, build the local CLI, and run `node dist/cl
 
 ## If You Only Copied This Skill Folder
 
-Install or expose a `context-tree` binary first.
+Install or expose the CLI first. The npm package is `first-tree`, and it installs the `context-tree` command.
 
 Practical options:
 
-1. Clone `agent-team-foundation/first-tree`, then from that repo run:
+1. For one-off runs without installing anything globally, use the published package directly:
+
+```bash
+npx first-tree --help
+npx first-tree help onboarding
+```
+
+2. To make this skill's helper script work outside the repo, install the package so `context-tree` is on your PATH:
+
+```bash
+npm install -g first-tree
+context-tree --help
+context-tree help onboarding
+```
+
+3. Clone `agent-team-foundation/first-tree`, then from that repo run:
 
 ```bash
 pnpm install
 pnpm build
-node dist/cli.js --help
-```
-
-If you want the `context-tree` command on your PATH, use your preferred link/install workflow after building.
-
-2. If your environment already has a `context-tree` binary installed, run:
-
-```bash
+npm install -g .
 context-tree --help
-context-tree help onboarding
+node dist/cli.js --help
 ```
 
 After that, this skill's helper script can use the installed binary:

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/AGENTS.md
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/AGENTS.md
@@ -1,4 +1,4 @@
-# Agent Instructions for seed-tree
+# Agent Instructions for first-tree
 
 This repo is the **template source and CLI** for Context Tree. It is NOT a context tree itself.
 
@@ -16,7 +16,7 @@ This repo is the **template source and CLI** for Context Tree. It is NOT a conte
 - The CLI is a **harness for the agent** — it generates situation-aware task lists, not executes them
 - `.context-tree/` is the framework directory that gets copied wholesale into users' repos
 - Templates in `.context-tree/templates/` are rendered to `NODE.md`, `AGENT.md`, `members/NODE.md` in users' repos
-- The CLI is installed via npm (`npx context-tree`) — it is never bundled in `.context-tree/`
+- The npm package is `first-tree`, and it installs the `context-tree` command. Use `npx first-tree ...` for one-off runs or `npm install -g first-tree` to put `context-tree` on your PATH.
 
 ## Before Making Changes
 

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/README.md
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/README.md
@@ -1,4 +1,4 @@
-# seed-tree
+# first-tree
 
 Template source and CLI for [Context Tree](https://context-tree.ai) — the living source of truth for your organization.
 
@@ -9,10 +9,10 @@ A tree-structured knowledge base that agents and humans build and maintain toget
 ## Quick Start
 
 ```bash
-npx context-tree init
+npx first-tree init
 ```
 
-Run this inside a git repo. It clones the framework, renders scaffolding, and generates a task list for your agent to work through.
+Run this inside a git repo. The npm package is `first-tree`; it installs the `context-tree` command. For a global install, run `npm install -g first-tree` and then use `context-tree init`.
 
 ## Commands
 
@@ -26,7 +26,7 @@ Run this inside a git repo. It clones the framework, renders scaffolding, and ge
 
 ```
 your-tree/
-  .context-tree/           # framework (upgradable from seed-tree)
+  .context-tree/           # framework (upgradable from first-tree)
     VERSION
     principles.md
     ownership-and-naming.md
@@ -41,7 +41,7 @@ your-tree/
 
 ## Upgrades
 
-After init, seed-tree is added as a git remote (`context-tree-upstream`). To upgrade the framework:
+After init, first-tree is added as a git remote (`context-tree-upstream`). To upgrade the framework:
 
 ```bash
 context-tree upgrade      # shows what changed and what to do

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/docs/onboarding.md
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/docs/onboarding.md
@@ -55,7 +55,7 @@ Information an agent needs to **decide** on an approach — not to execute it.
 
 - A Git repository for your tree (separate from your code repos)
 - Node.js 18+
-- `npm install -g context-tree` (or use `npx context-tree` without installing)
+- The npm package is `first-tree`. Use `npx first-tree init` for one-off runs, or `npm install -g first-tree` to add the `context-tree` command to your PATH
 
 ### Step 1: Initialize
 
@@ -131,7 +131,7 @@ The tree doesn't duplicate source code — it captures what connects things and 
 
 ## Upgrading the Framework
 
-After init, the seed-tree repo is added as a git remote (`context-tree-upstream`). When the framework updates:
+After init, the first-tree repo is added as a git remote (`context-tree-upstream`). When the framework updates:
 
 ```bash
 context-tree upgrade

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/cli.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/cli.ts
@@ -5,7 +5,7 @@ const USAGE = `usage: context-tree <command>
   New to context-tree? Run \`context-tree help onboarding\` first.
 
 Commands:
-  init      Bootstrap a new context tree (clones seed-tree, copies framework files)
+  init      Bootstrap a new context tree (clones first-tree, copies framework files)
   verify    Run verification checks against the current tree
   upgrade   Generate an upgrade task list from upstream changes
   help      Show help for a topic (e.g. \`help onboarding\`)

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/init.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/init.ts
@@ -15,7 +15,7 @@ import { ONBOARDING_TEXT } from "#src/onboarding.js";
 import { evaluateAll } from "#src/rules/index.js";
 import type { RuleResult } from "#src/rules/index.js";
 
-const SEED_TREE_URL = "https://github.com/agent-team-foundation/seed-tree";
+const FIRST_TREE_REPO_URL = "https://github.com/agent-team-foundation/first-tree";
 const FRAMEWORK_DIR = ".context-tree";
 
 /**
@@ -31,18 +31,18 @@ const TEMPLATE_MAP: [string, string][] = [
   ["members-domain.md.template", "members/NODE.md"],
 ];
 
-function cloneSeedTree(): string {
+function cloneFirstTree(): string {
   const tmp = mkdtempSync(join(tmpdir(), "context-tree-"));
-  console.log(`Cloning seed-tree from ${SEED_TREE_URL}...`);
+  console.log(`Cloning first-tree from ${FIRST_TREE_REPO_URL}...`);
   try {
-    execFileSync("git", ["clone", "--depth", "1", SEED_TREE_URL, tmp], {
+    execFileSync("git", ["clone", "--depth", "1", FIRST_TREE_REPO_URL, tmp], {
       encoding: "utf-8",
       stdio: "pipe",
     });
   } catch (err) {
     const message =
       err instanceof Error ? err.message : "unknown error";
-    console.error(`Failed to clone seed-tree: ${message}`);
+    console.error(`Failed to clone first-tree: ${message}`);
     rmSync(tmp, { recursive: true, force: true });
     process.exit(1);
   }
@@ -83,11 +83,11 @@ function addUpstreamRemote(target: string): void {
     if (!result.split(/\s+/).includes("context-tree-upstream")) {
       execFileSync(
         "git",
-        ["remote", "add", "context-tree-upstream", SEED_TREE_URL],
+        ["remote", "add", "context-tree-upstream", FIRST_TREE_REPO_URL],
         { cwd: target, encoding: "utf-8", stdio: "pipe" },
       );
       console.log(
-        `  Added git remote 'context-tree-upstream' -> ${SEED_TREE_URL}`,
+        `  Added git remote 'context-tree-upstream' -> ${FIRST_TREE_REPO_URL}`,
       );
     }
   } catch {
@@ -153,7 +153,7 @@ export function runInit(repo?: Repo): number {
   }
 
   if (!r.hasFramework()) {
-    const seed = cloneSeedTree();
+    const seed = cloneFirstTree();
     try {
       console.log("Copying framework and scaffolding...");
       copyFramework(seed, r.root);

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/framework.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/framework.ts
@@ -1,13 +1,13 @@
 import type { Repo } from "#src/repo.js";
 import type { RuleResult } from "#src/rules/index.js";
 
-const SEED_TREE_URL = "https://github.com/agent-team-foundation/seed-tree";
+const FIRST_TREE_REPO_URL = "https://github.com/agent-team-foundation/first-tree";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
   if (!repo.hasFramework()) {
     tasks.push(
-      `\`.context-tree/\` not found — run \`context-tree init\` to clone the framework from ${SEED_TREE_URL}`,
+      `\`.context-tree/\` not found — run \`context-tree init\` to clone the framework from ${FIRST_TREE_REPO_URL}`,
     );
   }
   return { group: "Framework", order: 1, tasks };

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/upgrade.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/upgrade.ts
@@ -3,7 +3,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { Repo } from "#src/repo.js";
 
-const SEED_TREE_URL = "https://github.com/agent-team-foundation/seed-tree";
+const FIRST_TREE_REPO_URL = "https://github.com/agent-team-foundation/first-tree";
 
 function getUpstreamVersion(repo: Repo): string | null {
   try {
@@ -51,7 +51,7 @@ export function runUpgrade(): number {
     const lines = [
       "# Context Tree Upgrade\n",
       "## Setup",
-      `- [ ] Add upstream remote: \`git remote add context-tree-upstream ${SEED_TREE_URL}\``,
+      `- [ ] Add upstream remote: \`git remote add context-tree-upstream ${FIRST_TREE_REPO_URL}\``,
       "- [ ] Then run `context-tree upgrade` again to check for updates",
     ];
     const output = lines.join("\n");

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/tests/skill-artifacts.test.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/tests/skill-artifacts.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
@@ -26,5 +26,24 @@ describe("skill artifacts", () => {
       stdio: "pipe",
       encoding: "utf-8",
     });
+  });
+
+  it("keeps naming and installation guidance aligned", () => {
+    const read = (path: string) => readFileSync(join(ROOT, path), "utf-8");
+
+    expect(read("README.md")).not.toContain("seed-tree");
+    expect(read("docs/onboarding.md")).not.toContain("seed-tree");
+    expect(read("AGENTS.md")).not.toContain("seed-tree");
+
+    const onboarding = read("docs/onboarding.md");
+    expect(onboarding).toContain("npx first-tree init");
+    expect(onboarding).toContain("npm install -g first-tree");
+
+    const quickstart = read("skills/first-tree-cli-framework/references/portable-quickstart.md");
+    expect(quickstart).toContain("npx first-tree --help");
+    expect(quickstart).toContain("npm install -g first-tree");
+    expect(quickstart).toMatch(
+      /snapshot base commit when this portable copy was refreshed: `[0-9a-f]{40}`/,
+    );
   });
 });

--- a/.agents/skills/first-tree-cli-framework/scripts/run-local-cli.sh
+++ b/.agents/skills/first-tree-cli-framework/scripts/run-local-cli.sh
@@ -29,6 +29,7 @@ if command -v context-tree >/dev/null 2>&1; then
   exec context-tree "$@"
 fi
 
-echo "Could not find a live first-tree checkout or an installed 'context-tree' binary." >&2
+echo "Could not find a live first-tree checkout or a 'context-tree' binary on PATH." >&2
+echo "Install the npm package 'first-tree' if you want the portable runner to invoke the CLI outside the repo." >&2
 echo "Read the portable install guide at: ${INSTALL_GUIDE}" >&2
 exit 1

--- a/.agents/skills/first-tree-cli-framework/scripts/sync-portable-snapshot.sh
+++ b/.agents/skills/first-tree-cli-framework/scripts/sync-portable-snapshot.sh
@@ -39,4 +39,7 @@ cp -R "${REPO_ROOT}/tests" "${SNAPSHOT_DIR}/"
 cp "${REPO_ROOT}/evals/helpers/case-loader.ts" "${SNAPSHOT_DIR}/evals/helpers/"
 cp "${REPO_ROOT}/evals/tests/eval-helpers.test.ts" "${SNAPSHOT_DIR}/evals/tests/"
 
+CURRENT_COMMIT="$(git -C "${REPO_ROOT}" rev-parse HEAD)"
+perl -0pi -e 's/snapshot base commit when this portable copy was refreshed: `[^`]+`/snapshot base commit when this portable copy was refreshed: `'"${CURRENT_COMMIT}"'`/g' "${SKILL_DIR}/references/portable-quickstart.md"
+
 echo "Refreshed portable snapshot at ${SNAPSHOT_DIR}"

--- a/.claude/skills/first-tree-cli-framework/references/context-tree-maintenance-principles.md
+++ b/.claude/skills/first-tree-cli-framework/references/context-tree-maintenance-principles.md
@@ -31,7 +31,7 @@ Read these first when the boundary is unclear:
 
 - `context-tree init`:
   - requires a git repo
-  - clones `https://github.com/agent-team-foundation/seed-tree`
+  - clones `https://github.com/agent-team-foundation/first-tree`
   - copies `.context-tree/`
   - renders `NODE.md`, `AGENT.md`, and `members/NODE.md` from templates when missing
   - adds `context-tree-upstream`

--- a/.claude/skills/first-tree-cli-framework/references/portable-quickstart.md
+++ b/.claude/skills/first-tree-cli-framework/references/portable-quickstart.md
@@ -11,7 +11,7 @@ This skill is meant to keep working even after the `skills/first-tree-cli-framew
 Snapshot source:
 
 - live repo: `agent-team-foundation/first-tree`
-- snapshot base commit when this portable copy was refreshed: `50f157ac815ab1d1cd94eddb113ea7b0b3ae1df9`
+- snapshot base commit when this portable copy was refreshed: `7654fa51341659cf24ab2b03bc1b066f881919ed`
 
 ## If You Have A Live `first-tree` Checkout
 
@@ -27,25 +27,33 @@ The script will detect the repo root, build the local CLI, and run `node dist/cl
 
 ## If You Only Copied This Skill Folder
 
-Install or expose a `context-tree` binary first.
+Install or expose the CLI first. The npm package is `first-tree`, and it installs the `context-tree` command.
 
 Practical options:
 
-1. Clone `agent-team-foundation/first-tree`, then from that repo run:
+1. For one-off runs without installing anything globally, use the published package directly:
+
+```bash
+npx first-tree --help
+npx first-tree help onboarding
+```
+
+2. To make this skill's helper script work outside the repo, install the package so `context-tree` is on your PATH:
+
+```bash
+npm install -g first-tree
+context-tree --help
+context-tree help onboarding
+```
+
+3. Clone `agent-team-foundation/first-tree`, then from that repo run:
 
 ```bash
 pnpm install
 pnpm build
-node dist/cli.js --help
-```
-
-If you want the `context-tree` command on your PATH, use your preferred link/install workflow after building.
-
-2. If your environment already has a `context-tree` binary installed, run:
-
-```bash
+npm install -g .
 context-tree --help
-context-tree help onboarding
+node dist/cli.js --help
 ```
 
 After that, this skill's helper script can use the installed binary:

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/AGENTS.md
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/AGENTS.md
@@ -1,4 +1,4 @@
-# Agent Instructions for seed-tree
+# Agent Instructions for first-tree
 
 This repo is the **template source and CLI** for Context Tree. It is NOT a context tree itself.
 
@@ -16,7 +16,7 @@ This repo is the **template source and CLI** for Context Tree. It is NOT a conte
 - The CLI is a **harness for the agent** — it generates situation-aware task lists, not executes them
 - `.context-tree/` is the framework directory that gets copied wholesale into users' repos
 - Templates in `.context-tree/templates/` are rendered to `NODE.md`, `AGENT.md`, `members/NODE.md` in users' repos
-- The CLI is installed via npm (`npx context-tree`) — it is never bundled in `.context-tree/`
+- The npm package is `first-tree`, and it installs the `context-tree` command. Use `npx first-tree ...` for one-off runs or `npm install -g first-tree` to put `context-tree` on your PATH.
 
 ## Before Making Changes
 

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/README.md
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/README.md
@@ -1,4 +1,4 @@
-# seed-tree
+# first-tree
 
 Template source and CLI for [Context Tree](https://context-tree.ai) — the living source of truth for your organization.
 
@@ -9,10 +9,10 @@ A tree-structured knowledge base that agents and humans build and maintain toget
 ## Quick Start
 
 ```bash
-npx context-tree init
+npx first-tree init
 ```
 
-Run this inside a git repo. It clones the framework, renders scaffolding, and generates a task list for your agent to work through.
+Run this inside a git repo. The npm package is `first-tree`; it installs the `context-tree` command. For a global install, run `npm install -g first-tree` and then use `context-tree init`.
 
 ## Commands
 
@@ -26,7 +26,7 @@ Run this inside a git repo. It clones the framework, renders scaffolding, and ge
 
 ```
 your-tree/
-  .context-tree/           # framework (upgradable from seed-tree)
+  .context-tree/           # framework (upgradable from first-tree)
     VERSION
     principles.md
     ownership-and-naming.md
@@ -41,7 +41,7 @@ your-tree/
 
 ## Upgrades
 
-After init, seed-tree is added as a git remote (`context-tree-upstream`). To upgrade the framework:
+After init, first-tree is added as a git remote (`context-tree-upstream`). To upgrade the framework:
 
 ```bash
 context-tree upgrade      # shows what changed and what to do

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/docs/onboarding.md
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/docs/onboarding.md
@@ -55,7 +55,7 @@ Information an agent needs to **decide** on an approach — not to execute it.
 
 - A Git repository for your tree (separate from your code repos)
 - Node.js 18+
-- `npm install -g context-tree` (or use `npx context-tree` without installing)
+- The npm package is `first-tree`. Use `npx first-tree init` for one-off runs, or `npm install -g first-tree` to add the `context-tree` command to your PATH
 
 ### Step 1: Initialize
 
@@ -131,7 +131,7 @@ The tree doesn't duplicate source code — it captures what connects things and 
 
 ## Upgrading the Framework
 
-After init, the seed-tree repo is added as a git remote (`context-tree-upstream`). When the framework updates:
+After init, the first-tree repo is added as a git remote (`context-tree-upstream`). When the framework updates:
 
 ```bash
 context-tree upgrade

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/cli.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/cli.ts
@@ -5,7 +5,7 @@ const USAGE = `usage: context-tree <command>
   New to context-tree? Run \`context-tree help onboarding\` first.
 
 Commands:
-  init      Bootstrap a new context tree (clones seed-tree, copies framework files)
+  init      Bootstrap a new context tree (clones first-tree, copies framework files)
   verify    Run verification checks against the current tree
   upgrade   Generate an upgrade task list from upstream changes
   help      Show help for a topic (e.g. \`help onboarding\`)

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/init.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/init.ts
@@ -15,7 +15,7 @@ import { ONBOARDING_TEXT } from "#src/onboarding.js";
 import { evaluateAll } from "#src/rules/index.js";
 import type { RuleResult } from "#src/rules/index.js";
 
-const SEED_TREE_URL = "https://github.com/agent-team-foundation/seed-tree";
+const FIRST_TREE_REPO_URL = "https://github.com/agent-team-foundation/first-tree";
 const FRAMEWORK_DIR = ".context-tree";
 
 /**
@@ -31,18 +31,18 @@ const TEMPLATE_MAP: [string, string][] = [
   ["members-domain.md.template", "members/NODE.md"],
 ];
 
-function cloneSeedTree(): string {
+function cloneFirstTree(): string {
   const tmp = mkdtempSync(join(tmpdir(), "context-tree-"));
-  console.log(`Cloning seed-tree from ${SEED_TREE_URL}...`);
+  console.log(`Cloning first-tree from ${FIRST_TREE_REPO_URL}...`);
   try {
-    execFileSync("git", ["clone", "--depth", "1", SEED_TREE_URL, tmp], {
+    execFileSync("git", ["clone", "--depth", "1", FIRST_TREE_REPO_URL, tmp], {
       encoding: "utf-8",
       stdio: "pipe",
     });
   } catch (err) {
     const message =
       err instanceof Error ? err.message : "unknown error";
-    console.error(`Failed to clone seed-tree: ${message}`);
+    console.error(`Failed to clone first-tree: ${message}`);
     rmSync(tmp, { recursive: true, force: true });
     process.exit(1);
   }
@@ -83,11 +83,11 @@ function addUpstreamRemote(target: string): void {
     if (!result.split(/\s+/).includes("context-tree-upstream")) {
       execFileSync(
         "git",
-        ["remote", "add", "context-tree-upstream", SEED_TREE_URL],
+        ["remote", "add", "context-tree-upstream", FIRST_TREE_REPO_URL],
         { cwd: target, encoding: "utf-8", stdio: "pipe" },
       );
       console.log(
-        `  Added git remote 'context-tree-upstream' -> ${SEED_TREE_URL}`,
+        `  Added git remote 'context-tree-upstream' -> ${FIRST_TREE_REPO_URL}`,
       );
     }
   } catch {
@@ -153,7 +153,7 @@ export function runInit(repo?: Repo): number {
   }
 
   if (!r.hasFramework()) {
-    const seed = cloneSeedTree();
+    const seed = cloneFirstTree();
     try {
       console.log("Copying framework and scaffolding...");
       copyFramework(seed, r.root);

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/framework.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/framework.ts
@@ -1,13 +1,13 @@
 import type { Repo } from "#src/repo.js";
 import type { RuleResult } from "#src/rules/index.js";
 
-const SEED_TREE_URL = "https://github.com/agent-team-foundation/seed-tree";
+const FIRST_TREE_REPO_URL = "https://github.com/agent-team-foundation/first-tree";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
   if (!repo.hasFramework()) {
     tasks.push(
-      `\`.context-tree/\` not found — run \`context-tree init\` to clone the framework from ${SEED_TREE_URL}`,
+      `\`.context-tree/\` not found — run \`context-tree init\` to clone the framework from ${FIRST_TREE_REPO_URL}`,
     );
   }
   return { group: "Framework", order: 1, tasks };

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/upgrade.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/upgrade.ts
@@ -3,7 +3,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { Repo } from "#src/repo.js";
 
-const SEED_TREE_URL = "https://github.com/agent-team-foundation/seed-tree";
+const FIRST_TREE_REPO_URL = "https://github.com/agent-team-foundation/first-tree";
 
 function getUpstreamVersion(repo: Repo): string | null {
   try {
@@ -51,7 +51,7 @@ export function runUpgrade(): number {
     const lines = [
       "# Context Tree Upgrade\n",
       "## Setup",
-      `- [ ] Add upstream remote: \`git remote add context-tree-upstream ${SEED_TREE_URL}\``,
+      `- [ ] Add upstream remote: \`git remote add context-tree-upstream ${FIRST_TREE_REPO_URL}\``,
       "- [ ] Then run `context-tree upgrade` again to check for updates",
     ];
     const output = lines.join("\n");

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/tests/skill-artifacts.test.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/tests/skill-artifacts.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
@@ -26,5 +26,24 @@ describe("skill artifacts", () => {
       stdio: "pipe",
       encoding: "utf-8",
     });
+  });
+
+  it("keeps naming and installation guidance aligned", () => {
+    const read = (path: string) => readFileSync(join(ROOT, path), "utf-8");
+
+    expect(read("README.md")).not.toContain("seed-tree");
+    expect(read("docs/onboarding.md")).not.toContain("seed-tree");
+    expect(read("AGENTS.md")).not.toContain("seed-tree");
+
+    const onboarding = read("docs/onboarding.md");
+    expect(onboarding).toContain("npx first-tree init");
+    expect(onboarding).toContain("npm install -g first-tree");
+
+    const quickstart = read("skills/first-tree-cli-framework/references/portable-quickstart.md");
+    expect(quickstart).toContain("npx first-tree --help");
+    expect(quickstart).toContain("npm install -g first-tree");
+    expect(quickstart).toMatch(
+      /snapshot base commit when this portable copy was refreshed: `[0-9a-f]{40}`/,
+    );
   });
 });

--- a/.claude/skills/first-tree-cli-framework/scripts/run-local-cli.sh
+++ b/.claude/skills/first-tree-cli-framework/scripts/run-local-cli.sh
@@ -29,6 +29,7 @@ if command -v context-tree >/dev/null 2>&1; then
   exec context-tree "$@"
 fi
 
-echo "Could not find a live first-tree checkout or an installed 'context-tree' binary." >&2
+echo "Could not find a live first-tree checkout or a 'context-tree' binary on PATH." >&2
+echo "Install the npm package 'first-tree' if you want the portable runner to invoke the CLI outside the repo." >&2
 echo "Read the portable install guide at: ${INSTALL_GUIDE}" >&2
 exit 1

--- a/.claude/skills/first-tree-cli-framework/scripts/sync-portable-snapshot.sh
+++ b/.claude/skills/first-tree-cli-framework/scripts/sync-portable-snapshot.sh
@@ -39,4 +39,7 @@ cp -R "${REPO_ROOT}/tests" "${SNAPSHOT_DIR}/"
 cp "${REPO_ROOT}/evals/helpers/case-loader.ts" "${SNAPSHOT_DIR}/evals/helpers/"
 cp "${REPO_ROOT}/evals/tests/eval-helpers.test.ts" "${SNAPSHOT_DIR}/evals/tests/"
 
+CURRENT_COMMIT="$(git -C "${REPO_ROOT}" rev-parse HEAD)"
+perl -0pi -e 's/snapshot base commit when this portable copy was refreshed: `[^`]+`/snapshot base commit when this portable copy was refreshed: `'"${CURRENT_COMMIT}"'`/g' "${SKILL_DIR}/references/portable-quickstart.md"
+
 echo "Refreshed portable snapshot at ${SNAPSHOT_DIR}"

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,4 +1,4 @@
-# Agent Instructions for seed-tree
+# Agent Instructions for first-tree
 
 This repo is the **template source and CLI** for Context Tree. It is NOT a context tree itself.
 
@@ -16,7 +16,7 @@ This repo is the **template source and CLI** for Context Tree. It is NOT a conte
 - The CLI is a **harness for the agent** — it generates situation-aware task lists, not executes them
 - `.context-tree/` is the framework directory that gets copied wholesale into users' repos
 - Templates in `.context-tree/templates/` are rendered to `NODE.md`, `AGENT.md`, `members/NODE.md` in users' repos
-- The CLI is installed via npm (`npx context-tree`) — it is never bundled in `.context-tree/`
+- The npm package is `first-tree`, and it installs the `context-tree` command. Use `npx first-tree ...` for one-off runs or `npm install -g first-tree` to put `context-tree` on your PATH.
 
 ## Before Making Changes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Agent Instructions for seed-tree
+# Agent Instructions for first-tree
 
 This repo is the **template source and CLI** for Context Tree. It is NOT a context tree itself.
 
@@ -16,7 +16,7 @@ This repo is the **template source and CLI** for Context Tree. It is NOT a conte
 - The CLI is a **harness for the agent** — it generates situation-aware task lists, not executes them
 - `.context-tree/` is the framework directory that gets copied wholesale into users' repos
 - Templates in `.context-tree/templates/` are rendered to `NODE.md`, `AGENT.md`, `members/NODE.md` in users' repos
-- The CLI is installed via npm (`npx context-tree`) — it is never bundled in `.context-tree/`
+- The npm package is `first-tree`, and it installs the `context-tree` command. Use `npx first-tree ...` for one-off runs or `npm install -g first-tree` to put `context-tree` on your PATH.
 
 ## Before Making Changes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Agent Instructions for seed-tree
+# Agent Instructions for first-tree
 
 This repo is the **template source and CLI** for Context Tree. It is NOT a context tree itself.
 
@@ -16,7 +16,7 @@ This repo is the **template source and CLI** for Context Tree. It is NOT a conte
 - The CLI is a **harness for the agent** — it generates situation-aware task lists, not executes them
 - `.context-tree/` is the framework directory that gets copied wholesale into users' repos
 - Templates in `.context-tree/templates/` are rendered to `NODE.md`, `AGENT.md`, `members/NODE.md` in users' repos
-- The CLI is installed via npm (`npx context-tree`) — it is never bundled in `.context-tree/`
+- The npm package is `first-tree`, and it installs the `context-tree` command. Use `npx first-tree ...` for one-off runs or `npm install -g first-tree` to put `context-tree` on your PATH.
 
 ## Before Making Changes
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# seed-tree
+# first-tree
 
 Template source and CLI for [Context Tree](https://context-tree.ai) — the living source of truth for your organization.
 
@@ -9,10 +9,10 @@ A tree-structured knowledge base that agents and humans build and maintain toget
 ## Quick Start
 
 ```bash
-npx context-tree init
+npx first-tree init
 ```
 
-Run this inside a git repo. It clones the framework, renders scaffolding, and generates a task list for your agent to work through.
+Run this inside a git repo. The npm package is `first-tree`; it installs the `context-tree` command. For a global install, run `npm install -g first-tree` and then use `context-tree init`.
 
 ## Commands
 
@@ -26,7 +26,7 @@ Run this inside a git repo. It clones the framework, renders scaffolding, and ge
 
 ```
 your-tree/
-  .context-tree/           # framework (upgradable from seed-tree)
+  .context-tree/           # framework (upgradable from first-tree)
     VERSION
     principles.md
     ownership-and-naming.md
@@ -41,7 +41,7 @@ your-tree/
 
 ## Upgrades
 
-After init, seed-tree is added as a git remote (`context-tree-upstream`). To upgrade the framework:
+After init, first-tree is added as a git remote (`context-tree-upstream`). To upgrade the framework:
 
 ```bash
 context-tree upgrade      # shows what changed and what to do

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -55,7 +55,7 @@ Information an agent needs to **decide** on an approach — not to execute it.
 
 - A Git repository for your tree (separate from your code repos)
 - Node.js 18+
-- `npm install -g context-tree` (or use `npx context-tree` without installing)
+- The npm package is `first-tree`. Use `npx first-tree init` for one-off runs, or `npm install -g first-tree` to add the `context-tree` command to your PATH
 
 ### Step 1: Initialize
 
@@ -131,7 +131,7 @@ The tree doesn't duplicate source code — it captures what connects things and 
 
 ## Upgrading the Framework
 
-After init, the seed-tree repo is added as a git remote (`context-tree-upstream`). When the framework updates:
+After init, the first-tree repo is added as a git remote (`context-tree-upstream`). When the framework updates:
 
 ```bash
 context-tree upgrade

--- a/skills/first-tree-cli-framework/references/context-tree-maintenance-principles.md
+++ b/skills/first-tree-cli-framework/references/context-tree-maintenance-principles.md
@@ -31,7 +31,7 @@ Read these first when the boundary is unclear:
 
 - `context-tree init`:
   - requires a git repo
-  - clones `https://github.com/agent-team-foundation/seed-tree`
+  - clones `https://github.com/agent-team-foundation/first-tree`
   - copies `.context-tree/`
   - renders `NODE.md`, `AGENT.md`, and `members/NODE.md` from templates when missing
   - adds `context-tree-upstream`

--- a/skills/first-tree-cli-framework/references/portable-quickstart.md
+++ b/skills/first-tree-cli-framework/references/portable-quickstart.md
@@ -11,7 +11,7 @@ This skill is meant to keep working even after the `skills/first-tree-cli-framew
 Snapshot source:
 
 - live repo: `agent-team-foundation/first-tree`
-- snapshot base commit when this portable copy was refreshed: `50f157ac815ab1d1cd94eddb113ea7b0b3ae1df9`
+- snapshot base commit when this portable copy was refreshed: `7654fa51341659cf24ab2b03bc1b066f881919ed`
 
 ## If You Have A Live `first-tree` Checkout
 
@@ -27,25 +27,33 @@ The script will detect the repo root, build the local CLI, and run `node dist/cl
 
 ## If You Only Copied This Skill Folder
 
-Install or expose a `context-tree` binary first.
+Install or expose the CLI first. The npm package is `first-tree`, and it installs the `context-tree` command.
 
 Practical options:
 
-1. Clone `agent-team-foundation/first-tree`, then from that repo run:
+1. For one-off runs without installing anything globally, use the published package directly:
+
+```bash
+npx first-tree --help
+npx first-tree help onboarding
+```
+
+2. To make this skill's helper script work outside the repo, install the package so `context-tree` is on your PATH:
+
+```bash
+npm install -g first-tree
+context-tree --help
+context-tree help onboarding
+```
+
+3. Clone `agent-team-foundation/first-tree`, then from that repo run:
 
 ```bash
 pnpm install
 pnpm build
-node dist/cli.js --help
-```
-
-If you want the `context-tree` command on your PATH, use your preferred link/install workflow after building.
-
-2. If your environment already has a `context-tree` binary installed, run:
-
-```bash
+npm install -g .
 context-tree --help
-context-tree help onboarding
+node dist/cli.js --help
 ```
 
 After that, this skill's helper script can use the installed binary:

--- a/skills/first-tree-cli-framework/references/repo-snapshot/AGENTS.md
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/AGENTS.md
@@ -1,4 +1,4 @@
-# Agent Instructions for seed-tree
+# Agent Instructions for first-tree
 
 This repo is the **template source and CLI** for Context Tree. It is NOT a context tree itself.
 
@@ -16,7 +16,7 @@ This repo is the **template source and CLI** for Context Tree. It is NOT a conte
 - The CLI is a **harness for the agent** — it generates situation-aware task lists, not executes them
 - `.context-tree/` is the framework directory that gets copied wholesale into users' repos
 - Templates in `.context-tree/templates/` are rendered to `NODE.md`, `AGENT.md`, `members/NODE.md` in users' repos
-- The CLI is installed via npm (`npx context-tree`) — it is never bundled in `.context-tree/`
+- The npm package is `first-tree`, and it installs the `context-tree` command. Use `npx first-tree ...` for one-off runs or `npm install -g first-tree` to put `context-tree` on your PATH.
 
 ## Before Making Changes
 

--- a/skills/first-tree-cli-framework/references/repo-snapshot/README.md
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/README.md
@@ -1,4 +1,4 @@
-# seed-tree
+# first-tree
 
 Template source and CLI for [Context Tree](https://context-tree.ai) — the living source of truth for your organization.
 
@@ -9,10 +9,10 @@ A tree-structured knowledge base that agents and humans build and maintain toget
 ## Quick Start
 
 ```bash
-npx context-tree init
+npx first-tree init
 ```
 
-Run this inside a git repo. It clones the framework, renders scaffolding, and generates a task list for your agent to work through.
+Run this inside a git repo. The npm package is `first-tree`; it installs the `context-tree` command. For a global install, run `npm install -g first-tree` and then use `context-tree init`.
 
 ## Commands
 
@@ -26,7 +26,7 @@ Run this inside a git repo. It clones the framework, renders scaffolding, and ge
 
 ```
 your-tree/
-  .context-tree/           # framework (upgradable from seed-tree)
+  .context-tree/           # framework (upgradable from first-tree)
     VERSION
     principles.md
     ownership-and-naming.md
@@ -41,7 +41,7 @@ your-tree/
 
 ## Upgrades
 
-After init, seed-tree is added as a git remote (`context-tree-upstream`). To upgrade the framework:
+After init, first-tree is added as a git remote (`context-tree-upstream`). To upgrade the framework:
 
 ```bash
 context-tree upgrade      # shows what changed and what to do

--- a/skills/first-tree-cli-framework/references/repo-snapshot/docs/onboarding.md
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/docs/onboarding.md
@@ -55,7 +55,7 @@ Information an agent needs to **decide** on an approach — not to execute it.
 
 - A Git repository for your tree (separate from your code repos)
 - Node.js 18+
-- `npm install -g context-tree` (or use `npx context-tree` without installing)
+- The npm package is `first-tree`. Use `npx first-tree init` for one-off runs, or `npm install -g first-tree` to add the `context-tree` command to your PATH
 
 ### Step 1: Initialize
 
@@ -131,7 +131,7 @@ The tree doesn't duplicate source code — it captures what connects things and 
 
 ## Upgrading the Framework
 
-After init, the seed-tree repo is added as a git remote (`context-tree-upstream`). When the framework updates:
+After init, the first-tree repo is added as a git remote (`context-tree-upstream`). When the framework updates:
 
 ```bash
 context-tree upgrade

--- a/skills/first-tree-cli-framework/references/repo-snapshot/src/cli.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/src/cli.ts
@@ -5,7 +5,7 @@ const USAGE = `usage: context-tree <command>
   New to context-tree? Run \`context-tree help onboarding\` first.
 
 Commands:
-  init      Bootstrap a new context tree (clones seed-tree, copies framework files)
+  init      Bootstrap a new context tree (clones first-tree, copies framework files)
   verify    Run verification checks against the current tree
   upgrade   Generate an upgrade task list from upstream changes
   help      Show help for a topic (e.g. \`help onboarding\`)

--- a/skills/first-tree-cli-framework/references/repo-snapshot/src/init.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/src/init.ts
@@ -15,7 +15,7 @@ import { ONBOARDING_TEXT } from "#src/onboarding.js";
 import { evaluateAll } from "#src/rules/index.js";
 import type { RuleResult } from "#src/rules/index.js";
 
-const SEED_TREE_URL = "https://github.com/agent-team-foundation/seed-tree";
+const FIRST_TREE_REPO_URL = "https://github.com/agent-team-foundation/first-tree";
 const FRAMEWORK_DIR = ".context-tree";
 
 /**
@@ -31,18 +31,18 @@ const TEMPLATE_MAP: [string, string][] = [
   ["members-domain.md.template", "members/NODE.md"],
 ];
 
-function cloneSeedTree(): string {
+function cloneFirstTree(): string {
   const tmp = mkdtempSync(join(tmpdir(), "context-tree-"));
-  console.log(`Cloning seed-tree from ${SEED_TREE_URL}...`);
+  console.log(`Cloning first-tree from ${FIRST_TREE_REPO_URL}...`);
   try {
-    execFileSync("git", ["clone", "--depth", "1", SEED_TREE_URL, tmp], {
+    execFileSync("git", ["clone", "--depth", "1", FIRST_TREE_REPO_URL, tmp], {
       encoding: "utf-8",
       stdio: "pipe",
     });
   } catch (err) {
     const message =
       err instanceof Error ? err.message : "unknown error";
-    console.error(`Failed to clone seed-tree: ${message}`);
+    console.error(`Failed to clone first-tree: ${message}`);
     rmSync(tmp, { recursive: true, force: true });
     process.exit(1);
   }
@@ -83,11 +83,11 @@ function addUpstreamRemote(target: string): void {
     if (!result.split(/\s+/).includes("context-tree-upstream")) {
       execFileSync(
         "git",
-        ["remote", "add", "context-tree-upstream", SEED_TREE_URL],
+        ["remote", "add", "context-tree-upstream", FIRST_TREE_REPO_URL],
         { cwd: target, encoding: "utf-8", stdio: "pipe" },
       );
       console.log(
-        `  Added git remote 'context-tree-upstream' -> ${SEED_TREE_URL}`,
+        `  Added git remote 'context-tree-upstream' -> ${FIRST_TREE_REPO_URL}`,
       );
     }
   } catch {
@@ -153,7 +153,7 @@ export function runInit(repo?: Repo): number {
   }
 
   if (!r.hasFramework()) {
-    const seed = cloneSeedTree();
+    const seed = cloneFirstTree();
     try {
       console.log("Copying framework and scaffolding...");
       copyFramework(seed, r.root);

--- a/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/framework.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/framework.ts
@@ -1,13 +1,13 @@
 import type { Repo } from "#src/repo.js";
 import type { RuleResult } from "#src/rules/index.js";
 
-const SEED_TREE_URL = "https://github.com/agent-team-foundation/seed-tree";
+const FIRST_TREE_REPO_URL = "https://github.com/agent-team-foundation/first-tree";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
   if (!repo.hasFramework()) {
     tasks.push(
-      `\`.context-tree/\` not found — run \`context-tree init\` to clone the framework from ${SEED_TREE_URL}`,
+      `\`.context-tree/\` not found — run \`context-tree init\` to clone the framework from ${FIRST_TREE_REPO_URL}`,
     );
   }
   return { group: "Framework", order: 1, tasks };

--- a/skills/first-tree-cli-framework/references/repo-snapshot/src/upgrade.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/src/upgrade.ts
@@ -3,7 +3,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { Repo } from "#src/repo.js";
 
-const SEED_TREE_URL = "https://github.com/agent-team-foundation/seed-tree";
+const FIRST_TREE_REPO_URL = "https://github.com/agent-team-foundation/first-tree";
 
 function getUpstreamVersion(repo: Repo): string | null {
   try {
@@ -51,7 +51,7 @@ export function runUpgrade(): number {
     const lines = [
       "# Context Tree Upgrade\n",
       "## Setup",
-      `- [ ] Add upstream remote: \`git remote add context-tree-upstream ${SEED_TREE_URL}\``,
+      `- [ ] Add upstream remote: \`git remote add context-tree-upstream ${FIRST_TREE_REPO_URL}\``,
       "- [ ] Then run `context-tree upgrade` again to check for updates",
     ];
     const output = lines.join("\n");

--- a/skills/first-tree-cli-framework/references/repo-snapshot/tests/skill-artifacts.test.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/tests/skill-artifacts.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
@@ -26,5 +26,24 @@ describe("skill artifacts", () => {
       stdio: "pipe",
       encoding: "utf-8",
     });
+  });
+
+  it("keeps naming and installation guidance aligned", () => {
+    const read = (path: string) => readFileSync(join(ROOT, path), "utf-8");
+
+    expect(read("README.md")).not.toContain("seed-tree");
+    expect(read("docs/onboarding.md")).not.toContain("seed-tree");
+    expect(read("AGENTS.md")).not.toContain("seed-tree");
+
+    const onboarding = read("docs/onboarding.md");
+    expect(onboarding).toContain("npx first-tree init");
+    expect(onboarding).toContain("npm install -g first-tree");
+
+    const quickstart = read("skills/first-tree-cli-framework/references/portable-quickstart.md");
+    expect(quickstart).toContain("npx first-tree --help");
+    expect(quickstart).toContain("npm install -g first-tree");
+    expect(quickstart).toMatch(
+      /snapshot base commit when this portable copy was refreshed: `[0-9a-f]{40}`/,
+    );
   });
 });

--- a/skills/first-tree-cli-framework/scripts/run-local-cli.sh
+++ b/skills/first-tree-cli-framework/scripts/run-local-cli.sh
@@ -29,6 +29,7 @@ if command -v context-tree >/dev/null 2>&1; then
   exec context-tree "$@"
 fi
 
-echo "Could not find a live first-tree checkout or an installed 'context-tree' binary." >&2
+echo "Could not find a live first-tree checkout or a 'context-tree' binary on PATH." >&2
+echo "Install the npm package 'first-tree' if you want the portable runner to invoke the CLI outside the repo." >&2
 echo "Read the portable install guide at: ${INSTALL_GUIDE}" >&2
 exit 1

--- a/skills/first-tree-cli-framework/scripts/sync-portable-snapshot.sh
+++ b/skills/first-tree-cli-framework/scripts/sync-portable-snapshot.sh
@@ -39,4 +39,7 @@ cp -R "${REPO_ROOT}/tests" "${SNAPSHOT_DIR}/"
 cp "${REPO_ROOT}/evals/helpers/case-loader.ts" "${SNAPSHOT_DIR}/evals/helpers/"
 cp "${REPO_ROOT}/evals/tests/eval-helpers.test.ts" "${SNAPSHOT_DIR}/evals/tests/"
 
+CURRENT_COMMIT="$(git -C "${REPO_ROOT}" rev-parse HEAD)"
+perl -0pi -e 's/snapshot base commit when this portable copy was refreshed: `[^`]+`/snapshot base commit when this portable copy was refreshed: `'"${CURRENT_COMMIT}"'`/g' "${SKILL_DIR}/references/portable-quickstart.md"
+
 echo "Refreshed portable snapshot at ${SNAPSHOT_DIR}"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ const USAGE = `usage: context-tree <command>
   New to context-tree? Run \`context-tree help onboarding\` first.
 
 Commands:
-  init      Bootstrap a new context tree (clones seed-tree, copies framework files)
+  init      Bootstrap a new context tree (clones first-tree, copies framework files)
   verify    Run verification checks against the current tree
   upgrade   Generate an upgrade task list from upstream changes
   help      Show help for a topic (e.g. \`help onboarding\`)

--- a/src/init.ts
+++ b/src/init.ts
@@ -15,7 +15,7 @@ import { ONBOARDING_TEXT } from "#src/onboarding.js";
 import { evaluateAll } from "#src/rules/index.js";
 import type { RuleResult } from "#src/rules/index.js";
 
-const SEED_TREE_URL = "https://github.com/agent-team-foundation/seed-tree";
+const FIRST_TREE_REPO_URL = "https://github.com/agent-team-foundation/first-tree";
 const FRAMEWORK_DIR = ".context-tree";
 
 /**
@@ -31,18 +31,18 @@ const TEMPLATE_MAP: [string, string][] = [
   ["members-domain.md.template", "members/NODE.md"],
 ];
 
-function cloneSeedTree(): string {
+function cloneFirstTree(): string {
   const tmp = mkdtempSync(join(tmpdir(), "context-tree-"));
-  console.log(`Cloning seed-tree from ${SEED_TREE_URL}...`);
+  console.log(`Cloning first-tree from ${FIRST_TREE_REPO_URL}...`);
   try {
-    execFileSync("git", ["clone", "--depth", "1", SEED_TREE_URL, tmp], {
+    execFileSync("git", ["clone", "--depth", "1", FIRST_TREE_REPO_URL, tmp], {
       encoding: "utf-8",
       stdio: "pipe",
     });
   } catch (err) {
     const message =
       err instanceof Error ? err.message : "unknown error";
-    console.error(`Failed to clone seed-tree: ${message}`);
+    console.error(`Failed to clone first-tree: ${message}`);
     rmSync(tmp, { recursive: true, force: true });
     process.exit(1);
   }
@@ -83,11 +83,11 @@ function addUpstreamRemote(target: string): void {
     if (!result.split(/\s+/).includes("context-tree-upstream")) {
       execFileSync(
         "git",
-        ["remote", "add", "context-tree-upstream", SEED_TREE_URL],
+        ["remote", "add", "context-tree-upstream", FIRST_TREE_REPO_URL],
         { cwd: target, encoding: "utf-8", stdio: "pipe" },
       );
       console.log(
-        `  Added git remote 'context-tree-upstream' -> ${SEED_TREE_URL}`,
+        `  Added git remote 'context-tree-upstream' -> ${FIRST_TREE_REPO_URL}`,
       );
     }
   } catch {
@@ -153,7 +153,7 @@ export function runInit(repo?: Repo): number {
   }
 
   if (!r.hasFramework()) {
-    const seed = cloneSeedTree();
+    const seed = cloneFirstTree();
     try {
       console.log("Copying framework and scaffolding...");
       copyFramework(seed, r.root);

--- a/src/rules/framework.ts
+++ b/src/rules/framework.ts
@@ -1,13 +1,13 @@
 import type { Repo } from "#src/repo.js";
 import type { RuleResult } from "#src/rules/index.js";
 
-const SEED_TREE_URL = "https://github.com/agent-team-foundation/seed-tree";
+const FIRST_TREE_REPO_URL = "https://github.com/agent-team-foundation/first-tree";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
   if (!repo.hasFramework()) {
     tasks.push(
-      `\`.context-tree/\` not found — run \`context-tree init\` to clone the framework from ${SEED_TREE_URL}`,
+      `\`.context-tree/\` not found — run \`context-tree init\` to clone the framework from ${FIRST_TREE_REPO_URL}`,
     );
   }
   return { group: "Framework", order: 1, tasks };

--- a/src/upgrade.ts
+++ b/src/upgrade.ts
@@ -3,7 +3,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { Repo } from "#src/repo.js";
 
-const SEED_TREE_URL = "https://github.com/agent-team-foundation/seed-tree";
+const FIRST_TREE_REPO_URL = "https://github.com/agent-team-foundation/first-tree";
 
 function getUpstreamVersion(repo: Repo): string | null {
   try {
@@ -51,7 +51,7 @@ export function runUpgrade(): number {
     const lines = [
       "# Context Tree Upgrade\n",
       "## Setup",
-      `- [ ] Add upstream remote: \`git remote add context-tree-upstream ${SEED_TREE_URL}\``,
+      `- [ ] Add upstream remote: \`git remote add context-tree-upstream ${FIRST_TREE_REPO_URL}\``,
       "- [ ] Then run `context-tree upgrade` again to check for updates",
     ];
     const output = lines.join("\n");

--- a/tests/skill-artifacts.test.ts
+++ b/tests/skill-artifacts.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
@@ -26,5 +26,24 @@ describe("skill artifacts", () => {
       stdio: "pipe",
       encoding: "utf-8",
     });
+  });
+
+  it("keeps naming and installation guidance aligned", () => {
+    const read = (path: string) => readFileSync(join(ROOT, path), "utf-8");
+
+    expect(read("README.md")).not.toContain("seed-tree");
+    expect(read("docs/onboarding.md")).not.toContain("seed-tree");
+    expect(read("AGENTS.md")).not.toContain("seed-tree");
+
+    const onboarding = read("docs/onboarding.md");
+    expect(onboarding).toContain("npx first-tree init");
+    expect(onboarding).toContain("npm install -g first-tree");
+
+    const quickstart = read("skills/first-tree-cli-framework/references/portable-quickstart.md");
+    expect(quickstart).toContain("npx first-tree --help");
+    expect(quickstart).toContain("npm install -g first-tree");
+    expect(quickstart).toMatch(
+      /snapshot base commit when this portable copy was refreshed: `[0-9a-f]{40}`/,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- unify repo/framework naming on `first-tree` while keeping the CLI command name `context-tree`
- make the install docs explicit that the npm package is `first-tree` and the installed binary is `context-tree`
- update the skill snapshot refresh flow to rewrite the portable quickstart commit marker and sync mirrored artifacts

## Validation
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm validate:skill
- ./skills/first-tree-cli-framework/scripts/run-local-cli.sh --help
- ./skills/first-tree-cli-framework/scripts/run-local-cli.sh help onboarding