### PR TITLE
fix: enforce portable snapshot commit sync

### DIFF
--- a/.agents/skills/first-tree-cli-framework/references/portable-quickstart.md
+++ b/.agents/skills/first-tree-cli-framework/references/portable-quickstart.md
@@ -11,7 +11,7 @@ This skill is meant to keep working even after the `skills/first-tree-cli-framew
 Snapshot source:
 
 - live repo: `agent-team-foundation/first-tree`
-- snapshot base commit when this portable copy was refreshed: `7654fa51341659cf24ab2b03bc1b066f881919ed`
+- snapshot base commit when this portable copy was refreshed: `5974c552454524af3485af9d8a06067512276044`
 
 ## If You Have A Live `first-tree` Checkout
 

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/tests/skill-artifacts.test.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/tests/skill-artifacts.test.ts
@@ -5,6 +5,15 @@ import { describe, expect, it } from "vitest";
 
 const ROOT = process.cwd();
 
+function readPortableSnapshotCommit(quickstart: string): string {
+  const match = quickstart.match(
+    /snapshot base commit when this portable copy was refreshed: `([0-9a-f]{40})`/,
+  );
+
+  expect(match, "portable quickstart should record the snapshot source commit").not.toBeNull();
+  return match![1];
+}
+
 describe("skill artifacts", () => {
   it("keeps the source-of-truth skill and generated mirrors present", () => {
     expect(existsSync(join(ROOT, "skills", "first-tree-cli-framework", "SKILL.md"))).toBe(true);
@@ -42,8 +51,13 @@ describe("skill artifacts", () => {
     const quickstart = read("skills/first-tree-cli-framework/references/portable-quickstart.md");
     expect(quickstart).toContain("npx first-tree --help");
     expect(quickstart).toContain("npm install -g first-tree");
-    expect(quickstart).toMatch(
-      /snapshot base commit when this portable copy was refreshed: `[0-9a-f]{40}`/,
-    );
+
+    const snapshotCommit = readPortableSnapshotCommit(quickstart);
+    const headCommit = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: ROOT,
+      encoding: "utf-8",
+    }).trim();
+
+    expect(snapshotCommit).toBe(headCommit);
   });
 });

--- a/.agents/skills/first-tree-cli-framework/scripts/check-skill-sync.sh
+++ b/.agents/skills/first-tree-cli-framework/scripts/check-skill-sync.sh
@@ -70,4 +70,17 @@ compare_dir "$REPO_ROOT/tests" "$SNAPSHOT_DIR/tests"
 compare_dir "$SOURCE_DIR" "$REPO_ROOT/.agents/skills/first-tree-cli-framework"
 compare_dir "$SOURCE_DIR" "$REPO_ROOT/.claude/skills/first-tree-cli-framework"
 
+recorded_commit="$(perl -ne 'print "$1\n" if /snapshot base commit when this portable copy was refreshed: `([0-9a-f]{40})`/' "$SOURCE_DIR/references/portable-quickstart.md")"
+current_commit="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+
+if [[ -z "$recorded_commit" ]]; then
+  echo "Could not find the recorded snapshot base commit in references/portable-quickstart.md." >&2
+  exit 1
+fi
+
+if [[ "$recorded_commit" != "$current_commit" ]]; then
+  echo "Portable snapshot commit mismatch: quickstart records $recorded_commit but repo HEAD is $current_commit." >&2
+  exit 1
+fi
+
 echo "Skill source, mirrors, and bundled snapshot are in sync."

--- a/.claude/skills/first-tree-cli-framework/references/portable-quickstart.md
+++ b/.claude/skills/first-tree-cli-framework/references/portable-quickstart.md
@@ -11,7 +11,7 @@ This skill is meant to keep working even after the `skills/first-tree-cli-framew
 Snapshot source:
 
 - live repo: `agent-team-foundation/first-tree`
-- snapshot base commit when this portable copy was refreshed: `7654fa51341659cf24ab2b03bc1b066f881919ed`
+- snapshot base commit when this portable copy was refreshed: `5974c552454524af3485af9d8a06067512276044`
 
 ## If You Have A Live `first-tree` Checkout
 

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/tests/skill-artifacts.test.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/tests/skill-artifacts.test.ts
@@ -5,6 +5,15 @@ import { describe, expect, it } from "vitest";
 
 const ROOT = process.cwd();
 
+function readPortableSnapshotCommit(quickstart: string): string {
+  const match = quickstart.match(
+    /snapshot base commit when this portable copy was refreshed: `([0-9a-f]{40})`/,
+  );
+
+  expect(match, "portable quickstart should record the snapshot source commit").not.toBeNull();
+  return match![1];
+}
+
 describe("skill artifacts", () => {
   it("keeps the source-of-truth skill and generated mirrors present", () => {
     expect(existsSync(join(ROOT, "skills", "first-tree-cli-framework", "SKILL.md"))).toBe(true);
@@ -42,8 +51,13 @@ describe("skill artifacts", () => {
     const quickstart = read("skills/first-tree-cli-framework/references/portable-quickstart.md");
     expect(quickstart).toContain("npx first-tree --help");
     expect(quickstart).toContain("npm install -g first-tree");
-    expect(quickstart).toMatch(
-      /snapshot base commit when this portable copy was refreshed: `[0-9a-f]{40}`/,
-    );
+
+    const snapshotCommit = readPortableSnapshotCommit(quickstart);
+    const headCommit = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: ROOT,
+      encoding: "utf-8",
+    }).trim();
+
+    expect(snapshotCommit).toBe(headCommit);
   });
 });

--- a/.claude/skills/first-tree-cli-framework/scripts/check-skill-sync.sh
+++ b/.claude/skills/first-tree-cli-framework/scripts/check-skill-sync.sh
@@ -70,4 +70,17 @@ compare_dir "$REPO_ROOT/tests" "$SNAPSHOT_DIR/tests"
 compare_dir "$SOURCE_DIR" "$REPO_ROOT/.agents/skills/first-tree-cli-framework"
 compare_dir "$SOURCE_DIR" "$REPO_ROOT/.claude/skills/first-tree-cli-framework"
 
+recorded_commit="$(perl -ne 'print "$1\n" if /snapshot base commit when this portable copy was refreshed: `([0-9a-f]{40})`/' "$SOURCE_DIR/references/portable-quickstart.md")"
+current_commit="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+
+if [[ -z "$recorded_commit" ]]; then
+  echo "Could not find the recorded snapshot base commit in references/portable-quickstart.md." >&2
+  exit 1
+fi
+
+if [[ "$recorded_commit" != "$current_commit" ]]; then
+  echo "Portable snapshot commit mismatch: quickstart records $recorded_commit but repo HEAD is $current_commit." >&2
+  exit 1
+fi
+
 echo "Skill source, mirrors, and bundled snapshot are in sync."

--- a/skills/first-tree-cli-framework/references/portable-quickstart.md
+++ b/skills/first-tree-cli-framework/references/portable-quickstart.md
@@ -11,7 +11,7 @@ This skill is meant to keep working even after the `skills/first-tree-cli-framew
 Snapshot source:
 
 - live repo: `agent-team-foundation/first-tree`
-- snapshot base commit when this portable copy was refreshed: `7654fa51341659cf24ab2b03bc1b066f881919ed`
+- snapshot base commit when this portable copy was refreshed: `5974c552454524af3485af9d8a06067512276044`
 
 ## If You Have A Live `first-tree` Checkout
 

--- a/skills/first-tree-cli-framework/references/repo-snapshot/tests/skill-artifacts.test.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/tests/skill-artifacts.test.ts
@@ -5,6 +5,15 @@ import { describe, expect, it } from "vitest";
 
 const ROOT = process.cwd();
 
+function readPortableSnapshotCommit(quickstart: string): string {
+  const match = quickstart.match(
+    /snapshot base commit when this portable copy was refreshed: `([0-9a-f]{40})`/,
+  );
+
+  expect(match, "portable quickstart should record the snapshot source commit").not.toBeNull();
+  return match![1];
+}
+
 describe("skill artifacts", () => {
   it("keeps the source-of-truth skill and generated mirrors present", () => {
     expect(existsSync(join(ROOT, "skills", "first-tree-cli-framework", "SKILL.md"))).toBe(true);
@@ -42,8 +51,13 @@ describe("skill artifacts", () => {
     const quickstart = read("skills/first-tree-cli-framework/references/portable-quickstart.md");
     expect(quickstart).toContain("npx first-tree --help");
     expect(quickstart).toContain("npm install -g first-tree");
-    expect(quickstart).toMatch(
-      /snapshot base commit when this portable copy was refreshed: `[0-9a-f]{40}`/,
-    );
+
+    const snapshotCommit = readPortableSnapshotCommit(quickstart);
+    const headCommit = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: ROOT,
+      encoding: "utf-8",
+    }).trim();
+
+    expect(snapshotCommit).toBe(headCommit);
   });
 });

--- a/skills/first-tree-cli-framework/scripts/check-skill-sync.sh
+++ b/skills/first-tree-cli-framework/scripts/check-skill-sync.sh
@@ -70,4 +70,17 @@ compare_dir "$REPO_ROOT/tests" "$SNAPSHOT_DIR/tests"
 compare_dir "$SOURCE_DIR" "$REPO_ROOT/.agents/skills/first-tree-cli-framework"
 compare_dir "$SOURCE_DIR" "$REPO_ROOT/.claude/skills/first-tree-cli-framework"
 
+recorded_commit="$(perl -ne 'print "$1\n" if /snapshot base commit when this portable copy was refreshed: `([0-9a-f]{40})`/' "$SOURCE_DIR/references/portable-quickstart.md")"
+current_commit="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+
+if [[ -z "$recorded_commit" ]]; then
+  echo "Could not find the recorded snapshot base commit in references/portable-quickstart.md." >&2
+  exit 1
+fi
+
+if [[ "$recorded_commit" != "$current_commit" ]]; then
+  echo "Portable snapshot commit mismatch: quickstart records $recorded_commit but repo HEAD is $current_commit." >&2
+  exit 1
+fi
+
 echo "Skill source, mirrors, and bundled snapshot are in sync."

--- a/tests/skill-artifacts.test.ts
+++ b/tests/skill-artifacts.test.ts
@@ -5,6 +5,15 @@ import { describe, expect, it } from "vitest";
 
 const ROOT = process.cwd();
 
+function readPortableSnapshotCommit(quickstart: string): string {
+  const match = quickstart.match(
+    /snapshot base commit when this portable copy was refreshed: `([0-9a-f]{40})`/,
+  );
+
+  expect(match, "portable quickstart should record the snapshot source commit").not.toBeNull();
+  return match![1];
+}
+
 describe("skill artifacts", () => {
   it("keeps the source-of-truth skill and generated mirrors present", () => {
     expect(existsSync(join(ROOT, "skills", "first-tree-cli-framework", "SKILL.md"))).toBe(true);
@@ -42,8 +51,13 @@ describe("skill artifacts", () => {
     const quickstart = read("skills/first-tree-cli-framework/references/portable-quickstart.md");
     expect(quickstart).toContain("npx first-tree --help");
     expect(quickstart).toContain("npm install -g first-tree");
-    expect(quickstart).toMatch(
-      /snapshot base commit when this portable copy was refreshed: `[0-9a-f]{40}`/,
-    );
+
+    const snapshotCommit = readPortableSnapshotCommit(quickstart);
+    const headCommit = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: ROOT,
+      encoding: "utf-8",
+    }).trim();
+
+    expect(snapshotCommit).toBe(headCommit);
   });
 });


### PR DESCRIPTION
## Summary
- require the portable snapshot commit recorded in quickstart to match the current repo HEAD
- fail skill sync checks when the recorded commit drifts from the source-of-truth repo
- refresh the portable snapshot and generated skill mirrors

## Testing
- bash ./skills/first-tree-cli-framework/scripts/check-skill-sync.sh
- pnpm test tests/skill-artifacts.test.ts
- pnpm test