### PR TITLE
docs: harden first-tree OSS entrypoints

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,51 @@
+name: Bug report
+description: Report a concrete problem in the first-tree CLI, framework payload, docs, or packaging.
+title: "[Bug]: "
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Describe the bug and why it matters.
+      placeholder: context-tree verify rejects a valid tree after upgrading from 0.0.x
+    validations:
+      required: true
+  - type: input
+    id: command
+    attributes:
+      label: Command or surface area
+      description: Which command, doc, or package surface is affected?
+      placeholder: context-tree init
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Include the smallest reproducible sequence you can.
+      placeholder: |
+        1. Create a new git repo
+        2. Run npx first-tree init
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: The CLI should scaffold AGENT.md and write progress.md
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Share versions and context that might affect the result.
+      placeholder: |
+        OS:
+        Node:
+        Package manager:
+        first-tree version:
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context
+      description: Screenshots, logs, tree layout notes, or related links.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Usage question or onboarding help
+    url: https://github.com/agent-team-foundation/first-tree/blob/main/skills/first-tree-cli-framework/references/onboarding.md
+    about: Start with the onboarding guide before opening a support issue.
+  - name: Contribution guide
+    url: https://github.com/agent-team-foundation/first-tree/blob/main/CONTRIBUTING.md
+    about: Read local setup, validation, and change-discipline guidance.
+  - name: Security report
+    url: https://github.com/agent-team-foundation/first-tree/blob/main/SECURITY.md
+    about: Please do not file public vulnerability reports.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,39 @@
+name: Feature request
+description: Propose an improvement to the CLI, framework payload, docs, or maintainer workflow.
+title: "[Feature]: "
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Start with the user or maintainer pain, not just the solution.
+      placeholder: New contributors do not know whether to run first-tree or context-tree after installing globally.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should change?
+      placeholder: Add a global first-tree alias that points to the same CLI entrypoint.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Affected areas
+      description: Which part of the repo would likely change?
+      placeholder: README, package bin aliases, thin CLI shell, onboarding docs
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any smaller or less risky options?
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Are you interested in contributing a PR?
+      options:
+        - Yes
+        - Maybe
+        - No

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## Summary
+
+- what changed?
+- why does it matter?
+
+## Validation
+
+- [ ] `pnpm validate:skill`
+- [ ] `pnpm typecheck`
+- [ ] `pnpm test`
+- [ ] `pnpm build`
+- [ ] `pnpm pack` if package contents or install/upgrade behavior changed
+
+## Change Surface
+
+- [ ] Thin CLI shell (`src/`, package/build wiring)
+- [ ] Canonical skill behavior (`skills/first-tree-cli-framework/engine/`)
+- [ ] Shipped framework payload (`skills/first-tree-cli-framework/assets/framework/`)
+- [ ] Maintainer or user docs (`README.md`, `CONTRIBUTING.md`, `references/`)
+
+## Notes
+
+- package/install behavior changes:
+- docs or tests updated to match:
+- follow-up work:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,34 @@
+# Code of Conduct
+
+## Our Standard
+
+This project is for people building with agents, CLI tools, and markdown-first
+ systems. We want the repo to feel rigorous, welcoming, and calm.
+
+When participating here, please:
+
+- be respectful, direct, and constructive
+- assume good intent, but prioritize clarity over ambiguity
+- focus criticism on ideas, tradeoffs, and implementation details
+- avoid harassment, personal attacks, dogpiling, discrimination, and bad-faith behavior
+- keep issues and pull requests grounded in reproducible problems, concrete proposals, or real user impact
+
+## Scope
+
+This applies to GitHub issues, pull requests, reviews, discussions, and other
+project-managed community spaces.
+
+## Maintainer Responsibilities
+
+Maintainers may edit, hide, lock, or remove comments, issues, pull requests, or
+other contributions that violate this code of conduct. Repeated or severe
+violations may lead to temporary or permanent bans from project spaces.
+
+## Reporting
+
+If you experience or witness behavior that violates this code of conduct, do
+not post sensitive details publicly.
+
+Open a short GitHub issue that asks for a private maintainer follow-up, and
+keep the public text limited to that request. A maintainer can then move the
+conversation to a private channel.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,10 @@ Helpful PRs for this repo usually include:
 - the validation commands you ran
 - notes about package/install behavior if the published tarball changes
 
+Use the GitHub issue forms for bug reports and feature requests, and follow the
+pull request template when opening a PR so maintainers get the same core
+context every time.
+
 ## Where To Start Reading
 
 - `README.md` for the public entrypoint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,82 @@
+# Contributing to first-tree
+
+Thanks for helping improve `first-tree`.
+
+This repository ships one canonical framework skill plus a thin CLI shell. Most
+changes should land in the canonical skill under
+`skills/first-tree-cli-framework/`, not in root-level prose or ad hoc helper
+files.
+
+## Before You Change Anything
+
+- If you are trying to use Context Tree in your own repo, start with `README.md`
+  and `skills/first-tree-cli-framework/references/onboarding.md` instead of this
+  maintainer guide.
+- If a change is large, cross-cutting, or changes the public contract, open an
+  issue or draft PR first so maintainers can align on scope before implementation.
+- Keep root shell files thin. If a change needs framework-specific knowledge,
+  move that knowledge into the skill references.
+
+## Local Setup
+
+Use the same baseline as CI:
+
+- Node.js 22
+- pnpm 10
+
+Install dependencies from the repo root:
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+## Validation
+
+Run the standard checks before opening a PR:
+
+```bash
+pnpm validate:skill
+pnpm typecheck
+pnpm test
+pnpm build
+```
+
+Also run this when package contents or install/upgrade behavior changes:
+
+```bash
+pnpm pack
+```
+
+Maintainer-only end-to-end evals live in `evals/`. Read `evals/README.md`
+before running `EVALS=1 pnpm eval`.
+
+## Change Discipline
+
+- Treat `skills/first-tree-cli-framework/` as the only canonical source of
+  framework knowledge.
+- If you change shipped payloads under `assets/framework/`, keep templates,
+  task text, docs, and tests aligned.
+- If you change anything that gets copied into user repos, bump
+  `skills/first-tree-cli-framework/assets/framework/VERSION`.
+- If you change installed layout or upgrade semantics, update
+  `skills/first-tree-cli-framework/references/upgrade-contract.md` and the
+  related tests in the same PR.
+- If you change maintainer workflows or package shell behavior, update the
+  relevant references under `skills/first-tree-cli-framework/references/`.
+
+## Pull Requests
+
+Helpful PRs for this repo usually include:
+
+- a short explanation of the user-facing or maintainer-facing problem
+- the affected command or package surface (`init`, `verify`, `upgrade`, help,
+  templates, validators, or packaging)
+- the validation commands you ran
+- notes about package/install behavior if the published tarball changes
+
+## Where To Start Reading
+
+- `README.md` for the public entrypoint
+- `skills/first-tree-cli-framework/SKILL.md` for the maintainer workflow
+- `skills/first-tree-cli-framework/references/source-map.md` for the canonical
+  reading index

--- a/README.md
+++ b/README.md
@@ -3,16 +3,38 @@
 Thin distribution package for the canonical `first-tree-cli-framework` skill
 and the `context-tree` CLI.
 
+## Package Name vs Command
+
+- The npm package is `first-tree`.
+- The installed CLI command is `context-tree`.
+- `npx first-tree init` is the quickest one-off entrypoint.
+- `npm install -g first-tree` adds `context-tree` to your PATH for repeated use.
+
+## What This Repo Ships
+
+- `src/` keeps the thin CLI shell that parses commands and dispatches to the bundled skill.
+- `skills/first-tree-cli-framework/` is the canonical source for framework behavior, shipped templates, maintainer references, and validation logic.
+- `evals/` is maintainer-only developer tooling for the source repo. It is intentionally not part of the published package.
+
 ## Quick Start
 
+If you are starting a brand-new tree, create a git repo first:
+
 ```bash
+mkdir my-org-tree && cd my-org-tree
+git init
 npx first-tree init
 ```
 
-The npm package is `first-tree`; it installs the `context-tree` command. Use
-`npm install -g first-tree` if you want the command on your PATH.
-The package carries the canonical `first-tree-cli-framework` skill, and
-`context-tree init` / `context-tree upgrade` install from that bundled skill.
+If you already have the command on your PATH:
+
+```bash
+context-tree init
+```
+
+The installed package carries the canonical bundled skill, and
+`context-tree init` / `context-tree upgrade` install from that bundled copy
+instead of cloning this source repo at runtime.
 
 ## Commands
 
@@ -22,6 +44,29 @@ The package carries the canonical `first-tree-cli-framework` skill, and
 | `context-tree verify` | Run verification checks against the current tree |
 | `context-tree upgrade` | Refresh the installed framework skill from the current `first-tree` package and write follow-up tasks |
 | `context-tree help onboarding` | Print the onboarding guide |
+
+## Runtime And Maintainer Prerequisites
+
+- User trees: the onboarding guide targets Node.js 18+.
+- This source repo: use Node.js 22 and pnpm 10 to match CI and the checked-in package manager version.
+
+## Developing This Repo
+
+Run these commands from the repo root:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm validate:skill
+pnpm typecheck
+pnpm test
+pnpm build
+```
+
+When package contents or install/upgrade behavior changes, also run:
+
+```bash
+pnpm pack
+```
 
 ## Canonical Documentation
 
@@ -34,6 +79,11 @@ live in `skills/first-tree-cli-framework/`.
 
 If you are maintaining this repo, start with the source map instead of relying
 on root-level prose.
+
+## Contributing And Security
+
+- See `CONTRIBUTING.md` for local setup, validation expectations, and where changes should live.
+- See `SECURITY.md` for vulnerability reporting guidance.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ on root-level prose.
 
 ## Contributing And Security
 
+- Use the GitHub issue forms for bug reports and feature requests so maintainers get reproducible context up front.
 - See `CONTRIBUTING.md` for local setup, validation expectations, and where changes should live.
+- See `CODE_OF_CONDUCT.md` for community expectations.
 - See `SECURITY.md` for vulnerability reporting guidance.
 
 ## License

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are prioritized for:
+
+- the latest `main` branch in this repository
+- the latest published `first-tree` npm package
+
+Older snapshots may receive best-effort guidance, but they should not be
+assumed to get backported fixes.
+
+## Reporting a Vulnerability
+
+Please do not post exploit details in a public GitHub issue.
+
+Preferred path:
+
+1. Use GitHub Private Vulnerability Reporting for this repository if that
+   option is available in the Security tab.
+
+Fallback path:
+
+1. Open a public issue with only the affected area and impact summary.
+2. Do not include proof-of-concept code, secrets, or reproduction steps that
+   would make the issue exploitable.
+3. Ask the maintainers to provide a private handoff path for the full report.
+
+## What To Include
+
+Helpful reports usually include:
+
+- affected command or surface area
+- impacted version or commit
+- prerequisites and expected impact
+- reproduction notes that a maintainer can validate privately
+- suggested remediation or patch direction, if you have one
+
+## Response Expectations
+
+Maintainers will try to confirm the report, understand the impact, and land a
+fix before requesting public disclosure details. Coordinated disclosure is
+appreciated once a fix or mitigation is available.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,21 @@
   "name": "first-tree",
   "version": "0.0.3",
   "description": "CLI tools for Context Tree — the living source of truth for your organization.",
+  "homepage": "https://github.com/agent-team-foundation/first-tree#readme",
+  "bugs": {
+    "url": "https://github.com/agent-team-foundation/first-tree/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/agent-team-foundation/first-tree.git"
+  },
+  "keywords": [
+    "context-tree",
+    "cli",
+    "agents",
+    "knowledge-base",
+    "markdown"
+  ],
   "type": "module",
   "bin": {
     "context-tree": "./dist/cli.js"

--- a/skills/first-tree-cli-framework/engine/commands/help.ts
+++ b/skills/first-tree-cli-framework/engine/commands/help.ts
@@ -6,22 +6,27 @@ Topics:
 
 export { HELP_USAGE };
 
-export async function runHelp(args: string[]): Promise<number> {
+type Output = (text: string) => void;
+
+export async function runHelp(
+  args: string[],
+  output: Output = console.log,
+): Promise<number> {
   const topic = args[0];
 
   if (!topic || topic === "--help" || topic === "-h") {
-    console.log(HELP_USAGE);
+    output(HELP_USAGE);
     return 0;
   }
 
   switch (topic) {
     case "onboarding": {
       const { runOnboarding } = await import("#skill/engine/onboarding.js");
-      return runOnboarding();
+      return runOnboarding(output);
     }
     default:
-      console.log(`Unknown help topic: ${topic}`);
-      console.log(HELP_USAGE);
+      output(`Unknown help topic: ${topic}`);
+      output(HELP_USAGE);
       return 1;
   }
 }

--- a/skills/first-tree-cli-framework/engine/onboarding.ts
+++ b/skills/first-tree-cli-framework/engine/onboarding.ts
@@ -2,7 +2,9 @@ import ONBOARDING_TEXT from "#skill/references/onboarding.md";
 
 export { ONBOARDING_TEXT };
 
-export function runOnboarding(): number {
-  console.log(ONBOARDING_TEXT);
+type Output = (text: string) => void;
+
+export function runOnboarding(output: Output = console.log): number {
+  output(ONBOARDING_TEXT);
   return 0;
 }

--- a/skills/first-tree-cli-framework/references/maintainer-testing.md
+++ b/skills/first-tree-cli-framework/references/maintainer-testing.md
@@ -28,6 +28,7 @@ Examples:
 pnpm test -- skills/first-tree-cli-framework/tests/rules.test.ts
 pnpm test -- skills/first-tree-cli-framework/tests/verify.test.ts
 pnpm test -- skills/first-tree-cli-framework/tests/skill-artifacts.test.ts
+pnpm test -- skills/first-tree-cli-framework/tests/thin-cli.test.ts
 ```
 
 If a future refactor changes these paths again, keep the command semantics and

--- a/skills/first-tree-cli-framework/references/source-map.md
+++ b/skills/first-tree-cli-framework/references/source-map.md
@@ -79,6 +79,7 @@ not become the only place important maintainer knowledge lives.
 | `tests/generate-codeowners.test.ts` | Ownership helper behavior |
 | `tests/run-review.test.ts` | Review helper behavior |
 | `tests/skill-artifacts.test.ts` | Skill export and documentation integrity |
+| `tests/thin-cli.test.ts` | Thin CLI entrypoint smoke coverage |
 | `tests/upgrade.test.ts` | Installed-skill upgrade behavior |
 
 ## Compatibility Notes

--- a/skills/first-tree-cli-framework/references/upgrade-contract.md
+++ b/skills/first-tree-cli-framework/references/upgrade-contract.md
@@ -1,7 +1,7 @@
 # Upgrade Contract
 
-This file describes the intended contract for the single-skill refactor and the
-compatibility rules we keep while the repo is migrating.
+This file describes the current installed-layout contract and the compatibility
+rules we keep for legacy `.context-tree/` repos.
 
 ## Canonical Source
 
@@ -15,7 +15,7 @@ compatibility rules we keep while the repo is migrating.
 
 ## Installed Layout
 
-The end-state installed layout in a user repo is:
+The current installed layout in a user repo is:
 
 ```text
 skills/
@@ -57,7 +57,7 @@ The tree content still lives outside the skill:
   - migrates legacy `.context-tree/` repos onto the installed skill layout
   - preserves user-authored sections such as the editable part of `AGENT.md`
 
-## Compatibility Rules During Migration
+## Compatibility Rules For Legacy Trees
 
 - `context-tree init` only installs the skill layout; it never creates a new
   `.context-tree/`.

--- a/skills/first-tree-cli-framework/tests/skill-artifacts.test.ts
+++ b/skills/first-tree-cli-framework/tests/skill-artifacts.test.ts
@@ -230,4 +230,35 @@ describe("skill artifacts", () => {
     expect(maintainerArchitecture).toContain("`evals/`");
     expect(maintainerArchitecture).not.toContain("tests, and evals");
   });
+
+  it("keeps public OSS entrypoints and package metadata in place", () => {
+    const read = (path: string) => readFileSync(join(ROOT, path), "utf-8");
+    const pkg = JSON.parse(read("package.json")) as {
+      homepage?: string;
+      bugs?: { url?: string };
+      repository?: { type?: string; url?: string };
+      keywords?: string[];
+    };
+
+    expect(read("README.md")).toContain("Package Name vs Command");
+    expect(read("README.md")).toContain("CONTRIBUTING.md");
+    expect(read("README.md")).toContain("SECURITY.md");
+
+    expect(read("CONTRIBUTING.md")).toContain("pnpm validate:skill");
+    expect(read("CONTRIBUTING.md")).toContain("source-map.md");
+    expect(read("SECURITY.md")).toContain("Private Vulnerability Reporting");
+    expect(read("SECURITY.md")).toContain("do not post exploit details");
+
+    expect(pkg.homepage).toBe("https://github.com/agent-team-foundation/first-tree#readme");
+    expect(pkg.bugs).toEqual({
+      url: "https://github.com/agent-team-foundation/first-tree/issues",
+    });
+    expect(pkg.repository).toEqual({
+      type: "git",
+      url: "git+https://github.com/agent-team-foundation/first-tree.git",
+    });
+    expect(pkg.keywords).toEqual(
+      expect.arrayContaining(["context-tree", "cli", "agents"]),
+    );
+  });
 });

--- a/skills/first-tree-cli-framework/tests/skill-artifacts.test.ts
+++ b/skills/first-tree-cli-framework/tests/skill-artifacts.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
 
 const ROOT = process.cwd();
 
@@ -242,12 +243,36 @@ describe("skill artifacts", () => {
 
     expect(read("README.md")).toContain("Package Name vs Command");
     expect(read("README.md")).toContain("CONTRIBUTING.md");
+    expect(read("README.md")).toContain("CODE_OF_CONDUCT.md");
     expect(read("README.md")).toContain("SECURITY.md");
 
     expect(read("CONTRIBUTING.md")).toContain("pnpm validate:skill");
+    expect(read("CONTRIBUTING.md")).toContain("pull request template");
     expect(read("CONTRIBUTING.md")).toContain("source-map.md");
+    expect(read("CODE_OF_CONDUCT.md")).toContain("private maintainer follow-up");
     expect(read("SECURITY.md")).toContain("Private Vulnerability Reporting");
     expect(read("SECURITY.md")).toContain("do not post exploit details");
+
+    expect(existsSync(join(ROOT, ".github", "PULL_REQUEST_TEMPLATE.md"))).toBe(true);
+
+    const bugTemplate = parse(read(".github/ISSUE_TEMPLATE/bug-report.yml")) as {
+      name?: string;
+      body?: unknown[];
+    };
+    const featureTemplate = parse(read(".github/ISSUE_TEMPLATE/feature-request.yml")) as {
+      name?: string;
+      body?: unknown[];
+    };
+    const issueConfig = parse(read(".github/ISSUE_TEMPLATE/config.yml")) as {
+      contact_links?: unknown[];
+    };
+
+    expect(bugTemplate.name).toBe("Bug report");
+    expect(Array.isArray(bugTemplate.body)).toBe(true);
+    expect(featureTemplate.name).toBe("Feature request");
+    expect(Array.isArray(featureTemplate.body)).toBe(true);
+    expect(Array.isArray(issueConfig.contact_links)).toBe(true);
+    expect(issueConfig.contact_links).toHaveLength(3);
 
     expect(pkg.homepage).toBe("https://github.com/agent-team-foundation/first-tree#readme");
     expect(pkg.bugs).toEqual({

--- a/skills/first-tree-cli-framework/tests/thin-cli.test.ts
+++ b/skills/first-tree-cli-framework/tests/thin-cli.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { runCli, USAGE } from "../../../src/cli.ts";
+
+const ROOT = process.cwd();
+
+function captureOutput(): { lines: string[]; write: (text: string) => void } {
+  const lines: string[] = [];
+  return {
+    lines,
+    write: (text: string) => {
+      lines.push(text);
+    },
+  };
+}
+
+describe("thin CLI shell", () => {
+  it("prints usage with no args", async () => {
+    const output = captureOutput();
+
+    const code = await runCli([], output.write);
+
+    expect(code).toBe(0);
+    expect(output.lines).toEqual([USAGE]);
+  });
+
+  it("prints the package version", async () => {
+    const output = captureOutput();
+    const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf-8")) as {
+      version: string;
+    };
+
+    const code = await runCli(["--version"], output.write);
+
+    expect(code).toBe(0);
+    expect(output.lines).toEqual([pkg.version]);
+  });
+
+  it("routes help onboarding through the CLI entrypoint", async () => {
+    const output = captureOutput();
+
+    const code = await runCli(["help", "onboarding"], output.write);
+
+    expect(code).toBe(0);
+    expect(output.lines.join("\n")).toContain("# Context Tree Onboarding");
+    expect(output.lines.join("\n")).toContain("Node.js 18+");
+  });
+
+  it("fails with usage for an unknown command", async () => {
+    const output = captureOutput();
+
+    const code = await runCli(["wat"], output.write);
+
+    expect(code).toBe(1);
+    expect(output.lines[0]).toBe("Unknown command: wat");
+    expect(output.lines[1]).toBe(USAGE);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import { pathToFileURL } from "node:url";
+
 const USAGE = `usage: context-tree <command>
 
   New to context-tree? Run \`context-tree help onboarding\` first.
@@ -15,11 +17,18 @@ Options:
   --version    Show version number
 `;
 
-async function main(): Promise<number> {
-  const args = process.argv.slice(2);
+type Output = (text: string) => void;
+
+export { USAGE };
+
+export async function runCli(
+  args: string[],
+  output: Output = console.log,
+): Promise<number> {
+  const write = (text: string): void => output(text);
 
   if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
-    console.log(USAGE);
+    write(USAGE);
     return 0;
   }
 
@@ -27,7 +36,7 @@ async function main(): Promise<number> {
     const { createRequire } = await import("node:module");
     const require = createRequire(import.meta.url);
     const pkg = require("../package.json") as { version: string };
-    console.log(pkg.version);
+    write(pkg.version);
     return 0;
   }
 
@@ -47,12 +56,21 @@ async function main(): Promise<number> {
       return runUpgrade();
     }
     case "help":
-      return (await import("#skill/engine/commands/help.js")).runHelp(args.slice(1));
+      return (await import("#skill/engine/commands/help.js")).runHelp(args.slice(1), write);
     default:
-      console.log(`Unknown command: ${command}`);
-      console.log(USAGE);
+      write(`Unknown command: ${command}`);
+      write(USAGE);
       return 1;
   }
 }
 
-main().then((code) => process.exit(code));
+async function main(): Promise<number> {
+  return runCli(process.argv.slice(2));
+}
+
+if (
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().then((code) => process.exit(code));
+}


### PR DESCRIPTION
## Summary
- expand the public README so package-vs-command naming, quick start, maintainer prerequisites, and validation steps are explicit
- add CONTRIBUTING.md and SECURITY.md so the repo has clear contribution and vulnerability-reporting entrypoints
- refresh the upgrade-contract wording now that the single-skill layout is the current state, and add tests that lock in the public OSS metadata/docs

## Validation
- pnpm validate:skill
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm pack