### PR TITLE
fix: install first-tree into workspace skill roots

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,9 @@ Naming note:
 
 - `first-tree` is the npm package name.
 - `context-tree` is the installed CLI command.
-- `skills/first-tree/` is the bundled skill path inside this repo and inside
-  user trees after install.
+- `skills/first-tree/` is the bundled skill path inside this repo.
+- User trees install that payload into `.agents/skills/first-tree/` and
+  `.claude/skills/first-tree/`.
 
 Most changes should land in the canonical skill under `skills/first-tree/`,
 not in root-level prose or ad hoc helper files.

--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ git init
 context-tree init --here
 ```
 
-- `context-tree init` installs `skills/first-tree/`, creates `NODE.md`,
-  `AGENTS.md`, `members/NODE.md`, and writes a checklist to
-  `skills/first-tree/progress.md`.
+- `context-tree init` installs `.agents/skills/first-tree/` and
+  `.claude/skills/first-tree/`, creates `NODE.md`, `AGENTS.md`,
+  `members/NODE.md`, and writes a checklist to
+  `.agents/skills/first-tree/progress.md`.
 - `context-tree verify` checks both the progress checklist and deterministic
   tree validation. It is expected to fail until the required onboarding tasks
   are complete.
@@ -79,11 +80,17 @@ runtime.
 
 ## Package Name vs Command
 
-- npm package name: `first-tree`
-- installed CLI command: `context-tree`
-- installed skill directory inside a user tree: `skills/first-tree/`
-- when maintainer docs mention "the `first-tree` skill", they mean that
-  bundled skill directory, not the npm package name
+- The npm package is `first-tree`.
+- The installed CLI command is `context-tree`.
+- The installed skill directories inside a user tree are
+  `.agents/skills/first-tree/` and `.claude/skills/first-tree/`.
+- The published package keeps its bundled canonical source under
+  `skills/first-tree/`.
+- When maintainer docs say "the `first-tree` skill", they mean that bundled
+  skill directory, not the npm package name.
+- `npx first-tree init` is the quickest one-off entrypoint.
+- `npm install -g first-tree` adds `context-tree` to your PATH for repeated
+  use.
 
 ## Runtime And Maintainer Prerequisites
 
@@ -97,6 +104,8 @@ runtime.
   bundled skill.
 - `skills/first-tree/` is the canonical source for framework behavior, shipped
   templates, maintainer references, and validation logic.
+- `context-tree init` installs that bundled skill into `.agents/skills/first-tree/`
+  and `.claude/skills/first-tree/` inside user repos.
 - `evals/` is maintainer-only developer tooling for the source repo. It is
   intentionally not part of the published package.
 

--- a/skills/first-tree/SKILL.md
+++ b/skills/first-tree/SKILL.md
@@ -6,8 +6,9 @@ description: Maintain the canonical `first-tree` skill and the thin `context-tre
 # First Tree
 
 Use this skill when the task depends on the exact behavior of the
-`context-tree` CLI or the installed `skills/first-tree/` payload that
-`context-tree init` ships to user repos.
+`context-tree` CLI or the installed `.agents/skills/first-tree/` and
+`.claude/skills/first-tree/` payloads that `context-tree init` ships to user
+repos.
 
 ## Source Of Truth
 
@@ -17,9 +18,9 @@ Use this skill when the task depends on the exact behavior of the
   repos.
 - `engine/` holds the canonical framework and CLI behavior.
 - `scripts/` holds maintenance helpers for validating and running the skill.
-- In maintainer docs, use `context-tree` for the CLI and `skills/first-tree/`
-  for the installed skill path so it is not confused with the `first-tree`
-  npm package.
+- In maintainer docs, use `context-tree` for the CLI, `skills/first-tree/` for
+  the bundled source path, and `.agents/skills/first-tree/` /
+  `.claude/skills/first-tree/` for installed user-repo paths.
 
 ## When To Read What
 
@@ -61,11 +62,12 @@ Use this skill when the task depends on the exact behavior of the
   repo when invoked from a source/workspace repo. Use `--here` to initialize
   the current repo in place when you are already inside the tree repo.
 - `context-tree init` installs this skill into the target tree repo and
+  scaffolds `.agents/skills/first-tree/`, `.claude/skills/first-tree/`,
   `NODE.md`, `AGENTS.md`, and `members/NODE.md`.
 - `context-tree upgrade` refreshes the installed skill from the copy bundled
   with the currently running `first-tree` package. To pick up a newer
   framework, run a newer package version first. It also migrates older repos
-  that still use `skills/first-tree-cli-framework/`.
+  that still use `skills/first-tree/` or `skills/first-tree-cli-framework/`.
 - The user's tree content lives outside the skill; the skill only carries the
   reusable framework payload plus maintenance guidance.
 - The tree still stores decisions, constraints, and ownership; execution detail
@@ -79,6 +81,8 @@ Use this skill when the task depends on the exact behavior of the
 - Keep decision knowledge in the tree and execution detail in source systems.
 - Keep the skill as the only canonical knowledge source. The root CLI/package
   shell must not become a second source of framework semantics.
+- Keep the CLI name written as `context-tree` in maintainer and user-facing
+  docs so it is not confused with the `first-tree` package that ships it.
 - Keep normal `init` / `upgrade` flows self-contained. They must work from the
   skill bundled in the current package without cloning the source repo or
   relying on network access.

--- a/skills/first-tree/assets/framework/examples/claude-code/README.md
+++ b/skills/first-tree/assets/framework/examples/claude-code/README.md
@@ -6,9 +6,9 @@ Copy `settings.json` to your tree repo's `.claude/` directory:
 
 ```bash
 mkdir -p .claude
-cp skills/first-tree/assets/framework/examples/claude-code/settings.json .claude/settings.json
+cp .claude/skills/first-tree/assets/framework/examples/claude-code/settings.json .claude/settings.json
 ```
 
 ## What It Does
 
-The `SessionStart` hook runs `./skills/first-tree/assets/framework/helpers/inject-tree-context.sh` when a Claude Code session begins. This injects the root `NODE.md` content as additional context, giving the agent an overview of the tree structure before any task.
+The `SessionStart` hook runs `./.claude/skills/first-tree/assets/framework/helpers/inject-tree-context.sh` when a Claude Code session begins. This injects the root `NODE.md` content as additional context, giving the agent an overview of the tree structure before any task.

--- a/skills/first-tree/assets/framework/examples/claude-code/settings.json
+++ b/skills/first-tree/assets/framework/examples/claude-code/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "./skills/first-tree/assets/framework/helpers/inject-tree-context.sh"
+            "command": "./.claude/skills/first-tree/assets/framework/helpers/inject-tree-context.sh"
           }
         ]
       }

--- a/skills/first-tree/assets/framework/helpers/generate-codeowners.ts
+++ b/skills/first-tree/assets/framework/helpers/generate-codeowners.ts
@@ -205,7 +205,7 @@ export function generate(
       return 0;
     }
     console.log(
-      "CODEOWNERS is out-of-date. Run: npx tsx skills/first-tree/assets/framework/helpers/generate-codeowners.ts",
+      "CODEOWNERS is out-of-date. Run: npx tsx .agents/skills/first-tree/assets/framework/helpers/generate-codeowners.ts",
     );
     return 1;
   }

--- a/skills/first-tree/assets/framework/helpers/run-review.ts
+++ b/skills/first-tree/assets/framework/helpers/run-review.ts
@@ -39,7 +39,7 @@ function buildPrompt(diffPath: string): string {
     ["Root NODE.md", "NODE.md"],
     [
       "Review Instructions",
-      "skills/first-tree/assets/framework/prompts/pr-review.md",
+      ".agents/skills/first-tree/assets/framework/prompts/pr-review.md",
     ],
   ];
   for (const [heading, path] of files) {

--- a/skills/first-tree/assets/framework/templates/agents.md.template
+++ b/skills/first-tree/assets/framework/templates/agents.md.template
@@ -13,7 +13,7 @@ You are working in a **Context Tree** — the living source of truth for decisio
 
 4. **Git-native tree structure.** Each node is a file; each domain is a directory. Soft links allow cross-references without the complexity of a full graph. History, ownership, and review follow Git conventions.
 
-See `skills/first-tree/references/principles.md` for detailed explanations and examples.
+See `.agents/skills/first-tree/references/principles.md` for detailed explanations and examples.
 
 ## Before Every Task
 
@@ -41,7 +41,7 @@ Ask yourself: **Does the tree need updating?**
 
 ## Reference
 
-For ownership rules, tree structure, and key files, see [NODE.md](NODE.md) and `skills/first-tree/references/ownership-and-naming.md`.
+For ownership rules, tree structure, and key files, see [NODE.md](NODE.md) and `.agents/skills/first-tree/references/ownership-and-naming.md`.
 <!-- END CONTEXT-TREE FRAMEWORK -->
 
 # Project-Specific Instructions

--- a/skills/first-tree/assets/framework/templates/members-domain.md.template
+++ b/skills/first-tree/assets/framework/templates/members-domain.md.template
@@ -34,7 +34,7 @@ domains:
 ---
 ```
 
-See `skills/first-tree/assets/framework/templates/member-node.md.template` for a full scaffold.
+See `.agents/skills/first-tree/assets/framework/templates/member-node.md.template` for a full scaffold.
 
 ---
 

--- a/skills/first-tree/assets/framework/templates/root-node.md.template
+++ b/skills/first-tree/assets/framework/templates/root-node.md.template
@@ -34,8 +34,8 @@ tree describes.
 
 See [AGENTS.md](AGENTS.md) for agent instructions — the before/during/after workflow, ownership model, and tree maintenance.
 
-See [about.md](skills/first-tree/references/about.md) for background — the problem, the idea, and who it's for.
+See [about.md](.agents/skills/first-tree/references/about.md) for background — the problem, the idea, and who it's for.
 
 See the installed framework documentation:
-- [principles.md](skills/first-tree/references/principles.md) — core principles with examples
-- [ownership-and-naming.md](skills/first-tree/references/ownership-and-naming.md) — node naming and ownership model
+- [principles.md](.agents/skills/first-tree/references/principles.md) — core principles with examples
+- [ownership-and-naming.md](.agents/skills/first-tree/references/ownership-and-naming.md) — node naming and ownership model

--- a/skills/first-tree/assets/framework/workflows/codeowners.yml
+++ b/skills/first-tree/assets/framework/workflows/codeowners.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: "22"
 
-      - run: npx tsx skills/first-tree/assets/framework/helpers/generate-codeowners.ts
+      - run: npx tsx .agents/skills/first-tree/assets/framework/helpers/generate-codeowners.ts
 
       - name: Commit if changed
         run: |

--- a/skills/first-tree/assets/framework/workflows/pr-review.yml
+++ b/skills/first-tree/assets/framework/workflows/pr-review.yml
@@ -45,7 +45,7 @@ jobs:
           gh pr view "$PR_NUMBER" --json headRefOid -q .headRefOid > /tmp/pr-head-sha.txt
 
       - name: Run Claude review
-        run: npx tsx skills/first-tree/assets/framework/helpers/run-review.ts
+        run: npx tsx .agents/skills/first-tree/assets/framework/helpers/run-review.ts
 
       - name: Parse and post review
         run: |

--- a/skills/first-tree/engine/init.ts
+++ b/skills/first-tree/engine/init.ts
@@ -23,6 +23,7 @@ import {
   FRAMEWORK_VERSION,
   INSTALLED_PROGRESS,
   LEGACY_AGENT_INSTRUCTIONS_FILE,
+  installedSkillRootsDisplay,
 } from "#skill/engine/runtime/asset-loader.js";
 
 /**
@@ -67,7 +68,7 @@ interface TaskListContext {
 function installSkill(source: string, target: string): void {
   copyCanonicalSkill(source, target);
   console.log(
-    "  Installed skills/first-tree/ from the bundled first-tree package",
+    `  Installed ${installedSkillRootsDisplay()} from the bundled first-tree package`,
   );
 }
 
@@ -198,7 +199,7 @@ export function runInit(repo?: Repo, options?: InitOptions): number {
     console.log();
   }
 
-  if (!r.hasFramework()) {
+  if (!r.hasCurrentInstalledSkill()) {
     try {
       const sourceRoot = options?.sourceRoot ?? resolveBundledPackageRoot();
       console.log(

--- a/skills/first-tree/engine/repo.ts
+++ b/skills/first-tree/engine/repo.ts
@@ -2,14 +2,19 @@ import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import {
   AGENT_INSTRUCTIONS_FILE,
+  CLAUDE_FRAMEWORK_VERSION,
+  CLAUDE_INSTALLED_PROGRESS,
   FRAMEWORK_VERSION,
-  LEGACY_SKILL_PROGRESS,
-  LEGACY_SKILL_VERSION,
+  INSTALLED_PROGRESS,
   LEGACY_AGENT_INSTRUCTIONS_FILE,
   LEGACY_PROGRESS,
+  LEGACY_REPO_SKILL_PROGRESS,
+  LEGACY_REPO_SKILL_VERSION,
+  LEGACY_SKILL_PROGRESS,
+  LEGACY_SKILL_VERSION,
   LEGACY_VERSION,
-  INSTALLED_PROGRESS,
   agentInstructionsFileCandidates,
+  installedSkillRoots,
   type FrameworkLayout,
   detectFrameworkLayout,
   frameworkVersionCandidates,
@@ -164,6 +169,22 @@ export class Repo {
     return knownConfigs.some((c) => this.pathExists(c));
   }
 
+  installedSkillRoots(): string[] {
+    return installedSkillRoots();
+  }
+
+  missingInstalledSkillRoots(): string[] {
+    return this.installedSkillRoots().filter(
+      (root) =>
+        !this.pathExists(join(root, "SKILL.md")) ||
+        !this.pathExists(join(root, "assets", "framework", "VERSION")),
+    );
+  }
+
+  hasCurrentInstalledSkill(): boolean {
+    return this.missingInstalledSkillRoots().length === 0;
+  }
+
   isGitRepo(): boolean {
     return hasGitMetadata(this.root);
   }
@@ -198,6 +219,12 @@ export class Repo {
     if (layout === "legacy-skill") {
       return LEGACY_SKILL_PROGRESS;
     }
+    if (layout === "legacy-repo-skill") {
+      return LEGACY_REPO_SKILL_PROGRESS;
+    }
+    if (layout === "claude-skill") {
+      return CLAUDE_INSTALLED_PROGRESS;
+    }
     return INSTALLED_PROGRESS;
   }
 
@@ -208,6 +235,12 @@ export class Repo {
     }
     if (layout === "legacy-skill") {
       return LEGACY_SKILL_VERSION;
+    }
+    if (layout === "legacy-repo-skill") {
+      return LEGACY_REPO_SKILL_VERSION;
+    }
+    if (layout === "claude-skill") {
+      return CLAUDE_FRAMEWORK_VERSION;
     }
     return FRAMEWORK_VERSION;
   }

--- a/skills/first-tree/engine/rules/agent-integration.ts
+++ b/skills/first-tree/engine/rules/agent-integration.ts
@@ -1,13 +1,15 @@
 import type { Repo } from "#skill/engine/repo.js";
 import type { RuleResult } from "#skill/engine/rules/index.js";
+import { claudeCodeExampleCandidates } from "#skill/engine/runtime/adapters.js";
 import { FRAMEWORK_EXAMPLES_DIR } from "#skill/engine/runtime/asset-loader.js";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
+  const [claudeExamplePath] = claudeCodeExampleCandidates();
   if (repo.pathExists(".claude/settings.json")) {
     if (!repo.fileContains(".claude/settings.json", "inject-tree-context")) {
       tasks.push(
-        `Add SessionStart hook to \`.claude/settings.json\` (see \`${FRAMEWORK_EXAMPLES_DIR}/claude-code/\`)`,
+        `Add SessionStart hook to \`.claude/settings.json\` (see \`${claudeExamplePath}/\`)`,
       );
     }
   } else if (!repo.anyAgentConfig()) {

--- a/skills/first-tree/engine/rules/framework.ts
+++ b/skills/first-tree/engine/rules/framework.ts
@@ -1,12 +1,12 @@
 import type { Repo } from "#skill/engine/repo.js";
 import type { RuleResult } from "#skill/engine/rules/index.js";
-import { SKILL_ROOT } from "#skill/engine/runtime/asset-loader.js";
+import { installedSkillRootsDisplay } from "#skill/engine/runtime/asset-loader.js";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
   if (!repo.hasFramework()) {
     tasks.push(
-      `\`${SKILL_ROOT}/\` not found — run \`context-tree init\` to install the framework skill bundled with the current \`first-tree\` package`,
+      `${installedSkillRootsDisplay()} not found — run \`context-tree init\` to install the framework skill bundled with the current \`first-tree\` package`,
     );
   }
   return { group: "Framework", order: 1, tasks };

--- a/skills/first-tree/engine/runtime/adapters.ts
+++ b/skills/first-tree/engine/runtime/adapters.ts
@@ -1,7 +1,9 @@
 import { join } from "node:path";
 import {
+  CLAUDE_FRAMEWORK_EXAMPLES_DIR,
+  CLAUDE_FRAMEWORK_HELPERS_DIR,
   FRAMEWORK_EXAMPLES_DIR,
-  FRAMEWORK_HELPERS_DIR,
+  LEGACY_REPO_SKILL_EXAMPLES_DIR,
   LEGACY_SKILL_EXAMPLES_DIR,
   LEGACY_EXAMPLES_DIR,
 } from "#skill/engine/runtime/asset-loader.js";
@@ -11,12 +13,14 @@ export const CODEX_CONFIG_PATH = ".codex/config.json";
 
 export function claudeCodeExampleCandidates(): string[] {
   return [
+    join(CLAUDE_FRAMEWORK_EXAMPLES_DIR, "claude-code"),
     join(FRAMEWORK_EXAMPLES_DIR, "claude-code"),
+    join(LEGACY_REPO_SKILL_EXAMPLES_DIR, "claude-code"),
     join(LEGACY_SKILL_EXAMPLES_DIR, "claude-code"),
     join(LEGACY_EXAMPLES_DIR, "claude-code"),
   ];
 }
 
 export function injectTreeContextHint(): string {
-  return join(FRAMEWORK_HELPERS_DIR, "inject-tree-context.sh");
+  return join(CLAUDE_FRAMEWORK_HELPERS_DIR, "inject-tree-context.sh");
 }

--- a/skills/first-tree/engine/runtime/asset-loader.ts
+++ b/skills/first-tree/engine/runtime/asset-loader.ts
@@ -2,7 +2,11 @@ import { existsSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 export const SKILL_NAME = "first-tree";
-export const SKILL_ROOT = join("skills", SKILL_NAME);
+export const BUNDLED_SKILL_ROOT = join("skills", SKILL_NAME);
+export const SKILL_ROOT = join(".agents", "skills", SKILL_NAME);
+export const CLAUDE_SKILL_ROOT = join(".claude", "skills", SKILL_NAME);
+export const INSTALLED_SKILL_ROOTS = [SKILL_ROOT, CLAUDE_SKILL_ROOT] as const;
+
 export const SKILL_AGENTS_DIR = join(SKILL_ROOT, "agents");
 export const SKILL_REFERENCES_DIR = join(SKILL_ROOT, "references");
 export const FRAMEWORK_ASSET_ROOT = join(SKILL_ROOT, "assets", "framework");
@@ -17,6 +21,93 @@ export const INSTALLED_PROGRESS = join(SKILL_ROOT, "progress.md");
 export const AGENT_INSTRUCTIONS_FILE = "AGENTS.md";
 export const LEGACY_AGENT_INSTRUCTIONS_FILE = "AGENT.md";
 export const AGENT_INSTRUCTIONS_TEMPLATE = "agents.md.template";
+
+export const CLAUDE_SKILL_AGENTS_DIR = join(CLAUDE_SKILL_ROOT, "agents");
+export const CLAUDE_SKILL_REFERENCES_DIR = join(CLAUDE_SKILL_ROOT, "references");
+export const CLAUDE_FRAMEWORK_ASSET_ROOT = join(
+  CLAUDE_SKILL_ROOT,
+  "assets",
+  "framework",
+);
+export const CLAUDE_FRAMEWORK_MANIFEST = join(
+  CLAUDE_FRAMEWORK_ASSET_ROOT,
+  "manifest.json",
+);
+export const CLAUDE_FRAMEWORK_VERSION = join(
+  CLAUDE_FRAMEWORK_ASSET_ROOT,
+  "VERSION",
+);
+export const CLAUDE_FRAMEWORK_TEMPLATES_DIR = join(
+  CLAUDE_FRAMEWORK_ASSET_ROOT,
+  "templates",
+);
+export const CLAUDE_FRAMEWORK_WORKFLOWS_DIR = join(
+  CLAUDE_FRAMEWORK_ASSET_ROOT,
+  "workflows",
+);
+export const CLAUDE_FRAMEWORK_PROMPTS_DIR = join(
+  CLAUDE_FRAMEWORK_ASSET_ROOT,
+  "prompts",
+);
+export const CLAUDE_FRAMEWORK_EXAMPLES_DIR = join(
+  CLAUDE_FRAMEWORK_ASSET_ROOT,
+  "examples",
+);
+export const CLAUDE_FRAMEWORK_HELPERS_DIR = join(
+  CLAUDE_FRAMEWORK_ASSET_ROOT,
+  "helpers",
+);
+export const CLAUDE_INSTALLED_PROGRESS = join(
+  CLAUDE_SKILL_ROOT,
+  "progress.md",
+);
+
+export const LEGACY_REPO_SKILL_ROOT = join("skills", SKILL_NAME);
+export const LEGACY_REPO_SKILL_AGENTS_DIR = join(
+  LEGACY_REPO_SKILL_ROOT,
+  "agents",
+);
+export const LEGACY_REPO_SKILL_REFERENCES_DIR = join(
+  LEGACY_REPO_SKILL_ROOT,
+  "references",
+);
+export const LEGACY_REPO_SKILL_ASSET_ROOT = join(
+  LEGACY_REPO_SKILL_ROOT,
+  "assets",
+  "framework",
+);
+export const LEGACY_REPO_SKILL_MANIFEST = join(
+  LEGACY_REPO_SKILL_ASSET_ROOT,
+  "manifest.json",
+);
+export const LEGACY_REPO_SKILL_VERSION = join(
+  LEGACY_REPO_SKILL_ASSET_ROOT,
+  "VERSION",
+);
+export const LEGACY_REPO_SKILL_TEMPLATES_DIR = join(
+  LEGACY_REPO_SKILL_ASSET_ROOT,
+  "templates",
+);
+export const LEGACY_REPO_SKILL_WORKFLOWS_DIR = join(
+  LEGACY_REPO_SKILL_ASSET_ROOT,
+  "workflows",
+);
+export const LEGACY_REPO_SKILL_PROMPTS_DIR = join(
+  LEGACY_REPO_SKILL_ASSET_ROOT,
+  "prompts",
+);
+export const LEGACY_REPO_SKILL_EXAMPLES_DIR = join(
+  LEGACY_REPO_SKILL_ASSET_ROOT,
+  "examples",
+);
+export const LEGACY_REPO_SKILL_HELPERS_DIR = join(
+  LEGACY_REPO_SKILL_ASSET_ROOT,
+  "helpers",
+);
+export const LEGACY_REPO_SKILL_PROGRESS = join(
+  LEGACY_REPO_SKILL_ROOT,
+  "progress.md",
+);
 
 export const LEGACY_SKILL_NAME = "first-tree-cli-framework";
 export const LEGACY_SKILL_ROOT = join("skills", LEGACY_SKILL_NAME);
@@ -52,7 +143,12 @@ export const LEGACY_WORKFLOWS_DIR = join(LEGACY_FRAMEWORK_ROOT, "workflows");
 export const LEGACY_PROMPTS_DIR = join(LEGACY_FRAMEWORK_ROOT, "prompts");
 export const LEGACY_EXAMPLES_DIR = join(LEGACY_FRAMEWORK_ROOT, "examples");
 
-export type FrameworkLayout = "skill" | "legacy-skill" | "legacy";
+export type FrameworkLayout =
+  | "skill"
+  | "claude-skill"
+  | "legacy-repo-skill"
+  | "legacy-skill"
+  | "legacy";
 
 function pathExists(root: string, relPath: string): boolean {
   const fullPath = join(root, relPath);
@@ -63,12 +159,34 @@ function pathExists(root: string, relPath: string): boolean {
   }
 }
 
+export function installedSkillRoots(): string[] {
+  return [...INSTALLED_SKILL_ROOTS];
+}
+
+export function installedSkillRootsDisplay(): string {
+  return installedSkillRoots()
+    .map((root) => `\`${root}/\``)
+    .join(" and ");
+}
+
 export function frameworkVersionCandidates(): string[] {
-  return [FRAMEWORK_VERSION, LEGACY_SKILL_VERSION, LEGACY_VERSION];
+  return [
+    FRAMEWORK_VERSION,
+    CLAUDE_FRAMEWORK_VERSION,
+    LEGACY_REPO_SKILL_VERSION,
+    LEGACY_SKILL_VERSION,
+    LEGACY_VERSION,
+  ];
 }
 
 export function progressFileCandidates(): string[] {
-  return [INSTALLED_PROGRESS, LEGACY_SKILL_PROGRESS, LEGACY_PROGRESS];
+  return [
+    INSTALLED_PROGRESS,
+    CLAUDE_INSTALLED_PROGRESS,
+    LEGACY_REPO_SKILL_PROGRESS,
+    LEGACY_SKILL_PROGRESS,
+    LEGACY_PROGRESS,
+  ];
 }
 
 export function agentInstructionsFileCandidates(): string[] {
@@ -78,6 +196,8 @@ export function agentInstructionsFileCandidates(): string[] {
 export function frameworkTemplateDirCandidates(): string[] {
   return [
     FRAMEWORK_TEMPLATES_DIR,
+    CLAUDE_FRAMEWORK_TEMPLATES_DIR,
+    LEGACY_REPO_SKILL_TEMPLATES_DIR,
     LEGACY_SKILL_TEMPLATES_DIR,
     LEGACY_TEMPLATES_DIR,
   ];
@@ -86,6 +206,8 @@ export function frameworkTemplateDirCandidates(): string[] {
 export function frameworkWorkflowDirCandidates(): string[] {
   return [
     FRAMEWORK_WORKFLOWS_DIR,
+    CLAUDE_FRAMEWORK_WORKFLOWS_DIR,
+    LEGACY_REPO_SKILL_WORKFLOWS_DIR,
     LEGACY_SKILL_WORKFLOWS_DIR,
     LEGACY_WORKFLOWS_DIR,
   ];
@@ -94,6 +216,8 @@ export function frameworkWorkflowDirCandidates(): string[] {
 export function frameworkPromptDirCandidates(): string[] {
   return [
     FRAMEWORK_PROMPTS_DIR,
+    CLAUDE_FRAMEWORK_PROMPTS_DIR,
+    LEGACY_REPO_SKILL_PROMPTS_DIR,
     LEGACY_SKILL_PROMPTS_DIR,
     LEGACY_PROMPTS_DIR,
   ];
@@ -102,6 +226,8 @@ export function frameworkPromptDirCandidates(): string[] {
 export function frameworkExampleDirCandidates(): string[] {
   return [
     FRAMEWORK_EXAMPLES_DIR,
+    CLAUDE_FRAMEWORK_EXAMPLES_DIR,
+    LEGACY_REPO_SKILL_EXAMPLES_DIR,
     LEGACY_SKILL_EXAMPLES_DIR,
     LEGACY_EXAMPLES_DIR,
   ];
@@ -122,6 +248,12 @@ export function resolveFirstExistingPath(
 export function detectFrameworkLayout(root: string): FrameworkLayout | null {
   if (pathExists(root, FRAMEWORK_VERSION)) {
     return "skill";
+  }
+  if (pathExists(root, CLAUDE_FRAMEWORK_VERSION)) {
+    return "claude-skill";
+  }
+  if (pathExists(root, LEGACY_REPO_SKILL_VERSION)) {
+    return "legacy-repo-skill";
   }
   if (pathExists(root, LEGACY_SKILL_VERSION)) {
     return "legacy-skill";

--- a/skills/first-tree/engine/runtime/installer.ts
+++ b/skills/first-tree/engine/runtime/installer.ts
@@ -2,9 +2,10 @@ import { copyFileSync, cpSync, existsSync, mkdirSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
-  FRAMEWORK_ASSET_ROOT,
+  BUNDLED_SKILL_ROOT,
+  INSTALLED_SKILL_ROOTS,
+  LEGACY_REPO_SKILL_ROOT,
   LEGACY_SKILL_ROOT,
-  SKILL_ROOT,
 } from "#skill/engine/runtime/asset-loader.js";
 
 export function resolveBundledPackageRoot(startUrl = import.meta.url): string {
@@ -12,7 +13,7 @@ export function resolveBundledPackageRoot(startUrl = import.meta.url): string {
   while (true) {
     if (
       existsSync(join(dir, "package.json")) &&
-      existsSync(join(dir, SKILL_ROOT, "SKILL.md"))
+      existsSync(join(dir, BUNDLED_SKILL_ROOT, "SKILL.md"))
     ) {
       return dir;
     }
@@ -38,7 +39,7 @@ export function resolveCanonicalSkillRoot(sourceRoot: string): string {
     return directSkillRoot;
   }
 
-  const nestedSkillRoot = join(sourceRoot, SKILL_ROOT);
+  const nestedSkillRoot = join(sourceRoot, BUNDLED_SKILL_ROOT);
   if (
     existsSync(join(nestedSkillRoot, "SKILL.md")) &&
     existsSync(join(nestedSkillRoot, "assets", "framework", "VERSION"))
@@ -53,16 +54,21 @@ export function resolveCanonicalSkillRoot(sourceRoot: string): string {
 
 export function copyCanonicalSkill(sourceRoot: string, targetRoot: string): void {
   const src = resolveCanonicalSkillRoot(sourceRoot);
-  const dst = join(targetRoot, SKILL_ROOT);
-  const legacyDst = join(targetRoot, LEGACY_SKILL_ROOT);
-  if (existsSync(dst)) {
-    rmSync(dst, { recursive: true, force: true });
+  for (const relPath of [
+    ...INSTALLED_SKILL_ROOTS,
+    LEGACY_REPO_SKILL_ROOT,
+    LEGACY_SKILL_ROOT,
+  ]) {
+    const fullPath = join(targetRoot, relPath);
+    if (existsSync(fullPath)) {
+      rmSync(fullPath, { recursive: true, force: true });
+    }
   }
-  if (legacyDst !== dst && existsSync(legacyDst)) {
-    rmSync(legacyDst, { recursive: true, force: true });
+  for (const relPath of INSTALLED_SKILL_ROOTS) {
+    const dst = join(targetRoot, relPath);
+    mkdirSync(dirname(dst), { recursive: true });
+    cpSync(src, dst, { recursive: true });
   }
-  mkdirSync(dirname(dst), { recursive: true });
-  cpSync(src, dst, { recursive: true });
 }
 
 export function renderTemplateFile(

--- a/skills/first-tree/engine/upgrade.ts
+++ b/skills/first-tree/engine/upgrade.ts
@@ -4,14 +4,17 @@ import { Repo } from "#skill/engine/repo.js";
 import {
   AGENT_INSTRUCTIONS_FILE,
   AGENT_INSTRUCTIONS_TEMPLATE,
+  CLAUDE_SKILL_ROOT,
   FRAMEWORK_WORKFLOWS_DIR,
   FRAMEWORK_TEMPLATES_DIR,
   FRAMEWORK_VERSION,
   INSTALLED_PROGRESS,
   LEGACY_AGENT_INSTRUCTIONS_FILE,
   LEGACY_FRAMEWORK_ROOT,
+  LEGACY_REPO_SKILL_ROOT,
   LEGACY_SKILL_ROOT,
   SKILL_ROOT,
+  installedSkillRootsDisplay,
   type FrameworkLayout,
 } from "#skill/engine/runtime/asset-loader.js";
 import {
@@ -45,9 +48,10 @@ function formatUpgradeTaskList(
   const lines: string[] = [
     `# Context Tree Upgrade — v${localVersion} -> v${packagedVersion}\n`,
     "## Installed Skill",
-    `- [ ] Review local customizations under \`${SKILL_ROOT}/\` and reapply them if needed`,
+    `- [ ] Review local customizations under ${installedSkillRootsDisplay()} and reapply them if needed`,
     `- [ ] Re-copy any workflow updates you want from \`${FRAMEWORK_WORKFLOWS_DIR}/\` into \`.github/workflows/\``,
-    `- [ ] Re-check any local agent setup that references \`${SKILL_ROOT}/assets/framework/examples/\` or \`${SKILL_ROOT}/assets/framework/helpers/\``,
+    `- [ ] Re-check any local agent setup that references \`${CLAUDE_SKILL_ROOT}/assets/framework/examples/\` or \`${CLAUDE_SKILL_ROOT}/assets/framework/helpers/\``,
+    `- [ ] Re-check any repo scripts or workflow files that reference \`${SKILL_ROOT}/assets/framework/\``,
     "",
   ];
 
@@ -55,6 +59,14 @@ function formatUpgradeTaskList(
   if (layout === "legacy") {
     migrationTasks.push(
       "- [ ] Remove any stale `.context-tree/` references from repo-specific docs, scripts, or workflow files",
+    );
+  }
+
+  if (layout === "legacy-repo-skill") {
+    lines.push(
+      "## Migration",
+      `- [ ] Remove any stale \`${LEGACY_REPO_SKILL_ROOT}/\` references from repo-specific docs, scripts, workflow files, or agent config`,
+      "",
     );
   }
 
@@ -165,7 +177,12 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
     return 1;
   }
 
-  if (layout === "skill" && packagedVersion === localVersion) {
+  const missingInstalledRoots = workingRepo.missingInstalledSkillRoots();
+  if (
+    layout === "skill" &&
+    missingInstalledRoots.length === 0 &&
+    packagedVersion === localVersion
+  ) {
     console.log(
       `Already up to date with the bundled skill (${FRAMEWORK_VERSION} = ${localVersion}).`,
     );
@@ -179,16 +196,26 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
       force: true,
     });
     console.log(
-      "Migrated legacy .context-tree/ layout to skills/first-tree/.",
+      `Migrated legacy .context-tree/ layout to ${installedSkillRootsDisplay()}.`,
+    );
+  } else if (layout === "legacy-repo-skill") {
+    console.log(
+      `Migrated legacy ${LEGACY_REPO_SKILL_ROOT}/ layout to ${installedSkillRootsDisplay()}.`,
     );
   } else if (layout === "legacy-skill") {
     console.log(
-      "Migrated skills/first-tree-cli-framework/ to skills/first-tree/.",
+      `Migrated ${LEGACY_SKILL_ROOT}/ to ${installedSkillRootsDisplay()}.`,
     );
   } else {
-    console.log(
-      "Refreshed skills/first-tree/ from the bundled first-tree package.",
-    );
+    if (missingInstalledRoots.length > 0) {
+      console.log(
+        `Repaired missing installed skill roots (${missingInstalledRoots.map((root) => `${root}/`).join(", ")}) and refreshed ${installedSkillRootsDisplay()} from the bundled first-tree package.`,
+      );
+    } else {
+      console.log(
+        `Refreshed ${installedSkillRootsDisplay()} from the bundled first-tree package.`,
+      );
+    }
   }
 
   const output = formatUpgradeTaskList(

--- a/skills/first-tree/references/onboarding.md
+++ b/skills/first-tree/references/onboarding.md
@@ -56,8 +56,9 @@ Information an agent needs to **decide** on an approach — not to execute it.
 - A source/workspace Git repository, or an already-created dedicated tree repo
 - Node.js 18+
 - The npm package is `first-tree`, the installed CLI command is
-  `context-tree`, and the installed skill directory in the tree is
-  `skills/first-tree/`
+  `context-tree`.
+- `context-tree init` installs the framework skill into
+  `.agents/skills/first-tree/` and `.claude/skills/first-tree/`.
 - Use `npx first-tree init` for one-off runs, or `npm install -g first-tree`
   to add the `context-tree` command to your PATH
 
@@ -81,24 +82,30 @@ git init
 context-tree init --here
 ```
 
-Either way, the framework installs into `skills/first-tree/`, renders
-scaffolding (`NODE.md`, `AGENTS.md`, `members/NODE.md`), and generates a task
-list in `skills/first-tree/progress.md`.
+Either way, the framework installs into `.agents/skills/first-tree/` and
+`.claude/skills/first-tree/`, renders scaffolding (`NODE.md`, `AGENTS.md`,
+`members/NODE.md`), and generates a task list in
+`.agents/skills/first-tree/progress.md`.
 
 Publishing tip: keep the tree repo in the same GitHub organization as the
 source repo unless you have a reason not to.
 
 ### Step 2: Work Through the Task List
 
-Read `skills/first-tree/progress.md`. It contains a checklist tailored to the current state of the repo. Complete each task:
+Read `.agents/skills/first-tree/progress.md`. It contains a checklist tailored
+to the current state of the repo. Complete each task:
 
 - Fill in `NODE.md` with your organization name, owners, and domains
 - Add project-specific instructions to `AGENTS.md` below the framework markers
 - Create member nodes under `members/`
-- Optionally configure agent integration (e.g., Claude Code session hooks)
-- Copy validation workflows from `skills/first-tree/assets/framework/workflows/` to `.github/workflows/`
+- Optionally configure agent integration (for Claude Code, the installed hook
+  assets live under `.claude/skills/first-tree/`)
+- Copy validation workflows from
+  `.agents/skills/first-tree/assets/framework/workflows/` to
+  `.github/workflows/`
 
-As you complete each task, check it off in `skills/first-tree/progress.md` by changing `- [ ]` to `- [x]`.
+As you complete each task, check it off in
+`.agents/skills/first-tree/progress.md` by changing `- [ ]` to `- [x]`.
 
 ### Step 3: Verify
 
@@ -112,7 +119,9 @@ Or, from your source/workspace repo:
 context-tree verify --tree-path ../my-org-context
 ```
 
-This fails if any items in `skills/first-tree/progress.md` remain unchecked, and runs deterministic checks (valid frontmatter, node structure, member nodes exist).
+This fails if any items in `.agents/skills/first-tree/progress.md` remain
+unchecked, and runs deterministic checks (valid frontmatter, node structure,
+member nodes exist).
 
 ### Step 4: Design Your Domains
 
@@ -164,13 +173,14 @@ When the framework updates:
 context-tree upgrade
 ```
 
-`context-tree upgrade` refreshes `skills/first-tree/` from the
-skill bundled with the currently running `first-tree` npm package, preserves your
-tree content, and generates follow-up tasks in
-`skills/first-tree/progress.md`.
+`context-tree upgrade` refreshes `.agents/skills/first-tree/` and
+`.claude/skills/first-tree/` from the skill bundled with the currently running
+`first-tree` npm package, preserves your tree content, and generates follow-up
+tasks in `.agents/skills/first-tree/progress.md`.
 
-If your repo still uses the older `skills/first-tree-cli-framework/` path,
-`context-tree upgrade` will migrate it to `skills/first-tree/` first.
+If your repo still uses the older `skills/first-tree/`,
+`skills/first-tree-cli-framework/`, or `.context-tree/` layouts,
+`context-tree upgrade` will migrate it to the current installed layout first.
 
 To pick up a newer framework release, first run a newer package version, for
 example `npx first-tree@latest upgrade`, or update your global `first-tree`
@@ -180,6 +190,6 @@ install before running `context-tree upgrade`.
 
 ## Further Reading
 
-- `skills/first-tree/references/principles.md` — Core principles with detailed examples
-- `skills/first-tree/references/ownership-and-naming.md` — How nodes are named and owned
+- `.agents/skills/first-tree/references/principles.md` — Core principles with detailed examples
+- `.agents/skills/first-tree/references/ownership-and-naming.md` — How nodes are named and owned
 - `AGENTS.md` in your tree — The before/during/after workflow for every task

--- a/skills/first-tree/references/upgrade-contract.md
+++ b/skills/first-tree/references/upgrade-contract.md
@@ -1,8 +1,8 @@
 # Upgrade Contract
 
 This file describes the current installed-layout contract and the compatibility
-rules we keep for legacy `skills/first-tree-cli-framework/` and
-`.context-tree/` repos.
+rules we keep for legacy `skills/first-tree/`,
+`skills/first-tree-cli-framework/`, and `.context-tree/` repos.
 
 ## Canonical Source
 
@@ -19,20 +19,35 @@ rules we keep for legacy `skills/first-tree-cli-framework/` and
 The current installed layout in a user repo is:
 
 ```text
-skills/
-  first-tree/
-    SKILL.md
-    progress.md
-    references/
-    assets/
-      framework/
-        manifest.json
-        VERSION
-        templates/
-        workflows/
-        prompts/
-        examples/
-        helpers/
+.agents/
+  skills/
+    first-tree/
+      SKILL.md
+      progress.md
+      references/
+      assets/
+        framework/
+          manifest.json
+          VERSION
+          templates/
+          workflows/
+          prompts/
+          examples/
+          helpers/
+.claude/
+  skills/
+    first-tree/
+      SKILL.md
+      references/
+      assets/
+        framework/
+          manifest.json
+          VERSION
+          templates/
+          workflows/
+          prompts/
+          examples/
+          helpers/
 ```
 
 The tree content still lives outside the skill:
@@ -41,6 +56,11 @@ The tree content still lives outside the skill:
 - `AGENTS.md`
 - `members/`
 
+The repo-owned `.agents/skills/first-tree/` path is the primary installed root
+for progress state, workflow references, and helper scripts. The matching
+`.claude/skills/first-tree/` path mirrors the same payload for Claude-facing
+skill discovery and hooks.
+
 ## Command Intent
 
 - `context-tree init`
@@ -48,7 +68,7 @@ The tree content still lives outside the skill:
     tree repo by default
   - installs the skill into the target tree repo
   - renders top-level tree scaffolding from the skill templates
-  - writes progress state to `skills/first-tree/progress.md`
+  - writes progress state to `.agents/skills/first-tree/progress.md`
 - `context-tree verify`
   - checks progress state from the installed skill
   - validates root/frontmatter/agent markers
@@ -57,8 +77,11 @@ The tree content still lives outside the skill:
   - compares the installed skill payload version to the skill bundled with the
     currently running `first-tree` package
   - refreshes the installed skill payload without overwriting tree content
+  - migrates repos that still use the previous `skills/first-tree/` path onto
+    `.agents/skills/first-tree/` and `.claude/skills/first-tree/`
   - migrates repos that still use the previous
-    `skills/first-tree-cli-framework/` path onto `skills/first-tree/`
+    `skills/first-tree-cli-framework/` path onto `.agents/skills/first-tree/`
+    and `.claude/skills/first-tree/`
   - migrates legacy `.context-tree/` repos onto the installed skill layout
   - preserves user-authored sections such as the editable part of `AGENTS.md`
 
@@ -73,14 +96,17 @@ The tree content still lives outside the skill:
 - Normal `context-tree init` and `context-tree upgrade` flows do not clone the
   source repo or require network access.
 - `context-tree verify` may still read a legacy
-  `skills/first-tree-cli-framework/...` or `.context-tree/...` layout in an
-  existing user repo so the repo can be upgraded in place.
+  `.claude/skills/first-tree/...`, `skills/first-tree/...`,
+  `skills/first-tree-cli-framework/...`, or `.context-tree/...` layout in an
+  existing user repo so the repo can be repaired or upgraded in place.
 - `context-tree upgrade` must migrate either legacy layout onto
-  `skills/first-tree/` and remove the old directory afterward.
-- When both layouts are present, prefer the installed skill layout.
+  `.agents/skills/first-tree/` and `.claude/skills/first-tree/`, and remove
+  old skill directories afterward.
+- When both current and legacy layouts are present, prefer the
+  `.agents/skills/first-tree/` layout.
 - Existing repos may still have a legacy `AGENT.md`; `init` and `upgrade`
   must not silently overwrite it, and follow-up tasks should direct users to
-  rename it to `AGENTS.md`.
+  rename or merge it into `AGENTS.md`.
 
 ## Invariants
 

--- a/skills/first-tree/tests/asset-loader.test.ts
+++ b/skills/first-tree/tests/asset-loader.test.ts
@@ -2,8 +2,11 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  CLAUDE_INSTALLED_PROGRESS,
   FRAMEWORK_VERSION,
   INSTALLED_PROGRESS,
+  LEGACY_REPO_SKILL_PROGRESS,
+  LEGACY_REPO_SKILL_VERSION,
   LEGACY_SKILL_PROGRESS,
   LEGACY_SKILL_VERSION,
   LEGACY_PROGRESS,
@@ -18,7 +21,7 @@ import { useTmpDir } from "./helpers.js";
 describe("asset-loader", () => {
   it("prefers the installed skill layout when both layouts exist", () => {
     const tmp = useTmpDir();
-    mkdirSync(join(tmp.path, "skills", "first-tree", "assets", "framework"), {
+    mkdirSync(join(tmp.path, ".agents", "skills", "first-tree", "assets", "framework"), {
       recursive: true,
     });
     mkdirSync(join(tmp.path, ".context-tree"), { recursive: true });
@@ -37,6 +40,21 @@ describe("asset-loader", () => {
     writeFileSync(join(tmp.path, LEGACY_VERSION), "0.1.0\n");
 
     expect(detectFrameworkLayout(tmp.path)).toBe("legacy");
+  });
+
+  it("detects the previous workspace skill path before older layouts", () => {
+    const tmp = useTmpDir();
+    mkdirSync(join(tmp.path, "skills", "first-tree", "assets", "framework"), {
+      recursive: true,
+    });
+    mkdirSync(join(tmp.path, ".context-tree"), { recursive: true });
+    writeFileSync(join(tmp.path, LEGACY_REPO_SKILL_VERSION), "0.2.0\n");
+    writeFileSync(join(tmp.path, LEGACY_VERSION), "0.1.0\n");
+
+    expect(detectFrameworkLayout(tmp.path)).toBe("legacy-repo-skill");
+    expect(
+      resolveFirstExistingPath(tmp.path, frameworkVersionCandidates()),
+    ).toBe(LEGACY_REPO_SKILL_VERSION);
   });
 
   it("detects the previous installed skill name before the .context-tree layout", () => {
@@ -59,12 +77,16 @@ describe("asset-loader", () => {
 
   it("prefers the installed progress file candidate", () => {
     const tmp = useTmpDir();
+    mkdirSync(join(tmp.path, ".agents", "skills", "first-tree"), { recursive: true });
+    mkdirSync(join(tmp.path, ".claude", "skills", "first-tree"), { recursive: true });
     mkdirSync(join(tmp.path, "skills", "first-tree"), { recursive: true });
     mkdirSync(join(tmp.path, "skills", "first-tree-cli-framework"), {
       recursive: true,
     });
     mkdirSync(join(tmp.path, ".context-tree"), { recursive: true });
     writeFileSync(join(tmp.path, INSTALLED_PROGRESS), "new");
+    writeFileSync(join(tmp.path, CLAUDE_INSTALLED_PROGRESS), "claude");
+    writeFileSync(join(tmp.path, LEGACY_REPO_SKILL_PROGRESS), "old-repo-skill");
     writeFileSync(join(tmp.path, LEGACY_SKILL_PROGRESS), "old-skill");
     writeFileSync(join(tmp.path, LEGACY_PROGRESS), "old");
 

--- a/skills/first-tree/tests/helpers.ts
+++ b/skills/first-tree/tests/helpers.ts
@@ -5,10 +5,13 @@ import { afterEach } from "vitest";
 import {
   AGENT_INSTRUCTIONS_FILE,
   AGENT_INSTRUCTIONS_TEMPLATE,
+  CLAUDE_SKILL_ROOT,
   FRAMEWORK_VERSION,
   LEGACY_AGENT_INSTRUCTIONS_FILE,
+  LEGACY_REPO_SKILL_VERSION,
   LEGACY_SKILL_VERSION,
   LEGACY_VERSION,
+  SKILL_ROOT,
 } from "#skill/engine/runtime/asset-loader.js";
 
 interface TmpDir {
@@ -24,10 +27,20 @@ export function useTmpDir(): TmpDir {
 }
 
 export function makeFramework(root: string, version = "0.1.0"): void {
-  mkdirSync(join(root, "skills", "first-tree", "assets", "framework"), {
-    recursive: true,
-  });
+  for (const skillRoot of [SKILL_ROOT, CLAUDE_SKILL_ROOT]) {
+    mkdirSync(join(root, skillRoot, "assets", "framework"), {
+      recursive: true,
+    });
+    writeFileSync(
+      join(root, skillRoot, "SKILL.md"),
+      "---\nname: first-tree\ndescription: installed\n---\n",
+    );
+  }
   writeFileSync(join(root, FRAMEWORK_VERSION), `${version}\n`);
+  writeFileSync(
+    join(root, CLAUDE_SKILL_ROOT, "assets", "framework", "VERSION"),
+    `${version}\n`,
+  );
 }
 
 export function makeGitRepo(root: string): void {
@@ -48,6 +61,17 @@ export function makeLegacyFramework(root: string, version = "0.1.0"): void {
   const ct = join(root, ".context-tree");
   mkdirSync(ct, { recursive: true });
   writeFileSync(join(root, LEGACY_VERSION), `${version}\n`);
+}
+
+export function makeLegacyRepoFramework(root: string, version = "0.1.0"): void {
+  mkdirSync(join(root, "skills", "first-tree", "assets", "framework"), {
+    recursive: true,
+  });
+  writeFileSync(
+    join(root, "skills", "first-tree", "SKILL.md"),
+    "---\nname: first-tree\ndescription: legacy installed\n---\n",
+  );
+  writeFileSync(join(root, LEGACY_REPO_SKILL_VERSION), `${version}\n`);
 }
 
 export function makeLegacyNamedFramework(

--- a/skills/first-tree/tests/init.test.ts
+++ b/skills/first-tree/tests/init.test.ts
@@ -100,7 +100,7 @@ describe("writeProgress", () => {
 
   it("overwrites existing file", () => {
     const tmp = useTmpDir();
-    mkdirSync(join(tmp.path, "skills", "first-tree"), {
+    mkdirSync(join(tmp.path, ".agents", "skills", "first-tree"), {
       recursive: true,
     });
     writeFileSync(join(tmp.path, INSTALLED_PROGRESS), "old");
@@ -145,7 +145,10 @@ describe("runInit", () => {
 
     expect(ret).toBe(0);
     expect(
-      existsSync(join(repoDir.path, "skills", "first-tree", "SKILL.md")),
+      existsSync(join(repoDir.path, ".agents", "skills", "first-tree", "SKILL.md")),
+    ).toBe(true);
+    expect(
+      existsSync(join(repoDir.path, ".claude", "skills", "first-tree", "SKILL.md")),
     ).toBe(true);
     expect(readFileSync(join(repoDir.path, FRAMEWORK_VERSION), "utf-8").trim()).toBe("0.2.0");
     expect(existsSync(join(repoDir.path, "NODE.md"))).toBe(true);
@@ -202,7 +205,12 @@ describe("runInit", () => {
     );
 
     expect(ret).toBe(0);
-    expect(existsSync(join(treeRepo, "skills", "first-tree", "SKILL.md"))).toBe(true);
+    expect(
+      existsSync(join(treeRepo, ".agents", "skills", "first-tree", "SKILL.md")),
+    ).toBe(true);
+    expect(
+      existsSync(join(treeRepo, ".claude", "skills", "first-tree", "SKILL.md")),
+    ).toBe(true);
     expect(existsSync(join(treeRepo, "NODE.md"))).toBe(true);
     expect(existsSync(join(treeRepo, AGENT_INSTRUCTIONS_FILE))).toBe(true);
     expect(existsSync(join(treeRepo, "members", "NODE.md"))).toBe(true);

--- a/skills/first-tree/tests/repo.test.ts
+++ b/skills/first-tree/tests/repo.test.ts
@@ -4,9 +4,12 @@ import { describe, expect, it } from "vitest";
 import { Repo } from "#skill/engine/repo.js";
 import {
   AGENT_INSTRUCTIONS_FILE,
+  CLAUDE_INSTALLED_PROGRESS,
   FRAMEWORK_VERSION,
   INSTALLED_PROGRESS,
   LEGACY_AGENT_INSTRUCTIONS_FILE,
+  LEGACY_REPO_SKILL_PROGRESS,
+  LEGACY_REPO_SKILL_VERSION,
   LEGACY_SKILL_PROGRESS,
   LEGACY_SKILL_VERSION,
   LEGACY_PROGRESS,
@@ -17,6 +20,7 @@ import {
   makeFramework,
   makeGitRepo,
   makeLegacyFramework,
+  makeLegacyRepoFramework,
   makeLegacyNamedFramework,
   makeSourceRepo,
   makeSourceSkill,
@@ -182,6 +186,13 @@ describe("hasFramework", () => {
     expect(repo.hasFramework()).toBe(true);
   });
 
+  it("returns true with the previous workspace skill path", () => {
+    const tmp = useTmpDir();
+    makeLegacyRepoFramework(tmp.path);
+    const repo = new Repo(tmp.path);
+    expect(repo.hasFramework()).toBe(true);
+  });
+
   it("returns false without VERSION file", () => {
     const tmp = useTmpDir();
     const repo = new Repo(tmp.path);
@@ -211,6 +222,13 @@ describe("readVersion", () => {
     makeLegacyNamedFramework(tmp.path, "0.2.5");
     const repo = new Repo(tmp.path);
     expect(repo.readVersion()).toBe("0.2.5");
+  });
+
+  it("reads the previous workspace skill version", () => {
+    const tmp = useTmpDir();
+    makeLegacyRepoFramework(tmp.path, "0.2.4");
+    const repo = new Repo(tmp.path);
+    expect(repo.readVersion()).toBe("0.2.4");
   });
 
   it("returns null when missing", () => {
@@ -244,6 +262,14 @@ describe("path preferences", () => {
     const repo = new Repo(tmp.path);
     expect(repo.preferredProgressPath()).toBe(LEGACY_SKILL_PROGRESS);
     expect(repo.frameworkVersionPath()).toBe(LEGACY_SKILL_VERSION);
+  });
+
+  it("switches path preferences for repos using the previous workspace skill path", () => {
+    const tmp = useTmpDir();
+    makeLegacyRepoFramework(tmp.path);
+    const repo = new Repo(tmp.path);
+    expect(repo.preferredProgressPath()).toBe(LEGACY_REPO_SKILL_PROGRESS);
+    expect(repo.frameworkVersionPath()).toBe(LEGACY_REPO_SKILL_VERSION);
   });
 });
 

--- a/skills/first-tree/tests/rules.test.ts
+++ b/skills/first-tree/tests/rules.test.ts
@@ -29,7 +29,7 @@ describe("framework rule", () => {
     const result = framework.evaluate(repo);
     expect(result.group).toBe("Framework");
     expect(result.tasks).toHaveLength(1);
-    expect(result.tasks[0]).toContain("skills/first-tree/");
+    expect(result.tasks[0]).toContain(".agents/skills/first-tree/");
   });
 
   it("passes when framework exists", () => {
@@ -233,7 +233,9 @@ describe("ciValidation rule", () => {
     const result = ciValidation.evaluate(repo);
     expect(result.tasks).toHaveLength(4);
     expect(result.tasks[0]).toContain("validation workflow");
-    expect(result.tasks[0]).toContain("skills/first-tree/assets/framework/workflows/validate.yml");
+    expect(result.tasks[0]).toContain(
+      ".agents/skills/first-tree/assets/framework/workflows/validate.yml",
+    );
     expect(result.tasks[1]).toContain("PR reviews");
     expect(result.tasks[2]).toContain("API secret");
     expect(result.tasks[3]).toContain("CODEOWNERS");
@@ -271,7 +273,7 @@ describe("ciValidation rule", () => {
     mkdirSync(wfDir, { recursive: true });
     writeFileSync(
       join(wfDir, "pr-review.yml"),
-      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx skills/first-tree/assets/framework/helpers/run-review.ts\n",
+      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx .agents/skills/first-tree/assets/framework/helpers/run-review.ts\n",
     );
     const repo = new Repo(tmp.path);
     const result = ciValidation.evaluate(repo);
@@ -290,7 +292,7 @@ describe("ciValidation rule", () => {
     );
     writeFileSync(
       join(wfDir, "pr-review.yml"),
-      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx skills/first-tree/assets/framework/helpers/run-review.ts\n",
+      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx .agents/skills/first-tree/assets/framework/helpers/run-review.ts\n",
     );
     const repo = new Repo(tmp.path);
     const result = ciValidation.evaluate(repo);
@@ -308,11 +310,11 @@ describe("ciValidation rule", () => {
     );
     writeFileSync(
       join(wfDir, "pr-review.yml"),
-      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx skills/first-tree/assets/framework/helpers/run-review.ts\n",
+      "name: PR Review\non: pull_request\njobs:\n  review:\n    steps:\n      - run: npx tsx .agents/skills/first-tree/assets/framework/helpers/run-review.ts\n",
     );
     writeFileSync(
       join(wfDir, "codeowners.yml"),
-      "name: Update CODEOWNERS\non: pull_request\njobs:\n  update:\n    steps:\n      - run: npx tsx skills/first-tree/assets/framework/helpers/generate-codeowners.ts\n",
+      "name: Update CODEOWNERS\non: pull_request\njobs:\n  update:\n    steps:\n      - run: npx tsx .agents/skills/first-tree/assets/framework/helpers/generate-codeowners.ts\n",
     );
     const repo = new Repo(tmp.path);
     const result = ciValidation.evaluate(repo);
@@ -386,7 +388,7 @@ describe("evaluateAll", () => {
     makeNode(tmp.path);
     makeAgentsMd(tmp.path, { markers: true, userContent: true });
     makeMembers(tmp.path, 1);
-    mkdirSync(join(tmp.path, ".claude"));
+    mkdirSync(join(tmp.path, ".claude"), { recursive: true });
     writeFileSync(
       join(tmp.path, ".claude", "settings.json"),
       '{"hooks": {"inject-tree-context": true}}',

--- a/skills/first-tree/tests/skill-artifacts.test.ts
+++ b/skills/first-tree/tests/skill-artifacts.test.ts
@@ -201,6 +201,8 @@ describe("skill artifacts", () => {
     expect(read("README.md")).toContain("Canonical Documentation");
     expect(read("README.md")).toContain("references/source-map.md");
     expect(read("README.md")).toContain("skills/first-tree/");
+    expect(read("README.md")).toContain(".agents/skills/first-tree/");
+    expect(read("README.md")).toContain(".claude/skills/first-tree/");
     expect(read("README.md")).toContain("bundled canonical");
     expect(read("README.md")).toContain("dedicated tree repo");
     expect(read("README.md")).toContain("`first-tree` skill");
@@ -218,6 +220,8 @@ describe("skill artifacts", () => {
     expect(onboarding).toContain("installed CLI command is");
     expect(onboarding).toContain("currently running `first-tree` npm package");
     expect(onboarding).toContain("npx first-tree@latest upgrade");
+    expect(onboarding).toContain(".agents/skills/first-tree/");
+    expect(onboarding).toContain(".claude/skills/first-tree/");
     expect(onboarding).not.toContain("This clones the framework into `.context-tree/`");
     expect(onboarding).not.toContain("from upstream");
 
@@ -228,6 +232,8 @@ describe("skill artifacts", () => {
     expect(skillMd).toContain("maintainer-testing.md");
     expect(skillMd).toContain("currently running `first-tree` package");
     expect(skillMd).toContain("so it is not confused with the `first-tree`");
+    expect(skillMd).toContain(".agents/skills/first-tree/");
+    expect(skillMd).toContain(".claude/skills/first-tree/");
     expect(skillMd).not.toContain("canonical eval harness");
 
     const sourceMap = read("skills/first-tree/references/source-map.md");

--- a/skills/first-tree/tests/upgrade.test.ts
+++ b/skills/first-tree/tests/upgrade.test.ts
@@ -14,6 +14,7 @@ import {
   makeFramework,
   makeSourceRepo,
   makeLegacyFramework,
+  makeLegacyRepoFramework,
   makeLegacyNamedFramework,
   makeSourceSkill,
   useTmpDir,
@@ -35,7 +36,7 @@ describe("runUpgrade", () => {
     expect(existsSync(join(repoDir.path, ".context-tree"))).toBe(false);
     expect(readFileSync(join(repoDir.path, FRAMEWORK_VERSION), "utf-8").trim()).toBe("0.2.0");
     expect(readFileSync(join(repoDir.path, INSTALLED_PROGRESS), "utf-8")).toContain(
-      "skills/first-tree/assets/framework/VERSION",
+      ".agents/skills/first-tree/assets/framework/VERSION",
     );
     expect(readFileSync(join(repoDir.path, INSTALLED_PROGRESS), "utf-8")).toContain(
       `Rename \`${LEGACY_AGENT_INSTRUCTIONS_FILE}\` to \`${AGENT_INSTRUCTIONS_FILE}\``,
@@ -76,6 +77,24 @@ describe("runUpgrade", () => {
     expect(readFileSync(join(repoDir.path, FRAMEWORK_VERSION), "utf-8").trim()).toBe("0.2.0");
     expect(readFileSync(join(repoDir.path, INSTALLED_PROGRESS), "utf-8")).toContain(
       "skills/first-tree-cli-framework/",
+    );
+  });
+
+  it("migrates repos that still use the previous workspace skill path", () => {
+    const repoDir = useTmpDir();
+    const sourceDir = useTmpDir();
+    makeLegacyRepoFramework(repoDir.path, "0.1.0");
+    makeSourceSkill(sourceDir.path, "0.2.0");
+
+    const result = runUpgrade(new Repo(repoDir.path), {
+      sourceRoot: sourceDir.path,
+    });
+
+    expect(result).toBe(0);
+    expect(existsSync(join(repoDir.path, "skills", "first-tree"))).toBe(false);
+    expect(readFileSync(join(repoDir.path, FRAMEWORK_VERSION), "utf-8").trim()).toBe("0.2.0");
+    expect(readFileSync(join(repoDir.path, INSTALLED_PROGRESS), "utf-8")).toContain(
+      "skills/first-tree/",
     );
   });
 

--- a/skills/first-tree/tests/verify.test.ts
+++ b/skills/first-tree/tests/verify.test.ts
@@ -43,7 +43,7 @@ describe("checkProgress", () => {
 
   it("returns empty when all checked", () => {
     const tmp = useTmpDir();
-    mkdirSync(join(tmp.path, "skills", "first-tree"), { recursive: true });
+    makeFramework(tmp.path);
     writeFileSync(
       join(tmp.path, INSTALLED_PROGRESS),
       "# Progress\n- [x] Task one\n- [x] Task two\n",
@@ -54,7 +54,7 @@ describe("checkProgress", () => {
 
   it("returns unchecked items", () => {
     const tmp = useTmpDir();
-    mkdirSync(join(tmp.path, "skills", "first-tree"), { recursive: true });
+    makeFramework(tmp.path);
     writeFileSync(
       join(tmp.path, INSTALLED_PROGRESS),
       "# Progress\n- [x] Done task\n- [ ] Pending task\n- [ ] Another pending\n",
@@ -65,7 +65,7 @@ describe("checkProgress", () => {
 
   it("returns empty for empty progress", () => {
     const tmp = useTmpDir();
-    mkdirSync(join(tmp.path, "skills", "first-tree"), { recursive: true });
+    makeFramework(tmp.path);
     writeFileSync(join(tmp.path, INSTALLED_PROGRESS), "");
     const repo = new Repo(tmp.path);
     expect(checkProgress(repo)).toEqual([]);


### PR DESCRIPTION
## Summary
- install the bundled first-tree skill into `.agents/skills/first-tree/` and `.claude/skills/first-tree/` instead of user-repo `skills/first-tree/`
- migrate and repair legacy layouts during `init` and `upgrade`, while keeping the bundled canonical source under `skills/first-tree/`
- update templates, onboarding/docs, and test coverage so the new installed layout stays consistent with dedicated tree repo flows and `AGENTS.md`

## Validation
- `pnpm test`
- `pnpm validate:skill`
- `pnpm build`