### PR TITLE
fix: validate portable snapshots by fingerprint

### DIFF
--- a/.agents/skills/first-tree-cli-framework/references/portable-quickstart.md
+++ b/.agents/skills/first-tree-cli-framework/references/portable-quickstart.md
@@ -11,8 +11,8 @@ This skill is meant to keep working even after the `skills/first-tree-cli-framew
 Snapshot source:
 
 - live repo: `agent-team-foundation/first-tree`
-- snapshot base commit when this portable copy was refreshed: `edc0c437ba437c20f8a1893277499d604aa7abd0`
-- snapshot content fingerprint: `sha256:10cd8d5bf3c72022698b886dcd4f2ff79e5ac1b80faec2523059fec1a73f484a`
+- snapshot base commit when this portable copy was refreshed: `074befd0ef28a10ce44d01bd7d3df1e98db41ecb`
+- snapshot content fingerprint: `sha256:ff4bb57da5dfca923a4f894a25c1106c8b4ba9e5bfc8ed6f58a5a8edd16b7f7e`
 
 The base commit records which live checkout the refresh started from. Generated artifact updates may land in a later commit, so strict sync validation uses the content fingerprint above.
 

--- a/.agents/skills/first-tree-cli-framework/references/portable-quickstart.md
+++ b/.agents/skills/first-tree-cli-framework/references/portable-quickstart.md
@@ -11,7 +11,7 @@ This skill is meant to keep working even after the `skills/first-tree-cli-framew
 Snapshot source:
 
 - live repo: `agent-team-foundation/first-tree`
-- snapshot base commit when this portable copy was refreshed: `074befd0ef28a10ce44d01bd7d3df1e98db41ecb`
+- snapshot base commit when this portable copy was refreshed: `e61aac675bee10613e1128d7f808bf22d21c3e09`
 - snapshot content fingerprint: `sha256:ff4bb57da5dfca923a4f894a25c1106c8b4ba9e5bfc8ed6f58a5a8edd16b7f7e`
 
 The base commit records which live checkout the refresh started from. Generated artifact updates may land in a later commit, so strict sync validation uses the content fingerprint above.

--- a/.agents/skills/first-tree-cli-framework/references/portable-quickstart.md
+++ b/.agents/skills/first-tree-cli-framework/references/portable-quickstart.md
@@ -12,6 +12,9 @@ Snapshot source:
 
 - live repo: `agent-team-foundation/first-tree`
 - snapshot base commit when this portable copy was refreshed: `edc0c437ba437c20f8a1893277499d604aa7abd0`
+- snapshot content fingerprint: `sha256:10cd8d5bf3c72022698b886dcd4f2ff79e5ac1b80faec2523059fec1a73f484a`
+
+The base commit records which live checkout the refresh started from. Generated artifact updates may land in a later commit, so strict sync validation uses the content fingerprint above.
 
 ## If You Have A Live `first-tree` Checkout
 

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/tests/skill-artifacts.test.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/tests/skill-artifacts.test.ts
@@ -74,13 +74,26 @@ describe("skill artifacts", () => {
         encoding: "utf-8",
       },
     ).trim();
+    let commitIsAvailable = true;
+    try {
+      execFileSync("git", ["cat-file", "-e", `${snapshotCommit}^{commit}`], {
+        cwd: ROOT,
+        encoding: "utf-8",
+        stdio: "pipe",
+      });
+    } catch {
+      commitIsAvailable = false;
+    }
 
-    const mergeBase = execFileSync("git", ["merge-base", snapshotCommit, headCommit], {
-      cwd: ROOT,
-      encoding: "utf-8",
-    }).trim();
+    if (commitIsAvailable) {
+      const mergeBase = execFileSync("git", ["merge-base", snapshotCommit, headCommit], {
+        cwd: ROOT,
+        encoding: "utf-8",
+      }).trim();
 
-    expect(mergeBase).toBe(snapshotCommit);
+      expect(mergeBase).toBe(snapshotCommit);
+    }
+
     expect(snapshotFingerprint).toBe(computedFingerprint);
   });
 });

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/tests/skill-artifacts.test.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/tests/skill-artifacts.test.ts
@@ -14,6 +14,13 @@ function readPortableSnapshotCommit(quickstart: string): string {
   return match![1];
 }
 
+function readPortableSnapshotFingerprint(quickstart: string): string {
+  const match = quickstart.match(/snapshot content fingerprint: `(sha256:[0-9a-f]{64})`/);
+
+  expect(match, "portable quickstart should record the snapshot fingerprint").not.toBeNull();
+  return match![1];
+}
+
 describe("skill artifacts", () => {
   it("keeps the source-of-truth skill and generated mirrors present", () => {
     expect(existsSync(join(ROOT, "skills", "first-tree-cli-framework", "SKILL.md"))).toBe(true);
@@ -51,13 +58,29 @@ describe("skill artifacts", () => {
     const quickstart = read("skills/first-tree-cli-framework/references/portable-quickstart.md");
     expect(quickstart).toContain("npx first-tree --help");
     expect(quickstart).toContain("npm install -g first-tree");
+    expect(quickstart).toContain("strict sync validation uses the content fingerprint above");
 
     const snapshotCommit = readPortableSnapshotCommit(quickstart);
+    const snapshotFingerprint = readPortableSnapshotFingerprint(quickstart);
     const headCommit = execFileSync("git", ["rev-parse", "HEAD"], {
       cwd: ROOT,
       encoding: "utf-8",
     }).trim();
+    const computedFingerprint = execFileSync(
+      "python3",
+      ["./skills/first-tree-cli-framework/scripts/snapshot_fingerprint.py", "--root", ROOT],
+      {
+        cwd: ROOT,
+        encoding: "utf-8",
+      },
+    ).trim();
 
-    expect(snapshotCommit).toBe(headCommit);
+    const mergeBase = execFileSync("git", ["merge-base", snapshotCommit, headCommit], {
+      cwd: ROOT,
+      encoding: "utf-8",
+    }).trim();
+
+    expect(mergeBase).toBe(snapshotCommit);
+    expect(snapshotFingerprint).toBe(computedFingerprint);
   });
 });

--- a/.agents/skills/first-tree-cli-framework/scripts/check-skill-sync.sh
+++ b/.agents/skills/first-tree-cli-framework/scripts/check-skill-sync.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+FINGERPRINT_SCRIPT="${SCRIPT_DIR}/snapshot_fingerprint.py"
 
 find_repo_root() {
   local dir="$SKILL_DIR"
@@ -71,15 +72,38 @@ compare_dir "$SOURCE_DIR" "$REPO_ROOT/.agents/skills/first-tree-cli-framework"
 compare_dir "$SOURCE_DIR" "$REPO_ROOT/.claude/skills/first-tree-cli-framework"
 
 recorded_commit="$(perl -ne 'print "$1\n" if /snapshot base commit when this portable copy was refreshed: `([0-9a-f]{40})`/' "$SOURCE_DIR/references/portable-quickstart.md")"
+recorded_fingerprint="$(perl -ne 'print "$1\n" if /snapshot content fingerprint: `(sha256:[0-9a-f]{64})`/' "$SOURCE_DIR/references/portable-quickstart.md")"
 current_commit="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+source_fingerprint="$(python3 "${FINGERPRINT_SCRIPT}" --root "${REPO_ROOT}")"
+snapshot_fingerprint="$(python3 "${FINGERPRINT_SCRIPT}" --root "${SNAPSHOT_DIR}")"
 
 if [[ -z "$recorded_commit" ]]; then
   echo "Could not find the recorded snapshot base commit in references/portable-quickstart.md." >&2
   exit 1
 fi
 
-if [[ "$recorded_commit" != "$current_commit" ]]; then
-  echo "Portable snapshot commit mismatch: quickstart records $recorded_commit but repo HEAD is $current_commit." >&2
+if [[ -z "$recorded_fingerprint" ]]; then
+  echo "Could not find the recorded snapshot content fingerprint in references/portable-quickstart.md." >&2
+  exit 1
+fi
+
+if ! git -C "$REPO_ROOT" cat-file -e "${recorded_commit}^{commit}" 2>/dev/null; then
+  echo "Portable snapshot base commit $recorded_commit does not exist in this checkout." >&2
+  exit 1
+fi
+
+if ! git -C "$REPO_ROOT" merge-base --is-ancestor "$recorded_commit" "$current_commit"; then
+  echo "Portable snapshot base commit $recorded_commit is not an ancestor of repo HEAD $current_commit." >&2
+  exit 1
+fi
+
+if [[ "$recorded_fingerprint" != "$source_fingerprint" ]]; then
+  echo "Portable snapshot fingerprint mismatch: quickstart records $recorded_fingerprint but repo source fingerprint is $source_fingerprint." >&2
+  exit 1
+fi
+
+if [[ "$recorded_fingerprint" != "$snapshot_fingerprint" ]]; then
+  echo "Portable snapshot fingerprint mismatch: quickstart records $recorded_fingerprint but bundled snapshot fingerprint is $snapshot_fingerprint." >&2
   exit 1
 fi
 

--- a/.agents/skills/first-tree-cli-framework/scripts/check-skill-sync.sh
+++ b/.agents/skills/first-tree-cli-framework/scripts/check-skill-sync.sh
@@ -87,14 +87,13 @@ if [[ -z "$recorded_fingerprint" ]]; then
   exit 1
 fi
 
-if ! git -C "$REPO_ROOT" cat-file -e "${recorded_commit}^{commit}" 2>/dev/null; then
-  echo "Portable snapshot base commit $recorded_commit does not exist in this checkout." >&2
-  exit 1
-fi
-
-if ! git -C "$REPO_ROOT" merge-base --is-ancestor "$recorded_commit" "$current_commit"; then
-  echo "Portable snapshot base commit $recorded_commit is not an ancestor of repo HEAD $current_commit." >&2
-  exit 1
+if git -C "$REPO_ROOT" cat-file -e "${recorded_commit}^{commit}" 2>/dev/null; then
+  if ! git -C "$REPO_ROOT" merge-base --is-ancestor "$recorded_commit" "$current_commit"; then
+    echo "Portable snapshot base commit $recorded_commit is not an ancestor of repo HEAD $current_commit." >&2
+    exit 1
+  fi
+else
+  echo "Portable snapshot base commit $recorded_commit is not present in this checkout; skipping ancestry validation." >&2
 fi
 
 if [[ "$recorded_fingerprint" != "$source_fingerprint" ]]; then

--- a/.agents/skills/first-tree-cli-framework/scripts/snapshot_fingerprint.py
+++ b/.agents/skills/first-tree-cli-framework/scripts/snapshot_fingerprint.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+from pathlib import Path
+
+SNAPSHOT_PATHS = (
+    "AGENTS.md",
+    "README.md",
+    "package.json",
+    "evals/helpers/case-loader.ts",
+    "evals/tests/eval-helpers.test.ts",
+    ".context-tree",
+    "docs",
+    "src",
+    "tests",
+)
+
+
+def iter_files(root: Path):
+    for relative_path in SNAPSHOT_PATHS:
+        path = root / relative_path
+        if not path.exists():
+            raise FileNotFoundError(f"Missing snapshot path: {relative_path}")
+        if path.is_file():
+            yield relative_path, path
+            continue
+
+        for child in sorted(candidate for candidate in path.rglob("*") if candidate.is_file()):
+            yield child.relative_to(root).as_posix(), child
+
+
+def build_fingerprint(root: Path) -> str:
+    digest = hashlib.sha256()
+
+    for relative_path, path in iter_files(root):
+        digest.update(relative_path.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+
+    return f"sha256:{digest.hexdigest()}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Compute a stable fingerprint for the first-tree portable snapshot inputs.",
+    )
+    parser.add_argument("--root", required=True, help="Repo root or repo-snapshot root to fingerprint")
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    if not root.is_dir():
+        print(f"Root is not a directory: {root}", file=sys.stderr)
+        return 1
+
+    try:
+        print(build_fingerprint(root))
+    except FileNotFoundError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/first-tree-cli-framework/scripts/sync-portable-snapshot.sh
+++ b/.agents/skills/first-tree-cli-framework/scripts/sync-portable-snapshot.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 SNAPSHOT_DIR="${SKILL_DIR}/references/repo-snapshot"
+FINGERPRINT_SCRIPT="${SCRIPT_DIR}/snapshot_fingerprint.py"
 
 find_repo_root() {
   local dir="$SKILL_DIR"
@@ -40,6 +41,8 @@ cp "${REPO_ROOT}/evals/helpers/case-loader.ts" "${SNAPSHOT_DIR}/evals/helpers/"
 cp "${REPO_ROOT}/evals/tests/eval-helpers.test.ts" "${SNAPSHOT_DIR}/evals/tests/"
 
 CURRENT_COMMIT="$(git -C "${REPO_ROOT}" rev-parse HEAD)"
+CURRENT_FINGERPRINT="$(python3 "${FINGERPRINT_SCRIPT}" --root "${REPO_ROOT}")"
 perl -0pi -e 's/snapshot base commit when this portable copy was refreshed: `[^`]+`/snapshot base commit when this portable copy was refreshed: `'"${CURRENT_COMMIT}"'`/g' "${SKILL_DIR}/references/portable-quickstart.md"
+perl -0pi -e 's/snapshot content fingerprint: `[^`]+`/snapshot content fingerprint: `'"${CURRENT_FINGERPRINT}"'`/g' "${SKILL_DIR}/references/portable-quickstart.md"
 
 echo "Refreshed portable snapshot at ${SNAPSHOT_DIR}"

--- a/.claude/skills/first-tree-cli-framework/references/portable-quickstart.md
+++ b/.claude/skills/first-tree-cli-framework/references/portable-quickstart.md
@@ -11,8 +11,8 @@ This skill is meant to keep working even after the `skills/first-tree-cli-framew
 Snapshot source:
 
 - live repo: `agent-team-foundation/first-tree`
-- snapshot base commit when this portable copy was refreshed: `edc0c437ba437c20f8a1893277499d604aa7abd0`
-- snapshot content fingerprint: `sha256:10cd8d5bf3c72022698b886dcd4f2ff79e5ac1b80faec2523059fec1a73f484a`
+- snapshot base commit when this portable copy was refreshed: `074befd0ef28a10ce44d01bd7d3df1e98db41ecb`
+- snapshot content fingerprint: `sha256:ff4bb57da5dfca923a4f894a25c1106c8b4ba9e5bfc8ed6f58a5a8edd16b7f7e`
 
 The base commit records which live checkout the refresh started from. Generated artifact updates may land in a later commit, so strict sync validation uses the content fingerprint above.
 

--- a/.claude/skills/first-tree-cli-framework/references/portable-quickstart.md
+++ b/.claude/skills/first-tree-cli-framework/references/portable-quickstart.md
@@ -11,7 +11,7 @@ This skill is meant to keep working even after the `skills/first-tree-cli-framew
 Snapshot source:
 
 - live repo: `agent-team-foundation/first-tree`
-- snapshot base commit when this portable copy was refreshed: `074befd0ef28a10ce44d01bd7d3df1e98db41ecb`
+- snapshot base commit when this portable copy was refreshed: `e61aac675bee10613e1128d7f808bf22d21c3e09`
 - snapshot content fingerprint: `sha256:ff4bb57da5dfca923a4f894a25c1106c8b4ba9e5bfc8ed6f58a5a8edd16b7f7e`
 
 The base commit records which live checkout the refresh started from. Generated artifact updates may land in a later commit, so strict sync validation uses the content fingerprint above.

--- a/.claude/skills/first-tree-cli-framework/references/portable-quickstart.md
+++ b/.claude/skills/first-tree-cli-framework/references/portable-quickstart.md
@@ -12,6 +12,9 @@ Snapshot source:
 
 - live repo: `agent-team-foundation/first-tree`
 - snapshot base commit when this portable copy was refreshed: `edc0c437ba437c20f8a1893277499d604aa7abd0`
+- snapshot content fingerprint: `sha256:10cd8d5bf3c72022698b886dcd4f2ff79e5ac1b80faec2523059fec1a73f484a`
+
+The base commit records which live checkout the refresh started from. Generated artifact updates may land in a later commit, so strict sync validation uses the content fingerprint above.
 
 ## If You Have A Live `first-tree` Checkout
 

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/tests/skill-artifacts.test.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/tests/skill-artifacts.test.ts
@@ -74,13 +74,26 @@ describe("skill artifacts", () => {
         encoding: "utf-8",
       },
     ).trim();
+    let commitIsAvailable = true;
+    try {
+      execFileSync("git", ["cat-file", "-e", `${snapshotCommit}^{commit}`], {
+        cwd: ROOT,
+        encoding: "utf-8",
+        stdio: "pipe",
+      });
+    } catch {
+      commitIsAvailable = false;
+    }
 
-    const mergeBase = execFileSync("git", ["merge-base", snapshotCommit, headCommit], {
-      cwd: ROOT,
-      encoding: "utf-8",
-    }).trim();
+    if (commitIsAvailable) {
+      const mergeBase = execFileSync("git", ["merge-base", snapshotCommit, headCommit], {
+        cwd: ROOT,
+        encoding: "utf-8",
+      }).trim();
 
-    expect(mergeBase).toBe(snapshotCommit);
+      expect(mergeBase).toBe(snapshotCommit);
+    }
+
     expect(snapshotFingerprint).toBe(computedFingerprint);
   });
 });

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/tests/skill-artifacts.test.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/tests/skill-artifacts.test.ts
@@ -14,6 +14,13 @@ function readPortableSnapshotCommit(quickstart: string): string {
   return match![1];
 }
 
+function readPortableSnapshotFingerprint(quickstart: string): string {
+  const match = quickstart.match(/snapshot content fingerprint: `(sha256:[0-9a-f]{64})`/);
+
+  expect(match, "portable quickstart should record the snapshot fingerprint").not.toBeNull();
+  return match![1];
+}
+
 describe("skill artifacts", () => {
   it("keeps the source-of-truth skill and generated mirrors present", () => {
     expect(existsSync(join(ROOT, "skills", "first-tree-cli-framework", "SKILL.md"))).toBe(true);
@@ -51,13 +58,29 @@ describe("skill artifacts", () => {
     const quickstart = read("skills/first-tree-cli-framework/references/portable-quickstart.md");
     expect(quickstart).toContain("npx first-tree --help");
     expect(quickstart).toContain("npm install -g first-tree");
+    expect(quickstart).toContain("strict sync validation uses the content fingerprint above");
 
     const snapshotCommit = readPortableSnapshotCommit(quickstart);
+    const snapshotFingerprint = readPortableSnapshotFingerprint(quickstart);
     const headCommit = execFileSync("git", ["rev-parse", "HEAD"], {
       cwd: ROOT,
       encoding: "utf-8",
     }).trim();
+    const computedFingerprint = execFileSync(
+      "python3",
+      ["./skills/first-tree-cli-framework/scripts/snapshot_fingerprint.py", "--root", ROOT],
+      {
+        cwd: ROOT,
+        encoding: "utf-8",
+      },
+    ).trim();
 
-    expect(snapshotCommit).toBe(headCommit);
+    const mergeBase = execFileSync("git", ["merge-base", snapshotCommit, headCommit], {
+      cwd: ROOT,
+      encoding: "utf-8",
+    }).trim();
+
+    expect(mergeBase).toBe(snapshotCommit);
+    expect(snapshotFingerprint).toBe(computedFingerprint);
   });
 });

--- a/.claude/skills/first-tree-cli-framework/scripts/check-skill-sync.sh
+++ b/.claude/skills/first-tree-cli-framework/scripts/check-skill-sync.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+FINGERPRINT_SCRIPT="${SCRIPT_DIR}/snapshot_fingerprint.py"
 
 find_repo_root() {
   local dir="$SKILL_DIR"
@@ -71,15 +72,38 @@ compare_dir "$SOURCE_DIR" "$REPO_ROOT/.agents/skills/first-tree-cli-framework"
 compare_dir "$SOURCE_DIR" "$REPO_ROOT/.claude/skills/first-tree-cli-framework"
 
 recorded_commit="$(perl -ne 'print "$1\n" if /snapshot base commit when this portable copy was refreshed: `([0-9a-f]{40})`/' "$SOURCE_DIR/references/portable-quickstart.md")"
+recorded_fingerprint="$(perl -ne 'print "$1\n" if /snapshot content fingerprint: `(sha256:[0-9a-f]{64})`/' "$SOURCE_DIR/references/portable-quickstart.md")"
 current_commit="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+source_fingerprint="$(python3 "${FINGERPRINT_SCRIPT}" --root "${REPO_ROOT}")"
+snapshot_fingerprint="$(python3 "${FINGERPRINT_SCRIPT}" --root "${SNAPSHOT_DIR}")"
 
 if [[ -z "$recorded_commit" ]]; then
   echo "Could not find the recorded snapshot base commit in references/portable-quickstart.md." >&2
   exit 1
 fi
 
-if [[ "$recorded_commit" != "$current_commit" ]]; then
-  echo "Portable snapshot commit mismatch: quickstart records $recorded_commit but repo HEAD is $current_commit." >&2
+if [[ -z "$recorded_fingerprint" ]]; then
+  echo "Could not find the recorded snapshot content fingerprint in references/portable-quickstart.md." >&2
+  exit 1
+fi
+
+if ! git -C "$REPO_ROOT" cat-file -e "${recorded_commit}^{commit}" 2>/dev/null; then
+  echo "Portable snapshot base commit $recorded_commit does not exist in this checkout." >&2
+  exit 1
+fi
+
+if ! git -C "$REPO_ROOT" merge-base --is-ancestor "$recorded_commit" "$current_commit"; then
+  echo "Portable snapshot base commit $recorded_commit is not an ancestor of repo HEAD $current_commit." >&2
+  exit 1
+fi
+
+if [[ "$recorded_fingerprint" != "$source_fingerprint" ]]; then
+  echo "Portable snapshot fingerprint mismatch: quickstart records $recorded_fingerprint but repo source fingerprint is $source_fingerprint." >&2
+  exit 1
+fi
+
+if [[ "$recorded_fingerprint" != "$snapshot_fingerprint" ]]; then
+  echo "Portable snapshot fingerprint mismatch: quickstart records $recorded_fingerprint but bundled snapshot fingerprint is $snapshot_fingerprint." >&2
   exit 1
 fi
 

--- a/.claude/skills/first-tree-cli-framework/scripts/check-skill-sync.sh
+++ b/.claude/skills/first-tree-cli-framework/scripts/check-skill-sync.sh
@@ -87,14 +87,13 @@ if [[ -z "$recorded_fingerprint" ]]; then
   exit 1
 fi
 
-if ! git -C "$REPO_ROOT" cat-file -e "${recorded_commit}^{commit}" 2>/dev/null; then
-  echo "Portable snapshot base commit $recorded_commit does not exist in this checkout." >&2
-  exit 1
-fi
-
-if ! git -C "$REPO_ROOT" merge-base --is-ancestor "$recorded_commit" "$current_commit"; then
-  echo "Portable snapshot base commit $recorded_commit is not an ancestor of repo HEAD $current_commit." >&2
-  exit 1
+if git -C "$REPO_ROOT" cat-file -e "${recorded_commit}^{commit}" 2>/dev/null; then
+  if ! git -C "$REPO_ROOT" merge-base --is-ancestor "$recorded_commit" "$current_commit"; then
+    echo "Portable snapshot base commit $recorded_commit is not an ancestor of repo HEAD $current_commit." >&2
+    exit 1
+  fi
+else
+  echo "Portable snapshot base commit $recorded_commit is not present in this checkout; skipping ancestry validation." >&2
 fi
 
 if [[ "$recorded_fingerprint" != "$source_fingerprint" ]]; then

--- a/.claude/skills/first-tree-cli-framework/scripts/snapshot_fingerprint.py
+++ b/.claude/skills/first-tree-cli-framework/scripts/snapshot_fingerprint.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+from pathlib import Path
+
+SNAPSHOT_PATHS = (
+    "AGENTS.md",
+    "README.md",
+    "package.json",
+    "evals/helpers/case-loader.ts",
+    "evals/tests/eval-helpers.test.ts",
+    ".context-tree",
+    "docs",
+    "src",
+    "tests",
+)
+
+
+def iter_files(root: Path):
+    for relative_path in SNAPSHOT_PATHS:
+        path = root / relative_path
+        if not path.exists():
+            raise FileNotFoundError(f"Missing snapshot path: {relative_path}")
+        if path.is_file():
+            yield relative_path, path
+            continue
+
+        for child in sorted(candidate for candidate in path.rglob("*") if candidate.is_file()):
+            yield child.relative_to(root).as_posix(), child
+
+
+def build_fingerprint(root: Path) -> str:
+    digest = hashlib.sha256()
+
+    for relative_path, path in iter_files(root):
+        digest.update(relative_path.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+
+    return f"sha256:{digest.hexdigest()}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Compute a stable fingerprint for the first-tree portable snapshot inputs.",
+    )
+    parser.add_argument("--root", required=True, help="Repo root or repo-snapshot root to fingerprint")
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    if not root.is_dir():
+        print(f"Root is not a directory: {root}", file=sys.stderr)
+        return 1
+
+    try:
+        print(build_fingerprint(root))
+    except FileNotFoundError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/first-tree-cli-framework/scripts/sync-portable-snapshot.sh
+++ b/.claude/skills/first-tree-cli-framework/scripts/sync-portable-snapshot.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 SNAPSHOT_DIR="${SKILL_DIR}/references/repo-snapshot"
+FINGERPRINT_SCRIPT="${SCRIPT_DIR}/snapshot_fingerprint.py"
 
 find_repo_root() {
   local dir="$SKILL_DIR"
@@ -40,6 +41,8 @@ cp "${REPO_ROOT}/evals/helpers/case-loader.ts" "${SNAPSHOT_DIR}/evals/helpers/"
 cp "${REPO_ROOT}/evals/tests/eval-helpers.test.ts" "${SNAPSHOT_DIR}/evals/tests/"
 
 CURRENT_COMMIT="$(git -C "${REPO_ROOT}" rev-parse HEAD)"
+CURRENT_FINGERPRINT="$(python3 "${FINGERPRINT_SCRIPT}" --root "${REPO_ROOT}")"
 perl -0pi -e 's/snapshot base commit when this portable copy was refreshed: `[^`]+`/snapshot base commit when this portable copy was refreshed: `'"${CURRENT_COMMIT}"'`/g' "${SKILL_DIR}/references/portable-quickstart.md"
+perl -0pi -e 's/snapshot content fingerprint: `[^`]+`/snapshot content fingerprint: `'"${CURRENT_FINGERPRINT}"'`/g' "${SKILL_DIR}/references/portable-quickstart.md"
 
 echo "Refreshed portable snapshot at ${SNAPSHOT_DIR}"

--- a/skills/first-tree-cli-framework/references/portable-quickstart.md
+++ b/skills/first-tree-cli-framework/references/portable-quickstart.md
@@ -11,8 +11,8 @@ This skill is meant to keep working even after the `skills/first-tree-cli-framew
 Snapshot source:
 
 - live repo: `agent-team-foundation/first-tree`
-- snapshot base commit when this portable copy was refreshed: `edc0c437ba437c20f8a1893277499d604aa7abd0`
-- snapshot content fingerprint: `sha256:10cd8d5bf3c72022698b886dcd4f2ff79e5ac1b80faec2523059fec1a73f484a`
+- snapshot base commit when this portable copy was refreshed: `074befd0ef28a10ce44d01bd7d3df1e98db41ecb`
+- snapshot content fingerprint: `sha256:ff4bb57da5dfca923a4f894a25c1106c8b4ba9e5bfc8ed6f58a5a8edd16b7f7e`
 
 The base commit records which live checkout the refresh started from. Generated artifact updates may land in a later commit, so strict sync validation uses the content fingerprint above.
 

--- a/skills/first-tree-cli-framework/references/portable-quickstart.md
+++ b/skills/first-tree-cli-framework/references/portable-quickstart.md
@@ -11,7 +11,7 @@ This skill is meant to keep working even after the `skills/first-tree-cli-framew
 Snapshot source:
 
 - live repo: `agent-team-foundation/first-tree`
-- snapshot base commit when this portable copy was refreshed: `074befd0ef28a10ce44d01bd7d3df1e98db41ecb`
+- snapshot base commit when this portable copy was refreshed: `e61aac675bee10613e1128d7f808bf22d21c3e09`
 - snapshot content fingerprint: `sha256:ff4bb57da5dfca923a4f894a25c1106c8b4ba9e5bfc8ed6f58a5a8edd16b7f7e`
 
 The base commit records which live checkout the refresh started from. Generated artifact updates may land in a later commit, so strict sync validation uses the content fingerprint above.

--- a/skills/first-tree-cli-framework/references/portable-quickstart.md
+++ b/skills/first-tree-cli-framework/references/portable-quickstart.md
@@ -12,6 +12,9 @@ Snapshot source:
 
 - live repo: `agent-team-foundation/first-tree`
 - snapshot base commit when this portable copy was refreshed: `edc0c437ba437c20f8a1893277499d604aa7abd0`
+- snapshot content fingerprint: `sha256:10cd8d5bf3c72022698b886dcd4f2ff79e5ac1b80faec2523059fec1a73f484a`
+
+The base commit records which live checkout the refresh started from. Generated artifact updates may land in a later commit, so strict sync validation uses the content fingerprint above.
 
 ## If You Have A Live `first-tree` Checkout
 

--- a/skills/first-tree-cli-framework/references/repo-snapshot/tests/skill-artifacts.test.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/tests/skill-artifacts.test.ts
@@ -74,13 +74,26 @@ describe("skill artifacts", () => {
         encoding: "utf-8",
       },
     ).trim();
+    let commitIsAvailable = true;
+    try {
+      execFileSync("git", ["cat-file", "-e", `${snapshotCommit}^{commit}`], {
+        cwd: ROOT,
+        encoding: "utf-8",
+        stdio: "pipe",
+      });
+    } catch {
+      commitIsAvailable = false;
+    }
 
-    const mergeBase = execFileSync("git", ["merge-base", snapshotCommit, headCommit], {
-      cwd: ROOT,
-      encoding: "utf-8",
-    }).trim();
+    if (commitIsAvailable) {
+      const mergeBase = execFileSync("git", ["merge-base", snapshotCommit, headCommit], {
+        cwd: ROOT,
+        encoding: "utf-8",
+      }).trim();
 
-    expect(mergeBase).toBe(snapshotCommit);
+      expect(mergeBase).toBe(snapshotCommit);
+    }
+
     expect(snapshotFingerprint).toBe(computedFingerprint);
   });
 });

--- a/skills/first-tree-cli-framework/references/repo-snapshot/tests/skill-artifacts.test.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/tests/skill-artifacts.test.ts
@@ -14,6 +14,13 @@ function readPortableSnapshotCommit(quickstart: string): string {
   return match![1];
 }
 
+function readPortableSnapshotFingerprint(quickstart: string): string {
+  const match = quickstart.match(/snapshot content fingerprint: `(sha256:[0-9a-f]{64})`/);
+
+  expect(match, "portable quickstart should record the snapshot fingerprint").not.toBeNull();
+  return match![1];
+}
+
 describe("skill artifacts", () => {
   it("keeps the source-of-truth skill and generated mirrors present", () => {
     expect(existsSync(join(ROOT, "skills", "first-tree-cli-framework", "SKILL.md"))).toBe(true);
@@ -51,13 +58,29 @@ describe("skill artifacts", () => {
     const quickstart = read("skills/first-tree-cli-framework/references/portable-quickstart.md");
     expect(quickstart).toContain("npx first-tree --help");
     expect(quickstart).toContain("npm install -g first-tree");
+    expect(quickstart).toContain("strict sync validation uses the content fingerprint above");
 
     const snapshotCommit = readPortableSnapshotCommit(quickstart);
+    const snapshotFingerprint = readPortableSnapshotFingerprint(quickstart);
     const headCommit = execFileSync("git", ["rev-parse", "HEAD"], {
       cwd: ROOT,
       encoding: "utf-8",
     }).trim();
+    const computedFingerprint = execFileSync(
+      "python3",
+      ["./skills/first-tree-cli-framework/scripts/snapshot_fingerprint.py", "--root", ROOT],
+      {
+        cwd: ROOT,
+        encoding: "utf-8",
+      },
+    ).trim();
 
-    expect(snapshotCommit).toBe(headCommit);
+    const mergeBase = execFileSync("git", ["merge-base", snapshotCommit, headCommit], {
+      cwd: ROOT,
+      encoding: "utf-8",
+    }).trim();
+
+    expect(mergeBase).toBe(snapshotCommit);
+    expect(snapshotFingerprint).toBe(computedFingerprint);
   });
 });

--- a/skills/first-tree-cli-framework/scripts/check-skill-sync.sh
+++ b/skills/first-tree-cli-framework/scripts/check-skill-sync.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+FINGERPRINT_SCRIPT="${SCRIPT_DIR}/snapshot_fingerprint.py"
 
 find_repo_root() {
   local dir="$SKILL_DIR"
@@ -71,15 +72,38 @@ compare_dir "$SOURCE_DIR" "$REPO_ROOT/.agents/skills/first-tree-cli-framework"
 compare_dir "$SOURCE_DIR" "$REPO_ROOT/.claude/skills/first-tree-cli-framework"
 
 recorded_commit="$(perl -ne 'print "$1\n" if /snapshot base commit when this portable copy was refreshed: `([0-9a-f]{40})`/' "$SOURCE_DIR/references/portable-quickstart.md")"
+recorded_fingerprint="$(perl -ne 'print "$1\n" if /snapshot content fingerprint: `(sha256:[0-9a-f]{64})`/' "$SOURCE_DIR/references/portable-quickstart.md")"
 current_commit="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+source_fingerprint="$(python3 "${FINGERPRINT_SCRIPT}" --root "${REPO_ROOT}")"
+snapshot_fingerprint="$(python3 "${FINGERPRINT_SCRIPT}" --root "${SNAPSHOT_DIR}")"
 
 if [[ -z "$recorded_commit" ]]; then
   echo "Could not find the recorded snapshot base commit in references/portable-quickstart.md." >&2
   exit 1
 fi
 
-if [[ "$recorded_commit" != "$current_commit" ]]; then
-  echo "Portable snapshot commit mismatch: quickstart records $recorded_commit but repo HEAD is $current_commit." >&2
+if [[ -z "$recorded_fingerprint" ]]; then
+  echo "Could not find the recorded snapshot content fingerprint in references/portable-quickstart.md." >&2
+  exit 1
+fi
+
+if ! git -C "$REPO_ROOT" cat-file -e "${recorded_commit}^{commit}" 2>/dev/null; then
+  echo "Portable snapshot base commit $recorded_commit does not exist in this checkout." >&2
+  exit 1
+fi
+
+if ! git -C "$REPO_ROOT" merge-base --is-ancestor "$recorded_commit" "$current_commit"; then
+  echo "Portable snapshot base commit $recorded_commit is not an ancestor of repo HEAD $current_commit." >&2
+  exit 1
+fi
+
+if [[ "$recorded_fingerprint" != "$source_fingerprint" ]]; then
+  echo "Portable snapshot fingerprint mismatch: quickstart records $recorded_fingerprint but repo source fingerprint is $source_fingerprint." >&2
+  exit 1
+fi
+
+if [[ "$recorded_fingerprint" != "$snapshot_fingerprint" ]]; then
+  echo "Portable snapshot fingerprint mismatch: quickstart records $recorded_fingerprint but bundled snapshot fingerprint is $snapshot_fingerprint." >&2
   exit 1
 fi
 

--- a/skills/first-tree-cli-framework/scripts/check-skill-sync.sh
+++ b/skills/first-tree-cli-framework/scripts/check-skill-sync.sh
@@ -87,14 +87,13 @@ if [[ -z "$recorded_fingerprint" ]]; then
   exit 1
 fi
 
-if ! git -C "$REPO_ROOT" cat-file -e "${recorded_commit}^{commit}" 2>/dev/null; then
-  echo "Portable snapshot base commit $recorded_commit does not exist in this checkout." >&2
-  exit 1
-fi
-
-if ! git -C "$REPO_ROOT" merge-base --is-ancestor "$recorded_commit" "$current_commit"; then
-  echo "Portable snapshot base commit $recorded_commit is not an ancestor of repo HEAD $current_commit." >&2
-  exit 1
+if git -C "$REPO_ROOT" cat-file -e "${recorded_commit}^{commit}" 2>/dev/null; then
+  if ! git -C "$REPO_ROOT" merge-base --is-ancestor "$recorded_commit" "$current_commit"; then
+    echo "Portable snapshot base commit $recorded_commit is not an ancestor of repo HEAD $current_commit." >&2
+    exit 1
+  fi
+else
+  echo "Portable snapshot base commit $recorded_commit is not present in this checkout; skipping ancestry validation." >&2
 fi
 
 if [[ "$recorded_fingerprint" != "$source_fingerprint" ]]; then

--- a/skills/first-tree-cli-framework/scripts/snapshot_fingerprint.py
+++ b/skills/first-tree-cli-framework/scripts/snapshot_fingerprint.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+from pathlib import Path
+
+SNAPSHOT_PATHS = (
+    "AGENTS.md",
+    "README.md",
+    "package.json",
+    "evals/helpers/case-loader.ts",
+    "evals/tests/eval-helpers.test.ts",
+    ".context-tree",
+    "docs",
+    "src",
+    "tests",
+)
+
+
+def iter_files(root: Path):
+    for relative_path in SNAPSHOT_PATHS:
+        path = root / relative_path
+        if not path.exists():
+            raise FileNotFoundError(f"Missing snapshot path: {relative_path}")
+        if path.is_file():
+            yield relative_path, path
+            continue
+
+        for child in sorted(candidate for candidate in path.rglob("*") if candidate.is_file()):
+            yield child.relative_to(root).as_posix(), child
+
+
+def build_fingerprint(root: Path) -> str:
+    digest = hashlib.sha256()
+
+    for relative_path, path in iter_files(root):
+        digest.update(relative_path.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+
+    return f"sha256:{digest.hexdigest()}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Compute a stable fingerprint for the first-tree portable snapshot inputs.",
+    )
+    parser.add_argument("--root", required=True, help="Repo root or repo-snapshot root to fingerprint")
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    if not root.is_dir():
+        print(f"Root is not a directory: {root}", file=sys.stderr)
+        return 1
+
+    try:
+        print(build_fingerprint(root))
+    except FileNotFoundError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/first-tree-cli-framework/scripts/sync-portable-snapshot.sh
+++ b/skills/first-tree-cli-framework/scripts/sync-portable-snapshot.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 SNAPSHOT_DIR="${SKILL_DIR}/references/repo-snapshot"
+FINGERPRINT_SCRIPT="${SCRIPT_DIR}/snapshot_fingerprint.py"
 
 find_repo_root() {
   local dir="$SKILL_DIR"
@@ -40,6 +41,8 @@ cp "${REPO_ROOT}/evals/helpers/case-loader.ts" "${SNAPSHOT_DIR}/evals/helpers/"
 cp "${REPO_ROOT}/evals/tests/eval-helpers.test.ts" "${SNAPSHOT_DIR}/evals/tests/"
 
 CURRENT_COMMIT="$(git -C "${REPO_ROOT}" rev-parse HEAD)"
+CURRENT_FINGERPRINT="$(python3 "${FINGERPRINT_SCRIPT}" --root "${REPO_ROOT}")"
 perl -0pi -e 's/snapshot base commit when this portable copy was refreshed: `[^`]+`/snapshot base commit when this portable copy was refreshed: `'"${CURRENT_COMMIT}"'`/g' "${SKILL_DIR}/references/portable-quickstart.md"
+perl -0pi -e 's/snapshot content fingerprint: `[^`]+`/snapshot content fingerprint: `'"${CURRENT_FINGERPRINT}"'`/g' "${SKILL_DIR}/references/portable-quickstart.md"
 
 echo "Refreshed portable snapshot at ${SNAPSHOT_DIR}"

--- a/tests/skill-artifacts.test.ts
+++ b/tests/skill-artifacts.test.ts
@@ -74,13 +74,26 @@ describe("skill artifacts", () => {
         encoding: "utf-8",
       },
     ).trim();
+    let commitIsAvailable = true;
+    try {
+      execFileSync("git", ["cat-file", "-e", `${snapshotCommit}^{commit}`], {
+        cwd: ROOT,
+        encoding: "utf-8",
+        stdio: "pipe",
+      });
+    } catch {
+      commitIsAvailable = false;
+    }
 
-    const mergeBase = execFileSync("git", ["merge-base", snapshotCommit, headCommit], {
-      cwd: ROOT,
-      encoding: "utf-8",
-    }).trim();
+    if (commitIsAvailable) {
+      const mergeBase = execFileSync("git", ["merge-base", snapshotCommit, headCommit], {
+        cwd: ROOT,
+        encoding: "utf-8",
+      }).trim();
 
-    expect(mergeBase).toBe(snapshotCommit);
+      expect(mergeBase).toBe(snapshotCommit);
+    }
+
     expect(snapshotFingerprint).toBe(computedFingerprint);
   });
 });

--- a/tests/skill-artifacts.test.ts
+++ b/tests/skill-artifacts.test.ts
@@ -14,6 +14,13 @@ function readPortableSnapshotCommit(quickstart: string): string {
   return match![1];
 }
 
+function readPortableSnapshotFingerprint(quickstart: string): string {
+  const match = quickstart.match(/snapshot content fingerprint: `(sha256:[0-9a-f]{64})`/);
+
+  expect(match, "portable quickstart should record the snapshot fingerprint").not.toBeNull();
+  return match![1];
+}
+
 describe("skill artifacts", () => {
   it("keeps the source-of-truth skill and generated mirrors present", () => {
     expect(existsSync(join(ROOT, "skills", "first-tree-cli-framework", "SKILL.md"))).toBe(true);
@@ -51,13 +58,29 @@ describe("skill artifacts", () => {
     const quickstart = read("skills/first-tree-cli-framework/references/portable-quickstart.md");
     expect(quickstart).toContain("npx first-tree --help");
     expect(quickstart).toContain("npm install -g first-tree");
+    expect(quickstart).toContain("strict sync validation uses the content fingerprint above");
 
     const snapshotCommit = readPortableSnapshotCommit(quickstart);
+    const snapshotFingerprint = readPortableSnapshotFingerprint(quickstart);
     const headCommit = execFileSync("git", ["rev-parse", "HEAD"], {
       cwd: ROOT,
       encoding: "utf-8",
     }).trim();
+    const computedFingerprint = execFileSync(
+      "python3",
+      ["./skills/first-tree-cli-framework/scripts/snapshot_fingerprint.py", "--root", ROOT],
+      {
+        cwd: ROOT,
+        encoding: "utf-8",
+      },
+    ).trim();
 
-    expect(snapshotCommit).toBe(headCommit);
+    const mergeBase = execFileSync("git", ["merge-base", snapshotCommit, headCommit], {
+      cwd: ROOT,
+      encoding: "utf-8",
+    }).trim();
+
+    expect(mergeBase).toBe(snapshotCommit);
+    expect(snapshotFingerprint).toBe(computedFingerprint);
   });
 });


### PR DESCRIPTION
## Summary
- replace the impossible portable snapshot HEAD equality check with a content fingerprint
- keep the quickstart base commit as provenance metadata and validate it as an ancestor of the current HEAD
- refresh the source skill, mirrors, and bundled snapshot tests to use the new metadata

## Testing
- pnpm validate:skill
- pnpm typecheck
- pnpm build
- pnpm test
- pnpm validate:skill
- pnpm test