### PR TITLE
fix: restore published cli execution and verify flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-tree",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "CLI tools for Context Tree — the living source of truth for your organization.",
   "homepage": "https://github.com/agent-team-foundation/first-tree#readme",
   "bugs": {

--- a/skills/first-tree/engine/validators/nodes.ts
+++ b/skills/first-tree/engine/validators/nodes.ts
@@ -3,6 +3,10 @@ import { join, relative, posix } from "node:path";
 import {
   AGENT_INSTRUCTIONS_FILE,
   LEGACY_AGENT_INSTRUCTIONS_FILE,
+  LEGACY_SKILL_NAME,
+  LEGACY_SKILL_ROOT,
+  SKILL_NAME,
+  SKILL_ROOT,
 } from "#skill/engine/runtime/asset-loader.js";
 
 const FRONTMATTER_RE = /^---\s*\n(.*?)\n---/s;
@@ -83,9 +87,42 @@ function rel(path: string): string {
   return relative(treeRoot, path);
 }
 
+function isInstalledSkillPath(relPath: string): boolean {
+  return (
+    relPath === SKILL_ROOT ||
+    relPath.startsWith(`${SKILL_ROOT}/`) ||
+    relPath === LEGACY_SKILL_ROOT ||
+    relPath.startsWith(`${LEGACY_SKILL_ROOT}/`)
+  );
+}
+
+function isFrameworkContainerDir(relPath: string, fullPath: string): boolean {
+  if (relPath !== "skills") {
+    return false;
+  }
+
+  try {
+    const entries = readdirSync(fullPath).filter((entry) => !entry.startsWith("."));
+    if (entries.length === 0) {
+      return false;
+    }
+    return entries.every(
+      (entry) => entry === SKILL_NAME || entry === LEGACY_SKILL_NAME,
+    );
+  } catch {
+    return false;
+  }
+}
+
 function shouldSkip(path: string): boolean {
-  const parts = relative(treeRoot, path).split("/");
-  return parts.some((part) => SKIP.has(part) || part.startsWith("."));
+  const relPath = relative(treeRoot, path);
+  const parts = relPath.split("/");
+
+  if (parts.some((part) => SKIP.has(part) || part.startsWith("."))) {
+    return true;
+  }
+
+  return isInstalledSkillPath(relPath) || isFrameworkContainerDir(relPath, path);
 }
 
 function readText(path: string): string | null {

--- a/skills/first-tree/tests/thin-cli.test.ts
+++ b/skills/first-tree/tests/thin-cli.test.ts
@@ -1,9 +1,17 @@
-import { readFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
-import { USAGE, runCli } from "../../../src/cli.ts";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { USAGE, isDirectExecution, runCli } from "../../../src/cli.ts";
 
-const ROOT = process.cwd();
+const TEMP_DIRS: string[] = [];
 
 function captureOutput(): { lines: string[]; write: (text: string) => void } {
   const lines: string[] = [];
@@ -15,7 +23,45 @@ function captureOutput(): { lines: string[]; write: (text: string) => void } {
   };
 }
 
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "first-tree-thin-cli-"));
+  TEMP_DIRS.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (TEMP_DIRS.length > 0) {
+    const dir = TEMP_DIRS.pop();
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
 describe("thin CLI shell", () => {
+  it("treats a symlinked npm bin path as direct execution", () => {
+    const dir = makeTempDir();
+    const target = join(dir, "cli.js");
+    const symlinkPath = join(dir, "context-tree");
+
+    writeFileSync(target, "#!/usr/bin/env node\n");
+    symlinkSync(target, symlinkPath);
+
+    expect(isDirectExecution(symlinkPath, pathToFileURL(target).href)).toBe(true);
+  });
+
+  it("does not treat unrelated argv[1] values as direct execution", () => {
+    const dir = makeTempDir();
+    const target = join(dir, "cli.js");
+    const other = join(dir, "other.js");
+
+    writeFileSync(target, "#!/usr/bin/env node\n");
+    writeFileSync(other, "#!/usr/bin/env node\n");
+
+    expect(isDirectExecution(other, pathToFileURL(target).href)).toBe(false);
+    expect(isDirectExecution(undefined, pathToFileURL(target).href)).toBe(false);
+  });
+
   it("prints usage with no args", async () => {
     const output = captureOutput();
 
@@ -27,9 +73,8 @@ describe("thin CLI shell", () => {
 
   it("prints the package version", async () => {
     const output = captureOutput();
-    const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf-8")) as {
-      version: string;
-    };
+    const pkgPath = fileURLToPath(new URL("../../../package.json", import.meta.url));
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as { version: string };
 
     const code = await runCli(["--version"], output.write);
 

--- a/skills/first-tree/tests/verify.test.ts
+++ b/skills/first-tree/tests/verify.test.ts
@@ -1,6 +1,7 @@
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { runInit } from "#skill/engine/init.js";
 import { check, checkProgress, runVerify } from "#skill/engine/verify.js";
 import { Repo } from "#skill/engine/repo.js";
 import {
@@ -15,6 +16,7 @@ import {
   makeLegacyFramework,
   makeNode,
   makeMembers,
+  makeSourceSkill,
 } from "./helpers.js";
 
 // --- check ---
@@ -105,6 +107,74 @@ describe("runVerify all passing", () => {
     const repo = new Repo(tmp.path);
     const ret = runVerify(repo, passValidator);
     expect(ret).toBe(0);
+  });
+
+  it("passes after a real init flow when only the user tree remains to validate", () => {
+    const repoDir = useTmpDir();
+    const sourceDir = useTmpDir();
+    mkdirSync(join(repoDir.path, ".git"));
+    makeSourceSkill(sourceDir.path, "0.2.0");
+
+    expect(runInit(new Repo(repoDir.path), { sourceRoot: sourceDir.path })).toBe(0);
+
+    writeFileSync(
+      join(repoDir.path, "NODE.md"),
+      [
+        "---",
+        'title: "Example Tree"',
+        "owners: [alice]",
+        "---",
+        "",
+        "# Example Tree",
+        "",
+        "A repository initialized from the bundled skill for verification coverage.",
+        "",
+        "## Domains",
+        "",
+        "- **[members/](members/NODE.md)** — Team member definitions and responsibilities.",
+        "",
+      ].join("\n"),
+    );
+
+    const agentPath = join(repoDir.path, AGENT_INSTRUCTIONS_FILE);
+    writeFileSync(
+      agentPath,
+      `${readFileSync(agentPath, "utf-8").trim()}\n\nProject-specific verification instructions.\n`,
+    );
+
+    mkdirSync(join(repoDir.path, "members", "alice"), { recursive: true });
+    writeFileSync(
+      join(repoDir.path, "members", "alice", "NODE.md"),
+      [
+        "---",
+        'title: "Alice"',
+        "owners: [alice]",
+        'type: "human"',
+        'role: "Maintainer"',
+        "domains:",
+        '  - "members"',
+        "---",
+        "",
+        "# Alice",
+        "",
+        "## About",
+        "",
+        "Maintains the initialized tree and keeps the docs current.",
+        "",
+        "## Current Focus",
+        "",
+        "Validating the init-to-verify workflow.",
+        "",
+      ].join("\n"),
+    );
+
+    const progressPath = join(repoDir.path, INSTALLED_PROGRESS);
+    writeFileSync(
+      progressPath,
+      readFileSync(progressPath, "utf-8").replace(/^- \[ \]/gm, "- [x]"),
+    );
+
+    expect(runVerify(new Repo(repoDir.path))).toBe(0);
   });
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-import { pathToFileURL } from "node:url";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 const USAGE = `usage: context-tree <command>
 
@@ -20,6 +21,22 @@ Options:
 type Output = (text: string) => void;
 
 export { USAGE };
+
+export function isDirectExecution(
+  argv1: string | undefined,
+  metaUrl: string = import.meta.url,
+): boolean {
+  if (argv1 === undefined) {
+    return false;
+  }
+
+  try {
+    // npm commonly invokes bins through a symlink or shim path.
+    return realpathSync(argv1) === realpathSync(fileURLToPath(metaUrl));
+  } catch {
+    return false;
+  }
+}
 
 export async function runCli(
   args: string[],
@@ -71,9 +88,6 @@ async function main(): Promise<number> {
   return runCli(process.argv.slice(2));
 }
 
-if (
-  process.argv[1] !== undefined &&
-  import.meta.url === pathToFileURL(process.argv[1]).href
-) {
+if (isDirectExecution(process.argv[1])) {
   main().then((code) => process.exit(code));
 }


### PR DESCRIPTION
## Summary
- fix the published CLI entrypoint so npm bin and `npx` / `npm exec` runs actually execute commands
- stop node validation from walking the installed `skills/first-tree/` payload in user trees
- add regression coverage for symlinked bin execution and a real init-to-verify flow, and bump the package version to `0.0.4`

## Validation
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `npm pack`
- local black-box smoke tests via installed bin and `npm exec` for `--version`, `--help`, `help onboarding`, `init`, `verify`, and `upgrade`
