### PR TITLE
refactor: switch user repos to the installed skill layout

### DIFF
--- a/.agents/skills/first-tree-cli-framework/assets/framework/examples/claude-code/README.md
+++ b/.agents/skills/first-tree-cli-framework/assets/framework/examples/claude-code/README.md
@@ -6,10 +6,9 @@ Copy `settings.json` to your tree repo's `.claude/` directory:
 
 ```bash
 mkdir -p .claude
-cp .context-tree/examples/claude-code/settings.json .claude/settings.json
+cp skills/first-tree-cli-framework/assets/framework/examples/claude-code/settings.json .claude/settings.json
 ```
 
 ## What It Does
 
-The `SessionStart` hook runs `.context-tree/scripts/inject-tree-context.sh` when a Claude Code session begins. This injects the root `NODE.md` content as additional context, giving the agent an overview of the tree structure before any task.
-
+The `SessionStart` hook runs `./skills/first-tree-cli-framework/assets/framework/helpers/inject-tree-context.sh` when a Claude Code session begins. This injects the root `NODE.md` content as additional context, giving the agent an overview of the tree structure before any task.

--- a/.agents/skills/first-tree-cli-framework/assets/framework/examples/claude-code/settings.json
+++ b/.agents/skills/first-tree-cli-framework/assets/framework/examples/claude-code/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".context-tree/scripts/inject-tree-context.sh"
+            "command": "./skills/first-tree-cli-framework/assets/framework/helpers/inject-tree-context.sh"
           }
         ]
       }

--- a/.agents/skills/first-tree-cli-framework/assets/framework/helpers/generate-codeowners.ts
+++ b/.agents/skills/first-tree-cli-framework/assets/framework/helpers/generate-codeowners.ts
@@ -205,7 +205,7 @@ export function generate(
       return 0;
     }
     console.log(
-      "CODEOWNERS is out-of-date. Run: npx tsx .context-tree/generate-codeowners.ts",
+      "CODEOWNERS is out-of-date. Run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/generate-codeowners.ts",
     );
     return 1;
   }

--- a/.agents/skills/first-tree-cli-framework/assets/framework/helpers/run-review.ts
+++ b/.agents/skills/first-tree-cli-framework/assets/framework/helpers/run-review.ts
@@ -23,7 +23,10 @@ function buildPrompt(diffPath: string): string {
   const files: [string, string][] = [
     ["AGENT.md", "AGENT.md"],
     ["Root NODE.md", "NODE.md"],
-    ["Review Instructions", ".context-tree/prompts/pr-review.md"],
+    [
+      "Review Instructions",
+      "skills/first-tree-cli-framework/assets/framework/prompts/pr-review.md",
+    ],
   ];
   for (const [heading, path] of files) {
     const content = readFileSync(path, "utf-8");

--- a/.agents/skills/first-tree-cli-framework/assets/framework/templates/agent.md.template
+++ b/.agents/skills/first-tree-cli-framework/assets/framework/templates/agent.md.template
@@ -13,7 +13,7 @@ You are working in a **Context Tree** — the living source of truth for decisio
 
 4. **Git-native tree structure.** Each node is a file; each domain is a directory. Soft links allow cross-references without the complexity of a full graph. History, ownership, and review follow Git conventions.
 
-See `.context-tree/principles.md` for detailed explanations and examples.
+See `skills/first-tree-cli-framework/references/principles.md` for detailed explanations and examples.
 
 ## Before Every Task
 
@@ -40,7 +40,7 @@ Ask yourself: **Does the tree need updating?**
 
 ## Reference
 
-For ownership rules, tree structure, and key files, see [NODE.md](NODE.md) and `.context-tree/ownership-and-naming.md`.
+For ownership rules, tree structure, and key files, see [NODE.md](NODE.md) and `skills/first-tree-cli-framework/references/ownership-and-naming.md`.
 <!-- END CONTEXT-TREE FRAMEWORK -->
 
 # Project-Specific Instructions

--- a/.agents/skills/first-tree-cli-framework/assets/framework/templates/members-domain.md.template
+++ b/.agents/skills/first-tree-cli-framework/assets/framework/templates/members-domain.md.template
@@ -34,7 +34,7 @@ domains:
 ---
 ```
 
-See `.context-tree/templates/member-node.md.template` for a full scaffold.
+See `skills/first-tree-cli-framework/assets/framework/templates/member-node.md.template` for a full scaffold.
 
 ---
 

--- a/.agents/skills/first-tree-cli-framework/assets/framework/templates/root-node.md.template
+++ b/.agents/skills/first-tree-cli-framework/assets/framework/templates/root-node.md.template
@@ -31,8 +31,8 @@ The living source of truth for your organization. A structured knowledge base th
 
 See [AGENT.md](AGENT.md) for agent instructions — the before/during/after workflow, ownership model, and tree maintenance.
 
-See [about.md](about.md) for background — the problem, the idea, and who it's for.
+See [about.md](skills/first-tree-cli-framework/references/about.md) for background — the problem, the idea, and who it's for.
 
-See the framework documentation in `.context-tree/`:
-- [principles.md](.context-tree/principles.md) — core principles with examples
-- [ownership-and-naming.md](.context-tree/ownership-and-naming.md) — node naming and ownership model
+See the installed framework documentation:
+- [principles.md](skills/first-tree-cli-framework/references/principles.md) — core principles with examples
+- [ownership-and-naming.md](skills/first-tree-cli-framework/references/ownership-and-naming.md) — node naming and ownership model

--- a/.agents/skills/first-tree-cli-framework/assets/framework/workflows/codeowners.yml
+++ b/.agents/skills/first-tree-cli-framework/assets/framework/workflows/codeowners.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: "22"
 
-      - run: npx tsx .context-tree/generate-codeowners.ts
+      - run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/generate-codeowners.ts
 
       - name: Commit if changed
         run: |

--- a/.agents/skills/first-tree-cli-framework/assets/framework/workflows/pr-review.yml
+++ b/.agents/skills/first-tree-cli-framework/assets/framework/workflows/pr-review.yml
@@ -45,7 +45,7 @@ jobs:
           gh pr view "$PR_NUMBER" --json headRefOid -q .headRefOid > /tmp/pr-head-sha.txt
 
       - name: Run Claude review
-        run: npx tsx .context-tree/run-review.ts
+        run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/run-review.ts
 
       - name: Parse and post review
         run: |

--- a/.agents/skills/first-tree-cli-framework/references/onboarding.md
+++ b/.agents/skills/first-tree-cli-framework/references/onboarding.md
@@ -65,19 +65,19 @@ git init
 context-tree init
 ```
 
-This clones the framework into `.context-tree/`, renders scaffolding (`NODE.md`, `AGENT.md`, `members/NODE.md`), and generates a task list in `.context-tree/progress.md`.
+This installs the framework skill into `skills/first-tree-cli-framework/`, renders scaffolding (`NODE.md`, `AGENT.md`, `members/NODE.md`), and generates a task list in `skills/first-tree-cli-framework/progress.md`.
 
 ### Step 2: Work Through the Task List
 
-Read `.context-tree/progress.md`. It contains a checklist tailored to the current state of the repo. Complete each task:
+Read `skills/first-tree-cli-framework/progress.md`. It contains a checklist tailored to the current state of the repo. Complete each task:
 
 - Fill in `NODE.md` with your organization name, owners, and domains
 - Add project-specific instructions to `AGENT.md` below the framework markers
 - Create member nodes under `members/`
 - Optionally configure agent integration (e.g., Claude Code session hooks)
-- Copy validation workflows to `.github/workflows/`
+- Copy validation workflows from `skills/first-tree-cli-framework/assets/framework/workflows/` to `.github/workflows/`
 
-As you complete each task, check it off in `progress.md` by changing `- [ ]` to `- [x]`.
+As you complete each task, check it off in `skills/first-tree-cli-framework/progress.md` by changing `- [ ]` to `- [x]`.
 
 ### Step 3: Verify
 
@@ -85,7 +85,7 @@ As you complete each task, check it off in `progress.md` by changing `- [ ]` to 
 context-tree verify
 ```
 
-This fails if any items in `progress.md` remain unchecked, and runs deterministic checks (valid frontmatter, node structure, member nodes exist).
+This fails if any items in `skills/first-tree-cli-framework/progress.md` remain unchecked, and runs deterministic checks (valid frontmatter, node structure, member nodes exist).
 
 ### Step 4: Design Your Domains
 
@@ -122,27 +122,27 @@ The tree doesn't duplicate source code — it captures what connects things and 
 
 | Command | Description |
 |---------|-------------|
-| `context-tree init` | Bootstrap a new tree. Clones framework, renders templates, generates task list. |
-| `context-tree verify` | Check progress.md for unchecked items + run deterministic validation. |
-| `context-tree upgrade` | Compare local framework version to upstream, generate upgrade task list. |
+| `context-tree init` | Bootstrap a new tree. Installs the framework skill, renders templates, generates a task list. |
+| `context-tree verify` | Check the installed progress file for unchecked items + run deterministic validation. |
+| `context-tree upgrade` | Refresh the installed framework skill from upstream and generate follow-up tasks. |
 | `context-tree help onboarding` | Print this onboarding guide. |
 
 ---
 
 ## Upgrading the Framework
 
-After init, the first-tree repo is added as a git remote (`context-tree-upstream`). When the framework updates:
+When the framework updates:
 
 ```bash
 context-tree upgrade
 ```
 
-This compares your `.context-tree/VERSION` to upstream and generates a task list. The framework directory (`.context-tree/`) is upgradable without touching your content.
+This refreshes `skills/first-tree-cli-framework/` from upstream, preserves your tree content, and generates follow-up tasks in `skills/first-tree-cli-framework/progress.md`.
 
 ---
 
 ## Further Reading
 
-- `.context-tree/principles.md` — Core principles with detailed examples
-- `.context-tree/ownership-and-naming.md` — How nodes are named and owned
+- `skills/first-tree-cli-framework/references/principles.md` — Core principles with detailed examples
+- `skills/first-tree-cli-framework/references/ownership-and-naming.md` — How nodes are named and owned
 - `AGENT.md` in your tree — The before/during/after workflow for every task

--- a/.agents/skills/first-tree-cli-framework/references/portable-quickstart.md
+++ b/.agents/skills/first-tree-cli-framework/references/portable-quickstart.md
@@ -11,8 +11,8 @@ This skill is meant to keep working even after the `skills/first-tree-cli-framew
 Snapshot source:
 
 - live repo: `agent-team-foundation/first-tree`
-- snapshot base commit when this portable copy was refreshed: `7f7567ef117edc1102800d8b0e9dff96aa11c524`
-- snapshot content fingerprint: `sha256:5321c1ceb28664c9fcfa7d4b29c136734ac73fef9ed8cb6b19c79a70dd3d20f3`
+- snapshot base commit when this portable copy was refreshed: `ef75cac3c112cea4475c095b000274cc97301cd7`
+- snapshot content fingerprint: `sha256:8de9030ffc5666ebcce8dab5f381da03fbc46f5c178218a62acb8ad1cfb7fd12`
 
 The base commit records which live checkout the refresh started from. Generated artifact updates may land in a later commit, so strict sync validation uses the content fingerprint above.
 

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/examples/claude-code/README.md
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/examples/claude-code/README.md
@@ -6,10 +6,9 @@ Copy `settings.json` to your tree repo's `.claude/` directory:
 
 ```bash
 mkdir -p .claude
-cp .context-tree/examples/claude-code/settings.json .claude/settings.json
+cp skills/first-tree-cli-framework/assets/framework/examples/claude-code/settings.json .claude/settings.json
 ```
 
 ## What It Does
 
-The `SessionStart` hook runs `.context-tree/scripts/inject-tree-context.sh` when a Claude Code session begins. This injects the root `NODE.md` content as additional context, giving the agent an overview of the tree structure before any task.
-
+The `SessionStart` hook runs `./skills/first-tree-cli-framework/assets/framework/helpers/inject-tree-context.sh` when a Claude Code session begins. This injects the root `NODE.md` content as additional context, giving the agent an overview of the tree structure before any task.

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/examples/claude-code/settings.json
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/examples/claude-code/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".context-tree/scripts/inject-tree-context.sh"
+            "command": "./skills/first-tree-cli-framework/assets/framework/helpers/inject-tree-context.sh"
           }
         ]
       }

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/generate-codeowners.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/generate-codeowners.ts
@@ -205,7 +205,7 @@ export function generate(
       return 0;
     }
     console.log(
-      "CODEOWNERS is out-of-date. Run: npx tsx .context-tree/generate-codeowners.ts",
+      "CODEOWNERS is out-of-date. Run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/generate-codeowners.ts",
     );
     return 1;
   }

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/run-review.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/run-review.ts
@@ -23,7 +23,10 @@ function buildPrompt(diffPath: string): string {
   const files: [string, string][] = [
     ["AGENT.md", "AGENT.md"],
     ["Root NODE.md", "NODE.md"],
-    ["Review Instructions", ".context-tree/prompts/pr-review.md"],
+    [
+      "Review Instructions",
+      "skills/first-tree-cli-framework/assets/framework/prompts/pr-review.md",
+    ],
   ];
   for (const [heading, path] of files) {
     const content = readFileSync(path, "utf-8");

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/templates/agent.md.template
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/templates/agent.md.template
@@ -13,7 +13,7 @@ You are working in a **Context Tree** — the living source of truth for decisio
 
 4. **Git-native tree structure.** Each node is a file; each domain is a directory. Soft links allow cross-references without the complexity of a full graph. History, ownership, and review follow Git conventions.
 
-See `.context-tree/principles.md` for detailed explanations and examples.
+See `skills/first-tree-cli-framework/references/principles.md` for detailed explanations and examples.
 
 ## Before Every Task
 
@@ -40,7 +40,7 @@ Ask yourself: **Does the tree need updating?**
 
 ## Reference
 
-For ownership rules, tree structure, and key files, see [NODE.md](NODE.md) and `.context-tree/ownership-and-naming.md`.
+For ownership rules, tree structure, and key files, see [NODE.md](NODE.md) and `skills/first-tree-cli-framework/references/ownership-and-naming.md`.
 <!-- END CONTEXT-TREE FRAMEWORK -->
 
 # Project-Specific Instructions

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/templates/members-domain.md.template
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/templates/members-domain.md.template
@@ -34,7 +34,7 @@ domains:
 ---
 ```
 
-See `.context-tree/templates/member-node.md.template` for a full scaffold.
+See `skills/first-tree-cli-framework/assets/framework/templates/member-node.md.template` for a full scaffold.
 
 ---
 

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/templates/root-node.md.template
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/templates/root-node.md.template
@@ -31,8 +31,8 @@ The living source of truth for your organization. A structured knowledge base th
 
 See [AGENT.md](AGENT.md) for agent instructions — the before/during/after workflow, ownership model, and tree maintenance.
 
-See [about.md](about.md) for background — the problem, the idea, and who it's for.
+See [about.md](skills/first-tree-cli-framework/references/about.md) for background — the problem, the idea, and who it's for.
 
-See the framework documentation in `.context-tree/`:
-- [principles.md](.context-tree/principles.md) — core principles with examples
-- [ownership-and-naming.md](.context-tree/ownership-and-naming.md) — node naming and ownership model
+See the installed framework documentation:
+- [principles.md](skills/first-tree-cli-framework/references/principles.md) — core principles with examples
+- [ownership-and-naming.md](skills/first-tree-cli-framework/references/ownership-and-naming.md) — node naming and ownership model

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/workflows/codeowners.yml
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/workflows/codeowners.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: "22"
 
-      - run: npx tsx .context-tree/generate-codeowners.ts
+      - run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/generate-codeowners.ts
 
       - name: Commit if changed
         run: |

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/workflows/pr-review.yml
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/workflows/pr-review.yml
@@ -45,7 +45,7 @@ jobs:
           gh pr view "$PR_NUMBER" --json headRefOid -q .headRefOid > /tmp/pr-head-sha.txt
 
       - name: Run Claude review
-        run: npx tsx .context-tree/run-review.ts
+        run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/run-review.ts
 
       - name: Parse and post review
         run: |

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/AGENTS.md
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/AGENTS.md
@@ -9,7 +9,7 @@ This repo is the **template source and CLI** for Context Tree. It is NOT a conte
   - `src/validators/` — Node, member, and CODEOWNERS validation
 - `src/runtime/` — Shared path, install, adapter, and upgrade helpers
 - `skills/first-tree-cli-framework/` — Canonical skill source for docs and shipped runtime assets
-- `.context-tree/` — Temporary exported mirror of the shipped runtime assets during the single-skill migration
+- `.context-tree/` — Temporary exported mirror in the source repo during the single-skill migration
   - `tests/` — Unit tests (Vitest)
   - `docs/` — Introduction and documentation
 
@@ -17,7 +17,7 @@ This repo is the **template source and CLI** for Context Tree. It is NOT a conte
 
 - The CLI is a **harness for the agent** — it generates situation-aware task lists, not executes them
 - `skills/first-tree-cli-framework/` is the single canonical source; `assets/framework/` is the shipped runtime payload
-- `.context-tree/` is currently an exported compatibility mirror while the refactor converges
+- New user repos install `skills/first-tree-cli-framework/` directly; `.context-tree/` remains only as a source-repo compatibility mirror while the refactor converges
 - Templates in `skills/first-tree-cli-framework/assets/framework/templates/` ultimately render `NODE.md`, `AGENT.md`, `members/NODE.md` in users' repos
 - The npm package is `first-tree`, and it installs the `context-tree` command. Use `npx first-tree ...` for one-off runs or `npm install -g first-tree` to put `context-tree` on your PATH.
 

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/docs/onboarding.md
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/docs/onboarding.md
@@ -65,19 +65,19 @@ git init
 context-tree init
 ```
 
-This clones the framework into `.context-tree/`, renders scaffolding (`NODE.md`, `AGENT.md`, `members/NODE.md`), and generates a task list in `.context-tree/progress.md`.
+This installs the framework skill into `skills/first-tree-cli-framework/`, renders scaffolding (`NODE.md`, `AGENT.md`, `members/NODE.md`), and generates a task list in `skills/first-tree-cli-framework/progress.md`.
 
 ### Step 2: Work Through the Task List
 
-Read `.context-tree/progress.md`. It contains a checklist tailored to the current state of the repo. Complete each task:
+Read `skills/first-tree-cli-framework/progress.md`. It contains a checklist tailored to the current state of the repo. Complete each task:
 
 - Fill in `NODE.md` with your organization name, owners, and domains
 - Add project-specific instructions to `AGENT.md` below the framework markers
 - Create member nodes under `members/`
 - Optionally configure agent integration (e.g., Claude Code session hooks)
-- Copy validation workflows to `.github/workflows/`
+- Copy validation workflows from `skills/first-tree-cli-framework/assets/framework/workflows/` to `.github/workflows/`
 
-As you complete each task, check it off in `progress.md` by changing `- [ ]` to `- [x]`.
+As you complete each task, check it off in `skills/first-tree-cli-framework/progress.md` by changing `- [ ]` to `- [x]`.
 
 ### Step 3: Verify
 
@@ -85,7 +85,7 @@ As you complete each task, check it off in `progress.md` by changing `- [ ]` to 
 context-tree verify
 ```
 
-This fails if any items in `progress.md` remain unchecked, and runs deterministic checks (valid frontmatter, node structure, member nodes exist).
+This fails if any items in `skills/first-tree-cli-framework/progress.md` remain unchecked, and runs deterministic checks (valid frontmatter, node structure, member nodes exist).
 
 ### Step 4: Design Your Domains
 
@@ -122,27 +122,27 @@ The tree doesn't duplicate source code — it captures what connects things and 
 
 | Command | Description |
 |---------|-------------|
-| `context-tree init` | Bootstrap a new tree. Clones framework, renders templates, generates task list. |
-| `context-tree verify` | Check progress.md for unchecked items + run deterministic validation. |
-| `context-tree upgrade` | Compare local framework version to upstream, generate upgrade task list. |
+| `context-tree init` | Bootstrap a new tree. Installs the framework skill, renders templates, generates a task list. |
+| `context-tree verify` | Check the installed progress file for unchecked items + run deterministic validation. |
+| `context-tree upgrade` | Refresh the installed framework skill from upstream and generate follow-up tasks. |
 | `context-tree help onboarding` | Print this onboarding guide. |
 
 ---
 
 ## Upgrading the Framework
 
-After init, the first-tree repo is added as a git remote (`context-tree-upstream`). When the framework updates:
+When the framework updates:
 
 ```bash
 context-tree upgrade
 ```
 
-This compares your `.context-tree/VERSION` to upstream and generates a task list. The framework directory (`.context-tree/`) is upgradable without touching your content.
+This refreshes `skills/first-tree-cli-framework/` from upstream, preserves your tree content, and generates follow-up tasks in `skills/first-tree-cli-framework/progress.md`.
 
 ---
 
 ## Further Reading
 
-- `.context-tree/principles.md` — Core principles with detailed examples
-- `.context-tree/ownership-and-naming.md` — How nodes are named and owned
+- `skills/first-tree-cli-framework/references/principles.md` — Core principles with detailed examples
+- `skills/first-tree-cli-framework/references/ownership-and-naming.md` — How nodes are named and owned
 - `AGENT.md` in your tree — The before/during/after workflow for every task

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/package.json
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/package.json
@@ -9,7 +9,8 @@
   "imports": {
     "#src/*.js": "./src/*.ts",
     "#evals/*.js": "./evals/*.ts",
-    "#docs/*": "./docs/*"
+    "#docs/*": "./docs/*",
+    "#skill/*": "./skills/first-tree-cli-framework/*"
   },
   "files": [
     "dist"

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/cli.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/cli.ts
@@ -5,9 +5,9 @@ const USAGE = `usage: context-tree <command>
   New to context-tree? Run \`context-tree help onboarding\` first.
 
 Commands:
-  init      Bootstrap a new context tree (clones first-tree, copies framework files)
+  init      Bootstrap a new context tree (installs the framework skill)
   verify    Run verification checks against the current tree
-  upgrade   Generate an upgrade task list from upstream changes
+  upgrade   Refresh the installed skill from upstream and generate follow-up tasks
   help      Show help for a topic (e.g. \`help onboarding\`)
 
 Options:

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/init.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/init.ts
@@ -1,24 +1,26 @@
-import { execFileSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
-  mkdtempSync,
-  rmSync,
   writeFileSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
-import { tmpdir } from "node:os";
 import { Repo } from "#src/repo.js";
 import { ONBOARDING_TEXT } from "#src/onboarding.js";
 import { evaluateAll } from "#src/rules/index.js";
 import type { RuleResult } from "#src/rules/index.js";
 import {
-  copyLegacyFrameworkMirror,
+  copyCanonicalSkill,
   renderTemplateFile,
 } from "#src/runtime/installer.js";
-import { FRAMEWORK_ASSET_ROOT } from "#src/runtime/asset-loader.js";
-
-const FIRST_TREE_REPO_URL = "https://github.com/agent-team-foundation/first-tree";
+import {
+  FRAMEWORK_ASSET_ROOT,
+  FRAMEWORK_VERSION,
+  INSTALLED_PROGRESS,
+} from "#src/runtime/asset-loader.js";
+import {
+  cleanupUpstreamRepo,
+  cloneUpstreamRepo,
+} from "#src/runtime/upgrader.js";
 
 /**
  * The interactive prompt tool the agent should use to present choices.
@@ -33,57 +35,19 @@ const TEMPLATE_MAP: [string, string][] = [
   ["members-domain.md.template", "members/NODE.md"],
 ];
 
-function cloneFirstTree(): string {
-  const tmp = mkdtempSync(join(tmpdir(), "context-tree-"));
-  console.log(`Cloning first-tree from ${FIRST_TREE_REPO_URL}...`);
-  try {
-    execFileSync("git", ["clone", "--depth", "1", FIRST_TREE_REPO_URL, tmp], {
-      encoding: "utf-8",
-      stdio: "pipe",
-    });
-  } catch (err) {
-    const message =
-      err instanceof Error ? err.message : "unknown error";
-    console.error(`Failed to clone first-tree: ${message}`);
-    rmSync(tmp, { recursive: true, force: true });
-    process.exit(1);
-  }
-  return tmp;
+function installSkill(source: string, target: string): void {
+  copyCanonicalSkill(source, target);
+  console.log("  Installed skills/first-tree-cli-framework/ from the upstream skill");
 }
 
-function copyFramework(source: string, target: string): void {
-  copyLegacyFrameworkMirror(source, target);
-  console.log("  Copied .context-tree/ from the canonical skill assets");
-}
-
-function renderTemplates(frameworkDir: string, target: string): void {
+function renderTemplates(target: string): void {
+  const frameworkDir = join(target, FRAMEWORK_ASSET_ROOT);
   for (const [templateName, targetPath] of TEMPLATE_MAP) {
     if (existsSync(join(target, targetPath))) {
       console.log(`  Skipped ${targetPath} (already exists)`);
     } else if (renderTemplateFile(frameworkDir, templateName, target, targetPath)) {
       console.log(`  Created ${targetPath}`);
     }
-  }
-}
-
-function addUpstreamRemote(target: string): void {
-  try {
-    const result = execFileSync("git", ["remote"], {
-      cwd: target,
-      encoding: "utf-8",
-    });
-    if (!result.split(/\s+/).includes("context-tree-upstream")) {
-      execFileSync(
-        "git",
-        ["remote", "add", "context-tree-upstream", FIRST_TREE_REPO_URL],
-        { cwd: target, encoding: "utf-8", stdio: "pipe" },
-      );
-      console.log(
-        `  Added git remote 'context-tree-upstream' -> ${FIRST_TREE_REPO_URL}`,
-      );
-    }
-  } catch {
-    // ignore
   }
 }
 
@@ -110,7 +74,7 @@ export function formatTaskList(groups: RuleResult[]): string {
   lines.push(
     "After completing the tasks above, run `context-tree verify` to confirm:",
   );
-  lines.push("- [ ] `.context-tree/VERSION` exists");
+  lines.push(`- [ ] \`${FRAMEWORK_VERSION}\` exists`);
   lines.push("- [ ] Root NODE.md has valid frontmatter (title, owners)");
   lines.push("- [ ] AGENT.md exists with framework markers");
   lines.push("- [ ] `context-tree verify` passes with no errors");
@@ -120,7 +84,7 @@ export function formatTaskList(groups: RuleResult[]): string {
   lines.push("");
   lines.push(
     "**Important:** As you complete each task, check it off in" +
-      " `.context-tree/progress.md` by changing `- [ ]` to `- [x]`." +
+      ` \`${INSTALLED_PROGRESS}\` by changing \`- [ ]\` to \`- [x]\`.` +
       " Run `context-tree verify` when done — it will fail if any" +
       " items remain unchecked.",
   );
@@ -129,7 +93,7 @@ export function formatTaskList(groups: RuleResult[]): string {
 }
 
 export function writeProgress(repo: Repo, content: string): void {
-  const progressPath = join(repo.root, ".context-tree", "progress.md");
+  const progressPath = join(repo.root, repo.preferredProgressPath());
   mkdirSync(dirname(progressPath), { recursive: true });
   writeFileSync(progressPath, content);
 }
@@ -145,15 +109,14 @@ export function runInit(repo?: Repo): number {
   }
 
   if (!r.hasFramework()) {
-    const seed = cloneFirstTree();
+    console.log("Cloning first-tree to install the framework skill...");
+    const seed = cloneUpstreamRepo();
     try {
-      console.log("Copying framework and scaffolding...");
-      copyFramework(seed, r.root);
-      const frameworkDir = join(seed, FRAMEWORK_ASSET_ROOT);
-      renderTemplates(frameworkDir, r.root);
-      addUpstreamRemote(r.root);
+      console.log("Installing skill and scaffolding...");
+      installSkill(seed, r.root);
+      renderTemplates(r.root);
     } finally {
-      rmSync(seed, { recursive: true, force: true });
+      cleanupUpstreamRepo(seed);
     }
     console.log();
   }
@@ -170,6 +133,6 @@ export function runInit(repo?: Repo): number {
   const output = formatTaskList(groups);
   console.log(output);
   writeProgress(r, output);
-  console.log("Progress file written to .context-tree/progress.md");
+  console.log(`Progress file written to ${r.preferredProgressPath()}`);
   return 0;
 }

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/onboarding.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/onboarding.ts
@@ -1,4 +1,4 @@
-import ONBOARDING_TEXT from "#docs/onboarding.md";
+import ONBOARDING_TEXT from "#skill/references/onboarding.md";
 
 export { ONBOARDING_TEXT };
 

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/repo.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/repo.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 import {
@@ -6,6 +5,7 @@ import {
   LEGACY_PROGRESS,
   LEGACY_VERSION,
   INSTALLED_PROGRESS,
+  type FrameworkLayout,
   detectFrameworkLayout,
   progressFileCandidates,
   resolveFirstExistingPath,
@@ -90,7 +90,11 @@ export class Repo {
   }
 
   hasFramework(): boolean {
-    return detectFrameworkLayout(this.root) !== null;
+    return this.frameworkLayout() !== null;
+  }
+
+  frameworkLayout(): FrameworkLayout | null {
+    return detectFrameworkLayout(this.root);
   }
 
   readVersion(): string | null {
@@ -106,7 +110,11 @@ export class Repo {
   }
 
   preferredProgressPath(): string {
-    return this.pathExists(INSTALLED_PROGRESS) ? INSTALLED_PROGRESS : LEGACY_PROGRESS;
+    return this.frameworkLayout() === "legacy" ? LEGACY_PROGRESS : INSTALLED_PROGRESS;
+  }
+
+  frameworkVersionPath(): string {
+    return this.frameworkLayout() === "legacy" ? LEGACY_VERSION : FRAMEWORK_VERSION;
   }
 
   hasAgentMdMarkers(): boolean {
@@ -153,17 +161,5 @@ export class Repo {
 
   hasPlaceholderNode(): boolean {
     return this.fileContains("NODE.md", "<!-- PLACEHOLDER");
-  }
-
-  hasUpstreamRemote(): boolean {
-    try {
-      const result = execFileSync("git", ["remote"], {
-        cwd: this.root,
-        encoding: "utf-8",
-      });
-      return result.split(/\s+/).includes("context-tree-upstream");
-    } catch {
-      return false;
-    }
   }
 }

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/agent-instructions.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/agent-instructions.ts
@@ -1,12 +1,13 @@
 import { FRAMEWORK_END_MARKER } from "#src/repo.js";
 import type { Repo } from "#src/repo.js";
 import type { RuleResult } from "#src/rules/index.js";
+import { FRAMEWORK_TEMPLATES_DIR } from "#src/runtime/asset-loader.js";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
   if (!repo.pathExists("AGENT.md")) {
     tasks.push(
-      "AGENT.md is missing — create from `.context-tree/templates/agent.md.template`",
+      `AGENT.md is missing — create from \`${FRAMEWORK_TEMPLATES_DIR}/agent.md.template\``,
     );
   } else if (!repo.hasAgentMdMarkers()) {
     tasks.push(

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/agent-integration.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/agent-integration.ts
@@ -1,17 +1,18 @@
 import type { Repo } from "#src/repo.js";
 import type { RuleResult } from "#src/rules/index.js";
+import { FRAMEWORK_EXAMPLES_DIR } from "#src/runtime/asset-loader.js";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
   if (repo.pathExists(".claude/settings.json")) {
     if (!repo.fileContains(".claude/settings.json", "inject-tree-context")) {
       tasks.push(
-        "Add SessionStart hook to `.claude/settings.json` (see `.context-tree/examples/claude-code/`)",
+        `Add SessionStart hook to \`.claude/settings.json\` (see \`${FRAMEWORK_EXAMPLES_DIR}/claude-code/\`)`,
       );
     }
   } else if (!repo.anyAgentConfig()) {
     tasks.push(
-      "No agent configuration detected. Configure your agent to load tree context at session start. See `.context-tree/examples/` for supported agents. You can skip this and set it up later.",
+      `No agent configuration detected. Configure your agent to load tree context at session start. See \`${FRAMEWORK_EXAMPLES_DIR}/\` for supported agents. You can skip this and set it up later.`,
     );
   }
   return { group: "Agent Integration", order: 5, tasks };

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/ci-validation.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/ci-validation.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { INTERACTIVE_TOOL } from "#src/init.js";
 import type { Repo } from "#src/repo.js";
 import type { RuleResult } from "#src/rules/index.js";
+import { FRAMEWORK_WORKFLOWS_DIR } from "#src/runtime/asset-loader.js";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
@@ -40,7 +41,7 @@ export function evaluate(repo: Repo): RuleResult {
   }
   if (!hasValidation) {
     tasks.push(
-      "No validation workflow found — copy `.context-tree/workflows/validate.yml` to `.github/workflows/validate.yml`",
+      `No validation workflow found — copy \`${FRAMEWORK_WORKFLOWS_DIR}/validate.yml\` to \`.github/workflows/validate.yml\``,
     );
   }
   if (!hasPrReview) {
@@ -49,7 +50,7 @@ export function evaluate(repo: Repo): RuleResult {
       "  1. **OpenRouter** — use an OpenRouter API key\n" +
       "  2. **Claude API** — use a Claude API key directly\n" +
       "  3. **Skip** — do not set up PR reviews\n" +
-      "If (1): copy `.context-tree/workflows/pr-review.yml` to `.github/workflows/pr-review.yml` as-is; the repo secret name is `OPENROUTER_API_KEY`. " +
+      `If (1): copy \`${FRAMEWORK_WORKFLOWS_DIR}/pr-review.yml\` to \`.github/workflows/pr-review.yml\` as-is; the repo secret name is \`OPENROUTER_API_KEY\`. ` +
       "If (2): copy the workflow and replace the `env` block with `ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}`, remove the `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, and `ANTHROPIC_DEFAULT_SONNET_MODEL` lines; the repo secret name is `ANTHROPIC_API_KEY`. " +
       "If (3): skip this and the next task.",
     );
@@ -64,7 +65,7 @@ export function evaluate(repo: Repo): RuleResult {
   }
   if (!hasCodeowners) {
     tasks.push(
-      "No CODEOWNERS workflow found — copy `.context-tree/workflows/codeowners.yml` to `.github/workflows/codeowners.yml` to auto-generate CODEOWNERS from tree ownership on every PR.",
+      `No CODEOWNERS workflow found — copy \`${FRAMEWORK_WORKFLOWS_DIR}/codeowners.yml\` to \`.github/workflows/codeowners.yml\` to auto-generate CODEOWNERS from tree ownership on every PR.`,
     );
   }
   return { group: "CI / Validation", order: 6, tasks };

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/framework.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/framework.ts
@@ -1,5 +1,6 @@
 import type { Repo } from "#src/repo.js";
 import type { RuleResult } from "#src/rules/index.js";
+import { SKILL_ROOT } from "#src/runtime/asset-loader.js";
 
 const FIRST_TREE_REPO_URL = "https://github.com/agent-team-foundation/first-tree";
 
@@ -7,7 +8,7 @@ export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
   if (!repo.hasFramework()) {
     tasks.push(
-      `\`.context-tree/\` not found — run \`context-tree init\` to clone the framework from ${FIRST_TREE_REPO_URL}`,
+      `\`${SKILL_ROOT}/\` not found — run \`context-tree init\` to install the framework skill from ${FIRST_TREE_REPO_URL}`,
     );
   }
   return { group: "Framework", order: 1, tasks };

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/root-node.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/root-node.ts
@@ -1,11 +1,12 @@
 import type { Repo } from "#src/repo.js";
 import type { RuleResult } from "#src/rules/index.js";
+import { FRAMEWORK_TEMPLATES_DIR } from "#src/runtime/asset-loader.js";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
   if (!repo.pathExists("NODE.md")) {
     tasks.push(
-      "NODE.md is missing — create from `.context-tree/templates/root-node.md.template`. " +
+      `NODE.md is missing — create from \`${FRAMEWORK_TEMPLATES_DIR}/root-node.md.template\`. ` +
       "Ask the user for their code repositories or project directories, then analyze the source to determine the project description and domain structure",
     );
   } else {

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/runtime/upgrader.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/runtime/upgrader.ts
@@ -1,38 +1,45 @@
 import { execFileSync } from "node:child_process";
-import { frameworkVersionCandidates } from "#src/runtime/asset-loader.js";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  frameworkVersionCandidates,
+  resolveFirstExistingPath,
+} from "#src/runtime/asset-loader.js";
 
-export function fetchUpstream(
-  repoRoot: string,
-  remote = "context-tree-upstream",
-): boolean {
+export const FIRST_TREE_REPO_URL =
+  "https://github.com/agent-team-foundation/first-tree";
+
+export function cloneUpstreamRepo(
+  repoUrl = FIRST_TREE_REPO_URL,
+): string {
+  const tmp = mkdtempSync(join(tmpdir(), "context-tree-upstream-"));
   try {
-    execFileSync("git", ["fetch", remote, "--depth", "1"], {
-      cwd: repoRoot,
+    execFileSync("git", ["clone", "--depth", "1", repoUrl, tmp], {
       encoding: "utf-8",
       stdio: "pipe",
     });
-    return true;
-  } catch {
-    return false;
+    return tmp;
+  } catch (err) {
+    rmSync(tmp, { recursive: true, force: true });
+    const message = err instanceof Error ? err.message : "unknown error";
+    throw new Error(`Failed to clone ${repoUrl}: ${message}`);
   }
 }
 
-export function readUpstreamVersion(
-  repoRoot: string,
-  remote = "context-tree-upstream",
-  ref = "main",
-): string | null {
-  for (const candidate of frameworkVersionCandidates()) {
-    try {
-      const result = execFileSync("git", ["show", `${remote}/${ref}:${candidate}`], {
-        cwd: repoRoot,
-        encoding: "utf-8",
-        stdio: "pipe",
-      });
-      return result.trim();
-    } catch {
-      continue;
-    }
+export function cleanupUpstreamRepo(root: string): void {
+  rmSync(root, { recursive: true, force: true });
+}
+
+export function readUpstreamVersion(sourceRoot: string): string | null {
+  const versionPath = resolveFirstExistingPath(
+    sourceRoot,
+    frameworkVersionCandidates(),
+  );
+  if (versionPath === null) return null;
+  try {
+    return readFileSync(join(sourceRoot, versionPath), "utf-8").trim();
+  } catch {
+    return null;
   }
-  return null;
 }

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/upgrade.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/upgrade.ts
@@ -1,100 +1,139 @@
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { Repo } from "#src/repo.js";
-import { fetchUpstream, readUpstreamVersion } from "#src/runtime/upgrader.js";
-
-const FIRST_TREE_REPO_URL = "https://github.com/agent-team-foundation/first-tree";
-
-function getUpstreamVersion(repo: Repo): string | null {
-  if (!fetchUpstream(repo.root)) {
-    return null;
-  }
-  return readUpstreamVersion(repo.root);
-}
+import {
+  FRAMEWORK_WORKFLOWS_DIR,
+  FRAMEWORK_TEMPLATES_DIR,
+  FRAMEWORK_VERSION,
+  INSTALLED_PROGRESS,
+  LEGACY_FRAMEWORK_ROOT,
+  SKILL_ROOT,
+} from "#src/runtime/asset-loader.js";
+import { copyCanonicalSkill } from "#src/runtime/installer.js";
+import {
+  cleanupUpstreamRepo,
+  cloneUpstreamRepo,
+  FIRST_TREE_REPO_URL,
+  readUpstreamVersion,
+} from "#src/runtime/upgrader.js";
 
 function writeProgress(repo: Repo, content: string): void {
-  const progressPath = join(repo.root, ".context-tree", "progress.md");
+  const progressPath = join(repo.root, repo.preferredProgressPath());
   mkdirSync(dirname(progressPath), { recursive: true });
   writeFileSync(progressPath, content);
 }
 
-export function runUpgrade(): number {
-  const repo = new Repo();
-
-  if (!repo.hasFramework()) {
-    console.error(
-      "Error: no .context-tree/ found. Run `context-tree init` first.",
-    );
-    return 1;
-  }
-
-  const localVersion = repo.readVersion() ?? "unknown";
-  console.log(`Local framework version: ${localVersion}\n`);
-
-  // Check for upstream remote
-  if (!repo.hasUpstreamRemote()) {
-    const lines = [
-      "# Context Tree Upgrade\n",
-      "## Setup",
-      `- [ ] Add upstream remote: \`git remote add context-tree-upstream ${FIRST_TREE_REPO_URL}\``,
-      "- [ ] Then run `context-tree upgrade` again to check for updates",
-    ];
-    const output = lines.join("\n");
-    console.log(output);
-    writeProgress(repo, output + "\n");
-    console.log("\nProgress file written to .context-tree/progress.md");
-    return 0;
-  }
-
-  // Fetch upstream version
-  const upstreamVersion = getUpstreamVersion(repo);
-  if (upstreamVersion === null) {
-    console.log(
-      "Could not fetch upstream version. Check your network and try again.",
-    );
-    return 1;
-  }
-
-  if (upstreamVersion === localVersion) {
-    console.log(`Already up to date (v${localVersion}).`);
-    return 0;
-  }
-
+function formatUpgradeTaskList(
+  repo: Repo,
+  localVersion: string,
+  upstreamVersion: string,
+  migratedFromLegacy: boolean,
+): string {
   const lines: string[] = [
     `# Context Tree Upgrade — v${localVersion} -> v${upstreamVersion}\n`,
-    "## Framework",
-    "- [ ] Pull latest from upstream: `git fetch context-tree-upstream && git merge context-tree-upstream/main`",
-    "- [ ] Resolve any conflicts in `.context-tree/` (framework files should generally take upstream version)",
+    "## Installed Skill",
+    `- [ ] Review local customizations under \`${SKILL_ROOT}/\` and reapply them if needed`,
+    `- [ ] Re-copy any workflow updates you want from \`${FRAMEWORK_WORKFLOWS_DIR}/\` into \`.github/workflows/\``,
+    `- [ ] Re-check any local agent setup that references \`${SKILL_ROOT}/assets/framework/examples/\` or \`${SKILL_ROOT}/assets/framework/helpers/\``,
     "",
   ];
 
-  // Check AGENT.md
+  if (migratedFromLegacy) {
+    lines.push(
+      "## Migration",
+      "- [ ] Remove any stale `.context-tree/` references from repo-specific docs, scripts, or workflow files",
+      "",
+    );
+  }
+
   if (repo.hasAgentMdMarkers()) {
     lines.push(
       "## Agent Instructions",
-      "- [ ] Check if AGENT.md framework section needs updating — compare content between markers to the new template",
+      `- [ ] Compare the framework section in \`AGENT.md\` with \`${FRAMEWORK_TEMPLATES_DIR}/agent.md.template\` and update the content between the markers if needed`,
       "",
     );
   }
 
   lines.push(
     "## Verification",
-    `- [ ] \`.context-tree/VERSION\` reads \`${upstreamVersion}\``,
+    `- [ ] \`${FRAMEWORK_VERSION}\` reads \`${upstreamVersion}\``,
     "- [ ] `context-tree verify` passes",
-    "- [ ] AGENT.md framework section matches upstream",
     "",
     "---",
     "",
     "**Important:** As you complete each task, check it off in" +
-      " `.context-tree/progress.md` by changing `- [ ]` to `- [x]`." +
+      ` \`${INSTALLED_PROGRESS}\` by changing \`- [ ]\` to \`- [x]\`.` +
       " Run `context-tree verify` when done — it will fail if any" +
       " items remain unchecked.",
     "",
   );
 
-  const output = lines.join("\n");
-  console.log(output);
-  writeProgress(repo, output);
-  console.log("Progress file written to .context-tree/progress.md");
-  return 0;
+  return lines.join("\n");
+}
+
+export interface UpgradeOptions {
+  upstreamRoot?: string;
+}
+
+export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
+  const workingRepo = repo ?? new Repo();
+
+  if (!workingRepo.hasFramework()) {
+    console.error(
+      "Error: no installed framework skill found. Run `context-tree init` first.",
+    );
+    return 1;
+  }
+
+  const layout = workingRepo.frameworkLayout();
+  const localVersion = workingRepo.readVersion() ?? "unknown";
+  console.log(`Local framework version: ${localVersion}\n`);
+
+  console.log(`Checking ${FIRST_TREE_REPO_URL} for the latest framework skill...`);
+
+  const clonedUpstream = options?.upstreamRoot === undefined;
+  const upstreamRoot = options?.upstreamRoot ?? cloneUpstreamRepo();
+
+  try {
+    const upstreamVersion = readUpstreamVersion(upstreamRoot);
+    if (upstreamVersion === null) {
+      console.log(
+        "Could not read the upstream framework version. Check your network and try again.",
+      );
+      return 1;
+    }
+
+    if (layout === "skill" && upstreamVersion === localVersion) {
+      console.log(`Already up to date (${FRAMEWORK_VERSION} = ${localVersion}).`);
+      return 0;
+    }
+
+    copyCanonicalSkill(upstreamRoot, workingRepo.root);
+    if (layout === "legacy") {
+      rmSync(join(workingRepo.root, LEGACY_FRAMEWORK_ROOT), {
+        recursive: true,
+        force: true,
+      });
+      console.log(
+        "Migrated legacy .context-tree/ layout to skills/first-tree-cli-framework/.",
+      );
+    } else {
+      console.log("Refreshed skills/first-tree-cli-framework/ from upstream.");
+    }
+
+    const output = formatUpgradeTaskList(
+      workingRepo,
+      localVersion,
+      upstreamVersion,
+      layout === "legacy",
+    );
+    console.log(`\n${output}`);
+    writeProgress(workingRepo, output);
+    console.log(`Progress file written to ${workingRepo.preferredProgressPath()}`);
+    return 0;
+  } finally {
+    if (clonedUpstream) {
+      cleanupUpstreamRepo(upstreamRoot);
+    }
+  }
 }

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/verify.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/src/verify.ts
@@ -39,19 +39,21 @@ export function runVerify(repo?: Repo, nodeValidator?: NodeValidator): number {
   const r = repo ?? new Repo();
   const validate = nodeValidator ?? defaultNodeValidator;
   let allPassed = true;
+  const progressPath = r.progressPath() ?? r.preferredProgressPath();
+  const frameworkVersionPath = r.frameworkVersionPath();
 
   console.log("Context Tree Verification\n");
 
   // Progress file check
   const unchecked = checkProgress(r);
   if (unchecked.length > 0) {
-    console.log("  Unchecked items in .context-tree/progress.md:\n");
+    console.log(`  Unchecked items in ${progressPath}:\n`);
     for (const item of unchecked) {
       console.log(`    - [ ] ${item}`);
     }
     console.log();
     console.log(
-      "  Verify each step above and check it off in progress.md before running verify again.\n",
+      `  Verify each step above and check it off in ${progressPath} before running verify again.\n`,
     );
     allPassed = false;
   }
@@ -60,7 +62,7 @@ export function runVerify(repo?: Repo, nodeValidator?: NodeValidator): number {
   console.log("  Checks:\n");
 
   // 1. Framework exists
-  allPassed = check(".context-tree/VERSION exists", r.hasFramework()) && allPassed;
+  allPassed = check(`${frameworkVersionPath} exists`, r.hasFramework()) && allPassed;
 
   // 2. Root NODE.md has valid frontmatter
   const fm = r.frontmatter("NODE.md");

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/tests/generate-codeowners.test.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/tests/generate-codeowners.test.ts
@@ -6,7 +6,7 @@ import {
   resolveNodeOwners,
   collectEntries,
   formatOwners,
-} from "../.context-tree/generate-codeowners.js";
+} from "../skills/first-tree-cli-framework/assets/framework/helpers/generate-codeowners.js";
 import { useTmpDir } from "./helpers.js";
 
 function write(root: string, relPath: string, content: string): string {

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/tests/helpers.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/tests/helpers.ts
@@ -2,6 +2,10 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach } from "vitest";
+import {
+  FRAMEWORK_VERSION,
+  LEGACY_VERSION,
+} from "#src/runtime/asset-loader.js";
 
 interface TmpDir {
   path: string;
@@ -15,10 +19,17 @@ export function useTmpDir(): TmpDir {
   return { path: dir };
 }
 
-export function makeFramework(root: string): void {
+export function makeFramework(root: string, version = "0.1.0"): void {
+  mkdirSync(join(root, "skills", "first-tree-cli-framework", "assets", "framework"), {
+    recursive: true,
+  });
+  writeFileSync(join(root, FRAMEWORK_VERSION), `${version}\n`);
+}
+
+export function makeLegacyFramework(root: string, version = "0.1.0"): void {
   const ct = join(root, ".context-tree");
   mkdirSync(ct, { recursive: true });
-  writeFileSync(join(ct, "VERSION"), "0.1.0\n");
+  writeFileSync(join(root, LEGACY_VERSION), `${version}\n`);
 }
 
 export function makeNode(

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/tests/init.test.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/tests/init.test.ts
@@ -3,7 +3,15 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { formatTaskList, writeProgress, runInit } from "#src/init.js";
 import { Repo } from "#src/repo.js";
-import { useTmpDir, makeFramework } from "./helpers.js";
+import {
+  INSTALLED_PROGRESS,
+  LEGACY_PROGRESS,
+} from "#src/runtime/asset-loader.js";
+import {
+  useTmpDir,
+  makeFramework,
+  makeLegacyFramework,
+} from "./helpers.js";
 
 // --- formatTaskList ---
 
@@ -66,7 +74,7 @@ describe("writeProgress", () => {
     const tmp = useTmpDir();
     const repo = new Repo(tmp.path);
     writeProgress(repo, "# hello\n");
-    const progress = join(tmp.path, ".context-tree", "progress.md");
+    const progress = join(tmp.path, INSTALLED_PROGRESS);
     expect(readFileSync(progress, "utf-8")).toBe("# hello\n");
   });
 
@@ -74,18 +82,27 @@ describe("writeProgress", () => {
     const tmp = useTmpDir();
     const repo = new Repo(tmp.path);
     writeProgress(repo, "content");
-    const progress = join(tmp.path, ".context-tree", "progress.md");
+    const progress = join(tmp.path, INSTALLED_PROGRESS);
     expect(readFileSync(progress, "utf-8")).toBe("content");
   });
 
   it("overwrites existing file", () => {
     const tmp = useTmpDir();
-    const ct = join(tmp.path, ".context-tree");
-    mkdirSync(ct);
-    writeFileSync(join(ct, "progress.md"), "old");
+    mkdirSync(join(tmp.path, "skills", "first-tree-cli-framework"), {
+      recursive: true,
+    });
+    writeFileSync(join(tmp.path, INSTALLED_PROGRESS), "old");
     const repo = new Repo(tmp.path);
     writeProgress(repo, "new");
-    expect(readFileSync(join(ct, "progress.md"), "utf-8")).toBe("new");
+    expect(readFileSync(join(tmp.path, INSTALLED_PROGRESS), "utf-8")).toBe("new");
+  });
+
+  it("keeps using the legacy progress path for legacy repos", () => {
+    const tmp = useTmpDir();
+    makeLegacyFramework(tmp.path);
+    const repo = new Repo(tmp.path);
+    writeProgress(repo, "legacy");
+    expect(readFileSync(join(tmp.path, LEGACY_PROGRESS), "utf-8")).toBe("legacy");
   });
 });
 

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/tests/repo.test.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/tests/repo.test.ts
@@ -2,7 +2,13 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { Repo } from "#src/repo.js";
-import { useTmpDir } from "./helpers.js";
+import {
+  FRAMEWORK_VERSION,
+  INSTALLED_PROGRESS,
+  LEGACY_PROGRESS,
+  LEGACY_VERSION,
+} from "#src/runtime/asset-loader.js";
+import { useTmpDir, makeFramework, makeLegacyFramework } from "./helpers.js";
 
 // --- pathExists ---
 
@@ -136,10 +142,16 @@ describe("isGitRepo", () => {
 // --- hasFramework ---
 
 describe("hasFramework", () => {
-  it("returns true with VERSION file", () => {
+  it("returns true with installed skill version file", () => {
     const tmp = useTmpDir();
-    mkdirSync(join(tmp.path, ".context-tree"));
-    writeFileSync(join(tmp.path, ".context-tree", "VERSION"), "0.1.0\n");
+    makeFramework(tmp.path);
+    const repo = new Repo(tmp.path);
+    expect(repo.hasFramework()).toBe(true);
+  });
+
+  it("returns true with legacy version file", () => {
+    const tmp = useTmpDir();
+    makeLegacyFramework(tmp.path);
     const repo = new Repo(tmp.path);
     expect(repo.hasFramework()).toBe(true);
   });
@@ -154,18 +166,43 @@ describe("hasFramework", () => {
 // --- readVersion ---
 
 describe("readVersion", () => {
-  it("reads valid version", () => {
+  it("reads the installed skill version", () => {
     const tmp = useTmpDir();
-    mkdirSync(join(tmp.path, ".context-tree"));
-    writeFileSync(join(tmp.path, ".context-tree", "VERSION"), "0.2.0\n");
+    makeFramework(tmp.path, "0.2.0");
     const repo = new Repo(tmp.path);
     expect(repo.readVersion()).toBe("0.2.0");
+  });
+
+  it("falls back to the legacy version", () => {
+    const tmp = useTmpDir();
+    makeLegacyFramework(tmp.path, "0.3.0");
+    const repo = new Repo(tmp.path);
+    expect(repo.readVersion()).toBe("0.3.0");
   });
 
   it("returns null when missing", () => {
     const tmp = useTmpDir();
     const repo = new Repo(tmp.path);
     expect(repo.readVersion()).toBeNull();
+  });
+});
+
+// --- preferredProgressPath / frameworkVersionPath ---
+
+describe("path preferences", () => {
+  it("prefers the installed-skill paths by default", () => {
+    const tmp = useTmpDir();
+    const repo = new Repo(tmp.path);
+    expect(repo.preferredProgressPath()).toBe(INSTALLED_PROGRESS);
+    expect(repo.frameworkVersionPath()).toBe(FRAMEWORK_VERSION);
+  });
+
+  it("switches path preferences for legacy repos", () => {
+    const tmp = useTmpDir();
+    makeLegacyFramework(tmp.path);
+    const repo = new Repo(tmp.path);
+    expect(repo.preferredProgressPath()).toBe(LEGACY_PROGRESS);
+    expect(repo.frameworkVersionPath()).toBe(LEGACY_VERSION);
   });
 });
 

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/tests/rules.test.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/tests/rules.test.ts
@@ -29,7 +29,7 @@ describe("framework rule", () => {
     const result = framework.evaluate(repo);
     expect(result.group).toBe("Framework");
     expect(result.tasks).toHaveLength(1);
-    expect(result.tasks[0]).toContain(".context-tree/");
+    expect(result.tasks[0]).toContain("skills/first-tree-cli-framework/");
   });
 
   it("passes when framework exists", () => {
@@ -214,6 +214,7 @@ describe("ciValidation rule", () => {
     const result = ciValidation.evaluate(repo);
     expect(result.tasks).toHaveLength(4);
     expect(result.tasks[0]).toContain("validation workflow");
+    expect(result.tasks[0]).toContain("skills/first-tree-cli-framework/assets/framework/workflows/validate.yml");
     expect(result.tasks[1]).toContain("PR reviews");
     expect(result.tasks[2]).toContain("API secret");
     expect(result.tasks[3]).toContain("CODEOWNERS");
@@ -251,7 +252,7 @@ describe("ciValidation rule", () => {
     mkdirSync(wfDir, { recursive: true });
     writeFileSync(
       join(wfDir, "pr-review.yml"),
-      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx .context-tree/run-review.ts\n",
+      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/run-review.ts\n",
     );
     const repo = new Repo(tmp.path);
     const result = ciValidation.evaluate(repo);
@@ -270,7 +271,7 @@ describe("ciValidation rule", () => {
     );
     writeFileSync(
       join(wfDir, "pr-review.yml"),
-      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx .context-tree/run-review.ts\n",
+      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/run-review.ts\n",
     );
     const repo = new Repo(tmp.path);
     const result = ciValidation.evaluate(repo);
@@ -288,11 +289,11 @@ describe("ciValidation rule", () => {
     );
     writeFileSync(
       join(wfDir, "pr-review.yml"),
-      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx .context-tree/run-review.ts\n",
+      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/run-review.ts\n",
     );
     writeFileSync(
       join(wfDir, "codeowners.yml"),
-      "name: Update CODEOWNERS\non: pull_request\njobs:\n  update:\n    steps:\n      - run: npx tsx .context-tree/generate-codeowners.ts\n",
+      "name: Update CODEOWNERS\non: pull_request\njobs:\n  update:\n    steps:\n      - run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/generate-codeowners.ts\n",
     );
     const repo = new Repo(tmp.path);
     const result = ciValidation.evaluate(repo);

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/tests/run-review.test.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/tests/run-review.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   extractStreamText,
   extractReviewJson,
-} from "../.context-tree/run-review.js";
+} from "../skills/first-tree-cli-framework/assets/framework/helpers/run-review.js";
 
 // --- extractStreamText ---
 

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/tests/upgrade.test.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/tests/upgrade.test.ts
@@ -1,0 +1,58 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { Repo } from "#src/repo.js";
+import { runUpgrade } from "#src/upgrade.js";
+import {
+  FRAMEWORK_VERSION,
+  INSTALLED_PROGRESS,
+} from "#src/runtime/asset-loader.js";
+import { makeFramework, makeLegacyFramework, useTmpDir } from "./helpers.js";
+
+function makeUpstreamSkill(root: string, version: string): void {
+  const skillRoot = join(root, "skills", "first-tree-cli-framework");
+  mkdirSync(join(skillRoot, "assets", "framework"), { recursive: true });
+  writeFileSync(
+    join(skillRoot, "SKILL.md"),
+    "---\nname: first-tree-cli-framework\ndescription: test\n---\n",
+  );
+  writeFileSync(join(root, FRAMEWORK_VERSION), `${version}\n`);
+}
+
+describe("runUpgrade", () => {
+  it("migrates a legacy repo to the installed skill layout", () => {
+    const repoDir = useTmpDir();
+    const upstreamDir = useTmpDir();
+    makeLegacyFramework(repoDir.path, "0.1.0");
+    writeFileSync(
+      join(repoDir.path, "AGENT.md"),
+      "<!-- BEGIN CONTEXT-TREE FRAMEWORK -->\nstuff\n<!-- END CONTEXT-TREE FRAMEWORK -->\n",
+    );
+    makeUpstreamSkill(upstreamDir.path, "0.2.0");
+
+    const result = runUpgrade(new Repo(repoDir.path), {
+      upstreamRoot: upstreamDir.path,
+    });
+
+    expect(result).toBe(0);
+    expect(existsSync(join(repoDir.path, ".context-tree"))).toBe(false);
+    expect(readFileSync(join(repoDir.path, FRAMEWORK_VERSION), "utf-8").trim()).toBe("0.2.0");
+    expect(readFileSync(join(repoDir.path, INSTALLED_PROGRESS), "utf-8")).toContain(
+      "skills/first-tree-cli-framework/assets/framework/VERSION",
+    );
+  });
+
+  it("returns early when the installed skill is already current", () => {
+    const repoDir = useTmpDir();
+    const upstreamDir = useTmpDir();
+    makeFramework(repoDir.path, "0.2.0");
+    makeUpstreamSkill(upstreamDir.path, "0.2.0");
+
+    const result = runUpgrade(new Repo(repoDir.path), {
+      upstreamRoot: upstreamDir.path,
+    });
+
+    expect(result).toBe(0);
+    expect(existsSync(join(repoDir.path, INSTALLED_PROGRESS))).toBe(false);
+  });
+});

--- a/.agents/skills/first-tree-cli-framework/references/repo-snapshot/tests/verify.test.ts
+++ b/.agents/skills/first-tree-cli-framework/references/repo-snapshot/tests/verify.test.ts
@@ -3,7 +3,18 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { check, checkProgress, runVerify } from "#src/verify.js";
 import { Repo } from "#src/repo.js";
-import { useTmpDir, makeFramework, makeNode, makeAgentMd, makeMembers } from "./helpers.js";
+import {
+  INSTALLED_PROGRESS,
+  LEGACY_PROGRESS,
+} from "#src/runtime/asset-loader.js";
+import {
+  useTmpDir,
+  makeFramework,
+  makeLegacyFramework,
+  makeNode,
+  makeAgentMd,
+  makeMembers,
+} from "./helpers.js";
 
 // --- check ---
 
@@ -28,10 +39,9 @@ describe("checkProgress", () => {
 
   it("returns empty when all checked", () => {
     const tmp = useTmpDir();
-    const ct = join(tmp.path, ".context-tree");
-    mkdirSync(ct);
+    mkdirSync(join(tmp.path, "skills", "first-tree-cli-framework"), { recursive: true });
     writeFileSync(
-      join(ct, "progress.md"),
+      join(tmp.path, INSTALLED_PROGRESS),
       "# Progress\n- [x] Task one\n- [x] Task two\n",
     );
     const repo = new Repo(tmp.path);
@@ -40,10 +50,9 @@ describe("checkProgress", () => {
 
   it("returns unchecked items", () => {
     const tmp = useTmpDir();
-    const ct = join(tmp.path, ".context-tree");
-    mkdirSync(ct);
+    mkdirSync(join(tmp.path, "skills", "first-tree-cli-framework"), { recursive: true });
     writeFileSync(
-      join(ct, "progress.md"),
+      join(tmp.path, INSTALLED_PROGRESS),
       "# Progress\n- [x] Done task\n- [ ] Pending task\n- [ ] Another pending\n",
     );
     const repo = new Repo(tmp.path);
@@ -52,11 +61,21 @@ describe("checkProgress", () => {
 
   it("returns empty for empty progress", () => {
     const tmp = useTmpDir();
-    const ct = join(tmp.path, ".context-tree");
-    mkdirSync(ct);
-    writeFileSync(join(ct, "progress.md"), "");
+    mkdirSync(join(tmp.path, "skills", "first-tree-cli-framework"), { recursive: true });
+    writeFileSync(join(tmp.path, INSTALLED_PROGRESS), "");
     const repo = new Repo(tmp.path);
     expect(checkProgress(repo)).toEqual([]);
+  });
+
+  it("falls back to the legacy progress file", () => {
+    const tmp = useTmpDir();
+    makeLegacyFramework(tmp.path);
+    writeFileSync(
+      join(tmp.path, LEGACY_PROGRESS),
+      "# Progress\n- [ ] Legacy task\n",
+    );
+    const repo = new Repo(tmp.path);
+    expect(checkProgress(repo)).toEqual(["Legacy task"]);
   });
 });
 

--- a/.agents/skills/first-tree-cli-framework/references/source-map.md
+++ b/.agents/skills/first-tree-cli-framework/references/source-map.md
@@ -19,7 +19,7 @@ This file is the fast index for the new single-skill architecture.
 | --- | --- |
 | `src/cli.ts` | Top-level command dispatch |
 | `src/commands/help.ts` | Help topic routing |
-| `src/init.ts` / `src/verify.ts` / `src/upgrade.ts` | Existing command implementations while the refactor converges |
+| `src/init.ts` / `src/verify.ts` / `src/upgrade.ts` | Command implementations for install, verify, and upgrade |
 | `src/commands/` | Stable command entrypoints the CLI imports |
 | `src/runtime/asset-loader.ts` | Canonical path constants and layout detection |
 | `src/runtime/installer.ts` | Copy and template-render helpers |
@@ -39,6 +39,7 @@ The installed skill payload lives under `assets/framework/`.
 | `assets/framework/prompts/` | Review prompt payload |
 | `assets/framework/examples/` | Agent integration examples |
 | `assets/framework/helpers/` | Shipped helper scripts and TypeScript utilities |
+| `progress.md` | Generated in user repos to track unfinished setup or upgrade tasks |
 
 ## Validation Surface
 
@@ -56,8 +57,8 @@ The installed skill payload lives under `assets/framework/`.
 
 ## Compatibility Notes
 
-- `docs/` and root `.context-tree/` are temporary exported mirrors while the
-  repo transitions to a single canonical skill.
+- In the source repo, `docs/` and root `.context-tree/` are temporary exported
+  mirrors. They are no longer part of the user-repo contract.
 - `references/repo-snapshot/` is a portable artifact, not the source of truth.
 - If you change `references/` or `assets/framework/`, run
   `bash ./skills/first-tree-cli-framework/scripts/sync-skill-artifacts.sh`.

--- a/.agents/skills/first-tree-cli-framework/references/upgrade-contract.md
+++ b/.agents/skills/first-tree-cli-framework/references/upgrade-contract.md
@@ -18,6 +18,7 @@ The end-state installed layout in a user repo is:
 skills/
   first-tree-cli-framework/
     SKILL.md
+    progress.md
     references/
     assets/
       framework/
@@ -41,15 +42,15 @@ The tree content still lives outside the skill:
 - `context-tree init`
   - installs the skill into the target repo
   - renders top-level tree scaffolding from the skill templates
-  - writes progress state
-  - wires an upstream remote for future upgrades
+  - writes progress state to `skills/first-tree-cli-framework/progress.md`
 - `context-tree verify`
-  - checks progress state
+  - checks progress state from the installed skill
   - validates root/frontmatter/agent markers
   - runs node and member validators
 - `context-tree upgrade`
   - compares the installed skill payload version to upstream
   - refreshes the installed skill payload without overwriting tree content
+  - migrates legacy `.context-tree/` repos onto the installed skill layout
   - preserves user-authored sections such as the editable part of `AGENT.md`
 
 ## Compatibility Rules During Migration
@@ -58,6 +59,8 @@ The tree content still lives outside the skill:
   - `skills/first-tree-cli-framework/...`
   - legacy `.context-tree/...`
 - When both layouts are present, prefer the installed skill layout.
+- `context-tree init` only installs the skill layout; it does not create a new `.context-tree/`.
+- `context-tree upgrade` should remove legacy `.context-tree/` after migrating a repo.
 - The legacy layout must be derivable from the canonical skill via
   `scripts/export-runtime-assets.sh`.
 - `references/repo-snapshot/` may exist as a portable artifact until cleanup,

--- a/.claude/skills/first-tree-cli-framework/assets/framework/examples/claude-code/README.md
+++ b/.claude/skills/first-tree-cli-framework/assets/framework/examples/claude-code/README.md
@@ -6,10 +6,9 @@ Copy `settings.json` to your tree repo's `.claude/` directory:
 
 ```bash
 mkdir -p .claude
-cp .context-tree/examples/claude-code/settings.json .claude/settings.json
+cp skills/first-tree-cli-framework/assets/framework/examples/claude-code/settings.json .claude/settings.json
 ```
 
 ## What It Does
 
-The `SessionStart` hook runs `.context-tree/scripts/inject-tree-context.sh` when a Claude Code session begins. This injects the root `NODE.md` content as additional context, giving the agent an overview of the tree structure before any task.
-
+The `SessionStart` hook runs `./skills/first-tree-cli-framework/assets/framework/helpers/inject-tree-context.sh` when a Claude Code session begins. This injects the root `NODE.md` content as additional context, giving the agent an overview of the tree structure before any task.

--- a/.claude/skills/first-tree-cli-framework/assets/framework/examples/claude-code/settings.json
+++ b/.claude/skills/first-tree-cli-framework/assets/framework/examples/claude-code/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".context-tree/scripts/inject-tree-context.sh"
+            "command": "./skills/first-tree-cli-framework/assets/framework/helpers/inject-tree-context.sh"
           }
         ]
       }

--- a/.claude/skills/first-tree-cli-framework/assets/framework/helpers/generate-codeowners.ts
+++ b/.claude/skills/first-tree-cli-framework/assets/framework/helpers/generate-codeowners.ts
@@ -205,7 +205,7 @@ export function generate(
       return 0;
     }
     console.log(
-      "CODEOWNERS is out-of-date. Run: npx tsx .context-tree/generate-codeowners.ts",
+      "CODEOWNERS is out-of-date. Run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/generate-codeowners.ts",
     );
     return 1;
   }

--- a/.claude/skills/first-tree-cli-framework/assets/framework/helpers/run-review.ts
+++ b/.claude/skills/first-tree-cli-framework/assets/framework/helpers/run-review.ts
@@ -23,7 +23,10 @@ function buildPrompt(diffPath: string): string {
   const files: [string, string][] = [
     ["AGENT.md", "AGENT.md"],
     ["Root NODE.md", "NODE.md"],
-    ["Review Instructions", ".context-tree/prompts/pr-review.md"],
+    [
+      "Review Instructions",
+      "skills/first-tree-cli-framework/assets/framework/prompts/pr-review.md",
+    ],
   ];
   for (const [heading, path] of files) {
     const content = readFileSync(path, "utf-8");

--- a/.claude/skills/first-tree-cli-framework/assets/framework/templates/agent.md.template
+++ b/.claude/skills/first-tree-cli-framework/assets/framework/templates/agent.md.template
@@ -13,7 +13,7 @@ You are working in a **Context Tree** — the living source of truth for decisio
 
 4. **Git-native tree structure.** Each node is a file; each domain is a directory. Soft links allow cross-references without the complexity of a full graph. History, ownership, and review follow Git conventions.
 
-See `.context-tree/principles.md` for detailed explanations and examples.
+See `skills/first-tree-cli-framework/references/principles.md` for detailed explanations and examples.
 
 ## Before Every Task
 
@@ -40,7 +40,7 @@ Ask yourself: **Does the tree need updating?**
 
 ## Reference
 
-For ownership rules, tree structure, and key files, see [NODE.md](NODE.md) and `.context-tree/ownership-and-naming.md`.
+For ownership rules, tree structure, and key files, see [NODE.md](NODE.md) and `skills/first-tree-cli-framework/references/ownership-and-naming.md`.
 <!-- END CONTEXT-TREE FRAMEWORK -->
 
 # Project-Specific Instructions

--- a/.claude/skills/first-tree-cli-framework/assets/framework/templates/members-domain.md.template
+++ b/.claude/skills/first-tree-cli-framework/assets/framework/templates/members-domain.md.template
@@ -34,7 +34,7 @@ domains:
 ---
 ```
 
-See `.context-tree/templates/member-node.md.template` for a full scaffold.
+See `skills/first-tree-cli-framework/assets/framework/templates/member-node.md.template` for a full scaffold.
 
 ---
 

--- a/.claude/skills/first-tree-cli-framework/assets/framework/templates/root-node.md.template
+++ b/.claude/skills/first-tree-cli-framework/assets/framework/templates/root-node.md.template
@@ -31,8 +31,8 @@ The living source of truth for your organization. A structured knowledge base th
 
 See [AGENT.md](AGENT.md) for agent instructions — the before/during/after workflow, ownership model, and tree maintenance.
 
-See [about.md](about.md) for background — the problem, the idea, and who it's for.
+See [about.md](skills/first-tree-cli-framework/references/about.md) for background — the problem, the idea, and who it's for.
 
-See the framework documentation in `.context-tree/`:
-- [principles.md](.context-tree/principles.md) — core principles with examples
-- [ownership-and-naming.md](.context-tree/ownership-and-naming.md) — node naming and ownership model
+See the installed framework documentation:
+- [principles.md](skills/first-tree-cli-framework/references/principles.md) — core principles with examples
+- [ownership-and-naming.md](skills/first-tree-cli-framework/references/ownership-and-naming.md) — node naming and ownership model

--- a/.claude/skills/first-tree-cli-framework/assets/framework/workflows/codeowners.yml
+++ b/.claude/skills/first-tree-cli-framework/assets/framework/workflows/codeowners.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: "22"
 
-      - run: npx tsx .context-tree/generate-codeowners.ts
+      - run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/generate-codeowners.ts
 
       - name: Commit if changed
         run: |

--- a/.claude/skills/first-tree-cli-framework/assets/framework/workflows/pr-review.yml
+++ b/.claude/skills/first-tree-cli-framework/assets/framework/workflows/pr-review.yml
@@ -45,7 +45,7 @@ jobs:
           gh pr view "$PR_NUMBER" --json headRefOid -q .headRefOid > /tmp/pr-head-sha.txt
 
       - name: Run Claude review
-        run: npx tsx .context-tree/run-review.ts
+        run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/run-review.ts
 
       - name: Parse and post review
         run: |

--- a/.claude/skills/first-tree-cli-framework/references/onboarding.md
+++ b/.claude/skills/first-tree-cli-framework/references/onboarding.md
@@ -65,19 +65,19 @@ git init
 context-tree init
 ```
 
-This clones the framework into `.context-tree/`, renders scaffolding (`NODE.md`, `AGENT.md`, `members/NODE.md`), and generates a task list in `.context-tree/progress.md`.
+This installs the framework skill into `skills/first-tree-cli-framework/`, renders scaffolding (`NODE.md`, `AGENT.md`, `members/NODE.md`), and generates a task list in `skills/first-tree-cli-framework/progress.md`.
 
 ### Step 2: Work Through the Task List
 
-Read `.context-tree/progress.md`. It contains a checklist tailored to the current state of the repo. Complete each task:
+Read `skills/first-tree-cli-framework/progress.md`. It contains a checklist tailored to the current state of the repo. Complete each task:
 
 - Fill in `NODE.md` with your organization name, owners, and domains
 - Add project-specific instructions to `AGENT.md` below the framework markers
 - Create member nodes under `members/`
 - Optionally configure agent integration (e.g., Claude Code session hooks)
-- Copy validation workflows to `.github/workflows/`
+- Copy validation workflows from `skills/first-tree-cli-framework/assets/framework/workflows/` to `.github/workflows/`
 
-As you complete each task, check it off in `progress.md` by changing `- [ ]` to `- [x]`.
+As you complete each task, check it off in `skills/first-tree-cli-framework/progress.md` by changing `- [ ]` to `- [x]`.
 
 ### Step 3: Verify
 
@@ -85,7 +85,7 @@ As you complete each task, check it off in `progress.md` by changing `- [ ]` to 
 context-tree verify
 ```
 
-This fails if any items in `progress.md` remain unchecked, and runs deterministic checks (valid frontmatter, node structure, member nodes exist).
+This fails if any items in `skills/first-tree-cli-framework/progress.md` remain unchecked, and runs deterministic checks (valid frontmatter, node structure, member nodes exist).
 
 ### Step 4: Design Your Domains
 
@@ -122,27 +122,27 @@ The tree doesn't duplicate source code — it captures what connects things and 
 
 | Command | Description |
 |---------|-------------|
-| `context-tree init` | Bootstrap a new tree. Clones framework, renders templates, generates task list. |
-| `context-tree verify` | Check progress.md for unchecked items + run deterministic validation. |
-| `context-tree upgrade` | Compare local framework version to upstream, generate upgrade task list. |
+| `context-tree init` | Bootstrap a new tree. Installs the framework skill, renders templates, generates a task list. |
+| `context-tree verify` | Check the installed progress file for unchecked items + run deterministic validation. |
+| `context-tree upgrade` | Refresh the installed framework skill from upstream and generate follow-up tasks. |
 | `context-tree help onboarding` | Print this onboarding guide. |
 
 ---
 
 ## Upgrading the Framework
 
-After init, the first-tree repo is added as a git remote (`context-tree-upstream`). When the framework updates:
+When the framework updates:
 
 ```bash
 context-tree upgrade
 ```
 
-This compares your `.context-tree/VERSION` to upstream and generates a task list. The framework directory (`.context-tree/`) is upgradable without touching your content.
+This refreshes `skills/first-tree-cli-framework/` from upstream, preserves your tree content, and generates follow-up tasks in `skills/first-tree-cli-framework/progress.md`.
 
 ---
 
 ## Further Reading
 
-- `.context-tree/principles.md` — Core principles with detailed examples
-- `.context-tree/ownership-and-naming.md` — How nodes are named and owned
+- `skills/first-tree-cli-framework/references/principles.md` — Core principles with detailed examples
+- `skills/first-tree-cli-framework/references/ownership-and-naming.md` — How nodes are named and owned
 - `AGENT.md` in your tree — The before/during/after workflow for every task

--- a/.claude/skills/first-tree-cli-framework/references/portable-quickstart.md
+++ b/.claude/skills/first-tree-cli-framework/references/portable-quickstart.md
@@ -11,8 +11,8 @@ This skill is meant to keep working even after the `skills/first-tree-cli-framew
 Snapshot source:
 
 - live repo: `agent-team-foundation/first-tree`
-- snapshot base commit when this portable copy was refreshed: `7f7567ef117edc1102800d8b0e9dff96aa11c524`
-- snapshot content fingerprint: `sha256:5321c1ceb28664c9fcfa7d4b29c136734ac73fef9ed8cb6b19c79a70dd3d20f3`
+- snapshot base commit when this portable copy was refreshed: `ef75cac3c112cea4475c095b000274cc97301cd7`
+- snapshot content fingerprint: `sha256:8de9030ffc5666ebcce8dab5f381da03fbc46f5c178218a62acb8ad1cfb7fd12`
 
 The base commit records which live checkout the refresh started from. Generated artifact updates may land in a later commit, so strict sync validation uses the content fingerprint above.
 

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/examples/claude-code/README.md
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/examples/claude-code/README.md
@@ -6,10 +6,9 @@ Copy `settings.json` to your tree repo's `.claude/` directory:
 
 ```bash
 mkdir -p .claude
-cp .context-tree/examples/claude-code/settings.json .claude/settings.json
+cp skills/first-tree-cli-framework/assets/framework/examples/claude-code/settings.json .claude/settings.json
 ```
 
 ## What It Does
 
-The `SessionStart` hook runs `.context-tree/scripts/inject-tree-context.sh` when a Claude Code session begins. This injects the root `NODE.md` content as additional context, giving the agent an overview of the tree structure before any task.
-
+The `SessionStart` hook runs `./skills/first-tree-cli-framework/assets/framework/helpers/inject-tree-context.sh` when a Claude Code session begins. This injects the root `NODE.md` content as additional context, giving the agent an overview of the tree structure before any task.

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/examples/claude-code/settings.json
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/examples/claude-code/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".context-tree/scripts/inject-tree-context.sh"
+            "command": "./skills/first-tree-cli-framework/assets/framework/helpers/inject-tree-context.sh"
           }
         ]
       }

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/generate-codeowners.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/generate-codeowners.ts
@@ -205,7 +205,7 @@ export function generate(
       return 0;
     }
     console.log(
-      "CODEOWNERS is out-of-date. Run: npx tsx .context-tree/generate-codeowners.ts",
+      "CODEOWNERS is out-of-date. Run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/generate-codeowners.ts",
     );
     return 1;
   }

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/run-review.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/run-review.ts
@@ -23,7 +23,10 @@ function buildPrompt(diffPath: string): string {
   const files: [string, string][] = [
     ["AGENT.md", "AGENT.md"],
     ["Root NODE.md", "NODE.md"],
-    ["Review Instructions", ".context-tree/prompts/pr-review.md"],
+    [
+      "Review Instructions",
+      "skills/first-tree-cli-framework/assets/framework/prompts/pr-review.md",
+    ],
   ];
   for (const [heading, path] of files) {
     const content = readFileSync(path, "utf-8");

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/templates/agent.md.template
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/templates/agent.md.template
@@ -13,7 +13,7 @@ You are working in a **Context Tree** — the living source of truth for decisio
 
 4. **Git-native tree structure.** Each node is a file; each domain is a directory. Soft links allow cross-references without the complexity of a full graph. History, ownership, and review follow Git conventions.
 
-See `.context-tree/principles.md` for detailed explanations and examples.
+See `skills/first-tree-cli-framework/references/principles.md` for detailed explanations and examples.
 
 ## Before Every Task
 
@@ -40,7 +40,7 @@ Ask yourself: **Does the tree need updating?**
 
 ## Reference
 
-For ownership rules, tree structure, and key files, see [NODE.md](NODE.md) and `.context-tree/ownership-and-naming.md`.
+For ownership rules, tree structure, and key files, see [NODE.md](NODE.md) and `skills/first-tree-cli-framework/references/ownership-and-naming.md`.
 <!-- END CONTEXT-TREE FRAMEWORK -->
 
 # Project-Specific Instructions

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/templates/members-domain.md.template
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/templates/members-domain.md.template
@@ -34,7 +34,7 @@ domains:
 ---
 ```
 
-See `.context-tree/templates/member-node.md.template` for a full scaffold.
+See `skills/first-tree-cli-framework/assets/framework/templates/member-node.md.template` for a full scaffold.
 
 ---
 

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/templates/root-node.md.template
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/templates/root-node.md.template
@@ -31,8 +31,8 @@ The living source of truth for your organization. A structured knowledge base th
 
 See [AGENT.md](AGENT.md) for agent instructions — the before/during/after workflow, ownership model, and tree maintenance.
 
-See [about.md](about.md) for background — the problem, the idea, and who it's for.
+See [about.md](skills/first-tree-cli-framework/references/about.md) for background — the problem, the idea, and who it's for.
 
-See the framework documentation in `.context-tree/`:
-- [principles.md](.context-tree/principles.md) — core principles with examples
-- [ownership-and-naming.md](.context-tree/ownership-and-naming.md) — node naming and ownership model
+See the installed framework documentation:
+- [principles.md](skills/first-tree-cli-framework/references/principles.md) — core principles with examples
+- [ownership-and-naming.md](skills/first-tree-cli-framework/references/ownership-and-naming.md) — node naming and ownership model

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/workflows/codeowners.yml
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/workflows/codeowners.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: "22"
 
-      - run: npx tsx .context-tree/generate-codeowners.ts
+      - run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/generate-codeowners.ts
 
       - name: Commit if changed
         run: |

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/workflows/pr-review.yml
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/workflows/pr-review.yml
@@ -45,7 +45,7 @@ jobs:
           gh pr view "$PR_NUMBER" --json headRefOid -q .headRefOid > /tmp/pr-head-sha.txt
 
       - name: Run Claude review
-        run: npx tsx .context-tree/run-review.ts
+        run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/run-review.ts
 
       - name: Parse and post review
         run: |

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/AGENTS.md
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/AGENTS.md
@@ -9,7 +9,7 @@ This repo is the **template source and CLI** for Context Tree. It is NOT a conte
   - `src/validators/` — Node, member, and CODEOWNERS validation
 - `src/runtime/` — Shared path, install, adapter, and upgrade helpers
 - `skills/first-tree-cli-framework/` — Canonical skill source for docs and shipped runtime assets
-- `.context-tree/` — Temporary exported mirror of the shipped runtime assets during the single-skill migration
+- `.context-tree/` — Temporary exported mirror in the source repo during the single-skill migration
   - `tests/` — Unit tests (Vitest)
   - `docs/` — Introduction and documentation
 
@@ -17,7 +17,7 @@ This repo is the **template source and CLI** for Context Tree. It is NOT a conte
 
 - The CLI is a **harness for the agent** — it generates situation-aware task lists, not executes them
 - `skills/first-tree-cli-framework/` is the single canonical source; `assets/framework/` is the shipped runtime payload
-- `.context-tree/` is currently an exported compatibility mirror while the refactor converges
+- New user repos install `skills/first-tree-cli-framework/` directly; `.context-tree/` remains only as a source-repo compatibility mirror while the refactor converges
 - Templates in `skills/first-tree-cli-framework/assets/framework/templates/` ultimately render `NODE.md`, `AGENT.md`, `members/NODE.md` in users' repos
 - The npm package is `first-tree`, and it installs the `context-tree` command. Use `npx first-tree ...` for one-off runs or `npm install -g first-tree` to put `context-tree` on your PATH.
 

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/docs/onboarding.md
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/docs/onboarding.md
@@ -65,19 +65,19 @@ git init
 context-tree init
 ```
 
-This clones the framework into `.context-tree/`, renders scaffolding (`NODE.md`, `AGENT.md`, `members/NODE.md`), and generates a task list in `.context-tree/progress.md`.
+This installs the framework skill into `skills/first-tree-cli-framework/`, renders scaffolding (`NODE.md`, `AGENT.md`, `members/NODE.md`), and generates a task list in `skills/first-tree-cli-framework/progress.md`.
 
 ### Step 2: Work Through the Task List
 
-Read `.context-tree/progress.md`. It contains a checklist tailored to the current state of the repo. Complete each task:
+Read `skills/first-tree-cli-framework/progress.md`. It contains a checklist tailored to the current state of the repo. Complete each task:
 
 - Fill in `NODE.md` with your organization name, owners, and domains
 - Add project-specific instructions to `AGENT.md` below the framework markers
 - Create member nodes under `members/`
 - Optionally configure agent integration (e.g., Claude Code session hooks)
-- Copy validation workflows to `.github/workflows/`
+- Copy validation workflows from `skills/first-tree-cli-framework/assets/framework/workflows/` to `.github/workflows/`
 
-As you complete each task, check it off in `progress.md` by changing `- [ ]` to `- [x]`.
+As you complete each task, check it off in `skills/first-tree-cli-framework/progress.md` by changing `- [ ]` to `- [x]`.
 
 ### Step 3: Verify
 
@@ -85,7 +85,7 @@ As you complete each task, check it off in `progress.md` by changing `- [ ]` to 
 context-tree verify
 ```
 
-This fails if any items in `progress.md` remain unchecked, and runs deterministic checks (valid frontmatter, node structure, member nodes exist).
+This fails if any items in `skills/first-tree-cli-framework/progress.md` remain unchecked, and runs deterministic checks (valid frontmatter, node structure, member nodes exist).
 
 ### Step 4: Design Your Domains
 
@@ -122,27 +122,27 @@ The tree doesn't duplicate source code — it captures what connects things and 
 
 | Command | Description |
 |---------|-------------|
-| `context-tree init` | Bootstrap a new tree. Clones framework, renders templates, generates task list. |
-| `context-tree verify` | Check progress.md for unchecked items + run deterministic validation. |
-| `context-tree upgrade` | Compare local framework version to upstream, generate upgrade task list. |
+| `context-tree init` | Bootstrap a new tree. Installs the framework skill, renders templates, generates a task list. |
+| `context-tree verify` | Check the installed progress file for unchecked items + run deterministic validation. |
+| `context-tree upgrade` | Refresh the installed framework skill from upstream and generate follow-up tasks. |
 | `context-tree help onboarding` | Print this onboarding guide. |
 
 ---
 
 ## Upgrading the Framework
 
-After init, the first-tree repo is added as a git remote (`context-tree-upstream`). When the framework updates:
+When the framework updates:
 
 ```bash
 context-tree upgrade
 ```
 
-This compares your `.context-tree/VERSION` to upstream and generates a task list. The framework directory (`.context-tree/`) is upgradable without touching your content.
+This refreshes `skills/first-tree-cli-framework/` from upstream, preserves your tree content, and generates follow-up tasks in `skills/first-tree-cli-framework/progress.md`.
 
 ---
 
 ## Further Reading
 
-- `.context-tree/principles.md` — Core principles with detailed examples
-- `.context-tree/ownership-and-naming.md` — How nodes are named and owned
+- `skills/first-tree-cli-framework/references/principles.md` — Core principles with detailed examples
+- `skills/first-tree-cli-framework/references/ownership-and-naming.md` — How nodes are named and owned
 - `AGENT.md` in your tree — The before/during/after workflow for every task

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/package.json
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/package.json
@@ -9,7 +9,8 @@
   "imports": {
     "#src/*.js": "./src/*.ts",
     "#evals/*.js": "./evals/*.ts",
-    "#docs/*": "./docs/*"
+    "#docs/*": "./docs/*",
+    "#skill/*": "./skills/first-tree-cli-framework/*"
   },
   "files": [
     "dist"

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/cli.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/cli.ts
@@ -5,9 +5,9 @@ const USAGE = `usage: context-tree <command>
   New to context-tree? Run \`context-tree help onboarding\` first.
 
 Commands:
-  init      Bootstrap a new context tree (clones first-tree, copies framework files)
+  init      Bootstrap a new context tree (installs the framework skill)
   verify    Run verification checks against the current tree
-  upgrade   Generate an upgrade task list from upstream changes
+  upgrade   Refresh the installed skill from upstream and generate follow-up tasks
   help      Show help for a topic (e.g. \`help onboarding\`)
 
 Options:

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/init.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/init.ts
@@ -1,24 +1,26 @@
-import { execFileSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
-  mkdtempSync,
-  rmSync,
   writeFileSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
-import { tmpdir } from "node:os";
 import { Repo } from "#src/repo.js";
 import { ONBOARDING_TEXT } from "#src/onboarding.js";
 import { evaluateAll } from "#src/rules/index.js";
 import type { RuleResult } from "#src/rules/index.js";
 import {
-  copyLegacyFrameworkMirror,
+  copyCanonicalSkill,
   renderTemplateFile,
 } from "#src/runtime/installer.js";
-import { FRAMEWORK_ASSET_ROOT } from "#src/runtime/asset-loader.js";
-
-const FIRST_TREE_REPO_URL = "https://github.com/agent-team-foundation/first-tree";
+import {
+  FRAMEWORK_ASSET_ROOT,
+  FRAMEWORK_VERSION,
+  INSTALLED_PROGRESS,
+} from "#src/runtime/asset-loader.js";
+import {
+  cleanupUpstreamRepo,
+  cloneUpstreamRepo,
+} from "#src/runtime/upgrader.js";
 
 /**
  * The interactive prompt tool the agent should use to present choices.
@@ -33,57 +35,19 @@ const TEMPLATE_MAP: [string, string][] = [
   ["members-domain.md.template", "members/NODE.md"],
 ];
 
-function cloneFirstTree(): string {
-  const tmp = mkdtempSync(join(tmpdir(), "context-tree-"));
-  console.log(`Cloning first-tree from ${FIRST_TREE_REPO_URL}...`);
-  try {
-    execFileSync("git", ["clone", "--depth", "1", FIRST_TREE_REPO_URL, tmp], {
-      encoding: "utf-8",
-      stdio: "pipe",
-    });
-  } catch (err) {
-    const message =
-      err instanceof Error ? err.message : "unknown error";
-    console.error(`Failed to clone first-tree: ${message}`);
-    rmSync(tmp, { recursive: true, force: true });
-    process.exit(1);
-  }
-  return tmp;
+function installSkill(source: string, target: string): void {
+  copyCanonicalSkill(source, target);
+  console.log("  Installed skills/first-tree-cli-framework/ from the upstream skill");
 }
 
-function copyFramework(source: string, target: string): void {
-  copyLegacyFrameworkMirror(source, target);
-  console.log("  Copied .context-tree/ from the canonical skill assets");
-}
-
-function renderTemplates(frameworkDir: string, target: string): void {
+function renderTemplates(target: string): void {
+  const frameworkDir = join(target, FRAMEWORK_ASSET_ROOT);
   for (const [templateName, targetPath] of TEMPLATE_MAP) {
     if (existsSync(join(target, targetPath))) {
       console.log(`  Skipped ${targetPath} (already exists)`);
     } else if (renderTemplateFile(frameworkDir, templateName, target, targetPath)) {
       console.log(`  Created ${targetPath}`);
     }
-  }
-}
-
-function addUpstreamRemote(target: string): void {
-  try {
-    const result = execFileSync("git", ["remote"], {
-      cwd: target,
-      encoding: "utf-8",
-    });
-    if (!result.split(/\s+/).includes("context-tree-upstream")) {
-      execFileSync(
-        "git",
-        ["remote", "add", "context-tree-upstream", FIRST_TREE_REPO_URL],
-        { cwd: target, encoding: "utf-8", stdio: "pipe" },
-      );
-      console.log(
-        `  Added git remote 'context-tree-upstream' -> ${FIRST_TREE_REPO_URL}`,
-      );
-    }
-  } catch {
-    // ignore
   }
 }
 
@@ -110,7 +74,7 @@ export function formatTaskList(groups: RuleResult[]): string {
   lines.push(
     "After completing the tasks above, run `context-tree verify` to confirm:",
   );
-  lines.push("- [ ] `.context-tree/VERSION` exists");
+  lines.push(`- [ ] \`${FRAMEWORK_VERSION}\` exists`);
   lines.push("- [ ] Root NODE.md has valid frontmatter (title, owners)");
   lines.push("- [ ] AGENT.md exists with framework markers");
   lines.push("- [ ] `context-tree verify` passes with no errors");
@@ -120,7 +84,7 @@ export function formatTaskList(groups: RuleResult[]): string {
   lines.push("");
   lines.push(
     "**Important:** As you complete each task, check it off in" +
-      " `.context-tree/progress.md` by changing `- [ ]` to `- [x]`." +
+      ` \`${INSTALLED_PROGRESS}\` by changing \`- [ ]\` to \`- [x]\`.` +
       " Run `context-tree verify` when done — it will fail if any" +
       " items remain unchecked.",
   );
@@ -129,7 +93,7 @@ export function formatTaskList(groups: RuleResult[]): string {
 }
 
 export function writeProgress(repo: Repo, content: string): void {
-  const progressPath = join(repo.root, ".context-tree", "progress.md");
+  const progressPath = join(repo.root, repo.preferredProgressPath());
   mkdirSync(dirname(progressPath), { recursive: true });
   writeFileSync(progressPath, content);
 }
@@ -145,15 +109,14 @@ export function runInit(repo?: Repo): number {
   }
 
   if (!r.hasFramework()) {
-    const seed = cloneFirstTree();
+    console.log("Cloning first-tree to install the framework skill...");
+    const seed = cloneUpstreamRepo();
     try {
-      console.log("Copying framework and scaffolding...");
-      copyFramework(seed, r.root);
-      const frameworkDir = join(seed, FRAMEWORK_ASSET_ROOT);
-      renderTemplates(frameworkDir, r.root);
-      addUpstreamRemote(r.root);
+      console.log("Installing skill and scaffolding...");
+      installSkill(seed, r.root);
+      renderTemplates(r.root);
     } finally {
-      rmSync(seed, { recursive: true, force: true });
+      cleanupUpstreamRepo(seed);
     }
     console.log();
   }
@@ -170,6 +133,6 @@ export function runInit(repo?: Repo): number {
   const output = formatTaskList(groups);
   console.log(output);
   writeProgress(r, output);
-  console.log("Progress file written to .context-tree/progress.md");
+  console.log(`Progress file written to ${r.preferredProgressPath()}`);
   return 0;
 }

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/onboarding.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/onboarding.ts
@@ -1,4 +1,4 @@
-import ONBOARDING_TEXT from "#docs/onboarding.md";
+import ONBOARDING_TEXT from "#skill/references/onboarding.md";
 
 export { ONBOARDING_TEXT };
 

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/repo.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/repo.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 import {
@@ -6,6 +5,7 @@ import {
   LEGACY_PROGRESS,
   LEGACY_VERSION,
   INSTALLED_PROGRESS,
+  type FrameworkLayout,
   detectFrameworkLayout,
   progressFileCandidates,
   resolveFirstExistingPath,
@@ -90,7 +90,11 @@ export class Repo {
   }
 
   hasFramework(): boolean {
-    return detectFrameworkLayout(this.root) !== null;
+    return this.frameworkLayout() !== null;
+  }
+
+  frameworkLayout(): FrameworkLayout | null {
+    return detectFrameworkLayout(this.root);
   }
 
   readVersion(): string | null {
@@ -106,7 +110,11 @@ export class Repo {
   }
 
   preferredProgressPath(): string {
-    return this.pathExists(INSTALLED_PROGRESS) ? INSTALLED_PROGRESS : LEGACY_PROGRESS;
+    return this.frameworkLayout() === "legacy" ? LEGACY_PROGRESS : INSTALLED_PROGRESS;
+  }
+
+  frameworkVersionPath(): string {
+    return this.frameworkLayout() === "legacy" ? LEGACY_VERSION : FRAMEWORK_VERSION;
   }
 
   hasAgentMdMarkers(): boolean {
@@ -153,17 +161,5 @@ export class Repo {
 
   hasPlaceholderNode(): boolean {
     return this.fileContains("NODE.md", "<!-- PLACEHOLDER");
-  }
-
-  hasUpstreamRemote(): boolean {
-    try {
-      const result = execFileSync("git", ["remote"], {
-        cwd: this.root,
-        encoding: "utf-8",
-      });
-      return result.split(/\s+/).includes("context-tree-upstream");
-    } catch {
-      return false;
-    }
   }
 }

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/agent-instructions.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/agent-instructions.ts
@@ -1,12 +1,13 @@
 import { FRAMEWORK_END_MARKER } from "#src/repo.js";
 import type { Repo } from "#src/repo.js";
 import type { RuleResult } from "#src/rules/index.js";
+import { FRAMEWORK_TEMPLATES_DIR } from "#src/runtime/asset-loader.js";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
   if (!repo.pathExists("AGENT.md")) {
     tasks.push(
-      "AGENT.md is missing — create from `.context-tree/templates/agent.md.template`",
+      `AGENT.md is missing — create from \`${FRAMEWORK_TEMPLATES_DIR}/agent.md.template\``,
     );
   } else if (!repo.hasAgentMdMarkers()) {
     tasks.push(

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/agent-integration.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/agent-integration.ts
@@ -1,17 +1,18 @@
 import type { Repo } from "#src/repo.js";
 import type { RuleResult } from "#src/rules/index.js";
+import { FRAMEWORK_EXAMPLES_DIR } from "#src/runtime/asset-loader.js";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
   if (repo.pathExists(".claude/settings.json")) {
     if (!repo.fileContains(".claude/settings.json", "inject-tree-context")) {
       tasks.push(
-        "Add SessionStart hook to `.claude/settings.json` (see `.context-tree/examples/claude-code/`)",
+        `Add SessionStart hook to \`.claude/settings.json\` (see \`${FRAMEWORK_EXAMPLES_DIR}/claude-code/\`)`,
       );
     }
   } else if (!repo.anyAgentConfig()) {
     tasks.push(
-      "No agent configuration detected. Configure your agent to load tree context at session start. See `.context-tree/examples/` for supported agents. You can skip this and set it up later.",
+      `No agent configuration detected. Configure your agent to load tree context at session start. See \`${FRAMEWORK_EXAMPLES_DIR}/\` for supported agents. You can skip this and set it up later.`,
     );
   }
   return { group: "Agent Integration", order: 5, tasks };

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/ci-validation.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/ci-validation.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { INTERACTIVE_TOOL } from "#src/init.js";
 import type { Repo } from "#src/repo.js";
 import type { RuleResult } from "#src/rules/index.js";
+import { FRAMEWORK_WORKFLOWS_DIR } from "#src/runtime/asset-loader.js";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
@@ -40,7 +41,7 @@ export function evaluate(repo: Repo): RuleResult {
   }
   if (!hasValidation) {
     tasks.push(
-      "No validation workflow found — copy `.context-tree/workflows/validate.yml` to `.github/workflows/validate.yml`",
+      `No validation workflow found — copy \`${FRAMEWORK_WORKFLOWS_DIR}/validate.yml\` to \`.github/workflows/validate.yml\``,
     );
   }
   if (!hasPrReview) {
@@ -49,7 +50,7 @@ export function evaluate(repo: Repo): RuleResult {
       "  1. **OpenRouter** — use an OpenRouter API key\n" +
       "  2. **Claude API** — use a Claude API key directly\n" +
       "  3. **Skip** — do not set up PR reviews\n" +
-      "If (1): copy `.context-tree/workflows/pr-review.yml` to `.github/workflows/pr-review.yml` as-is; the repo secret name is `OPENROUTER_API_KEY`. " +
+      `If (1): copy \`${FRAMEWORK_WORKFLOWS_DIR}/pr-review.yml\` to \`.github/workflows/pr-review.yml\` as-is; the repo secret name is \`OPENROUTER_API_KEY\`. ` +
       "If (2): copy the workflow and replace the `env` block with `ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}`, remove the `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, and `ANTHROPIC_DEFAULT_SONNET_MODEL` lines; the repo secret name is `ANTHROPIC_API_KEY`. " +
       "If (3): skip this and the next task.",
     );
@@ -64,7 +65,7 @@ export function evaluate(repo: Repo): RuleResult {
   }
   if (!hasCodeowners) {
     tasks.push(
-      "No CODEOWNERS workflow found — copy `.context-tree/workflows/codeowners.yml` to `.github/workflows/codeowners.yml` to auto-generate CODEOWNERS from tree ownership on every PR.",
+      `No CODEOWNERS workflow found — copy \`${FRAMEWORK_WORKFLOWS_DIR}/codeowners.yml\` to \`.github/workflows/codeowners.yml\` to auto-generate CODEOWNERS from tree ownership on every PR.`,
     );
   }
   return { group: "CI / Validation", order: 6, tasks };

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/framework.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/framework.ts
@@ -1,5 +1,6 @@
 import type { Repo } from "#src/repo.js";
 import type { RuleResult } from "#src/rules/index.js";
+import { SKILL_ROOT } from "#src/runtime/asset-loader.js";
 
 const FIRST_TREE_REPO_URL = "https://github.com/agent-team-foundation/first-tree";
 
@@ -7,7 +8,7 @@ export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
   if (!repo.hasFramework()) {
     tasks.push(
-      `\`.context-tree/\` not found — run \`context-tree init\` to clone the framework from ${FIRST_TREE_REPO_URL}`,
+      `\`${SKILL_ROOT}/\` not found — run \`context-tree init\` to install the framework skill from ${FIRST_TREE_REPO_URL}`,
     );
   }
   return { group: "Framework", order: 1, tasks };

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/root-node.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/root-node.ts
@@ -1,11 +1,12 @@
 import type { Repo } from "#src/repo.js";
 import type { RuleResult } from "#src/rules/index.js";
+import { FRAMEWORK_TEMPLATES_DIR } from "#src/runtime/asset-loader.js";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
   if (!repo.pathExists("NODE.md")) {
     tasks.push(
-      "NODE.md is missing — create from `.context-tree/templates/root-node.md.template`. " +
+      `NODE.md is missing — create from \`${FRAMEWORK_TEMPLATES_DIR}/root-node.md.template\`. ` +
       "Ask the user for their code repositories or project directories, then analyze the source to determine the project description and domain structure",
     );
   } else {

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/runtime/upgrader.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/runtime/upgrader.ts
@@ -1,38 +1,45 @@
 import { execFileSync } from "node:child_process";
-import { frameworkVersionCandidates } from "#src/runtime/asset-loader.js";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  frameworkVersionCandidates,
+  resolveFirstExistingPath,
+} from "#src/runtime/asset-loader.js";
 
-export function fetchUpstream(
-  repoRoot: string,
-  remote = "context-tree-upstream",
-): boolean {
+export const FIRST_TREE_REPO_URL =
+  "https://github.com/agent-team-foundation/first-tree";
+
+export function cloneUpstreamRepo(
+  repoUrl = FIRST_TREE_REPO_URL,
+): string {
+  const tmp = mkdtempSync(join(tmpdir(), "context-tree-upstream-"));
   try {
-    execFileSync("git", ["fetch", remote, "--depth", "1"], {
-      cwd: repoRoot,
+    execFileSync("git", ["clone", "--depth", "1", repoUrl, tmp], {
       encoding: "utf-8",
       stdio: "pipe",
     });
-    return true;
-  } catch {
-    return false;
+    return tmp;
+  } catch (err) {
+    rmSync(tmp, { recursive: true, force: true });
+    const message = err instanceof Error ? err.message : "unknown error";
+    throw new Error(`Failed to clone ${repoUrl}: ${message}`);
   }
 }
 
-export function readUpstreamVersion(
-  repoRoot: string,
-  remote = "context-tree-upstream",
-  ref = "main",
-): string | null {
-  for (const candidate of frameworkVersionCandidates()) {
-    try {
-      const result = execFileSync("git", ["show", `${remote}/${ref}:${candidate}`], {
-        cwd: repoRoot,
-        encoding: "utf-8",
-        stdio: "pipe",
-      });
-      return result.trim();
-    } catch {
-      continue;
-    }
+export function cleanupUpstreamRepo(root: string): void {
+  rmSync(root, { recursive: true, force: true });
+}
+
+export function readUpstreamVersion(sourceRoot: string): string | null {
+  const versionPath = resolveFirstExistingPath(
+    sourceRoot,
+    frameworkVersionCandidates(),
+  );
+  if (versionPath === null) return null;
+  try {
+    return readFileSync(join(sourceRoot, versionPath), "utf-8").trim();
+  } catch {
+    return null;
   }
-  return null;
 }

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/upgrade.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/upgrade.ts
@@ -1,100 +1,139 @@
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { Repo } from "#src/repo.js";
-import { fetchUpstream, readUpstreamVersion } from "#src/runtime/upgrader.js";
-
-const FIRST_TREE_REPO_URL = "https://github.com/agent-team-foundation/first-tree";
-
-function getUpstreamVersion(repo: Repo): string | null {
-  if (!fetchUpstream(repo.root)) {
-    return null;
-  }
-  return readUpstreamVersion(repo.root);
-}
+import {
+  FRAMEWORK_WORKFLOWS_DIR,
+  FRAMEWORK_TEMPLATES_DIR,
+  FRAMEWORK_VERSION,
+  INSTALLED_PROGRESS,
+  LEGACY_FRAMEWORK_ROOT,
+  SKILL_ROOT,
+} from "#src/runtime/asset-loader.js";
+import { copyCanonicalSkill } from "#src/runtime/installer.js";
+import {
+  cleanupUpstreamRepo,
+  cloneUpstreamRepo,
+  FIRST_TREE_REPO_URL,
+  readUpstreamVersion,
+} from "#src/runtime/upgrader.js";
 
 function writeProgress(repo: Repo, content: string): void {
-  const progressPath = join(repo.root, ".context-tree", "progress.md");
+  const progressPath = join(repo.root, repo.preferredProgressPath());
   mkdirSync(dirname(progressPath), { recursive: true });
   writeFileSync(progressPath, content);
 }
 
-export function runUpgrade(): number {
-  const repo = new Repo();
-
-  if (!repo.hasFramework()) {
-    console.error(
-      "Error: no .context-tree/ found. Run `context-tree init` first.",
-    );
-    return 1;
-  }
-
-  const localVersion = repo.readVersion() ?? "unknown";
-  console.log(`Local framework version: ${localVersion}\n`);
-
-  // Check for upstream remote
-  if (!repo.hasUpstreamRemote()) {
-    const lines = [
-      "# Context Tree Upgrade\n",
-      "## Setup",
-      `- [ ] Add upstream remote: \`git remote add context-tree-upstream ${FIRST_TREE_REPO_URL}\``,
-      "- [ ] Then run `context-tree upgrade` again to check for updates",
-    ];
-    const output = lines.join("\n");
-    console.log(output);
-    writeProgress(repo, output + "\n");
-    console.log("\nProgress file written to .context-tree/progress.md");
-    return 0;
-  }
-
-  // Fetch upstream version
-  const upstreamVersion = getUpstreamVersion(repo);
-  if (upstreamVersion === null) {
-    console.log(
-      "Could not fetch upstream version. Check your network and try again.",
-    );
-    return 1;
-  }
-
-  if (upstreamVersion === localVersion) {
-    console.log(`Already up to date (v${localVersion}).`);
-    return 0;
-  }
-
+function formatUpgradeTaskList(
+  repo: Repo,
+  localVersion: string,
+  upstreamVersion: string,
+  migratedFromLegacy: boolean,
+): string {
   const lines: string[] = [
     `# Context Tree Upgrade — v${localVersion} -> v${upstreamVersion}\n`,
-    "## Framework",
-    "- [ ] Pull latest from upstream: `git fetch context-tree-upstream && git merge context-tree-upstream/main`",
-    "- [ ] Resolve any conflicts in `.context-tree/` (framework files should generally take upstream version)",
+    "## Installed Skill",
+    `- [ ] Review local customizations under \`${SKILL_ROOT}/\` and reapply them if needed`,
+    `- [ ] Re-copy any workflow updates you want from \`${FRAMEWORK_WORKFLOWS_DIR}/\` into \`.github/workflows/\``,
+    `- [ ] Re-check any local agent setup that references \`${SKILL_ROOT}/assets/framework/examples/\` or \`${SKILL_ROOT}/assets/framework/helpers/\``,
     "",
   ];
 
-  // Check AGENT.md
+  if (migratedFromLegacy) {
+    lines.push(
+      "## Migration",
+      "- [ ] Remove any stale `.context-tree/` references from repo-specific docs, scripts, or workflow files",
+      "",
+    );
+  }
+
   if (repo.hasAgentMdMarkers()) {
     lines.push(
       "## Agent Instructions",
-      "- [ ] Check if AGENT.md framework section needs updating — compare content between markers to the new template",
+      `- [ ] Compare the framework section in \`AGENT.md\` with \`${FRAMEWORK_TEMPLATES_DIR}/agent.md.template\` and update the content between the markers if needed`,
       "",
     );
   }
 
   lines.push(
     "## Verification",
-    `- [ ] \`.context-tree/VERSION\` reads \`${upstreamVersion}\``,
+    `- [ ] \`${FRAMEWORK_VERSION}\` reads \`${upstreamVersion}\``,
     "- [ ] `context-tree verify` passes",
-    "- [ ] AGENT.md framework section matches upstream",
     "",
     "---",
     "",
     "**Important:** As you complete each task, check it off in" +
-      " `.context-tree/progress.md` by changing `- [ ]` to `- [x]`." +
+      ` \`${INSTALLED_PROGRESS}\` by changing \`- [ ]\` to \`- [x]\`.` +
       " Run `context-tree verify` when done — it will fail if any" +
       " items remain unchecked.",
     "",
   );
 
-  const output = lines.join("\n");
-  console.log(output);
-  writeProgress(repo, output);
-  console.log("Progress file written to .context-tree/progress.md");
-  return 0;
+  return lines.join("\n");
+}
+
+export interface UpgradeOptions {
+  upstreamRoot?: string;
+}
+
+export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
+  const workingRepo = repo ?? new Repo();
+
+  if (!workingRepo.hasFramework()) {
+    console.error(
+      "Error: no installed framework skill found. Run `context-tree init` first.",
+    );
+    return 1;
+  }
+
+  const layout = workingRepo.frameworkLayout();
+  const localVersion = workingRepo.readVersion() ?? "unknown";
+  console.log(`Local framework version: ${localVersion}\n`);
+
+  console.log(`Checking ${FIRST_TREE_REPO_URL} for the latest framework skill...`);
+
+  const clonedUpstream = options?.upstreamRoot === undefined;
+  const upstreamRoot = options?.upstreamRoot ?? cloneUpstreamRepo();
+
+  try {
+    const upstreamVersion = readUpstreamVersion(upstreamRoot);
+    if (upstreamVersion === null) {
+      console.log(
+        "Could not read the upstream framework version. Check your network and try again.",
+      );
+      return 1;
+    }
+
+    if (layout === "skill" && upstreamVersion === localVersion) {
+      console.log(`Already up to date (${FRAMEWORK_VERSION} = ${localVersion}).`);
+      return 0;
+    }
+
+    copyCanonicalSkill(upstreamRoot, workingRepo.root);
+    if (layout === "legacy") {
+      rmSync(join(workingRepo.root, LEGACY_FRAMEWORK_ROOT), {
+        recursive: true,
+        force: true,
+      });
+      console.log(
+        "Migrated legacy .context-tree/ layout to skills/first-tree-cli-framework/.",
+      );
+    } else {
+      console.log("Refreshed skills/first-tree-cli-framework/ from upstream.");
+    }
+
+    const output = formatUpgradeTaskList(
+      workingRepo,
+      localVersion,
+      upstreamVersion,
+      layout === "legacy",
+    );
+    console.log(`\n${output}`);
+    writeProgress(workingRepo, output);
+    console.log(`Progress file written to ${workingRepo.preferredProgressPath()}`);
+    return 0;
+  } finally {
+    if (clonedUpstream) {
+      cleanupUpstreamRepo(upstreamRoot);
+    }
+  }
 }

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/verify.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/src/verify.ts
@@ -39,19 +39,21 @@ export function runVerify(repo?: Repo, nodeValidator?: NodeValidator): number {
   const r = repo ?? new Repo();
   const validate = nodeValidator ?? defaultNodeValidator;
   let allPassed = true;
+  const progressPath = r.progressPath() ?? r.preferredProgressPath();
+  const frameworkVersionPath = r.frameworkVersionPath();
 
   console.log("Context Tree Verification\n");
 
   // Progress file check
   const unchecked = checkProgress(r);
   if (unchecked.length > 0) {
-    console.log("  Unchecked items in .context-tree/progress.md:\n");
+    console.log(`  Unchecked items in ${progressPath}:\n`);
     for (const item of unchecked) {
       console.log(`    - [ ] ${item}`);
     }
     console.log();
     console.log(
-      "  Verify each step above and check it off in progress.md before running verify again.\n",
+      `  Verify each step above and check it off in ${progressPath} before running verify again.\n`,
     );
     allPassed = false;
   }
@@ -60,7 +62,7 @@ export function runVerify(repo?: Repo, nodeValidator?: NodeValidator): number {
   console.log("  Checks:\n");
 
   // 1. Framework exists
-  allPassed = check(".context-tree/VERSION exists", r.hasFramework()) && allPassed;
+  allPassed = check(`${frameworkVersionPath} exists`, r.hasFramework()) && allPassed;
 
   // 2. Root NODE.md has valid frontmatter
   const fm = r.frontmatter("NODE.md");

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/tests/generate-codeowners.test.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/tests/generate-codeowners.test.ts
@@ -6,7 +6,7 @@ import {
   resolveNodeOwners,
   collectEntries,
   formatOwners,
-} from "../.context-tree/generate-codeowners.js";
+} from "../skills/first-tree-cli-framework/assets/framework/helpers/generate-codeowners.js";
 import { useTmpDir } from "./helpers.js";
 
 function write(root: string, relPath: string, content: string): string {

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/tests/helpers.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/tests/helpers.ts
@@ -2,6 +2,10 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach } from "vitest";
+import {
+  FRAMEWORK_VERSION,
+  LEGACY_VERSION,
+} from "#src/runtime/asset-loader.js";
 
 interface TmpDir {
   path: string;
@@ -15,10 +19,17 @@ export function useTmpDir(): TmpDir {
   return { path: dir };
 }
 
-export function makeFramework(root: string): void {
+export function makeFramework(root: string, version = "0.1.0"): void {
+  mkdirSync(join(root, "skills", "first-tree-cli-framework", "assets", "framework"), {
+    recursive: true,
+  });
+  writeFileSync(join(root, FRAMEWORK_VERSION), `${version}\n`);
+}
+
+export function makeLegacyFramework(root: string, version = "0.1.0"): void {
   const ct = join(root, ".context-tree");
   mkdirSync(ct, { recursive: true });
-  writeFileSync(join(ct, "VERSION"), "0.1.0\n");
+  writeFileSync(join(root, LEGACY_VERSION), `${version}\n`);
 }
 
 export function makeNode(

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/tests/init.test.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/tests/init.test.ts
@@ -3,7 +3,15 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { formatTaskList, writeProgress, runInit } from "#src/init.js";
 import { Repo } from "#src/repo.js";
-import { useTmpDir, makeFramework } from "./helpers.js";
+import {
+  INSTALLED_PROGRESS,
+  LEGACY_PROGRESS,
+} from "#src/runtime/asset-loader.js";
+import {
+  useTmpDir,
+  makeFramework,
+  makeLegacyFramework,
+} from "./helpers.js";
 
 // --- formatTaskList ---
 
@@ -66,7 +74,7 @@ describe("writeProgress", () => {
     const tmp = useTmpDir();
     const repo = new Repo(tmp.path);
     writeProgress(repo, "# hello\n");
-    const progress = join(tmp.path, ".context-tree", "progress.md");
+    const progress = join(tmp.path, INSTALLED_PROGRESS);
     expect(readFileSync(progress, "utf-8")).toBe("# hello\n");
   });
 
@@ -74,18 +82,27 @@ describe("writeProgress", () => {
     const tmp = useTmpDir();
     const repo = new Repo(tmp.path);
     writeProgress(repo, "content");
-    const progress = join(tmp.path, ".context-tree", "progress.md");
+    const progress = join(tmp.path, INSTALLED_PROGRESS);
     expect(readFileSync(progress, "utf-8")).toBe("content");
   });
 
   it("overwrites existing file", () => {
     const tmp = useTmpDir();
-    const ct = join(tmp.path, ".context-tree");
-    mkdirSync(ct);
-    writeFileSync(join(ct, "progress.md"), "old");
+    mkdirSync(join(tmp.path, "skills", "first-tree-cli-framework"), {
+      recursive: true,
+    });
+    writeFileSync(join(tmp.path, INSTALLED_PROGRESS), "old");
     const repo = new Repo(tmp.path);
     writeProgress(repo, "new");
-    expect(readFileSync(join(ct, "progress.md"), "utf-8")).toBe("new");
+    expect(readFileSync(join(tmp.path, INSTALLED_PROGRESS), "utf-8")).toBe("new");
+  });
+
+  it("keeps using the legacy progress path for legacy repos", () => {
+    const tmp = useTmpDir();
+    makeLegacyFramework(tmp.path);
+    const repo = new Repo(tmp.path);
+    writeProgress(repo, "legacy");
+    expect(readFileSync(join(tmp.path, LEGACY_PROGRESS), "utf-8")).toBe("legacy");
   });
 });
 

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/tests/repo.test.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/tests/repo.test.ts
@@ -2,7 +2,13 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { Repo } from "#src/repo.js";
-import { useTmpDir } from "./helpers.js";
+import {
+  FRAMEWORK_VERSION,
+  INSTALLED_PROGRESS,
+  LEGACY_PROGRESS,
+  LEGACY_VERSION,
+} from "#src/runtime/asset-loader.js";
+import { useTmpDir, makeFramework, makeLegacyFramework } from "./helpers.js";
 
 // --- pathExists ---
 
@@ -136,10 +142,16 @@ describe("isGitRepo", () => {
 // --- hasFramework ---
 
 describe("hasFramework", () => {
-  it("returns true with VERSION file", () => {
+  it("returns true with installed skill version file", () => {
     const tmp = useTmpDir();
-    mkdirSync(join(tmp.path, ".context-tree"));
-    writeFileSync(join(tmp.path, ".context-tree", "VERSION"), "0.1.0\n");
+    makeFramework(tmp.path);
+    const repo = new Repo(tmp.path);
+    expect(repo.hasFramework()).toBe(true);
+  });
+
+  it("returns true with legacy version file", () => {
+    const tmp = useTmpDir();
+    makeLegacyFramework(tmp.path);
     const repo = new Repo(tmp.path);
     expect(repo.hasFramework()).toBe(true);
   });
@@ -154,18 +166,43 @@ describe("hasFramework", () => {
 // --- readVersion ---
 
 describe("readVersion", () => {
-  it("reads valid version", () => {
+  it("reads the installed skill version", () => {
     const tmp = useTmpDir();
-    mkdirSync(join(tmp.path, ".context-tree"));
-    writeFileSync(join(tmp.path, ".context-tree", "VERSION"), "0.2.0\n");
+    makeFramework(tmp.path, "0.2.0");
     const repo = new Repo(tmp.path);
     expect(repo.readVersion()).toBe("0.2.0");
+  });
+
+  it("falls back to the legacy version", () => {
+    const tmp = useTmpDir();
+    makeLegacyFramework(tmp.path, "0.3.0");
+    const repo = new Repo(tmp.path);
+    expect(repo.readVersion()).toBe("0.3.0");
   });
 
   it("returns null when missing", () => {
     const tmp = useTmpDir();
     const repo = new Repo(tmp.path);
     expect(repo.readVersion()).toBeNull();
+  });
+});
+
+// --- preferredProgressPath / frameworkVersionPath ---
+
+describe("path preferences", () => {
+  it("prefers the installed-skill paths by default", () => {
+    const tmp = useTmpDir();
+    const repo = new Repo(tmp.path);
+    expect(repo.preferredProgressPath()).toBe(INSTALLED_PROGRESS);
+    expect(repo.frameworkVersionPath()).toBe(FRAMEWORK_VERSION);
+  });
+
+  it("switches path preferences for legacy repos", () => {
+    const tmp = useTmpDir();
+    makeLegacyFramework(tmp.path);
+    const repo = new Repo(tmp.path);
+    expect(repo.preferredProgressPath()).toBe(LEGACY_PROGRESS);
+    expect(repo.frameworkVersionPath()).toBe(LEGACY_VERSION);
   });
 });
 

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/tests/rules.test.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/tests/rules.test.ts
@@ -29,7 +29,7 @@ describe("framework rule", () => {
     const result = framework.evaluate(repo);
     expect(result.group).toBe("Framework");
     expect(result.tasks).toHaveLength(1);
-    expect(result.tasks[0]).toContain(".context-tree/");
+    expect(result.tasks[0]).toContain("skills/first-tree-cli-framework/");
   });
 
   it("passes when framework exists", () => {
@@ -214,6 +214,7 @@ describe("ciValidation rule", () => {
     const result = ciValidation.evaluate(repo);
     expect(result.tasks).toHaveLength(4);
     expect(result.tasks[0]).toContain("validation workflow");
+    expect(result.tasks[0]).toContain("skills/first-tree-cli-framework/assets/framework/workflows/validate.yml");
     expect(result.tasks[1]).toContain("PR reviews");
     expect(result.tasks[2]).toContain("API secret");
     expect(result.tasks[3]).toContain("CODEOWNERS");
@@ -251,7 +252,7 @@ describe("ciValidation rule", () => {
     mkdirSync(wfDir, { recursive: true });
     writeFileSync(
       join(wfDir, "pr-review.yml"),
-      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx .context-tree/run-review.ts\n",
+      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/run-review.ts\n",
     );
     const repo = new Repo(tmp.path);
     const result = ciValidation.evaluate(repo);
@@ -270,7 +271,7 @@ describe("ciValidation rule", () => {
     );
     writeFileSync(
       join(wfDir, "pr-review.yml"),
-      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx .context-tree/run-review.ts\n",
+      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/run-review.ts\n",
     );
     const repo = new Repo(tmp.path);
     const result = ciValidation.evaluate(repo);
@@ -288,11 +289,11 @@ describe("ciValidation rule", () => {
     );
     writeFileSync(
       join(wfDir, "pr-review.yml"),
-      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx .context-tree/run-review.ts\n",
+      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/run-review.ts\n",
     );
     writeFileSync(
       join(wfDir, "codeowners.yml"),
-      "name: Update CODEOWNERS\non: pull_request\njobs:\n  update:\n    steps:\n      - run: npx tsx .context-tree/generate-codeowners.ts\n",
+      "name: Update CODEOWNERS\non: pull_request\njobs:\n  update:\n    steps:\n      - run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/generate-codeowners.ts\n",
     );
     const repo = new Repo(tmp.path);
     const result = ciValidation.evaluate(repo);

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/tests/run-review.test.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/tests/run-review.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   extractStreamText,
   extractReviewJson,
-} from "../.context-tree/run-review.js";
+} from "../skills/first-tree-cli-framework/assets/framework/helpers/run-review.js";
 
 // --- extractStreamText ---
 

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/tests/upgrade.test.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/tests/upgrade.test.ts
@@ -1,0 +1,58 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { Repo } from "#src/repo.js";
+import { runUpgrade } from "#src/upgrade.js";
+import {
+  FRAMEWORK_VERSION,
+  INSTALLED_PROGRESS,
+} from "#src/runtime/asset-loader.js";
+import { makeFramework, makeLegacyFramework, useTmpDir } from "./helpers.js";
+
+function makeUpstreamSkill(root: string, version: string): void {
+  const skillRoot = join(root, "skills", "first-tree-cli-framework");
+  mkdirSync(join(skillRoot, "assets", "framework"), { recursive: true });
+  writeFileSync(
+    join(skillRoot, "SKILL.md"),
+    "---\nname: first-tree-cli-framework\ndescription: test\n---\n",
+  );
+  writeFileSync(join(root, FRAMEWORK_VERSION), `${version}\n`);
+}
+
+describe("runUpgrade", () => {
+  it("migrates a legacy repo to the installed skill layout", () => {
+    const repoDir = useTmpDir();
+    const upstreamDir = useTmpDir();
+    makeLegacyFramework(repoDir.path, "0.1.0");
+    writeFileSync(
+      join(repoDir.path, "AGENT.md"),
+      "<!-- BEGIN CONTEXT-TREE FRAMEWORK -->\nstuff\n<!-- END CONTEXT-TREE FRAMEWORK -->\n",
+    );
+    makeUpstreamSkill(upstreamDir.path, "0.2.0");
+
+    const result = runUpgrade(new Repo(repoDir.path), {
+      upstreamRoot: upstreamDir.path,
+    });
+
+    expect(result).toBe(0);
+    expect(existsSync(join(repoDir.path, ".context-tree"))).toBe(false);
+    expect(readFileSync(join(repoDir.path, FRAMEWORK_VERSION), "utf-8").trim()).toBe("0.2.0");
+    expect(readFileSync(join(repoDir.path, INSTALLED_PROGRESS), "utf-8")).toContain(
+      "skills/first-tree-cli-framework/assets/framework/VERSION",
+    );
+  });
+
+  it("returns early when the installed skill is already current", () => {
+    const repoDir = useTmpDir();
+    const upstreamDir = useTmpDir();
+    makeFramework(repoDir.path, "0.2.0");
+    makeUpstreamSkill(upstreamDir.path, "0.2.0");
+
+    const result = runUpgrade(new Repo(repoDir.path), {
+      upstreamRoot: upstreamDir.path,
+    });
+
+    expect(result).toBe(0);
+    expect(existsSync(join(repoDir.path, INSTALLED_PROGRESS))).toBe(false);
+  });
+});

--- a/.claude/skills/first-tree-cli-framework/references/repo-snapshot/tests/verify.test.ts
+++ b/.claude/skills/first-tree-cli-framework/references/repo-snapshot/tests/verify.test.ts
@@ -3,7 +3,18 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { check, checkProgress, runVerify } from "#src/verify.js";
 import { Repo } from "#src/repo.js";
-import { useTmpDir, makeFramework, makeNode, makeAgentMd, makeMembers } from "./helpers.js";
+import {
+  INSTALLED_PROGRESS,
+  LEGACY_PROGRESS,
+} from "#src/runtime/asset-loader.js";
+import {
+  useTmpDir,
+  makeFramework,
+  makeLegacyFramework,
+  makeNode,
+  makeAgentMd,
+  makeMembers,
+} from "./helpers.js";
 
 // --- check ---
 
@@ -28,10 +39,9 @@ describe("checkProgress", () => {
 
   it("returns empty when all checked", () => {
     const tmp = useTmpDir();
-    const ct = join(tmp.path, ".context-tree");
-    mkdirSync(ct);
+    mkdirSync(join(tmp.path, "skills", "first-tree-cli-framework"), { recursive: true });
     writeFileSync(
-      join(ct, "progress.md"),
+      join(tmp.path, INSTALLED_PROGRESS),
       "# Progress\n- [x] Task one\n- [x] Task two\n",
     );
     const repo = new Repo(tmp.path);
@@ -40,10 +50,9 @@ describe("checkProgress", () => {
 
   it("returns unchecked items", () => {
     const tmp = useTmpDir();
-    const ct = join(tmp.path, ".context-tree");
-    mkdirSync(ct);
+    mkdirSync(join(tmp.path, "skills", "first-tree-cli-framework"), { recursive: true });
     writeFileSync(
-      join(ct, "progress.md"),
+      join(tmp.path, INSTALLED_PROGRESS),
       "# Progress\n- [x] Done task\n- [ ] Pending task\n- [ ] Another pending\n",
     );
     const repo = new Repo(tmp.path);
@@ -52,11 +61,21 @@ describe("checkProgress", () => {
 
   it("returns empty for empty progress", () => {
     const tmp = useTmpDir();
-    const ct = join(tmp.path, ".context-tree");
-    mkdirSync(ct);
-    writeFileSync(join(ct, "progress.md"), "");
+    mkdirSync(join(tmp.path, "skills", "first-tree-cli-framework"), { recursive: true });
+    writeFileSync(join(tmp.path, INSTALLED_PROGRESS), "");
     const repo = new Repo(tmp.path);
     expect(checkProgress(repo)).toEqual([]);
+  });
+
+  it("falls back to the legacy progress file", () => {
+    const tmp = useTmpDir();
+    makeLegacyFramework(tmp.path);
+    writeFileSync(
+      join(tmp.path, LEGACY_PROGRESS),
+      "# Progress\n- [ ] Legacy task\n",
+    );
+    const repo = new Repo(tmp.path);
+    expect(checkProgress(repo)).toEqual(["Legacy task"]);
   });
 });
 

--- a/.claude/skills/first-tree-cli-framework/references/source-map.md
+++ b/.claude/skills/first-tree-cli-framework/references/source-map.md
@@ -19,7 +19,7 @@ This file is the fast index for the new single-skill architecture.
 | --- | --- |
 | `src/cli.ts` | Top-level command dispatch |
 | `src/commands/help.ts` | Help topic routing |
-| `src/init.ts` / `src/verify.ts` / `src/upgrade.ts` | Existing command implementations while the refactor converges |
+| `src/init.ts` / `src/verify.ts` / `src/upgrade.ts` | Command implementations for install, verify, and upgrade |
 | `src/commands/` | Stable command entrypoints the CLI imports |
 | `src/runtime/asset-loader.ts` | Canonical path constants and layout detection |
 | `src/runtime/installer.ts` | Copy and template-render helpers |
@@ -39,6 +39,7 @@ The installed skill payload lives under `assets/framework/`.
 | `assets/framework/prompts/` | Review prompt payload |
 | `assets/framework/examples/` | Agent integration examples |
 | `assets/framework/helpers/` | Shipped helper scripts and TypeScript utilities |
+| `progress.md` | Generated in user repos to track unfinished setup or upgrade tasks |
 
 ## Validation Surface
 
@@ -56,8 +57,8 @@ The installed skill payload lives under `assets/framework/`.
 
 ## Compatibility Notes
 
-- `docs/` and root `.context-tree/` are temporary exported mirrors while the
-  repo transitions to a single canonical skill.
+- In the source repo, `docs/` and root `.context-tree/` are temporary exported
+  mirrors. They are no longer part of the user-repo contract.
 - `references/repo-snapshot/` is a portable artifact, not the source of truth.
 - If you change `references/` or `assets/framework/`, run
   `bash ./skills/first-tree-cli-framework/scripts/sync-skill-artifacts.sh`.

--- a/.claude/skills/first-tree-cli-framework/references/upgrade-contract.md
+++ b/.claude/skills/first-tree-cli-framework/references/upgrade-contract.md
@@ -18,6 +18,7 @@ The end-state installed layout in a user repo is:
 skills/
   first-tree-cli-framework/
     SKILL.md
+    progress.md
     references/
     assets/
       framework/
@@ -41,15 +42,15 @@ The tree content still lives outside the skill:
 - `context-tree init`
   - installs the skill into the target repo
   - renders top-level tree scaffolding from the skill templates
-  - writes progress state
-  - wires an upstream remote for future upgrades
+  - writes progress state to `skills/first-tree-cli-framework/progress.md`
 - `context-tree verify`
-  - checks progress state
+  - checks progress state from the installed skill
   - validates root/frontmatter/agent markers
   - runs node and member validators
 - `context-tree upgrade`
   - compares the installed skill payload version to upstream
   - refreshes the installed skill payload without overwriting tree content
+  - migrates legacy `.context-tree/` repos onto the installed skill layout
   - preserves user-authored sections such as the editable part of `AGENT.md`
 
 ## Compatibility Rules During Migration
@@ -58,6 +59,8 @@ The tree content still lives outside the skill:
   - `skills/first-tree-cli-framework/...`
   - legacy `.context-tree/...`
 - When both layouts are present, prefer the installed skill layout.
+- `context-tree init` only installs the skill layout; it does not create a new `.context-tree/`.
+- `context-tree upgrade` should remove legacy `.context-tree/` after migrating a repo.
 - The legacy layout must be derivable from the canonical skill via
   `scripts/export-runtime-assets.sh`.
 - `references/repo-snapshot/` may exist as a portable artifact until cleanup,

--- a/.context-tree/examples/claude-code/README.md
+++ b/.context-tree/examples/claude-code/README.md
@@ -6,10 +6,9 @@ Copy `settings.json` to your tree repo's `.claude/` directory:
 
 ```bash
 mkdir -p .claude
-cp .context-tree/examples/claude-code/settings.json .claude/settings.json
+cp skills/first-tree-cli-framework/assets/framework/examples/claude-code/settings.json .claude/settings.json
 ```
 
 ## What It Does
 
-The `SessionStart` hook runs `.context-tree/scripts/inject-tree-context.sh` when a Claude Code session begins. This injects the root `NODE.md` content as additional context, giving the agent an overview of the tree structure before any task.
-
+The `SessionStart` hook runs `./skills/first-tree-cli-framework/assets/framework/helpers/inject-tree-context.sh` when a Claude Code session begins. This injects the root `NODE.md` content as additional context, giving the agent an overview of the tree structure before any task.

--- a/.context-tree/examples/claude-code/settings.json
+++ b/.context-tree/examples/claude-code/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".context-tree/scripts/inject-tree-context.sh"
+            "command": "./skills/first-tree-cli-framework/assets/framework/helpers/inject-tree-context.sh"
           }
         ]
       }

--- a/.context-tree/generate-codeowners.ts
+++ b/.context-tree/generate-codeowners.ts
@@ -205,7 +205,7 @@ export function generate(
       return 0;
     }
     console.log(
-      "CODEOWNERS is out-of-date. Run: npx tsx .context-tree/generate-codeowners.ts",
+      "CODEOWNERS is out-of-date. Run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/generate-codeowners.ts",
     );
     return 1;
   }

--- a/.context-tree/run-review.ts
+++ b/.context-tree/run-review.ts
@@ -23,7 +23,10 @@ function buildPrompt(diffPath: string): string {
   const files: [string, string][] = [
     ["AGENT.md", "AGENT.md"],
     ["Root NODE.md", "NODE.md"],
-    ["Review Instructions", ".context-tree/prompts/pr-review.md"],
+    [
+      "Review Instructions",
+      "skills/first-tree-cli-framework/assets/framework/prompts/pr-review.md",
+    ],
   ];
   for (const [heading, path] of files) {
     const content = readFileSync(path, "utf-8");

--- a/.context-tree/templates/agent.md.template
+++ b/.context-tree/templates/agent.md.template
@@ -13,7 +13,7 @@ You are working in a **Context Tree** — the living source of truth for decisio
 
 4. **Git-native tree structure.** Each node is a file; each domain is a directory. Soft links allow cross-references without the complexity of a full graph. History, ownership, and review follow Git conventions.
 
-See `.context-tree/principles.md` for detailed explanations and examples.
+See `skills/first-tree-cli-framework/references/principles.md` for detailed explanations and examples.
 
 ## Before Every Task
 
@@ -40,7 +40,7 @@ Ask yourself: **Does the tree need updating?**
 
 ## Reference
 
-For ownership rules, tree structure, and key files, see [NODE.md](NODE.md) and `.context-tree/ownership-and-naming.md`.
+For ownership rules, tree structure, and key files, see [NODE.md](NODE.md) and `skills/first-tree-cli-framework/references/ownership-and-naming.md`.
 <!-- END CONTEXT-TREE FRAMEWORK -->
 
 # Project-Specific Instructions

--- a/.context-tree/templates/members-domain.md.template
+++ b/.context-tree/templates/members-domain.md.template
@@ -34,7 +34,7 @@ domains:
 ---
 ```
 
-See `.context-tree/templates/member-node.md.template` for a full scaffold.
+See `skills/first-tree-cli-framework/assets/framework/templates/member-node.md.template` for a full scaffold.
 
 ---
 

--- a/.context-tree/templates/root-node.md.template
+++ b/.context-tree/templates/root-node.md.template
@@ -31,8 +31,8 @@ The living source of truth for your organization. A structured knowledge base th
 
 See [AGENT.md](AGENT.md) for agent instructions — the before/during/after workflow, ownership model, and tree maintenance.
 
-See [about.md](about.md) for background — the problem, the idea, and who it's for.
+See [about.md](skills/first-tree-cli-framework/references/about.md) for background — the problem, the idea, and who it's for.
 
-See the framework documentation in `.context-tree/`:
-- [principles.md](.context-tree/principles.md) — core principles with examples
-- [ownership-and-naming.md](.context-tree/ownership-and-naming.md) — node naming and ownership model
+See the installed framework documentation:
+- [principles.md](skills/first-tree-cli-framework/references/principles.md) — core principles with examples
+- [ownership-and-naming.md](skills/first-tree-cli-framework/references/ownership-and-naming.md) — node naming and ownership model

--- a/.context-tree/workflows/codeowners.yml
+++ b/.context-tree/workflows/codeowners.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: "22"
 
-      - run: npx tsx .context-tree/generate-codeowners.ts
+      - run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/generate-codeowners.ts
 
       - name: Commit if changed
         run: |

--- a/.context-tree/workflows/pr-review.yml
+++ b/.context-tree/workflows/pr-review.yml
@@ -45,7 +45,7 @@ jobs:
           gh pr view "$PR_NUMBER" --json headRefOid -q .headRefOid > /tmp/pr-head-sha.txt
 
       - name: Run Claude review
-        run: npx tsx .context-tree/run-review.ts
+        run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/run-review.ts
 
       - name: Parse and post review
         run: |

--- a/AGENT.md
+++ b/AGENT.md
@@ -9,7 +9,7 @@ This repo is the **template source and CLI** for Context Tree. It is NOT a conte
   - `src/validators/` — Node, member, and CODEOWNERS validation
 - `src/runtime/` — Shared path, install, adapter, and upgrade helpers
 - `skills/first-tree-cli-framework/` — Canonical skill source for docs and shipped runtime assets
-- `.context-tree/` — Temporary exported mirror of the shipped runtime assets during the single-skill migration
+- `.context-tree/` — Temporary exported mirror in the source repo during the single-skill migration
   - `tests/` — Unit tests (Vitest)
   - `docs/` — Introduction and documentation
 
@@ -17,7 +17,7 @@ This repo is the **template source and CLI** for Context Tree. It is NOT a conte
 
 - The CLI is a **harness for the agent** — it generates situation-aware task lists, not executes them
 - `skills/first-tree-cli-framework/` is the single canonical source; `assets/framework/` is the shipped runtime payload
-- `.context-tree/` is currently an exported compatibility mirror while the refactor converges
+- New user repos install `skills/first-tree-cli-framework/` directly; `.context-tree/` remains only as a source-repo compatibility mirror while the refactor converges
 - Templates in `skills/first-tree-cli-framework/assets/framework/templates/` ultimately render `NODE.md`, `AGENT.md`, `members/NODE.md` in users' repos
 - The npm package is `first-tree`, and it installs the `context-tree` command. Use `npx first-tree ...` for one-off runs or `npm install -g first-tree` to put `context-tree` on your PATH.
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -65,19 +65,19 @@ git init
 context-tree init
 ```
 
-This clones the framework into `.context-tree/`, renders scaffolding (`NODE.md`, `AGENT.md`, `members/NODE.md`), and generates a task list in `.context-tree/progress.md`.
+This installs the framework skill into `skills/first-tree-cli-framework/`, renders scaffolding (`NODE.md`, `AGENT.md`, `members/NODE.md`), and generates a task list in `skills/first-tree-cli-framework/progress.md`.
 
 ### Step 2: Work Through the Task List
 
-Read `.context-tree/progress.md`. It contains a checklist tailored to the current state of the repo. Complete each task:
+Read `skills/first-tree-cli-framework/progress.md`. It contains a checklist tailored to the current state of the repo. Complete each task:
 
 - Fill in `NODE.md` with your organization name, owners, and domains
 - Add project-specific instructions to `AGENT.md` below the framework markers
 - Create member nodes under `members/`
 - Optionally configure agent integration (e.g., Claude Code session hooks)
-- Copy validation workflows to `.github/workflows/`
+- Copy validation workflows from `skills/first-tree-cli-framework/assets/framework/workflows/` to `.github/workflows/`
 
-As you complete each task, check it off in `progress.md` by changing `- [ ]` to `- [x]`.
+As you complete each task, check it off in `skills/first-tree-cli-framework/progress.md` by changing `- [ ]` to `- [x]`.
 
 ### Step 3: Verify
 
@@ -85,7 +85,7 @@ As you complete each task, check it off in `progress.md` by changing `- [ ]` to 
 context-tree verify
 ```
 
-This fails if any items in `progress.md` remain unchecked, and runs deterministic checks (valid frontmatter, node structure, member nodes exist).
+This fails if any items in `skills/first-tree-cli-framework/progress.md` remain unchecked, and runs deterministic checks (valid frontmatter, node structure, member nodes exist).
 
 ### Step 4: Design Your Domains
 
@@ -122,27 +122,27 @@ The tree doesn't duplicate source code — it captures what connects things and 
 
 | Command | Description |
 |---------|-------------|
-| `context-tree init` | Bootstrap a new tree. Clones framework, renders templates, generates task list. |
-| `context-tree verify` | Check progress.md for unchecked items + run deterministic validation. |
-| `context-tree upgrade` | Compare local framework version to upstream, generate upgrade task list. |
+| `context-tree init` | Bootstrap a new tree. Installs the framework skill, renders templates, generates a task list. |
+| `context-tree verify` | Check the installed progress file for unchecked items + run deterministic validation. |
+| `context-tree upgrade` | Refresh the installed framework skill from upstream and generate follow-up tasks. |
 | `context-tree help onboarding` | Print this onboarding guide. |
 
 ---
 
 ## Upgrading the Framework
 
-After init, the first-tree repo is added as a git remote (`context-tree-upstream`). When the framework updates:
+When the framework updates:
 
 ```bash
 context-tree upgrade
 ```
 
-This compares your `.context-tree/VERSION` to upstream and generates a task list. The framework directory (`.context-tree/`) is upgradable without touching your content.
+This refreshes `skills/first-tree-cli-framework/` from upstream, preserves your tree content, and generates follow-up tasks in `skills/first-tree-cli-framework/progress.md`.
 
 ---
 
 ## Further Reading
 
-- `.context-tree/principles.md` — Core principles with detailed examples
-- `.context-tree/ownership-and-naming.md` — How nodes are named and owned
+- `skills/first-tree-cli-framework/references/principles.md` — Core principles with detailed examples
+- `skills/first-tree-cli-framework/references/ownership-and-naming.md` — How nodes are named and owned
 - `AGENT.md` in your tree — The before/during/after workflow for every task

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "imports": {
     "#src/*.js": "./src/*.ts",
     "#evals/*.js": "./evals/*.ts",
-    "#docs/*": "./docs/*"
+    "#docs/*": "./docs/*",
+    "#skill/*": "./skills/first-tree-cli-framework/*"
   },
   "files": [
     "dist"

--- a/skills/first-tree-cli-framework/assets/framework/examples/claude-code/README.md
+++ b/skills/first-tree-cli-framework/assets/framework/examples/claude-code/README.md
@@ -6,10 +6,9 @@ Copy `settings.json` to your tree repo's `.claude/` directory:
 
 ```bash
 mkdir -p .claude
-cp .context-tree/examples/claude-code/settings.json .claude/settings.json
+cp skills/first-tree-cli-framework/assets/framework/examples/claude-code/settings.json .claude/settings.json
 ```
 
 ## What It Does
 
-The `SessionStart` hook runs `.context-tree/scripts/inject-tree-context.sh` when a Claude Code session begins. This injects the root `NODE.md` content as additional context, giving the agent an overview of the tree structure before any task.
-
+The `SessionStart` hook runs `./skills/first-tree-cli-framework/assets/framework/helpers/inject-tree-context.sh` when a Claude Code session begins. This injects the root `NODE.md` content as additional context, giving the agent an overview of the tree structure before any task.

--- a/skills/first-tree-cli-framework/assets/framework/examples/claude-code/settings.json
+++ b/skills/first-tree-cli-framework/assets/framework/examples/claude-code/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".context-tree/scripts/inject-tree-context.sh"
+            "command": "./skills/first-tree-cli-framework/assets/framework/helpers/inject-tree-context.sh"
           }
         ]
       }

--- a/skills/first-tree-cli-framework/assets/framework/helpers/generate-codeowners.ts
+++ b/skills/first-tree-cli-framework/assets/framework/helpers/generate-codeowners.ts
@@ -205,7 +205,7 @@ export function generate(
       return 0;
     }
     console.log(
-      "CODEOWNERS is out-of-date. Run: npx tsx .context-tree/generate-codeowners.ts",
+      "CODEOWNERS is out-of-date. Run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/generate-codeowners.ts",
     );
     return 1;
   }

--- a/skills/first-tree-cli-framework/assets/framework/helpers/run-review.ts
+++ b/skills/first-tree-cli-framework/assets/framework/helpers/run-review.ts
@@ -23,7 +23,10 @@ function buildPrompt(diffPath: string): string {
   const files: [string, string][] = [
     ["AGENT.md", "AGENT.md"],
     ["Root NODE.md", "NODE.md"],
-    ["Review Instructions", ".context-tree/prompts/pr-review.md"],
+    [
+      "Review Instructions",
+      "skills/first-tree-cli-framework/assets/framework/prompts/pr-review.md",
+    ],
   ];
   for (const [heading, path] of files) {
     const content = readFileSync(path, "utf-8");

--- a/skills/first-tree-cli-framework/assets/framework/templates/agent.md.template
+++ b/skills/first-tree-cli-framework/assets/framework/templates/agent.md.template
@@ -13,7 +13,7 @@ You are working in a **Context Tree** — the living source of truth for decisio
 
 4. **Git-native tree structure.** Each node is a file; each domain is a directory. Soft links allow cross-references without the complexity of a full graph. History, ownership, and review follow Git conventions.
 
-See `.context-tree/principles.md` for detailed explanations and examples.
+See `skills/first-tree-cli-framework/references/principles.md` for detailed explanations and examples.
 
 ## Before Every Task
 
@@ -40,7 +40,7 @@ Ask yourself: **Does the tree need updating?**
 
 ## Reference
 
-For ownership rules, tree structure, and key files, see [NODE.md](NODE.md) and `.context-tree/ownership-and-naming.md`.
+For ownership rules, tree structure, and key files, see [NODE.md](NODE.md) and `skills/first-tree-cli-framework/references/ownership-and-naming.md`.
 <!-- END CONTEXT-TREE FRAMEWORK -->
 
 # Project-Specific Instructions

--- a/skills/first-tree-cli-framework/assets/framework/templates/members-domain.md.template
+++ b/skills/first-tree-cli-framework/assets/framework/templates/members-domain.md.template
@@ -34,7 +34,7 @@ domains:
 ---
 ```
 
-See `.context-tree/templates/member-node.md.template` for a full scaffold.
+See `skills/first-tree-cli-framework/assets/framework/templates/member-node.md.template` for a full scaffold.
 
 ---
 

--- a/skills/first-tree-cli-framework/assets/framework/templates/root-node.md.template
+++ b/skills/first-tree-cli-framework/assets/framework/templates/root-node.md.template
@@ -31,8 +31,8 @@ The living source of truth for your organization. A structured knowledge base th
 
 See [AGENT.md](AGENT.md) for agent instructions — the before/during/after workflow, ownership model, and tree maintenance.
 
-See [about.md](about.md) for background — the problem, the idea, and who it's for.
+See [about.md](skills/first-tree-cli-framework/references/about.md) for background — the problem, the idea, and who it's for.
 
-See the framework documentation in `.context-tree/`:
-- [principles.md](.context-tree/principles.md) — core principles with examples
-- [ownership-and-naming.md](.context-tree/ownership-and-naming.md) — node naming and ownership model
+See the installed framework documentation:
+- [principles.md](skills/first-tree-cli-framework/references/principles.md) — core principles with examples
+- [ownership-and-naming.md](skills/first-tree-cli-framework/references/ownership-and-naming.md) — node naming and ownership model

--- a/skills/first-tree-cli-framework/assets/framework/workflows/codeowners.yml
+++ b/skills/first-tree-cli-framework/assets/framework/workflows/codeowners.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: "22"
 
-      - run: npx tsx .context-tree/generate-codeowners.ts
+      - run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/generate-codeowners.ts
 
       - name: Commit if changed
         run: |

--- a/skills/first-tree-cli-framework/assets/framework/workflows/pr-review.yml
+++ b/skills/first-tree-cli-framework/assets/framework/workflows/pr-review.yml
@@ -45,7 +45,7 @@ jobs:
           gh pr view "$PR_NUMBER" --json headRefOid -q .headRefOid > /tmp/pr-head-sha.txt
 
       - name: Run Claude review
-        run: npx tsx .context-tree/run-review.ts
+        run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/run-review.ts
 
       - name: Parse and post review
         run: |

--- a/skills/first-tree-cli-framework/references/onboarding.md
+++ b/skills/first-tree-cli-framework/references/onboarding.md
@@ -65,19 +65,19 @@ git init
 context-tree init
 ```
 
-This clones the framework into `.context-tree/`, renders scaffolding (`NODE.md`, `AGENT.md`, `members/NODE.md`), and generates a task list in `.context-tree/progress.md`.
+This installs the framework skill into `skills/first-tree-cli-framework/`, renders scaffolding (`NODE.md`, `AGENT.md`, `members/NODE.md`), and generates a task list in `skills/first-tree-cli-framework/progress.md`.
 
 ### Step 2: Work Through the Task List
 
-Read `.context-tree/progress.md`. It contains a checklist tailored to the current state of the repo. Complete each task:
+Read `skills/first-tree-cli-framework/progress.md`. It contains a checklist tailored to the current state of the repo. Complete each task:
 
 - Fill in `NODE.md` with your organization name, owners, and domains
 - Add project-specific instructions to `AGENT.md` below the framework markers
 - Create member nodes under `members/`
 - Optionally configure agent integration (e.g., Claude Code session hooks)
-- Copy validation workflows to `.github/workflows/`
+- Copy validation workflows from `skills/first-tree-cli-framework/assets/framework/workflows/` to `.github/workflows/`
 
-As you complete each task, check it off in `progress.md` by changing `- [ ]` to `- [x]`.
+As you complete each task, check it off in `skills/first-tree-cli-framework/progress.md` by changing `- [ ]` to `- [x]`.
 
 ### Step 3: Verify
 
@@ -85,7 +85,7 @@ As you complete each task, check it off in `progress.md` by changing `- [ ]` to 
 context-tree verify
 ```
 
-This fails if any items in `progress.md` remain unchecked, and runs deterministic checks (valid frontmatter, node structure, member nodes exist).
+This fails if any items in `skills/first-tree-cli-framework/progress.md` remain unchecked, and runs deterministic checks (valid frontmatter, node structure, member nodes exist).
 
 ### Step 4: Design Your Domains
 
@@ -122,27 +122,27 @@ The tree doesn't duplicate source code — it captures what connects things and 
 
 | Command | Description |
 |---------|-------------|
-| `context-tree init` | Bootstrap a new tree. Clones framework, renders templates, generates task list. |
-| `context-tree verify` | Check progress.md for unchecked items + run deterministic validation. |
-| `context-tree upgrade` | Compare local framework version to upstream, generate upgrade task list. |
+| `context-tree init` | Bootstrap a new tree. Installs the framework skill, renders templates, generates a task list. |
+| `context-tree verify` | Check the installed progress file for unchecked items + run deterministic validation. |
+| `context-tree upgrade` | Refresh the installed framework skill from upstream and generate follow-up tasks. |
 | `context-tree help onboarding` | Print this onboarding guide. |
 
 ---
 
 ## Upgrading the Framework
 
-After init, the first-tree repo is added as a git remote (`context-tree-upstream`). When the framework updates:
+When the framework updates:
 
 ```bash
 context-tree upgrade
 ```
 
-This compares your `.context-tree/VERSION` to upstream and generates a task list. The framework directory (`.context-tree/`) is upgradable without touching your content.
+This refreshes `skills/first-tree-cli-framework/` from upstream, preserves your tree content, and generates follow-up tasks in `skills/first-tree-cli-framework/progress.md`.
 
 ---
 
 ## Further Reading
 
-- `.context-tree/principles.md` — Core principles with detailed examples
-- `.context-tree/ownership-and-naming.md` — How nodes are named and owned
+- `skills/first-tree-cli-framework/references/principles.md` — Core principles with detailed examples
+- `skills/first-tree-cli-framework/references/ownership-and-naming.md` — How nodes are named and owned
 - `AGENT.md` in your tree — The before/during/after workflow for every task

--- a/skills/first-tree-cli-framework/references/portable-quickstart.md
+++ b/skills/first-tree-cli-framework/references/portable-quickstart.md
@@ -11,8 +11,8 @@ This skill is meant to keep working even after the `skills/first-tree-cli-framew
 Snapshot source:
 
 - live repo: `agent-team-foundation/first-tree`
-- snapshot base commit when this portable copy was refreshed: `7f7567ef117edc1102800d8b0e9dff96aa11c524`
-- snapshot content fingerprint: `sha256:5321c1ceb28664c9fcfa7d4b29c136734ac73fef9ed8cb6b19c79a70dd3d20f3`
+- snapshot base commit when this portable copy was refreshed: `ef75cac3c112cea4475c095b000274cc97301cd7`
+- snapshot content fingerprint: `sha256:8de9030ffc5666ebcce8dab5f381da03fbc46f5c178218a62acb8ad1cfb7fd12`
 
 The base commit records which live checkout the refresh started from. Generated artifact updates may land in a later commit, so strict sync validation uses the content fingerprint above.
 

--- a/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/examples/claude-code/README.md
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/examples/claude-code/README.md
@@ -6,10 +6,9 @@ Copy `settings.json` to your tree repo's `.claude/` directory:
 
 ```bash
 mkdir -p .claude
-cp .context-tree/examples/claude-code/settings.json .claude/settings.json
+cp skills/first-tree-cli-framework/assets/framework/examples/claude-code/settings.json .claude/settings.json
 ```
 
 ## What It Does
 
-The `SessionStart` hook runs `.context-tree/scripts/inject-tree-context.sh` when a Claude Code session begins. This injects the root `NODE.md` content as additional context, giving the agent an overview of the tree structure before any task.
-
+The `SessionStart` hook runs `./skills/first-tree-cli-framework/assets/framework/helpers/inject-tree-context.sh` when a Claude Code session begins. This injects the root `NODE.md` content as additional context, giving the agent an overview of the tree structure before any task.

--- a/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/examples/claude-code/settings.json
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/examples/claude-code/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".context-tree/scripts/inject-tree-context.sh"
+            "command": "./skills/first-tree-cli-framework/assets/framework/helpers/inject-tree-context.sh"
           }
         ]
       }

--- a/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/generate-codeowners.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/generate-codeowners.ts
@@ -205,7 +205,7 @@ export function generate(
       return 0;
     }
     console.log(
-      "CODEOWNERS is out-of-date. Run: npx tsx .context-tree/generate-codeowners.ts",
+      "CODEOWNERS is out-of-date. Run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/generate-codeowners.ts",
     );
     return 1;
   }

--- a/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/run-review.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/run-review.ts
@@ -23,7 +23,10 @@ function buildPrompt(diffPath: string): string {
   const files: [string, string][] = [
     ["AGENT.md", "AGENT.md"],
     ["Root NODE.md", "NODE.md"],
-    ["Review Instructions", ".context-tree/prompts/pr-review.md"],
+    [
+      "Review Instructions",
+      "skills/first-tree-cli-framework/assets/framework/prompts/pr-review.md",
+    ],
   ];
   for (const [heading, path] of files) {
     const content = readFileSync(path, "utf-8");

--- a/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/templates/agent.md.template
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/templates/agent.md.template
@@ -13,7 +13,7 @@ You are working in a **Context Tree** — the living source of truth for decisio
 
 4. **Git-native tree structure.** Each node is a file; each domain is a directory. Soft links allow cross-references without the complexity of a full graph. History, ownership, and review follow Git conventions.
 
-See `.context-tree/principles.md` for detailed explanations and examples.
+See `skills/first-tree-cli-framework/references/principles.md` for detailed explanations and examples.
 
 ## Before Every Task
 
@@ -40,7 +40,7 @@ Ask yourself: **Does the tree need updating?**
 
 ## Reference
 
-For ownership rules, tree structure, and key files, see [NODE.md](NODE.md) and `.context-tree/ownership-and-naming.md`.
+For ownership rules, tree structure, and key files, see [NODE.md](NODE.md) and `skills/first-tree-cli-framework/references/ownership-and-naming.md`.
 <!-- END CONTEXT-TREE FRAMEWORK -->
 
 # Project-Specific Instructions

--- a/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/templates/members-domain.md.template
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/templates/members-domain.md.template
@@ -34,7 +34,7 @@ domains:
 ---
 ```
 
-See `.context-tree/templates/member-node.md.template` for a full scaffold.
+See `skills/first-tree-cli-framework/assets/framework/templates/member-node.md.template` for a full scaffold.
 
 ---
 

--- a/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/templates/root-node.md.template
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/templates/root-node.md.template
@@ -31,8 +31,8 @@ The living source of truth for your organization. A structured knowledge base th
 
 See [AGENT.md](AGENT.md) for agent instructions — the before/during/after workflow, ownership model, and tree maintenance.
 
-See [about.md](about.md) for background — the problem, the idea, and who it's for.
+See [about.md](skills/first-tree-cli-framework/references/about.md) for background — the problem, the idea, and who it's for.
 
-See the framework documentation in `.context-tree/`:
-- [principles.md](.context-tree/principles.md) — core principles with examples
-- [ownership-and-naming.md](.context-tree/ownership-and-naming.md) — node naming and ownership model
+See the installed framework documentation:
+- [principles.md](skills/first-tree-cli-framework/references/principles.md) — core principles with examples
+- [ownership-and-naming.md](skills/first-tree-cli-framework/references/ownership-and-naming.md) — node naming and ownership model

--- a/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/workflows/codeowners.yml
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/workflows/codeowners.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: "22"
 
-      - run: npx tsx .context-tree/generate-codeowners.ts
+      - run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/generate-codeowners.ts
 
       - name: Commit if changed
         run: |

--- a/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/workflows/pr-review.yml
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/.context-tree/workflows/pr-review.yml
@@ -45,7 +45,7 @@ jobs:
           gh pr view "$PR_NUMBER" --json headRefOid -q .headRefOid > /tmp/pr-head-sha.txt
 
       - name: Run Claude review
-        run: npx tsx .context-tree/run-review.ts
+        run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/run-review.ts
 
       - name: Parse and post review
         run: |

--- a/skills/first-tree-cli-framework/references/repo-snapshot/AGENTS.md
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/AGENTS.md
@@ -9,7 +9,7 @@ This repo is the **template source and CLI** for Context Tree. It is NOT a conte
   - `src/validators/` — Node, member, and CODEOWNERS validation
 - `src/runtime/` — Shared path, install, adapter, and upgrade helpers
 - `skills/first-tree-cli-framework/` — Canonical skill source for docs and shipped runtime assets
-- `.context-tree/` — Temporary exported mirror of the shipped runtime assets during the single-skill migration
+- `.context-tree/` — Temporary exported mirror in the source repo during the single-skill migration
   - `tests/` — Unit tests (Vitest)
   - `docs/` — Introduction and documentation
 
@@ -17,7 +17,7 @@ This repo is the **template source and CLI** for Context Tree. It is NOT a conte
 
 - The CLI is a **harness for the agent** — it generates situation-aware task lists, not executes them
 - `skills/first-tree-cli-framework/` is the single canonical source; `assets/framework/` is the shipped runtime payload
-- `.context-tree/` is currently an exported compatibility mirror while the refactor converges
+- New user repos install `skills/first-tree-cli-framework/` directly; `.context-tree/` remains only as a source-repo compatibility mirror while the refactor converges
 - Templates in `skills/first-tree-cli-framework/assets/framework/templates/` ultimately render `NODE.md`, `AGENT.md`, `members/NODE.md` in users' repos
 - The npm package is `first-tree`, and it installs the `context-tree` command. Use `npx first-tree ...` for one-off runs or `npm install -g first-tree` to put `context-tree` on your PATH.
 

--- a/skills/first-tree-cli-framework/references/repo-snapshot/docs/onboarding.md
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/docs/onboarding.md
@@ -65,19 +65,19 @@ git init
 context-tree init
 ```
 
-This clones the framework into `.context-tree/`, renders scaffolding (`NODE.md`, `AGENT.md`, `members/NODE.md`), and generates a task list in `.context-tree/progress.md`.
+This installs the framework skill into `skills/first-tree-cli-framework/`, renders scaffolding (`NODE.md`, `AGENT.md`, `members/NODE.md`), and generates a task list in `skills/first-tree-cli-framework/progress.md`.
 
 ### Step 2: Work Through the Task List
 
-Read `.context-tree/progress.md`. It contains a checklist tailored to the current state of the repo. Complete each task:
+Read `skills/first-tree-cli-framework/progress.md`. It contains a checklist tailored to the current state of the repo. Complete each task:
 
 - Fill in `NODE.md` with your organization name, owners, and domains
 - Add project-specific instructions to `AGENT.md` below the framework markers
 - Create member nodes under `members/`
 - Optionally configure agent integration (e.g., Claude Code session hooks)
-- Copy validation workflows to `.github/workflows/`
+- Copy validation workflows from `skills/first-tree-cli-framework/assets/framework/workflows/` to `.github/workflows/`
 
-As you complete each task, check it off in `progress.md` by changing `- [ ]` to `- [x]`.
+As you complete each task, check it off in `skills/first-tree-cli-framework/progress.md` by changing `- [ ]` to `- [x]`.
 
 ### Step 3: Verify
 
@@ -85,7 +85,7 @@ As you complete each task, check it off in `progress.md` by changing `- [ ]` to 
 context-tree verify
 ```
 
-This fails if any items in `progress.md` remain unchecked, and runs deterministic checks (valid frontmatter, node structure, member nodes exist).
+This fails if any items in `skills/first-tree-cli-framework/progress.md` remain unchecked, and runs deterministic checks (valid frontmatter, node structure, member nodes exist).
 
 ### Step 4: Design Your Domains
 
@@ -122,27 +122,27 @@ The tree doesn't duplicate source code — it captures what connects things and 
 
 | Command | Description |
 |---------|-------------|
-| `context-tree init` | Bootstrap a new tree. Clones framework, renders templates, generates task list. |
-| `context-tree verify` | Check progress.md for unchecked items + run deterministic validation. |
-| `context-tree upgrade` | Compare local framework version to upstream, generate upgrade task list. |
+| `context-tree init` | Bootstrap a new tree. Installs the framework skill, renders templates, generates a task list. |
+| `context-tree verify` | Check the installed progress file for unchecked items + run deterministic validation. |
+| `context-tree upgrade` | Refresh the installed framework skill from upstream and generate follow-up tasks. |
 | `context-tree help onboarding` | Print this onboarding guide. |
 
 ---
 
 ## Upgrading the Framework
 
-After init, the first-tree repo is added as a git remote (`context-tree-upstream`). When the framework updates:
+When the framework updates:
 
 ```bash
 context-tree upgrade
 ```
 
-This compares your `.context-tree/VERSION` to upstream and generates a task list. The framework directory (`.context-tree/`) is upgradable without touching your content.
+This refreshes `skills/first-tree-cli-framework/` from upstream, preserves your tree content, and generates follow-up tasks in `skills/first-tree-cli-framework/progress.md`.
 
 ---
 
 ## Further Reading
 
-- `.context-tree/principles.md` — Core principles with detailed examples
-- `.context-tree/ownership-and-naming.md` — How nodes are named and owned
+- `skills/first-tree-cli-framework/references/principles.md` — Core principles with detailed examples
+- `skills/first-tree-cli-framework/references/ownership-and-naming.md` — How nodes are named and owned
 - `AGENT.md` in your tree — The before/during/after workflow for every task

--- a/skills/first-tree-cli-framework/references/repo-snapshot/package.json
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/package.json
@@ -9,7 +9,8 @@
   "imports": {
     "#src/*.js": "./src/*.ts",
     "#evals/*.js": "./evals/*.ts",
-    "#docs/*": "./docs/*"
+    "#docs/*": "./docs/*",
+    "#skill/*": "./skills/first-tree-cli-framework/*"
   },
   "files": [
     "dist"

--- a/skills/first-tree-cli-framework/references/repo-snapshot/src/cli.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/src/cli.ts
@@ -5,9 +5,9 @@ const USAGE = `usage: context-tree <command>
   New to context-tree? Run \`context-tree help onboarding\` first.
 
 Commands:
-  init      Bootstrap a new context tree (clones first-tree, copies framework files)
+  init      Bootstrap a new context tree (installs the framework skill)
   verify    Run verification checks against the current tree
-  upgrade   Generate an upgrade task list from upstream changes
+  upgrade   Refresh the installed skill from upstream and generate follow-up tasks
   help      Show help for a topic (e.g. \`help onboarding\`)
 
 Options:

--- a/skills/first-tree-cli-framework/references/repo-snapshot/src/init.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/src/init.ts
@@ -1,24 +1,26 @@
-import { execFileSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
-  mkdtempSync,
-  rmSync,
   writeFileSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
-import { tmpdir } from "node:os";
 import { Repo } from "#src/repo.js";
 import { ONBOARDING_TEXT } from "#src/onboarding.js";
 import { evaluateAll } from "#src/rules/index.js";
 import type { RuleResult } from "#src/rules/index.js";
 import {
-  copyLegacyFrameworkMirror,
+  copyCanonicalSkill,
   renderTemplateFile,
 } from "#src/runtime/installer.js";
-import { FRAMEWORK_ASSET_ROOT } from "#src/runtime/asset-loader.js";
-
-const FIRST_TREE_REPO_URL = "https://github.com/agent-team-foundation/first-tree";
+import {
+  FRAMEWORK_ASSET_ROOT,
+  FRAMEWORK_VERSION,
+  INSTALLED_PROGRESS,
+} from "#src/runtime/asset-loader.js";
+import {
+  cleanupUpstreamRepo,
+  cloneUpstreamRepo,
+} from "#src/runtime/upgrader.js";
 
 /**
  * The interactive prompt tool the agent should use to present choices.
@@ -33,57 +35,19 @@ const TEMPLATE_MAP: [string, string][] = [
   ["members-domain.md.template", "members/NODE.md"],
 ];
 
-function cloneFirstTree(): string {
-  const tmp = mkdtempSync(join(tmpdir(), "context-tree-"));
-  console.log(`Cloning first-tree from ${FIRST_TREE_REPO_URL}...`);
-  try {
-    execFileSync("git", ["clone", "--depth", "1", FIRST_TREE_REPO_URL, tmp], {
-      encoding: "utf-8",
-      stdio: "pipe",
-    });
-  } catch (err) {
-    const message =
-      err instanceof Error ? err.message : "unknown error";
-    console.error(`Failed to clone first-tree: ${message}`);
-    rmSync(tmp, { recursive: true, force: true });
-    process.exit(1);
-  }
-  return tmp;
+function installSkill(source: string, target: string): void {
+  copyCanonicalSkill(source, target);
+  console.log("  Installed skills/first-tree-cli-framework/ from the upstream skill");
 }
 
-function copyFramework(source: string, target: string): void {
-  copyLegacyFrameworkMirror(source, target);
-  console.log("  Copied .context-tree/ from the canonical skill assets");
-}
-
-function renderTemplates(frameworkDir: string, target: string): void {
+function renderTemplates(target: string): void {
+  const frameworkDir = join(target, FRAMEWORK_ASSET_ROOT);
   for (const [templateName, targetPath] of TEMPLATE_MAP) {
     if (existsSync(join(target, targetPath))) {
       console.log(`  Skipped ${targetPath} (already exists)`);
     } else if (renderTemplateFile(frameworkDir, templateName, target, targetPath)) {
       console.log(`  Created ${targetPath}`);
     }
-  }
-}
-
-function addUpstreamRemote(target: string): void {
-  try {
-    const result = execFileSync("git", ["remote"], {
-      cwd: target,
-      encoding: "utf-8",
-    });
-    if (!result.split(/\s+/).includes("context-tree-upstream")) {
-      execFileSync(
-        "git",
-        ["remote", "add", "context-tree-upstream", FIRST_TREE_REPO_URL],
-        { cwd: target, encoding: "utf-8", stdio: "pipe" },
-      );
-      console.log(
-        `  Added git remote 'context-tree-upstream' -> ${FIRST_TREE_REPO_URL}`,
-      );
-    }
-  } catch {
-    // ignore
   }
 }
 
@@ -110,7 +74,7 @@ export function formatTaskList(groups: RuleResult[]): string {
   lines.push(
     "After completing the tasks above, run `context-tree verify` to confirm:",
   );
-  lines.push("- [ ] `.context-tree/VERSION` exists");
+  lines.push(`- [ ] \`${FRAMEWORK_VERSION}\` exists`);
   lines.push("- [ ] Root NODE.md has valid frontmatter (title, owners)");
   lines.push("- [ ] AGENT.md exists with framework markers");
   lines.push("- [ ] `context-tree verify` passes with no errors");
@@ -120,7 +84,7 @@ export function formatTaskList(groups: RuleResult[]): string {
   lines.push("");
   lines.push(
     "**Important:** As you complete each task, check it off in" +
-      " `.context-tree/progress.md` by changing `- [ ]` to `- [x]`." +
+      ` \`${INSTALLED_PROGRESS}\` by changing \`- [ ]\` to \`- [x]\`.` +
       " Run `context-tree verify` when done — it will fail if any" +
       " items remain unchecked.",
   );
@@ -129,7 +93,7 @@ export function formatTaskList(groups: RuleResult[]): string {
 }
 
 export function writeProgress(repo: Repo, content: string): void {
-  const progressPath = join(repo.root, ".context-tree", "progress.md");
+  const progressPath = join(repo.root, repo.preferredProgressPath());
   mkdirSync(dirname(progressPath), { recursive: true });
   writeFileSync(progressPath, content);
 }
@@ -145,15 +109,14 @@ export function runInit(repo?: Repo): number {
   }
 
   if (!r.hasFramework()) {
-    const seed = cloneFirstTree();
+    console.log("Cloning first-tree to install the framework skill...");
+    const seed = cloneUpstreamRepo();
     try {
-      console.log("Copying framework and scaffolding...");
-      copyFramework(seed, r.root);
-      const frameworkDir = join(seed, FRAMEWORK_ASSET_ROOT);
-      renderTemplates(frameworkDir, r.root);
-      addUpstreamRemote(r.root);
+      console.log("Installing skill and scaffolding...");
+      installSkill(seed, r.root);
+      renderTemplates(r.root);
     } finally {
-      rmSync(seed, { recursive: true, force: true });
+      cleanupUpstreamRepo(seed);
     }
     console.log();
   }
@@ -170,6 +133,6 @@ export function runInit(repo?: Repo): number {
   const output = formatTaskList(groups);
   console.log(output);
   writeProgress(r, output);
-  console.log("Progress file written to .context-tree/progress.md");
+  console.log(`Progress file written to ${r.preferredProgressPath()}`);
   return 0;
 }

--- a/skills/first-tree-cli-framework/references/repo-snapshot/src/onboarding.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/src/onboarding.ts
@@ -1,4 +1,4 @@
-import ONBOARDING_TEXT from "#docs/onboarding.md";
+import ONBOARDING_TEXT from "#skill/references/onboarding.md";
 
 export { ONBOARDING_TEXT };
 

--- a/skills/first-tree-cli-framework/references/repo-snapshot/src/repo.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/src/repo.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 import {
@@ -6,6 +5,7 @@ import {
   LEGACY_PROGRESS,
   LEGACY_VERSION,
   INSTALLED_PROGRESS,
+  type FrameworkLayout,
   detectFrameworkLayout,
   progressFileCandidates,
   resolveFirstExistingPath,
@@ -90,7 +90,11 @@ export class Repo {
   }
 
   hasFramework(): boolean {
-    return detectFrameworkLayout(this.root) !== null;
+    return this.frameworkLayout() !== null;
+  }
+
+  frameworkLayout(): FrameworkLayout | null {
+    return detectFrameworkLayout(this.root);
   }
 
   readVersion(): string | null {
@@ -106,7 +110,11 @@ export class Repo {
   }
 
   preferredProgressPath(): string {
-    return this.pathExists(INSTALLED_PROGRESS) ? INSTALLED_PROGRESS : LEGACY_PROGRESS;
+    return this.frameworkLayout() === "legacy" ? LEGACY_PROGRESS : INSTALLED_PROGRESS;
+  }
+
+  frameworkVersionPath(): string {
+    return this.frameworkLayout() === "legacy" ? LEGACY_VERSION : FRAMEWORK_VERSION;
   }
 
   hasAgentMdMarkers(): boolean {
@@ -153,17 +161,5 @@ export class Repo {
 
   hasPlaceholderNode(): boolean {
     return this.fileContains("NODE.md", "<!-- PLACEHOLDER");
-  }
-
-  hasUpstreamRemote(): boolean {
-    try {
-      const result = execFileSync("git", ["remote"], {
-        cwd: this.root,
-        encoding: "utf-8",
-      });
-      return result.split(/\s+/).includes("context-tree-upstream");
-    } catch {
-      return false;
-    }
   }
 }

--- a/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/agent-instructions.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/agent-instructions.ts
@@ -1,12 +1,13 @@
 import { FRAMEWORK_END_MARKER } from "#src/repo.js";
 import type { Repo } from "#src/repo.js";
 import type { RuleResult } from "#src/rules/index.js";
+import { FRAMEWORK_TEMPLATES_DIR } from "#src/runtime/asset-loader.js";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
   if (!repo.pathExists("AGENT.md")) {
     tasks.push(
-      "AGENT.md is missing — create from `.context-tree/templates/agent.md.template`",
+      `AGENT.md is missing — create from \`${FRAMEWORK_TEMPLATES_DIR}/agent.md.template\``,
     );
   } else if (!repo.hasAgentMdMarkers()) {
     tasks.push(

--- a/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/agent-integration.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/agent-integration.ts
@@ -1,17 +1,18 @@
 import type { Repo } from "#src/repo.js";
 import type { RuleResult } from "#src/rules/index.js";
+import { FRAMEWORK_EXAMPLES_DIR } from "#src/runtime/asset-loader.js";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
   if (repo.pathExists(".claude/settings.json")) {
     if (!repo.fileContains(".claude/settings.json", "inject-tree-context")) {
       tasks.push(
-        "Add SessionStart hook to `.claude/settings.json` (see `.context-tree/examples/claude-code/`)",
+        `Add SessionStart hook to \`.claude/settings.json\` (see \`${FRAMEWORK_EXAMPLES_DIR}/claude-code/\`)`,
       );
     }
   } else if (!repo.anyAgentConfig()) {
     tasks.push(
-      "No agent configuration detected. Configure your agent to load tree context at session start. See `.context-tree/examples/` for supported agents. You can skip this and set it up later.",
+      `No agent configuration detected. Configure your agent to load tree context at session start. See \`${FRAMEWORK_EXAMPLES_DIR}/\` for supported agents. You can skip this and set it up later.`,
     );
   }
   return { group: "Agent Integration", order: 5, tasks };

--- a/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/ci-validation.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/ci-validation.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { INTERACTIVE_TOOL } from "#src/init.js";
 import type { Repo } from "#src/repo.js";
 import type { RuleResult } from "#src/rules/index.js";
+import { FRAMEWORK_WORKFLOWS_DIR } from "#src/runtime/asset-loader.js";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
@@ -40,7 +41,7 @@ export function evaluate(repo: Repo): RuleResult {
   }
   if (!hasValidation) {
     tasks.push(
-      "No validation workflow found — copy `.context-tree/workflows/validate.yml` to `.github/workflows/validate.yml`",
+      `No validation workflow found — copy \`${FRAMEWORK_WORKFLOWS_DIR}/validate.yml\` to \`.github/workflows/validate.yml\``,
     );
   }
   if (!hasPrReview) {
@@ -49,7 +50,7 @@ export function evaluate(repo: Repo): RuleResult {
       "  1. **OpenRouter** — use an OpenRouter API key\n" +
       "  2. **Claude API** — use a Claude API key directly\n" +
       "  3. **Skip** — do not set up PR reviews\n" +
-      "If (1): copy `.context-tree/workflows/pr-review.yml` to `.github/workflows/pr-review.yml` as-is; the repo secret name is `OPENROUTER_API_KEY`. " +
+      `If (1): copy \`${FRAMEWORK_WORKFLOWS_DIR}/pr-review.yml\` to \`.github/workflows/pr-review.yml\` as-is; the repo secret name is \`OPENROUTER_API_KEY\`. ` +
       "If (2): copy the workflow and replace the `env` block with `ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}`, remove the `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, and `ANTHROPIC_DEFAULT_SONNET_MODEL` lines; the repo secret name is `ANTHROPIC_API_KEY`. " +
       "If (3): skip this and the next task.",
     );
@@ -64,7 +65,7 @@ export function evaluate(repo: Repo): RuleResult {
   }
   if (!hasCodeowners) {
     tasks.push(
-      "No CODEOWNERS workflow found — copy `.context-tree/workflows/codeowners.yml` to `.github/workflows/codeowners.yml` to auto-generate CODEOWNERS from tree ownership on every PR.",
+      `No CODEOWNERS workflow found — copy \`${FRAMEWORK_WORKFLOWS_DIR}/codeowners.yml\` to \`.github/workflows/codeowners.yml\` to auto-generate CODEOWNERS from tree ownership on every PR.`,
     );
   }
   return { group: "CI / Validation", order: 6, tasks };

--- a/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/framework.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/framework.ts
@@ -1,5 +1,6 @@
 import type { Repo } from "#src/repo.js";
 import type { RuleResult } from "#src/rules/index.js";
+import { SKILL_ROOT } from "#src/runtime/asset-loader.js";
 
 const FIRST_TREE_REPO_URL = "https://github.com/agent-team-foundation/first-tree";
 
@@ -7,7 +8,7 @@ export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
   if (!repo.hasFramework()) {
     tasks.push(
-      `\`.context-tree/\` not found — run \`context-tree init\` to clone the framework from ${FIRST_TREE_REPO_URL}`,
+      `\`${SKILL_ROOT}/\` not found — run \`context-tree init\` to install the framework skill from ${FIRST_TREE_REPO_URL}`,
     );
   }
   return { group: "Framework", order: 1, tasks };

--- a/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/root-node.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/src/rules/root-node.ts
@@ -1,11 +1,12 @@
 import type { Repo } from "#src/repo.js";
 import type { RuleResult } from "#src/rules/index.js";
+import { FRAMEWORK_TEMPLATES_DIR } from "#src/runtime/asset-loader.js";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
   if (!repo.pathExists("NODE.md")) {
     tasks.push(
-      "NODE.md is missing — create from `.context-tree/templates/root-node.md.template`. " +
+      `NODE.md is missing — create from \`${FRAMEWORK_TEMPLATES_DIR}/root-node.md.template\`. ` +
       "Ask the user for their code repositories or project directories, then analyze the source to determine the project description and domain structure",
     );
   } else {

--- a/skills/first-tree-cli-framework/references/repo-snapshot/src/runtime/upgrader.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/src/runtime/upgrader.ts
@@ -1,38 +1,45 @@
 import { execFileSync } from "node:child_process";
-import { frameworkVersionCandidates } from "#src/runtime/asset-loader.js";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  frameworkVersionCandidates,
+  resolveFirstExistingPath,
+} from "#src/runtime/asset-loader.js";
 
-export function fetchUpstream(
-  repoRoot: string,
-  remote = "context-tree-upstream",
-): boolean {
+export const FIRST_TREE_REPO_URL =
+  "https://github.com/agent-team-foundation/first-tree";
+
+export function cloneUpstreamRepo(
+  repoUrl = FIRST_TREE_REPO_URL,
+): string {
+  const tmp = mkdtempSync(join(tmpdir(), "context-tree-upstream-"));
   try {
-    execFileSync("git", ["fetch", remote, "--depth", "1"], {
-      cwd: repoRoot,
+    execFileSync("git", ["clone", "--depth", "1", repoUrl, tmp], {
       encoding: "utf-8",
       stdio: "pipe",
     });
-    return true;
-  } catch {
-    return false;
+    return tmp;
+  } catch (err) {
+    rmSync(tmp, { recursive: true, force: true });
+    const message = err instanceof Error ? err.message : "unknown error";
+    throw new Error(`Failed to clone ${repoUrl}: ${message}`);
   }
 }
 
-export function readUpstreamVersion(
-  repoRoot: string,
-  remote = "context-tree-upstream",
-  ref = "main",
-): string | null {
-  for (const candidate of frameworkVersionCandidates()) {
-    try {
-      const result = execFileSync("git", ["show", `${remote}/${ref}:${candidate}`], {
-        cwd: repoRoot,
-        encoding: "utf-8",
-        stdio: "pipe",
-      });
-      return result.trim();
-    } catch {
-      continue;
-    }
+export function cleanupUpstreamRepo(root: string): void {
+  rmSync(root, { recursive: true, force: true });
+}
+
+export function readUpstreamVersion(sourceRoot: string): string | null {
+  const versionPath = resolveFirstExistingPath(
+    sourceRoot,
+    frameworkVersionCandidates(),
+  );
+  if (versionPath === null) return null;
+  try {
+    return readFileSync(join(sourceRoot, versionPath), "utf-8").trim();
+  } catch {
+    return null;
   }
-  return null;
 }

--- a/skills/first-tree-cli-framework/references/repo-snapshot/src/upgrade.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/src/upgrade.ts
@@ -1,100 +1,139 @@
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { Repo } from "#src/repo.js";
-import { fetchUpstream, readUpstreamVersion } from "#src/runtime/upgrader.js";
-
-const FIRST_TREE_REPO_URL = "https://github.com/agent-team-foundation/first-tree";
-
-function getUpstreamVersion(repo: Repo): string | null {
-  if (!fetchUpstream(repo.root)) {
-    return null;
-  }
-  return readUpstreamVersion(repo.root);
-}
+import {
+  FRAMEWORK_WORKFLOWS_DIR,
+  FRAMEWORK_TEMPLATES_DIR,
+  FRAMEWORK_VERSION,
+  INSTALLED_PROGRESS,
+  LEGACY_FRAMEWORK_ROOT,
+  SKILL_ROOT,
+} from "#src/runtime/asset-loader.js";
+import { copyCanonicalSkill } from "#src/runtime/installer.js";
+import {
+  cleanupUpstreamRepo,
+  cloneUpstreamRepo,
+  FIRST_TREE_REPO_URL,
+  readUpstreamVersion,
+} from "#src/runtime/upgrader.js";
 
 function writeProgress(repo: Repo, content: string): void {
-  const progressPath = join(repo.root, ".context-tree", "progress.md");
+  const progressPath = join(repo.root, repo.preferredProgressPath());
   mkdirSync(dirname(progressPath), { recursive: true });
   writeFileSync(progressPath, content);
 }
 
-export function runUpgrade(): number {
-  const repo = new Repo();
-
-  if (!repo.hasFramework()) {
-    console.error(
-      "Error: no .context-tree/ found. Run `context-tree init` first.",
-    );
-    return 1;
-  }
-
-  const localVersion = repo.readVersion() ?? "unknown";
-  console.log(`Local framework version: ${localVersion}\n`);
-
-  // Check for upstream remote
-  if (!repo.hasUpstreamRemote()) {
-    const lines = [
-      "# Context Tree Upgrade\n",
-      "## Setup",
-      `- [ ] Add upstream remote: \`git remote add context-tree-upstream ${FIRST_TREE_REPO_URL}\``,
-      "- [ ] Then run `context-tree upgrade` again to check for updates",
-    ];
-    const output = lines.join("\n");
-    console.log(output);
-    writeProgress(repo, output + "\n");
-    console.log("\nProgress file written to .context-tree/progress.md");
-    return 0;
-  }
-
-  // Fetch upstream version
-  const upstreamVersion = getUpstreamVersion(repo);
-  if (upstreamVersion === null) {
-    console.log(
-      "Could not fetch upstream version. Check your network and try again.",
-    );
-    return 1;
-  }
-
-  if (upstreamVersion === localVersion) {
-    console.log(`Already up to date (v${localVersion}).`);
-    return 0;
-  }
-
+function formatUpgradeTaskList(
+  repo: Repo,
+  localVersion: string,
+  upstreamVersion: string,
+  migratedFromLegacy: boolean,
+): string {
   const lines: string[] = [
     `# Context Tree Upgrade — v${localVersion} -> v${upstreamVersion}\n`,
-    "## Framework",
-    "- [ ] Pull latest from upstream: `git fetch context-tree-upstream && git merge context-tree-upstream/main`",
-    "- [ ] Resolve any conflicts in `.context-tree/` (framework files should generally take upstream version)",
+    "## Installed Skill",
+    `- [ ] Review local customizations under \`${SKILL_ROOT}/\` and reapply them if needed`,
+    `- [ ] Re-copy any workflow updates you want from \`${FRAMEWORK_WORKFLOWS_DIR}/\` into \`.github/workflows/\``,
+    `- [ ] Re-check any local agent setup that references \`${SKILL_ROOT}/assets/framework/examples/\` or \`${SKILL_ROOT}/assets/framework/helpers/\``,
     "",
   ];
 
-  // Check AGENT.md
+  if (migratedFromLegacy) {
+    lines.push(
+      "## Migration",
+      "- [ ] Remove any stale `.context-tree/` references from repo-specific docs, scripts, or workflow files",
+      "",
+    );
+  }
+
   if (repo.hasAgentMdMarkers()) {
     lines.push(
       "## Agent Instructions",
-      "- [ ] Check if AGENT.md framework section needs updating — compare content between markers to the new template",
+      `- [ ] Compare the framework section in \`AGENT.md\` with \`${FRAMEWORK_TEMPLATES_DIR}/agent.md.template\` and update the content between the markers if needed`,
       "",
     );
   }
 
   lines.push(
     "## Verification",
-    `- [ ] \`.context-tree/VERSION\` reads \`${upstreamVersion}\``,
+    `- [ ] \`${FRAMEWORK_VERSION}\` reads \`${upstreamVersion}\``,
     "- [ ] `context-tree verify` passes",
-    "- [ ] AGENT.md framework section matches upstream",
     "",
     "---",
     "",
     "**Important:** As you complete each task, check it off in" +
-      " `.context-tree/progress.md` by changing `- [ ]` to `- [x]`." +
+      ` \`${INSTALLED_PROGRESS}\` by changing \`- [ ]\` to \`- [x]\`.` +
       " Run `context-tree verify` when done — it will fail if any" +
       " items remain unchecked.",
     "",
   );
 
-  const output = lines.join("\n");
-  console.log(output);
-  writeProgress(repo, output);
-  console.log("Progress file written to .context-tree/progress.md");
-  return 0;
+  return lines.join("\n");
+}
+
+export interface UpgradeOptions {
+  upstreamRoot?: string;
+}
+
+export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
+  const workingRepo = repo ?? new Repo();
+
+  if (!workingRepo.hasFramework()) {
+    console.error(
+      "Error: no installed framework skill found. Run `context-tree init` first.",
+    );
+    return 1;
+  }
+
+  const layout = workingRepo.frameworkLayout();
+  const localVersion = workingRepo.readVersion() ?? "unknown";
+  console.log(`Local framework version: ${localVersion}\n`);
+
+  console.log(`Checking ${FIRST_TREE_REPO_URL} for the latest framework skill...`);
+
+  const clonedUpstream = options?.upstreamRoot === undefined;
+  const upstreamRoot = options?.upstreamRoot ?? cloneUpstreamRepo();
+
+  try {
+    const upstreamVersion = readUpstreamVersion(upstreamRoot);
+    if (upstreamVersion === null) {
+      console.log(
+        "Could not read the upstream framework version. Check your network and try again.",
+      );
+      return 1;
+    }
+
+    if (layout === "skill" && upstreamVersion === localVersion) {
+      console.log(`Already up to date (${FRAMEWORK_VERSION} = ${localVersion}).`);
+      return 0;
+    }
+
+    copyCanonicalSkill(upstreamRoot, workingRepo.root);
+    if (layout === "legacy") {
+      rmSync(join(workingRepo.root, LEGACY_FRAMEWORK_ROOT), {
+        recursive: true,
+        force: true,
+      });
+      console.log(
+        "Migrated legacy .context-tree/ layout to skills/first-tree-cli-framework/.",
+      );
+    } else {
+      console.log("Refreshed skills/first-tree-cli-framework/ from upstream.");
+    }
+
+    const output = formatUpgradeTaskList(
+      workingRepo,
+      localVersion,
+      upstreamVersion,
+      layout === "legacy",
+    );
+    console.log(`\n${output}`);
+    writeProgress(workingRepo, output);
+    console.log(`Progress file written to ${workingRepo.preferredProgressPath()}`);
+    return 0;
+  } finally {
+    if (clonedUpstream) {
+      cleanupUpstreamRepo(upstreamRoot);
+    }
+  }
 }

--- a/skills/first-tree-cli-framework/references/repo-snapshot/src/verify.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/src/verify.ts
@@ -39,19 +39,21 @@ export function runVerify(repo?: Repo, nodeValidator?: NodeValidator): number {
   const r = repo ?? new Repo();
   const validate = nodeValidator ?? defaultNodeValidator;
   let allPassed = true;
+  const progressPath = r.progressPath() ?? r.preferredProgressPath();
+  const frameworkVersionPath = r.frameworkVersionPath();
 
   console.log("Context Tree Verification\n");
 
   // Progress file check
   const unchecked = checkProgress(r);
   if (unchecked.length > 0) {
-    console.log("  Unchecked items in .context-tree/progress.md:\n");
+    console.log(`  Unchecked items in ${progressPath}:\n`);
     for (const item of unchecked) {
       console.log(`    - [ ] ${item}`);
     }
     console.log();
     console.log(
-      "  Verify each step above and check it off in progress.md before running verify again.\n",
+      `  Verify each step above and check it off in ${progressPath} before running verify again.\n`,
     );
     allPassed = false;
   }
@@ -60,7 +62,7 @@ export function runVerify(repo?: Repo, nodeValidator?: NodeValidator): number {
   console.log("  Checks:\n");
 
   // 1. Framework exists
-  allPassed = check(".context-tree/VERSION exists", r.hasFramework()) && allPassed;
+  allPassed = check(`${frameworkVersionPath} exists`, r.hasFramework()) && allPassed;
 
   // 2. Root NODE.md has valid frontmatter
   const fm = r.frontmatter("NODE.md");

--- a/skills/first-tree-cli-framework/references/repo-snapshot/tests/generate-codeowners.test.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/tests/generate-codeowners.test.ts
@@ -6,7 +6,7 @@ import {
   resolveNodeOwners,
   collectEntries,
   formatOwners,
-} from "../.context-tree/generate-codeowners.js";
+} from "../skills/first-tree-cli-framework/assets/framework/helpers/generate-codeowners.js";
 import { useTmpDir } from "./helpers.js";
 
 function write(root: string, relPath: string, content: string): string {

--- a/skills/first-tree-cli-framework/references/repo-snapshot/tests/helpers.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/tests/helpers.ts
@@ -2,6 +2,10 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach } from "vitest";
+import {
+  FRAMEWORK_VERSION,
+  LEGACY_VERSION,
+} from "#src/runtime/asset-loader.js";
 
 interface TmpDir {
   path: string;
@@ -15,10 +19,17 @@ export function useTmpDir(): TmpDir {
   return { path: dir };
 }
 
-export function makeFramework(root: string): void {
+export function makeFramework(root: string, version = "0.1.0"): void {
+  mkdirSync(join(root, "skills", "first-tree-cli-framework", "assets", "framework"), {
+    recursive: true,
+  });
+  writeFileSync(join(root, FRAMEWORK_VERSION), `${version}\n`);
+}
+
+export function makeLegacyFramework(root: string, version = "0.1.0"): void {
   const ct = join(root, ".context-tree");
   mkdirSync(ct, { recursive: true });
-  writeFileSync(join(ct, "VERSION"), "0.1.0\n");
+  writeFileSync(join(root, LEGACY_VERSION), `${version}\n`);
 }
 
 export function makeNode(

--- a/skills/first-tree-cli-framework/references/repo-snapshot/tests/init.test.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/tests/init.test.ts
@@ -3,7 +3,15 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { formatTaskList, writeProgress, runInit } from "#src/init.js";
 import { Repo } from "#src/repo.js";
-import { useTmpDir, makeFramework } from "./helpers.js";
+import {
+  INSTALLED_PROGRESS,
+  LEGACY_PROGRESS,
+} from "#src/runtime/asset-loader.js";
+import {
+  useTmpDir,
+  makeFramework,
+  makeLegacyFramework,
+} from "./helpers.js";
 
 // --- formatTaskList ---
 
@@ -66,7 +74,7 @@ describe("writeProgress", () => {
     const tmp = useTmpDir();
     const repo = new Repo(tmp.path);
     writeProgress(repo, "# hello\n");
-    const progress = join(tmp.path, ".context-tree", "progress.md");
+    const progress = join(tmp.path, INSTALLED_PROGRESS);
     expect(readFileSync(progress, "utf-8")).toBe("# hello\n");
   });
 
@@ -74,18 +82,27 @@ describe("writeProgress", () => {
     const tmp = useTmpDir();
     const repo = new Repo(tmp.path);
     writeProgress(repo, "content");
-    const progress = join(tmp.path, ".context-tree", "progress.md");
+    const progress = join(tmp.path, INSTALLED_PROGRESS);
     expect(readFileSync(progress, "utf-8")).toBe("content");
   });
 
   it("overwrites existing file", () => {
     const tmp = useTmpDir();
-    const ct = join(tmp.path, ".context-tree");
-    mkdirSync(ct);
-    writeFileSync(join(ct, "progress.md"), "old");
+    mkdirSync(join(tmp.path, "skills", "first-tree-cli-framework"), {
+      recursive: true,
+    });
+    writeFileSync(join(tmp.path, INSTALLED_PROGRESS), "old");
     const repo = new Repo(tmp.path);
     writeProgress(repo, "new");
-    expect(readFileSync(join(ct, "progress.md"), "utf-8")).toBe("new");
+    expect(readFileSync(join(tmp.path, INSTALLED_PROGRESS), "utf-8")).toBe("new");
+  });
+
+  it("keeps using the legacy progress path for legacy repos", () => {
+    const tmp = useTmpDir();
+    makeLegacyFramework(tmp.path);
+    const repo = new Repo(tmp.path);
+    writeProgress(repo, "legacy");
+    expect(readFileSync(join(tmp.path, LEGACY_PROGRESS), "utf-8")).toBe("legacy");
   });
 });
 

--- a/skills/first-tree-cli-framework/references/repo-snapshot/tests/repo.test.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/tests/repo.test.ts
@@ -2,7 +2,13 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { Repo } from "#src/repo.js";
-import { useTmpDir } from "./helpers.js";
+import {
+  FRAMEWORK_VERSION,
+  INSTALLED_PROGRESS,
+  LEGACY_PROGRESS,
+  LEGACY_VERSION,
+} from "#src/runtime/asset-loader.js";
+import { useTmpDir, makeFramework, makeLegacyFramework } from "./helpers.js";
 
 // --- pathExists ---
 
@@ -136,10 +142,16 @@ describe("isGitRepo", () => {
 // --- hasFramework ---
 
 describe("hasFramework", () => {
-  it("returns true with VERSION file", () => {
+  it("returns true with installed skill version file", () => {
     const tmp = useTmpDir();
-    mkdirSync(join(tmp.path, ".context-tree"));
-    writeFileSync(join(tmp.path, ".context-tree", "VERSION"), "0.1.0\n");
+    makeFramework(tmp.path);
+    const repo = new Repo(tmp.path);
+    expect(repo.hasFramework()).toBe(true);
+  });
+
+  it("returns true with legacy version file", () => {
+    const tmp = useTmpDir();
+    makeLegacyFramework(tmp.path);
     const repo = new Repo(tmp.path);
     expect(repo.hasFramework()).toBe(true);
   });
@@ -154,18 +166,43 @@ describe("hasFramework", () => {
 // --- readVersion ---
 
 describe("readVersion", () => {
-  it("reads valid version", () => {
+  it("reads the installed skill version", () => {
     const tmp = useTmpDir();
-    mkdirSync(join(tmp.path, ".context-tree"));
-    writeFileSync(join(tmp.path, ".context-tree", "VERSION"), "0.2.0\n");
+    makeFramework(tmp.path, "0.2.0");
     const repo = new Repo(tmp.path);
     expect(repo.readVersion()).toBe("0.2.0");
+  });
+
+  it("falls back to the legacy version", () => {
+    const tmp = useTmpDir();
+    makeLegacyFramework(tmp.path, "0.3.0");
+    const repo = new Repo(tmp.path);
+    expect(repo.readVersion()).toBe("0.3.0");
   });
 
   it("returns null when missing", () => {
     const tmp = useTmpDir();
     const repo = new Repo(tmp.path);
     expect(repo.readVersion()).toBeNull();
+  });
+});
+
+// --- preferredProgressPath / frameworkVersionPath ---
+
+describe("path preferences", () => {
+  it("prefers the installed-skill paths by default", () => {
+    const tmp = useTmpDir();
+    const repo = new Repo(tmp.path);
+    expect(repo.preferredProgressPath()).toBe(INSTALLED_PROGRESS);
+    expect(repo.frameworkVersionPath()).toBe(FRAMEWORK_VERSION);
+  });
+
+  it("switches path preferences for legacy repos", () => {
+    const tmp = useTmpDir();
+    makeLegacyFramework(tmp.path);
+    const repo = new Repo(tmp.path);
+    expect(repo.preferredProgressPath()).toBe(LEGACY_PROGRESS);
+    expect(repo.frameworkVersionPath()).toBe(LEGACY_VERSION);
   });
 });
 

--- a/skills/first-tree-cli-framework/references/repo-snapshot/tests/rules.test.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/tests/rules.test.ts
@@ -29,7 +29,7 @@ describe("framework rule", () => {
     const result = framework.evaluate(repo);
     expect(result.group).toBe("Framework");
     expect(result.tasks).toHaveLength(1);
-    expect(result.tasks[0]).toContain(".context-tree/");
+    expect(result.tasks[0]).toContain("skills/first-tree-cli-framework/");
   });
 
   it("passes when framework exists", () => {
@@ -214,6 +214,7 @@ describe("ciValidation rule", () => {
     const result = ciValidation.evaluate(repo);
     expect(result.tasks).toHaveLength(4);
     expect(result.tasks[0]).toContain("validation workflow");
+    expect(result.tasks[0]).toContain("skills/first-tree-cli-framework/assets/framework/workflows/validate.yml");
     expect(result.tasks[1]).toContain("PR reviews");
     expect(result.tasks[2]).toContain("API secret");
     expect(result.tasks[3]).toContain("CODEOWNERS");
@@ -251,7 +252,7 @@ describe("ciValidation rule", () => {
     mkdirSync(wfDir, { recursive: true });
     writeFileSync(
       join(wfDir, "pr-review.yml"),
-      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx .context-tree/run-review.ts\n",
+      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/run-review.ts\n",
     );
     const repo = new Repo(tmp.path);
     const result = ciValidation.evaluate(repo);
@@ -270,7 +271,7 @@ describe("ciValidation rule", () => {
     );
     writeFileSync(
       join(wfDir, "pr-review.yml"),
-      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx .context-tree/run-review.ts\n",
+      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/run-review.ts\n",
     );
     const repo = new Repo(tmp.path);
     const result = ciValidation.evaluate(repo);
@@ -288,11 +289,11 @@ describe("ciValidation rule", () => {
     );
     writeFileSync(
       join(wfDir, "pr-review.yml"),
-      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx .context-tree/run-review.ts\n",
+      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/run-review.ts\n",
     );
     writeFileSync(
       join(wfDir, "codeowners.yml"),
-      "name: Update CODEOWNERS\non: pull_request\njobs:\n  update:\n    steps:\n      - run: npx tsx .context-tree/generate-codeowners.ts\n",
+      "name: Update CODEOWNERS\non: pull_request\njobs:\n  update:\n    steps:\n      - run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/generate-codeowners.ts\n",
     );
     const repo = new Repo(tmp.path);
     const result = ciValidation.evaluate(repo);

--- a/skills/first-tree-cli-framework/references/repo-snapshot/tests/run-review.test.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/tests/run-review.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   extractStreamText,
   extractReviewJson,
-} from "../.context-tree/run-review.js";
+} from "../skills/first-tree-cli-framework/assets/framework/helpers/run-review.js";
 
 // --- extractStreamText ---
 

--- a/skills/first-tree-cli-framework/references/repo-snapshot/tests/upgrade.test.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/tests/upgrade.test.ts
@@ -1,0 +1,58 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { Repo } from "#src/repo.js";
+import { runUpgrade } from "#src/upgrade.js";
+import {
+  FRAMEWORK_VERSION,
+  INSTALLED_PROGRESS,
+} from "#src/runtime/asset-loader.js";
+import { makeFramework, makeLegacyFramework, useTmpDir } from "./helpers.js";
+
+function makeUpstreamSkill(root: string, version: string): void {
+  const skillRoot = join(root, "skills", "first-tree-cli-framework");
+  mkdirSync(join(skillRoot, "assets", "framework"), { recursive: true });
+  writeFileSync(
+    join(skillRoot, "SKILL.md"),
+    "---\nname: first-tree-cli-framework\ndescription: test\n---\n",
+  );
+  writeFileSync(join(root, FRAMEWORK_VERSION), `${version}\n`);
+}
+
+describe("runUpgrade", () => {
+  it("migrates a legacy repo to the installed skill layout", () => {
+    const repoDir = useTmpDir();
+    const upstreamDir = useTmpDir();
+    makeLegacyFramework(repoDir.path, "0.1.0");
+    writeFileSync(
+      join(repoDir.path, "AGENT.md"),
+      "<!-- BEGIN CONTEXT-TREE FRAMEWORK -->\nstuff\n<!-- END CONTEXT-TREE FRAMEWORK -->\n",
+    );
+    makeUpstreamSkill(upstreamDir.path, "0.2.0");
+
+    const result = runUpgrade(new Repo(repoDir.path), {
+      upstreamRoot: upstreamDir.path,
+    });
+
+    expect(result).toBe(0);
+    expect(existsSync(join(repoDir.path, ".context-tree"))).toBe(false);
+    expect(readFileSync(join(repoDir.path, FRAMEWORK_VERSION), "utf-8").trim()).toBe("0.2.0");
+    expect(readFileSync(join(repoDir.path, INSTALLED_PROGRESS), "utf-8")).toContain(
+      "skills/first-tree-cli-framework/assets/framework/VERSION",
+    );
+  });
+
+  it("returns early when the installed skill is already current", () => {
+    const repoDir = useTmpDir();
+    const upstreamDir = useTmpDir();
+    makeFramework(repoDir.path, "0.2.0");
+    makeUpstreamSkill(upstreamDir.path, "0.2.0");
+
+    const result = runUpgrade(new Repo(repoDir.path), {
+      upstreamRoot: upstreamDir.path,
+    });
+
+    expect(result).toBe(0);
+    expect(existsSync(join(repoDir.path, INSTALLED_PROGRESS))).toBe(false);
+  });
+});

--- a/skills/first-tree-cli-framework/references/repo-snapshot/tests/verify.test.ts
+++ b/skills/first-tree-cli-framework/references/repo-snapshot/tests/verify.test.ts
@@ -3,7 +3,18 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { check, checkProgress, runVerify } from "#src/verify.js";
 import { Repo } from "#src/repo.js";
-import { useTmpDir, makeFramework, makeNode, makeAgentMd, makeMembers } from "./helpers.js";
+import {
+  INSTALLED_PROGRESS,
+  LEGACY_PROGRESS,
+} from "#src/runtime/asset-loader.js";
+import {
+  useTmpDir,
+  makeFramework,
+  makeLegacyFramework,
+  makeNode,
+  makeAgentMd,
+  makeMembers,
+} from "./helpers.js";
 
 // --- check ---
 
@@ -28,10 +39,9 @@ describe("checkProgress", () => {
 
   it("returns empty when all checked", () => {
     const tmp = useTmpDir();
-    const ct = join(tmp.path, ".context-tree");
-    mkdirSync(ct);
+    mkdirSync(join(tmp.path, "skills", "first-tree-cli-framework"), { recursive: true });
     writeFileSync(
-      join(ct, "progress.md"),
+      join(tmp.path, INSTALLED_PROGRESS),
       "# Progress\n- [x] Task one\n- [x] Task two\n",
     );
     const repo = new Repo(tmp.path);
@@ -40,10 +50,9 @@ describe("checkProgress", () => {
 
   it("returns unchecked items", () => {
     const tmp = useTmpDir();
-    const ct = join(tmp.path, ".context-tree");
-    mkdirSync(ct);
+    mkdirSync(join(tmp.path, "skills", "first-tree-cli-framework"), { recursive: true });
     writeFileSync(
-      join(ct, "progress.md"),
+      join(tmp.path, INSTALLED_PROGRESS),
       "# Progress\n- [x] Done task\n- [ ] Pending task\n- [ ] Another pending\n",
     );
     const repo = new Repo(tmp.path);
@@ -52,11 +61,21 @@ describe("checkProgress", () => {
 
   it("returns empty for empty progress", () => {
     const tmp = useTmpDir();
-    const ct = join(tmp.path, ".context-tree");
-    mkdirSync(ct);
-    writeFileSync(join(ct, "progress.md"), "");
+    mkdirSync(join(tmp.path, "skills", "first-tree-cli-framework"), { recursive: true });
+    writeFileSync(join(tmp.path, INSTALLED_PROGRESS), "");
     const repo = new Repo(tmp.path);
     expect(checkProgress(repo)).toEqual([]);
+  });
+
+  it("falls back to the legacy progress file", () => {
+    const tmp = useTmpDir();
+    makeLegacyFramework(tmp.path);
+    writeFileSync(
+      join(tmp.path, LEGACY_PROGRESS),
+      "# Progress\n- [ ] Legacy task\n",
+    );
+    const repo = new Repo(tmp.path);
+    expect(checkProgress(repo)).toEqual(["Legacy task"]);
   });
 });
 

--- a/skills/first-tree-cli-framework/references/source-map.md
+++ b/skills/first-tree-cli-framework/references/source-map.md
@@ -19,7 +19,7 @@ This file is the fast index for the new single-skill architecture.
 | --- | --- |
 | `src/cli.ts` | Top-level command dispatch |
 | `src/commands/help.ts` | Help topic routing |
-| `src/init.ts` / `src/verify.ts` / `src/upgrade.ts` | Existing command implementations while the refactor converges |
+| `src/init.ts` / `src/verify.ts` / `src/upgrade.ts` | Command implementations for install, verify, and upgrade |
 | `src/commands/` | Stable command entrypoints the CLI imports |
 | `src/runtime/asset-loader.ts` | Canonical path constants and layout detection |
 | `src/runtime/installer.ts` | Copy and template-render helpers |
@@ -39,6 +39,7 @@ The installed skill payload lives under `assets/framework/`.
 | `assets/framework/prompts/` | Review prompt payload |
 | `assets/framework/examples/` | Agent integration examples |
 | `assets/framework/helpers/` | Shipped helper scripts and TypeScript utilities |
+| `progress.md` | Generated in user repos to track unfinished setup or upgrade tasks |
 
 ## Validation Surface
 
@@ -56,8 +57,8 @@ The installed skill payload lives under `assets/framework/`.
 
 ## Compatibility Notes
 
-- `docs/` and root `.context-tree/` are temporary exported mirrors while the
-  repo transitions to a single canonical skill.
+- In the source repo, `docs/` and root `.context-tree/` are temporary exported
+  mirrors. They are no longer part of the user-repo contract.
 - `references/repo-snapshot/` is a portable artifact, not the source of truth.
 - If you change `references/` or `assets/framework/`, run
   `bash ./skills/first-tree-cli-framework/scripts/sync-skill-artifacts.sh`.

--- a/skills/first-tree-cli-framework/references/upgrade-contract.md
+++ b/skills/first-tree-cli-framework/references/upgrade-contract.md
@@ -18,6 +18,7 @@ The end-state installed layout in a user repo is:
 skills/
   first-tree-cli-framework/
     SKILL.md
+    progress.md
     references/
     assets/
       framework/
@@ -41,15 +42,15 @@ The tree content still lives outside the skill:
 - `context-tree init`
   - installs the skill into the target repo
   - renders top-level tree scaffolding from the skill templates
-  - writes progress state
-  - wires an upstream remote for future upgrades
+  - writes progress state to `skills/first-tree-cli-framework/progress.md`
 - `context-tree verify`
-  - checks progress state
+  - checks progress state from the installed skill
   - validates root/frontmatter/agent markers
   - runs node and member validators
 - `context-tree upgrade`
   - compares the installed skill payload version to upstream
   - refreshes the installed skill payload without overwriting tree content
+  - migrates legacy `.context-tree/` repos onto the installed skill layout
   - preserves user-authored sections such as the editable part of `AGENT.md`
 
 ## Compatibility Rules During Migration
@@ -58,6 +59,8 @@ The tree content still lives outside the skill:
   - `skills/first-tree-cli-framework/...`
   - legacy `.context-tree/...`
 - When both layouts are present, prefer the installed skill layout.
+- `context-tree init` only installs the skill layout; it does not create a new `.context-tree/`.
+- `context-tree upgrade` should remove legacy `.context-tree/` after migrating a repo.
 - The legacy layout must be derivable from the canonical skill via
   `scripts/export-runtime-assets.sh`.
 - `references/repo-snapshot/` may exist as a portable artifact until cleanup,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,9 +5,9 @@ const USAGE = `usage: context-tree <command>
   New to context-tree? Run \`context-tree help onboarding\` first.
 
 Commands:
-  init      Bootstrap a new context tree (clones first-tree, copies framework files)
+  init      Bootstrap a new context tree (installs the framework skill)
   verify    Run verification checks against the current tree
-  upgrade   Generate an upgrade task list from upstream changes
+  upgrade   Refresh the installed skill from upstream and generate follow-up tasks
   help      Show help for a topic (e.g. \`help onboarding\`)
 
 Options:

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,24 +1,26 @@
-import { execFileSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
-  mkdtempSync,
-  rmSync,
   writeFileSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
-import { tmpdir } from "node:os";
 import { Repo } from "#src/repo.js";
 import { ONBOARDING_TEXT } from "#src/onboarding.js";
 import { evaluateAll } from "#src/rules/index.js";
 import type { RuleResult } from "#src/rules/index.js";
 import {
-  copyLegacyFrameworkMirror,
+  copyCanonicalSkill,
   renderTemplateFile,
 } from "#src/runtime/installer.js";
-import { FRAMEWORK_ASSET_ROOT } from "#src/runtime/asset-loader.js";
-
-const FIRST_TREE_REPO_URL = "https://github.com/agent-team-foundation/first-tree";
+import {
+  FRAMEWORK_ASSET_ROOT,
+  FRAMEWORK_VERSION,
+  INSTALLED_PROGRESS,
+} from "#src/runtime/asset-loader.js";
+import {
+  cleanupUpstreamRepo,
+  cloneUpstreamRepo,
+} from "#src/runtime/upgrader.js";
 
 /**
  * The interactive prompt tool the agent should use to present choices.
@@ -33,57 +35,19 @@ const TEMPLATE_MAP: [string, string][] = [
   ["members-domain.md.template", "members/NODE.md"],
 ];
 
-function cloneFirstTree(): string {
-  const tmp = mkdtempSync(join(tmpdir(), "context-tree-"));
-  console.log(`Cloning first-tree from ${FIRST_TREE_REPO_URL}...`);
-  try {
-    execFileSync("git", ["clone", "--depth", "1", FIRST_TREE_REPO_URL, tmp], {
-      encoding: "utf-8",
-      stdio: "pipe",
-    });
-  } catch (err) {
-    const message =
-      err instanceof Error ? err.message : "unknown error";
-    console.error(`Failed to clone first-tree: ${message}`);
-    rmSync(tmp, { recursive: true, force: true });
-    process.exit(1);
-  }
-  return tmp;
+function installSkill(source: string, target: string): void {
+  copyCanonicalSkill(source, target);
+  console.log("  Installed skills/first-tree-cli-framework/ from the upstream skill");
 }
 
-function copyFramework(source: string, target: string): void {
-  copyLegacyFrameworkMirror(source, target);
-  console.log("  Copied .context-tree/ from the canonical skill assets");
-}
-
-function renderTemplates(frameworkDir: string, target: string): void {
+function renderTemplates(target: string): void {
+  const frameworkDir = join(target, FRAMEWORK_ASSET_ROOT);
   for (const [templateName, targetPath] of TEMPLATE_MAP) {
     if (existsSync(join(target, targetPath))) {
       console.log(`  Skipped ${targetPath} (already exists)`);
     } else if (renderTemplateFile(frameworkDir, templateName, target, targetPath)) {
       console.log(`  Created ${targetPath}`);
     }
-  }
-}
-
-function addUpstreamRemote(target: string): void {
-  try {
-    const result = execFileSync("git", ["remote"], {
-      cwd: target,
-      encoding: "utf-8",
-    });
-    if (!result.split(/\s+/).includes("context-tree-upstream")) {
-      execFileSync(
-        "git",
-        ["remote", "add", "context-tree-upstream", FIRST_TREE_REPO_URL],
-        { cwd: target, encoding: "utf-8", stdio: "pipe" },
-      );
-      console.log(
-        `  Added git remote 'context-tree-upstream' -> ${FIRST_TREE_REPO_URL}`,
-      );
-    }
-  } catch {
-    // ignore
   }
 }
 
@@ -110,7 +74,7 @@ export function formatTaskList(groups: RuleResult[]): string {
   lines.push(
     "After completing the tasks above, run `context-tree verify` to confirm:",
   );
-  lines.push("- [ ] `.context-tree/VERSION` exists");
+  lines.push(`- [ ] \`${FRAMEWORK_VERSION}\` exists`);
   lines.push("- [ ] Root NODE.md has valid frontmatter (title, owners)");
   lines.push("- [ ] AGENT.md exists with framework markers");
   lines.push("- [ ] `context-tree verify` passes with no errors");
@@ -120,7 +84,7 @@ export function formatTaskList(groups: RuleResult[]): string {
   lines.push("");
   lines.push(
     "**Important:** As you complete each task, check it off in" +
-      " `.context-tree/progress.md` by changing `- [ ]` to `- [x]`." +
+      ` \`${INSTALLED_PROGRESS}\` by changing \`- [ ]\` to \`- [x]\`.` +
       " Run `context-tree verify` when done — it will fail if any" +
       " items remain unchecked.",
   );
@@ -129,7 +93,7 @@ export function formatTaskList(groups: RuleResult[]): string {
 }
 
 export function writeProgress(repo: Repo, content: string): void {
-  const progressPath = join(repo.root, ".context-tree", "progress.md");
+  const progressPath = join(repo.root, repo.preferredProgressPath());
   mkdirSync(dirname(progressPath), { recursive: true });
   writeFileSync(progressPath, content);
 }
@@ -145,15 +109,14 @@ export function runInit(repo?: Repo): number {
   }
 
   if (!r.hasFramework()) {
-    const seed = cloneFirstTree();
+    console.log("Cloning first-tree to install the framework skill...");
+    const seed = cloneUpstreamRepo();
     try {
-      console.log("Copying framework and scaffolding...");
-      copyFramework(seed, r.root);
-      const frameworkDir = join(seed, FRAMEWORK_ASSET_ROOT);
-      renderTemplates(frameworkDir, r.root);
-      addUpstreamRemote(r.root);
+      console.log("Installing skill and scaffolding...");
+      installSkill(seed, r.root);
+      renderTemplates(r.root);
     } finally {
-      rmSync(seed, { recursive: true, force: true });
+      cleanupUpstreamRepo(seed);
     }
     console.log();
   }
@@ -170,6 +133,6 @@ export function runInit(repo?: Repo): number {
   const output = formatTaskList(groups);
   console.log(output);
   writeProgress(r, output);
-  console.log("Progress file written to .context-tree/progress.md");
+  console.log(`Progress file written to ${r.preferredProgressPath()}`);
   return 0;
 }

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -1,4 +1,4 @@
-import ONBOARDING_TEXT from "#docs/onboarding.md";
+import ONBOARDING_TEXT from "#skill/references/onboarding.md";
 
 export { ONBOARDING_TEXT };
 

--- a/src/repo.ts
+++ b/src/repo.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 import {
@@ -6,6 +5,7 @@ import {
   LEGACY_PROGRESS,
   LEGACY_VERSION,
   INSTALLED_PROGRESS,
+  type FrameworkLayout,
   detectFrameworkLayout,
   progressFileCandidates,
   resolveFirstExistingPath,
@@ -90,7 +90,11 @@ export class Repo {
   }
 
   hasFramework(): boolean {
-    return detectFrameworkLayout(this.root) !== null;
+    return this.frameworkLayout() !== null;
+  }
+
+  frameworkLayout(): FrameworkLayout | null {
+    return detectFrameworkLayout(this.root);
   }
 
   readVersion(): string | null {
@@ -106,7 +110,11 @@ export class Repo {
   }
 
   preferredProgressPath(): string {
-    return this.pathExists(INSTALLED_PROGRESS) ? INSTALLED_PROGRESS : LEGACY_PROGRESS;
+    return this.frameworkLayout() === "legacy" ? LEGACY_PROGRESS : INSTALLED_PROGRESS;
+  }
+
+  frameworkVersionPath(): string {
+    return this.frameworkLayout() === "legacy" ? LEGACY_VERSION : FRAMEWORK_VERSION;
   }
 
   hasAgentMdMarkers(): boolean {
@@ -153,17 +161,5 @@ export class Repo {
 
   hasPlaceholderNode(): boolean {
     return this.fileContains("NODE.md", "<!-- PLACEHOLDER");
-  }
-
-  hasUpstreamRemote(): boolean {
-    try {
-      const result = execFileSync("git", ["remote"], {
-        cwd: this.root,
-        encoding: "utf-8",
-      });
-      return result.split(/\s+/).includes("context-tree-upstream");
-    } catch {
-      return false;
-    }
   }
 }

--- a/src/rules/agent-instructions.ts
+++ b/src/rules/agent-instructions.ts
@@ -1,12 +1,13 @@
 import { FRAMEWORK_END_MARKER } from "#src/repo.js";
 import type { Repo } from "#src/repo.js";
 import type { RuleResult } from "#src/rules/index.js";
+import { FRAMEWORK_TEMPLATES_DIR } from "#src/runtime/asset-loader.js";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
   if (!repo.pathExists("AGENT.md")) {
     tasks.push(
-      "AGENT.md is missing — create from `.context-tree/templates/agent.md.template`",
+      `AGENT.md is missing — create from \`${FRAMEWORK_TEMPLATES_DIR}/agent.md.template\``,
     );
   } else if (!repo.hasAgentMdMarkers()) {
     tasks.push(

--- a/src/rules/agent-integration.ts
+++ b/src/rules/agent-integration.ts
@@ -1,17 +1,18 @@
 import type { Repo } from "#src/repo.js";
 import type { RuleResult } from "#src/rules/index.js";
+import { FRAMEWORK_EXAMPLES_DIR } from "#src/runtime/asset-loader.js";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
   if (repo.pathExists(".claude/settings.json")) {
     if (!repo.fileContains(".claude/settings.json", "inject-tree-context")) {
       tasks.push(
-        "Add SessionStart hook to `.claude/settings.json` (see `.context-tree/examples/claude-code/`)",
+        `Add SessionStart hook to \`.claude/settings.json\` (see \`${FRAMEWORK_EXAMPLES_DIR}/claude-code/\`)`,
       );
     }
   } else if (!repo.anyAgentConfig()) {
     tasks.push(
-      "No agent configuration detected. Configure your agent to load tree context at session start. See `.context-tree/examples/` for supported agents. You can skip this and set it up later.",
+      `No agent configuration detected. Configure your agent to load tree context at session start. See \`${FRAMEWORK_EXAMPLES_DIR}/\` for supported agents. You can skip this and set it up later.`,
     );
   }
   return { group: "Agent Integration", order: 5, tasks };

--- a/src/rules/ci-validation.ts
+++ b/src/rules/ci-validation.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { INTERACTIVE_TOOL } from "#src/init.js";
 import type { Repo } from "#src/repo.js";
 import type { RuleResult } from "#src/rules/index.js";
+import { FRAMEWORK_WORKFLOWS_DIR } from "#src/runtime/asset-loader.js";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
@@ -40,7 +41,7 @@ export function evaluate(repo: Repo): RuleResult {
   }
   if (!hasValidation) {
     tasks.push(
-      "No validation workflow found — copy `.context-tree/workflows/validate.yml` to `.github/workflows/validate.yml`",
+      `No validation workflow found — copy \`${FRAMEWORK_WORKFLOWS_DIR}/validate.yml\` to \`.github/workflows/validate.yml\``,
     );
   }
   if (!hasPrReview) {
@@ -49,7 +50,7 @@ export function evaluate(repo: Repo): RuleResult {
       "  1. **OpenRouter** — use an OpenRouter API key\n" +
       "  2. **Claude API** — use a Claude API key directly\n" +
       "  3. **Skip** — do not set up PR reviews\n" +
-      "If (1): copy `.context-tree/workflows/pr-review.yml` to `.github/workflows/pr-review.yml` as-is; the repo secret name is `OPENROUTER_API_KEY`. " +
+      `If (1): copy \`${FRAMEWORK_WORKFLOWS_DIR}/pr-review.yml\` to \`.github/workflows/pr-review.yml\` as-is; the repo secret name is \`OPENROUTER_API_KEY\`. ` +
       "If (2): copy the workflow and replace the `env` block with `ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}`, remove the `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, and `ANTHROPIC_DEFAULT_SONNET_MODEL` lines; the repo secret name is `ANTHROPIC_API_KEY`. " +
       "If (3): skip this and the next task.",
     );
@@ -64,7 +65,7 @@ export function evaluate(repo: Repo): RuleResult {
   }
   if (!hasCodeowners) {
     tasks.push(
-      "No CODEOWNERS workflow found — copy `.context-tree/workflows/codeowners.yml` to `.github/workflows/codeowners.yml` to auto-generate CODEOWNERS from tree ownership on every PR.",
+      `No CODEOWNERS workflow found — copy \`${FRAMEWORK_WORKFLOWS_DIR}/codeowners.yml\` to \`.github/workflows/codeowners.yml\` to auto-generate CODEOWNERS from tree ownership on every PR.`,
     );
   }
   return { group: "CI / Validation", order: 6, tasks };

--- a/src/rules/framework.ts
+++ b/src/rules/framework.ts
@@ -1,5 +1,6 @@
 import type { Repo } from "#src/repo.js";
 import type { RuleResult } from "#src/rules/index.js";
+import { SKILL_ROOT } from "#src/runtime/asset-loader.js";
 
 const FIRST_TREE_REPO_URL = "https://github.com/agent-team-foundation/first-tree";
 
@@ -7,7 +8,7 @@ export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
   if (!repo.hasFramework()) {
     tasks.push(
-      `\`.context-tree/\` not found — run \`context-tree init\` to clone the framework from ${FIRST_TREE_REPO_URL}`,
+      `\`${SKILL_ROOT}/\` not found — run \`context-tree init\` to install the framework skill from ${FIRST_TREE_REPO_URL}`,
     );
   }
   return { group: "Framework", order: 1, tasks };

--- a/src/rules/root-node.ts
+++ b/src/rules/root-node.ts
@@ -1,11 +1,12 @@
 import type { Repo } from "#src/repo.js";
 import type { RuleResult } from "#src/rules/index.js";
+import { FRAMEWORK_TEMPLATES_DIR } from "#src/runtime/asset-loader.js";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
   if (!repo.pathExists("NODE.md")) {
     tasks.push(
-      "NODE.md is missing — create from `.context-tree/templates/root-node.md.template`. " +
+      `NODE.md is missing — create from \`${FRAMEWORK_TEMPLATES_DIR}/root-node.md.template\`. ` +
       "Ask the user for their code repositories or project directories, then analyze the source to determine the project description and domain structure",
     );
   } else {

--- a/src/runtime/upgrader.ts
+++ b/src/runtime/upgrader.ts
@@ -1,38 +1,45 @@
 import { execFileSync } from "node:child_process";
-import { frameworkVersionCandidates } from "#src/runtime/asset-loader.js";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  frameworkVersionCandidates,
+  resolveFirstExistingPath,
+} from "#src/runtime/asset-loader.js";
 
-export function fetchUpstream(
-  repoRoot: string,
-  remote = "context-tree-upstream",
-): boolean {
+export const FIRST_TREE_REPO_URL =
+  "https://github.com/agent-team-foundation/first-tree";
+
+export function cloneUpstreamRepo(
+  repoUrl = FIRST_TREE_REPO_URL,
+): string {
+  const tmp = mkdtempSync(join(tmpdir(), "context-tree-upstream-"));
   try {
-    execFileSync("git", ["fetch", remote, "--depth", "1"], {
-      cwd: repoRoot,
+    execFileSync("git", ["clone", "--depth", "1", repoUrl, tmp], {
       encoding: "utf-8",
       stdio: "pipe",
     });
-    return true;
-  } catch {
-    return false;
+    return tmp;
+  } catch (err) {
+    rmSync(tmp, { recursive: true, force: true });
+    const message = err instanceof Error ? err.message : "unknown error";
+    throw new Error(`Failed to clone ${repoUrl}: ${message}`);
   }
 }
 
-export function readUpstreamVersion(
-  repoRoot: string,
-  remote = "context-tree-upstream",
-  ref = "main",
-): string | null {
-  for (const candidate of frameworkVersionCandidates()) {
-    try {
-      const result = execFileSync("git", ["show", `${remote}/${ref}:${candidate}`], {
-        cwd: repoRoot,
-        encoding: "utf-8",
-        stdio: "pipe",
-      });
-      return result.trim();
-    } catch {
-      continue;
-    }
+export function cleanupUpstreamRepo(root: string): void {
+  rmSync(root, { recursive: true, force: true });
+}
+
+export function readUpstreamVersion(sourceRoot: string): string | null {
+  const versionPath = resolveFirstExistingPath(
+    sourceRoot,
+    frameworkVersionCandidates(),
+  );
+  if (versionPath === null) return null;
+  try {
+    return readFileSync(join(sourceRoot, versionPath), "utf-8").trim();
+  } catch {
+    return null;
   }
-  return null;
 }

--- a/src/upgrade.ts
+++ b/src/upgrade.ts
@@ -1,100 +1,139 @@
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { Repo } from "#src/repo.js";
-import { fetchUpstream, readUpstreamVersion } from "#src/runtime/upgrader.js";
-
-const FIRST_TREE_REPO_URL = "https://github.com/agent-team-foundation/first-tree";
-
-function getUpstreamVersion(repo: Repo): string | null {
-  if (!fetchUpstream(repo.root)) {
-    return null;
-  }
-  return readUpstreamVersion(repo.root);
-}
+import {
+  FRAMEWORK_WORKFLOWS_DIR,
+  FRAMEWORK_TEMPLATES_DIR,
+  FRAMEWORK_VERSION,
+  INSTALLED_PROGRESS,
+  LEGACY_FRAMEWORK_ROOT,
+  SKILL_ROOT,
+} from "#src/runtime/asset-loader.js";
+import { copyCanonicalSkill } from "#src/runtime/installer.js";
+import {
+  cleanupUpstreamRepo,
+  cloneUpstreamRepo,
+  FIRST_TREE_REPO_URL,
+  readUpstreamVersion,
+} from "#src/runtime/upgrader.js";
 
 function writeProgress(repo: Repo, content: string): void {
-  const progressPath = join(repo.root, ".context-tree", "progress.md");
+  const progressPath = join(repo.root, repo.preferredProgressPath());
   mkdirSync(dirname(progressPath), { recursive: true });
   writeFileSync(progressPath, content);
 }
 
-export function runUpgrade(): number {
-  const repo = new Repo();
-
-  if (!repo.hasFramework()) {
-    console.error(
-      "Error: no .context-tree/ found. Run `context-tree init` first.",
-    );
-    return 1;
-  }
-
-  const localVersion = repo.readVersion() ?? "unknown";
-  console.log(`Local framework version: ${localVersion}\n`);
-
-  // Check for upstream remote
-  if (!repo.hasUpstreamRemote()) {
-    const lines = [
-      "# Context Tree Upgrade\n",
-      "## Setup",
-      `- [ ] Add upstream remote: \`git remote add context-tree-upstream ${FIRST_TREE_REPO_URL}\``,
-      "- [ ] Then run `context-tree upgrade` again to check for updates",
-    ];
-    const output = lines.join("\n");
-    console.log(output);
-    writeProgress(repo, output + "\n");
-    console.log("\nProgress file written to .context-tree/progress.md");
-    return 0;
-  }
-
-  // Fetch upstream version
-  const upstreamVersion = getUpstreamVersion(repo);
-  if (upstreamVersion === null) {
-    console.log(
-      "Could not fetch upstream version. Check your network and try again.",
-    );
-    return 1;
-  }
-
-  if (upstreamVersion === localVersion) {
-    console.log(`Already up to date (v${localVersion}).`);
-    return 0;
-  }
-
+function formatUpgradeTaskList(
+  repo: Repo,
+  localVersion: string,
+  upstreamVersion: string,
+  migratedFromLegacy: boolean,
+): string {
   const lines: string[] = [
     `# Context Tree Upgrade — v${localVersion} -> v${upstreamVersion}\n`,
-    "## Framework",
-    "- [ ] Pull latest from upstream: `git fetch context-tree-upstream && git merge context-tree-upstream/main`",
-    "- [ ] Resolve any conflicts in `.context-tree/` (framework files should generally take upstream version)",
+    "## Installed Skill",
+    `- [ ] Review local customizations under \`${SKILL_ROOT}/\` and reapply them if needed`,
+    `- [ ] Re-copy any workflow updates you want from \`${FRAMEWORK_WORKFLOWS_DIR}/\` into \`.github/workflows/\``,
+    `- [ ] Re-check any local agent setup that references \`${SKILL_ROOT}/assets/framework/examples/\` or \`${SKILL_ROOT}/assets/framework/helpers/\``,
     "",
   ];
 
-  // Check AGENT.md
+  if (migratedFromLegacy) {
+    lines.push(
+      "## Migration",
+      "- [ ] Remove any stale `.context-tree/` references from repo-specific docs, scripts, or workflow files",
+      "",
+    );
+  }
+
   if (repo.hasAgentMdMarkers()) {
     lines.push(
       "## Agent Instructions",
-      "- [ ] Check if AGENT.md framework section needs updating — compare content between markers to the new template",
+      `- [ ] Compare the framework section in \`AGENT.md\` with \`${FRAMEWORK_TEMPLATES_DIR}/agent.md.template\` and update the content between the markers if needed`,
       "",
     );
   }
 
   lines.push(
     "## Verification",
-    `- [ ] \`.context-tree/VERSION\` reads \`${upstreamVersion}\``,
+    `- [ ] \`${FRAMEWORK_VERSION}\` reads \`${upstreamVersion}\``,
     "- [ ] `context-tree verify` passes",
-    "- [ ] AGENT.md framework section matches upstream",
     "",
     "---",
     "",
     "**Important:** As you complete each task, check it off in" +
-      " `.context-tree/progress.md` by changing `- [ ]` to `- [x]`." +
+      ` \`${INSTALLED_PROGRESS}\` by changing \`- [ ]\` to \`- [x]\`.` +
       " Run `context-tree verify` when done — it will fail if any" +
       " items remain unchecked.",
     "",
   );
 
-  const output = lines.join("\n");
-  console.log(output);
-  writeProgress(repo, output);
-  console.log("Progress file written to .context-tree/progress.md");
-  return 0;
+  return lines.join("\n");
+}
+
+export interface UpgradeOptions {
+  upstreamRoot?: string;
+}
+
+export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
+  const workingRepo = repo ?? new Repo();
+
+  if (!workingRepo.hasFramework()) {
+    console.error(
+      "Error: no installed framework skill found. Run `context-tree init` first.",
+    );
+    return 1;
+  }
+
+  const layout = workingRepo.frameworkLayout();
+  const localVersion = workingRepo.readVersion() ?? "unknown";
+  console.log(`Local framework version: ${localVersion}\n`);
+
+  console.log(`Checking ${FIRST_TREE_REPO_URL} for the latest framework skill...`);
+
+  const clonedUpstream = options?.upstreamRoot === undefined;
+  const upstreamRoot = options?.upstreamRoot ?? cloneUpstreamRepo();
+
+  try {
+    const upstreamVersion = readUpstreamVersion(upstreamRoot);
+    if (upstreamVersion === null) {
+      console.log(
+        "Could not read the upstream framework version. Check your network and try again.",
+      );
+      return 1;
+    }
+
+    if (layout === "skill" && upstreamVersion === localVersion) {
+      console.log(`Already up to date (${FRAMEWORK_VERSION} = ${localVersion}).`);
+      return 0;
+    }
+
+    copyCanonicalSkill(upstreamRoot, workingRepo.root);
+    if (layout === "legacy") {
+      rmSync(join(workingRepo.root, LEGACY_FRAMEWORK_ROOT), {
+        recursive: true,
+        force: true,
+      });
+      console.log(
+        "Migrated legacy .context-tree/ layout to skills/first-tree-cli-framework/.",
+      );
+    } else {
+      console.log("Refreshed skills/first-tree-cli-framework/ from upstream.");
+    }
+
+    const output = formatUpgradeTaskList(
+      workingRepo,
+      localVersion,
+      upstreamVersion,
+      layout === "legacy",
+    );
+    console.log(`\n${output}`);
+    writeProgress(workingRepo, output);
+    console.log(`Progress file written to ${workingRepo.preferredProgressPath()}`);
+    return 0;
+  } finally {
+    if (clonedUpstream) {
+      cleanupUpstreamRepo(upstreamRoot);
+    }
+  }
 }

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -39,19 +39,21 @@ export function runVerify(repo?: Repo, nodeValidator?: NodeValidator): number {
   const r = repo ?? new Repo();
   const validate = nodeValidator ?? defaultNodeValidator;
   let allPassed = true;
+  const progressPath = r.progressPath() ?? r.preferredProgressPath();
+  const frameworkVersionPath = r.frameworkVersionPath();
 
   console.log("Context Tree Verification\n");
 
   // Progress file check
   const unchecked = checkProgress(r);
   if (unchecked.length > 0) {
-    console.log("  Unchecked items in .context-tree/progress.md:\n");
+    console.log(`  Unchecked items in ${progressPath}:\n`);
     for (const item of unchecked) {
       console.log(`    - [ ] ${item}`);
     }
     console.log();
     console.log(
-      "  Verify each step above and check it off in progress.md before running verify again.\n",
+      `  Verify each step above and check it off in ${progressPath} before running verify again.\n`,
     );
     allPassed = false;
   }
@@ -60,7 +62,7 @@ export function runVerify(repo?: Repo, nodeValidator?: NodeValidator): number {
   console.log("  Checks:\n");
 
   // 1. Framework exists
-  allPassed = check(".context-tree/VERSION exists", r.hasFramework()) && allPassed;
+  allPassed = check(`${frameworkVersionPath} exists`, r.hasFramework()) && allPassed;
 
   // 2. Root NODE.md has valid frontmatter
   const fm = r.frontmatter("NODE.md");

--- a/tests/generate-codeowners.test.ts
+++ b/tests/generate-codeowners.test.ts
@@ -6,7 +6,7 @@ import {
   resolveNodeOwners,
   collectEntries,
   formatOwners,
-} from "../.context-tree/generate-codeowners.js";
+} from "../skills/first-tree-cli-framework/assets/framework/helpers/generate-codeowners.js";
 import { useTmpDir } from "./helpers.js";
 
 function write(root: string, relPath: string, content: string): string {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -2,6 +2,10 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach } from "vitest";
+import {
+  FRAMEWORK_VERSION,
+  LEGACY_VERSION,
+} from "#src/runtime/asset-loader.js";
 
 interface TmpDir {
   path: string;
@@ -15,10 +19,17 @@ export function useTmpDir(): TmpDir {
   return { path: dir };
 }
 
-export function makeFramework(root: string): void {
+export function makeFramework(root: string, version = "0.1.0"): void {
+  mkdirSync(join(root, "skills", "first-tree-cli-framework", "assets", "framework"), {
+    recursive: true,
+  });
+  writeFileSync(join(root, FRAMEWORK_VERSION), `${version}\n`);
+}
+
+export function makeLegacyFramework(root: string, version = "0.1.0"): void {
   const ct = join(root, ".context-tree");
   mkdirSync(ct, { recursive: true });
-  writeFileSync(join(ct, "VERSION"), "0.1.0\n");
+  writeFileSync(join(root, LEGACY_VERSION), `${version}\n`);
 }
 
 export function makeNode(

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -3,7 +3,15 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { formatTaskList, writeProgress, runInit } from "#src/init.js";
 import { Repo } from "#src/repo.js";
-import { useTmpDir, makeFramework } from "./helpers.js";
+import {
+  INSTALLED_PROGRESS,
+  LEGACY_PROGRESS,
+} from "#src/runtime/asset-loader.js";
+import {
+  useTmpDir,
+  makeFramework,
+  makeLegacyFramework,
+} from "./helpers.js";
 
 // --- formatTaskList ---
 
@@ -66,7 +74,7 @@ describe("writeProgress", () => {
     const tmp = useTmpDir();
     const repo = new Repo(tmp.path);
     writeProgress(repo, "# hello\n");
-    const progress = join(tmp.path, ".context-tree", "progress.md");
+    const progress = join(tmp.path, INSTALLED_PROGRESS);
     expect(readFileSync(progress, "utf-8")).toBe("# hello\n");
   });
 
@@ -74,18 +82,27 @@ describe("writeProgress", () => {
     const tmp = useTmpDir();
     const repo = new Repo(tmp.path);
     writeProgress(repo, "content");
-    const progress = join(tmp.path, ".context-tree", "progress.md");
+    const progress = join(tmp.path, INSTALLED_PROGRESS);
     expect(readFileSync(progress, "utf-8")).toBe("content");
   });
 
   it("overwrites existing file", () => {
     const tmp = useTmpDir();
-    const ct = join(tmp.path, ".context-tree");
-    mkdirSync(ct);
-    writeFileSync(join(ct, "progress.md"), "old");
+    mkdirSync(join(tmp.path, "skills", "first-tree-cli-framework"), {
+      recursive: true,
+    });
+    writeFileSync(join(tmp.path, INSTALLED_PROGRESS), "old");
     const repo = new Repo(tmp.path);
     writeProgress(repo, "new");
-    expect(readFileSync(join(ct, "progress.md"), "utf-8")).toBe("new");
+    expect(readFileSync(join(tmp.path, INSTALLED_PROGRESS), "utf-8")).toBe("new");
+  });
+
+  it("keeps using the legacy progress path for legacy repos", () => {
+    const tmp = useTmpDir();
+    makeLegacyFramework(tmp.path);
+    const repo = new Repo(tmp.path);
+    writeProgress(repo, "legacy");
+    expect(readFileSync(join(tmp.path, LEGACY_PROGRESS), "utf-8")).toBe("legacy");
   });
 });
 

--- a/tests/repo.test.ts
+++ b/tests/repo.test.ts
@@ -2,7 +2,13 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { Repo } from "#src/repo.js";
-import { useTmpDir } from "./helpers.js";
+import {
+  FRAMEWORK_VERSION,
+  INSTALLED_PROGRESS,
+  LEGACY_PROGRESS,
+  LEGACY_VERSION,
+} from "#src/runtime/asset-loader.js";
+import { useTmpDir, makeFramework, makeLegacyFramework } from "./helpers.js";
 
 // --- pathExists ---
 
@@ -136,10 +142,16 @@ describe("isGitRepo", () => {
 // --- hasFramework ---
 
 describe("hasFramework", () => {
-  it("returns true with VERSION file", () => {
+  it("returns true with installed skill version file", () => {
     const tmp = useTmpDir();
-    mkdirSync(join(tmp.path, ".context-tree"));
-    writeFileSync(join(tmp.path, ".context-tree", "VERSION"), "0.1.0\n");
+    makeFramework(tmp.path);
+    const repo = new Repo(tmp.path);
+    expect(repo.hasFramework()).toBe(true);
+  });
+
+  it("returns true with legacy version file", () => {
+    const tmp = useTmpDir();
+    makeLegacyFramework(tmp.path);
     const repo = new Repo(tmp.path);
     expect(repo.hasFramework()).toBe(true);
   });
@@ -154,18 +166,43 @@ describe("hasFramework", () => {
 // --- readVersion ---
 
 describe("readVersion", () => {
-  it("reads valid version", () => {
+  it("reads the installed skill version", () => {
     const tmp = useTmpDir();
-    mkdirSync(join(tmp.path, ".context-tree"));
-    writeFileSync(join(tmp.path, ".context-tree", "VERSION"), "0.2.0\n");
+    makeFramework(tmp.path, "0.2.0");
     const repo = new Repo(tmp.path);
     expect(repo.readVersion()).toBe("0.2.0");
+  });
+
+  it("falls back to the legacy version", () => {
+    const tmp = useTmpDir();
+    makeLegacyFramework(tmp.path, "0.3.0");
+    const repo = new Repo(tmp.path);
+    expect(repo.readVersion()).toBe("0.3.0");
   });
 
   it("returns null when missing", () => {
     const tmp = useTmpDir();
     const repo = new Repo(tmp.path);
     expect(repo.readVersion()).toBeNull();
+  });
+});
+
+// --- preferredProgressPath / frameworkVersionPath ---
+
+describe("path preferences", () => {
+  it("prefers the installed-skill paths by default", () => {
+    const tmp = useTmpDir();
+    const repo = new Repo(tmp.path);
+    expect(repo.preferredProgressPath()).toBe(INSTALLED_PROGRESS);
+    expect(repo.frameworkVersionPath()).toBe(FRAMEWORK_VERSION);
+  });
+
+  it("switches path preferences for legacy repos", () => {
+    const tmp = useTmpDir();
+    makeLegacyFramework(tmp.path);
+    const repo = new Repo(tmp.path);
+    expect(repo.preferredProgressPath()).toBe(LEGACY_PROGRESS);
+    expect(repo.frameworkVersionPath()).toBe(LEGACY_VERSION);
   });
 });
 

--- a/tests/rules.test.ts
+++ b/tests/rules.test.ts
@@ -29,7 +29,7 @@ describe("framework rule", () => {
     const result = framework.evaluate(repo);
     expect(result.group).toBe("Framework");
     expect(result.tasks).toHaveLength(1);
-    expect(result.tasks[0]).toContain(".context-tree/");
+    expect(result.tasks[0]).toContain("skills/first-tree-cli-framework/");
   });
 
   it("passes when framework exists", () => {
@@ -214,6 +214,7 @@ describe("ciValidation rule", () => {
     const result = ciValidation.evaluate(repo);
     expect(result.tasks).toHaveLength(4);
     expect(result.tasks[0]).toContain("validation workflow");
+    expect(result.tasks[0]).toContain("skills/first-tree-cli-framework/assets/framework/workflows/validate.yml");
     expect(result.tasks[1]).toContain("PR reviews");
     expect(result.tasks[2]).toContain("API secret");
     expect(result.tasks[3]).toContain("CODEOWNERS");
@@ -251,7 +252,7 @@ describe("ciValidation rule", () => {
     mkdirSync(wfDir, { recursive: true });
     writeFileSync(
       join(wfDir, "pr-review.yml"),
-      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx .context-tree/run-review.ts\n",
+      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/run-review.ts\n",
     );
     const repo = new Repo(tmp.path);
     const result = ciValidation.evaluate(repo);
@@ -270,7 +271,7 @@ describe("ciValidation rule", () => {
     );
     writeFileSync(
       join(wfDir, "pr-review.yml"),
-      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx .context-tree/run-review.ts\n",
+      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/run-review.ts\n",
     );
     const repo = new Repo(tmp.path);
     const result = ciValidation.evaluate(repo);
@@ -288,11 +289,11 @@ describe("ciValidation rule", () => {
     );
     writeFileSync(
       join(wfDir, "pr-review.yml"),
-      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx .context-tree/run-review.ts\n",
+      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/run-review.ts\n",
     );
     writeFileSync(
       join(wfDir, "codeowners.yml"),
-      "name: Update CODEOWNERS\non: pull_request\njobs:\n  update:\n    steps:\n      - run: npx tsx .context-tree/generate-codeowners.ts\n",
+      "name: Update CODEOWNERS\non: pull_request\njobs:\n  update:\n    steps:\n      - run: npx tsx skills/first-tree-cli-framework/assets/framework/helpers/generate-codeowners.ts\n",
     );
     const repo = new Repo(tmp.path);
     const result = ciValidation.evaluate(repo);

--- a/tests/run-review.test.ts
+++ b/tests/run-review.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   extractStreamText,
   extractReviewJson,
-} from "../.context-tree/run-review.js";
+} from "../skills/first-tree-cli-framework/assets/framework/helpers/run-review.js";
 
 // --- extractStreamText ---
 

--- a/tests/upgrade.test.ts
+++ b/tests/upgrade.test.ts
@@ -1,0 +1,58 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { Repo } from "#src/repo.js";
+import { runUpgrade } from "#src/upgrade.js";
+import {
+  FRAMEWORK_VERSION,
+  INSTALLED_PROGRESS,
+} from "#src/runtime/asset-loader.js";
+import { makeFramework, makeLegacyFramework, useTmpDir } from "./helpers.js";
+
+function makeUpstreamSkill(root: string, version: string): void {
+  const skillRoot = join(root, "skills", "first-tree-cli-framework");
+  mkdirSync(join(skillRoot, "assets", "framework"), { recursive: true });
+  writeFileSync(
+    join(skillRoot, "SKILL.md"),
+    "---\nname: first-tree-cli-framework\ndescription: test\n---\n",
+  );
+  writeFileSync(join(root, FRAMEWORK_VERSION), `${version}\n`);
+}
+
+describe("runUpgrade", () => {
+  it("migrates a legacy repo to the installed skill layout", () => {
+    const repoDir = useTmpDir();
+    const upstreamDir = useTmpDir();
+    makeLegacyFramework(repoDir.path, "0.1.0");
+    writeFileSync(
+      join(repoDir.path, "AGENT.md"),
+      "<!-- BEGIN CONTEXT-TREE FRAMEWORK -->\nstuff\n<!-- END CONTEXT-TREE FRAMEWORK -->\n",
+    );
+    makeUpstreamSkill(upstreamDir.path, "0.2.0");
+
+    const result = runUpgrade(new Repo(repoDir.path), {
+      upstreamRoot: upstreamDir.path,
+    });
+
+    expect(result).toBe(0);
+    expect(existsSync(join(repoDir.path, ".context-tree"))).toBe(false);
+    expect(readFileSync(join(repoDir.path, FRAMEWORK_VERSION), "utf-8").trim()).toBe("0.2.0");
+    expect(readFileSync(join(repoDir.path, INSTALLED_PROGRESS), "utf-8")).toContain(
+      "skills/first-tree-cli-framework/assets/framework/VERSION",
+    );
+  });
+
+  it("returns early when the installed skill is already current", () => {
+    const repoDir = useTmpDir();
+    const upstreamDir = useTmpDir();
+    makeFramework(repoDir.path, "0.2.0");
+    makeUpstreamSkill(upstreamDir.path, "0.2.0");
+
+    const result = runUpgrade(new Repo(repoDir.path), {
+      upstreamRoot: upstreamDir.path,
+    });
+
+    expect(result).toBe(0);
+    expect(existsSync(join(repoDir.path, INSTALLED_PROGRESS))).toBe(false);
+  });
+});

--- a/tests/verify.test.ts
+++ b/tests/verify.test.ts
@@ -3,7 +3,18 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { check, checkProgress, runVerify } from "#src/verify.js";
 import { Repo } from "#src/repo.js";
-import { useTmpDir, makeFramework, makeNode, makeAgentMd, makeMembers } from "./helpers.js";
+import {
+  INSTALLED_PROGRESS,
+  LEGACY_PROGRESS,
+} from "#src/runtime/asset-loader.js";
+import {
+  useTmpDir,
+  makeFramework,
+  makeLegacyFramework,
+  makeNode,
+  makeAgentMd,
+  makeMembers,
+} from "./helpers.js";
 
 // --- check ---
 
@@ -28,10 +39,9 @@ describe("checkProgress", () => {
 
   it("returns empty when all checked", () => {
     const tmp = useTmpDir();
-    const ct = join(tmp.path, ".context-tree");
-    mkdirSync(ct);
+    mkdirSync(join(tmp.path, "skills", "first-tree-cli-framework"), { recursive: true });
     writeFileSync(
-      join(ct, "progress.md"),
+      join(tmp.path, INSTALLED_PROGRESS),
       "# Progress\n- [x] Task one\n- [x] Task two\n",
     );
     const repo = new Repo(tmp.path);
@@ -40,10 +50,9 @@ describe("checkProgress", () => {
 
   it("returns unchecked items", () => {
     const tmp = useTmpDir();
-    const ct = join(tmp.path, ".context-tree");
-    mkdirSync(ct);
+    mkdirSync(join(tmp.path, "skills", "first-tree-cli-framework"), { recursive: true });
     writeFileSync(
-      join(ct, "progress.md"),
+      join(tmp.path, INSTALLED_PROGRESS),
       "# Progress\n- [x] Done task\n- [ ] Pending task\n- [ ] Another pending\n",
     );
     const repo = new Repo(tmp.path);
@@ -52,11 +61,21 @@ describe("checkProgress", () => {
 
   it("returns empty for empty progress", () => {
     const tmp = useTmpDir();
-    const ct = join(tmp.path, ".context-tree");
-    mkdirSync(ct);
-    writeFileSync(join(ct, "progress.md"), "");
+    mkdirSync(join(tmp.path, "skills", "first-tree-cli-framework"), { recursive: true });
+    writeFileSync(join(tmp.path, INSTALLED_PROGRESS), "");
     const repo = new Repo(tmp.path);
     expect(checkProgress(repo)).toEqual([]);
+  });
+
+  it("falls back to the legacy progress file", () => {
+    const tmp = useTmpDir();
+    makeLegacyFramework(tmp.path);
+    writeFileSync(
+      join(tmp.path, LEGACY_PROGRESS),
+      "# Progress\n- [ ] Legacy task\n",
+    );
+    const repo = new Repo(tmp.path);
+    expect(checkProgress(repo)).toEqual(["Legacy task"]);
   });
 });
 


### PR DESCRIPTION
## Summary
- make `context-tree init` install `skills/first-tree-cli-framework/` into user repos instead of generating `.context-tree/`
- switch onboarding, rules, templates, workflows, helpers, verify, and upgrade logic to the installed-skill contract while keeping legacy reads for migration
- add upgrade coverage for migrating a legacy repo to the installed skill layout and refresh all exported mirrors/snapshots

## Testing
- pnpm typecheck
- pnpm build
- pnpm test