### PR TITLE
feat: rename CLI prefix to first-tree

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,10 +2,10 @@
 # Environment variables take precedence over .env values.
 
 # Local git repo cache directory (speeds up repeated eval runs)
-EVALS_REPO_CACHE=~/.context-tree/repo-cache
+EVALS_REPO_CACHE=~/.first-tree/repo-cache
 
 # Directory for storing eval results
-EVALS_STORE_DIR=~/.context-tree/evals
+EVALS_STORE_DIR=~/.first-tree/evals
 
 # Context tree repo slug (e.g. agent-team-foundation/eval-context-trees)
 EVALS_TREE_REPO=

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       label: What happened?
       description: Describe the bug and why it matters.
-      placeholder: context-tree verify rejects a valid tree after upgrading from 0.0.x
+      placeholder: first-tree verify rejects a valid tree after upgrading from 0.0.x
     validations:
       required: true
   - type: input
@@ -15,7 +15,7 @@ body:
     attributes:
       label: Command or surface area
       description: Which command, doc, or package surface is affected?
-      placeholder: context-tree init
+      placeholder: first-tree init
   - type: textarea
     id: reproduction
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       label: What problem are you trying to solve?
       description: Start with the user or maintainer pain, not just the solution.
-      placeholder: New contributors do not know whether to run first-tree or context-tree after installing globally.
+      placeholder: New contributors do not know whether `npx first-tree` and a globally installed `first-tree` share the same command surface.
     validations:
       required: true
   - type: textarea
@@ -15,7 +15,7 @@ body:
     attributes:
       label: Proposed solution
       description: What should change?
-      placeholder: Add a global first-tree alias that points to the same CLI entrypoint.
+      placeholder: Clarify the global-install workflow so every command example uses `first-tree`.
     validations:
       required: true
   - type: textarea

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-# Context Tree operational files
-.context-tree/progress.md
+# Local first-tree scratch data
+.first-tree/
 
 # IDE
 .idea/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Agent Instructions for first-tree
 
 This repo ships the canonical `first-tree` skill plus a thin
-`context-tree` CLI. It is not a user context tree.
+`first-tree` CLI. It is not a user context tree.
 
 ## Start Here
 
@@ -13,7 +13,7 @@ This repo ships the canonical `first-tree` skill plus a thin
 
 - Treat `skills/first-tree/` as the only canonical source of
   framework knowledge.
-- Use `first-tree` for the npm package, `context-tree` for the CLI command, and
+- Use `first-tree` for both the npm package and CLI command, and
   `skills/first-tree/` when you mean the bundled skill path.
 - Keep source/workspace installs limited to local skill integration; `NODE.md`,
   `members/`, and tree-scoped `AGENTS.md` belong only in a dedicated

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,12 +3,12 @@
 Thanks for helping improve `first-tree`.
 
 This repository ships one canonical `first-tree` skill plus a thin
-`context-tree` CLI shell.
+`first-tree` CLI shell.
 
 Naming note:
 
 - `first-tree` is the npm package name.
-- `context-tree` is the installed CLI command.
+- `first-tree` is also the installed CLI command.
 - `skills/first-tree/` is the bundled skill path inside this repo.
 - User trees install that payload into `.agents/skills/first-tree/` and
   `.claude/skills/first-tree/`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # first-tree
 
-`first-tree` publishes the `context-tree` CLI and bundles the canonical
+`first-tree` publishes the `first-tree` CLI and bundles the canonical
 `first-tree` skill used to bootstrap and maintain Context Tree repos.
 
 ## Install And Run
@@ -15,35 +15,34 @@
 
   ```bash
   npm install -g first-tree
-  context-tree init
+  first-tree init
   ```
 
 - Show the installed CLI version:
 
   ```bash
-  context-tree --version
+  first-tree --version
   ```
 
 - Show the command list:
 
   ```bash
-  context-tree --help
+  first-tree --help
   ```
 
-Although the npm package is named `first-tree`, the installed CLI command is
-`context-tree`.
+The npm package and installed CLI command are both `first-tree`.
 
 ## Quick Start
 
 Recommended workflow: start from your source or workspace repo and let
-`context-tree init` install local source/workspace integration and create a
+`first-tree init` installs local source/workspace integration and creates a
 sibling dedicated tree repo.
 
 ```bash
 cd my-app
 npx first-tree init
 cd ../my-app-context
-context-tree publish --open-pr
+first-tree publish --open-pr
 ```
 
 If you already created a dedicated tree repo yourself, initialize it in place:
@@ -51,14 +50,14 @@ If you already created a dedicated tree repo yourself, initialize it in place:
 ```bash
 mkdir my-org-context && cd my-org-context
 git init
-context-tree init --here
+first-tree init --here
 ```
 
 Only use `--here` after you have already switched into the dedicated tree repo.
 Do not use it inside the source/workspace repo unless you intentionally want
 that repo itself to become the Context Tree.
 
-- `context-tree init` installs `.agents/skills/first-tree/` and
+- `first-tree init` installs `.agents/skills/first-tree/` and
   `.claude/skills/first-tree/` in the current source/workspace repo, appends a
   single `FIRST-TREE-SOURCE-INTEGRATION:` line to root `AGENTS.md` and
   `CLAUDE.md`, then creates `NODE.md`, tree-scoped `AGENTS.md`,
@@ -67,17 +66,17 @@ that repo itself to become the Context Tree.
 - Never create `NODE.md`, `members/`, or tree-scoped `AGENTS.md` in the
   source/workspace repo. Those files live only in the dedicated `*-context`
   repo.
-- After drafting the initial tree version, run `context-tree publish --open-pr`
+- After drafting the initial tree version, run `first-tree publish --open-pr`
   from the dedicated tree repo. That command creates or reuses the GitHub
   `*-context` repo, adds it back to the source/workspace repo as a git
   submodule, and opens a PR instead of merging automatically.
-- After `context-tree publish` succeeds, treat the source repo's submodule
+- After `first-tree publish` succeeds, treat the source repo's submodule
   checkout as the canonical local working copy for the tree. The temporary
   sibling bootstrap checkout can be deleted when you no longer need it.
-- `context-tree verify` checks both the progress checklist and deterministic
+- `first-tree verify` checks both the progress checklist and deterministic
   tree validation. It is expected to fail until the required onboarding tasks
   are complete.
-- `context-tree upgrade` refreshes the installed skill from the currently
+- `first-tree upgrade` refreshes the installed skill from the currently
   running `first-tree` npm package. In a source/workspace repo it refreshes
   only the local installed skill plus the
   `FIRST-TREE-SOURCE-INTEGRATION:` line; use `--tree-path` to upgrade the
@@ -92,18 +91,18 @@ runtime.
 
 | Command | What it does |
 | --- | --- |
-| `context-tree init` | Install source/workspace integration locally and create or refresh a dedicated context tree repo; use `--here` only when you are already inside the dedicated tree repo |
-| `context-tree publish` | Publish a dedicated tree repo to GitHub, add it back to the source/workspace repo as a submodule, and optionally open the source-repo PR |
-| `context-tree verify` | Run verification checks against the current tree |
-| `context-tree upgrade` | Refresh the installed skill from the current `first-tree` npm package; in a source/workspace repo it updates only local integration, while tree repos also get follow-up tasks |
-| `context-tree help onboarding` | Print the onboarding guide |
-| `context-tree --help` | Show the available commands |
-| `context-tree --version` | Print the installed CLI version |
+| `first-tree init` | Install source/workspace integration locally and create or refresh a dedicated context tree repo; use `--here` only when you are already inside the dedicated tree repo |
+| `first-tree publish` | Publish a dedicated tree repo to GitHub, add it back to the source/workspace repo as a submodule, and optionally open the source-repo PR |
+| `first-tree verify` | Run verification checks against the current tree |
+| `first-tree upgrade` | Refresh the installed skill from the current `first-tree` npm package; in a source/workspace repo it updates only local integration, while tree repos also get follow-up tasks |
+| `first-tree help onboarding` | Print the onboarding guide |
+| `first-tree --help` | Show the available commands |
+| `first-tree --version` | Print the installed CLI version |
 
-## Package Name vs Command
+## Package And Command
 
 - The npm package is `first-tree`.
-- The installed CLI command is `context-tree`.
+- The installed CLI command is also `first-tree`.
 - The installed skill directories inside a user tree are
   `.agents/skills/first-tree/` and `.claude/skills/first-tree/`.
 - The published package keeps its bundled canonical source under
@@ -111,13 +110,13 @@ runtime.
 - When maintainer docs say "the `first-tree` skill", they mean that bundled
   skill directory, not the npm package name.
 - `npx first-tree init` is the quickest one-off entrypoint.
-- `npm install -g first-tree` adds `context-tree` to your PATH for repeated
+- `npm install -g first-tree` adds `first-tree` to your PATH for repeated
   use.
 
 ## Runtime And Maintainer Prerequisites
 
 - User trees: the onboarding guide targets Node.js 18+.
-- `context-tree publish` also expects GitHub CLI (`gh`) to be installed and
+- `first-tree publish` also expects GitHub CLI (`gh`) to be installed and
   authenticated against GitHub.
 - This source repo: use Node.js 22 and pnpm 10 to match CI and the checked-in
   package manager version.
@@ -128,7 +127,7 @@ runtime.
   bundled skill.
 - `skills/first-tree/` is the canonical source for framework behavior, shipped
   templates, maintainer references, and validation logic.
-- `context-tree init` installs that bundled skill into `.agents/skills/first-tree/`
+- `first-tree init` installs that bundled skill into `.agents/skills/first-tree/`
   and `.claude/skills/first-tree/` inside user repos.
 - `evals/` is maintainer-only developer tooling for the source repo. It is
   intentionally not part of the published package.

--- a/evals/Dockerfile
+++ b/evals/Dockerfile
@@ -1,7 +1,7 @@
-# Dockerfile for running context-tree evals with claude --dangerously-skip-permissions
+# Dockerfile for running first-tree evals with claude --dangerously-skip-permissions
 #
 # Build:
-#   docker build -t ct-eval -f evals/Dockerfile .
+#   docker build -t ft-eval -f evals/Dockerfile .
 #
 # Run (single case):
 #   docker run --rm \
@@ -10,8 +10,8 @@
 #     -e EVALS=1 \
 #     -e EVALS_CASES=pydantic-importstring-error \
 #     -e EVALS_TREE_REPO=agent-team-foundation/eval-context-trees \
-#     -v ~/.context-tree/evals:/home/eval/.context-tree/evals \
-#     ct-eval
+#     -v ~/.first-tree/evals:/home/eval/.first-tree/evals \
+#     ft-eval
 #
 # Run (all cases):
 #   docker run --rm \
@@ -19,8 +19,8 @@
 #     -e GH_TOKEN="$(gh auth token)" \
 #     -e EVALS=1 \
 #     -e EVALS_TREE_REPO=agent-team-foundation/eval-context-trees \
-#     -v ~/.context-tree/evals:/home/eval/.context-tree/evals \
-#     ct-eval
+#     -v ~/.first-tree/evals:/home/eval/.first-tree/evals \
+#     ft-eval
 #
 # The -v mount persists eval results (JSON + HTML) to your host.
 
@@ -74,7 +74,7 @@ USER eval
 WORKDIR /home/eval/first-tree
 
 # Create eval results directory and set git safe.directory globally
-RUN mkdir -p /home/eval/.context-tree/evals \
+RUN mkdir -p /home/eval/.first-tree/evals \
     && git config --global --add safe.directory '*'
 
 # Ensure uv/pnpm caches are writable inside the container

--- a/evals/README.md
+++ b/evals/README.md
@@ -12,7 +12,7 @@ repo. It is intentionally not part of the distributed
 - `scripts/`: developer utilities for creating, updating, listing, and
   aggregating eval runs
 - `tests/`: fast helper coverage
-- `context-tree-eval.test.ts`: the end-to-end eval entrypoint behind `pnpm eval`
+- `first-tree-eval.test.ts`: the end-to-end eval entrypoint behind `pnpm eval`
 
 ## Running Evals
 
@@ -35,5 +35,5 @@ for full end-to-end impact measurement.
 Aggregate reports with:
 
 ```bash
-npx tsx evals/scripts/aggregate-report.ts ~/.context-tree/evals/file1.json file2.json
+npx tsx evals/scripts/aggregate-report.ts ~/.first-tree/evals/file1.json file2.json
 ```

--- a/evals/first-tree-eval.test.ts
+++ b/evals/first-tree-eval.test.ts
@@ -37,7 +37,7 @@ const caseFilter = process.env.EVALS_CASES
 
 const describeEval = evalsEnabled ? describe : describe.skip;
 
-describeEval('context-tree eval', () => {
+describeEval('first-tree eval', () => {
   const collector = new EvalCollector({ model: agent.model, cli: agent.cli });
 
   let cases: ReturnType<typeof loadCases>;

--- a/evals/helpers/eval-store.ts
+++ b/evals/helpers/eval-store.ts
@@ -2,7 +2,7 @@
  * Eval result persistence.
  *
  * EvalCollector accumulates trial results, writes them to
- * ~/.context-tree/evals/{branch}-{timestamp}.json with crash-safe
+ * ~/.first-tree/evals/{branch}-{timestamp}.json with crash-safe
  * partial saves, and prints a summary table on finalize.
  *
  * Adapted from gstack's eval-store.ts.
@@ -18,7 +18,7 @@ import { getEnv } from '#evals/helpers/env.js';
 import { TIMEOUT_GIT_INFO } from '#evals/helpers/timeouts.js';
 
 const SCHEMA_VERSION = 1;
-const EVAL_DIR = getEnv('EVALS_STORE_DIR', '~/.context-tree/evals')!;
+const EVAL_DIR = getEnv('EVALS_STORE_DIR', '~/.first-tree/evals')!;
 
 function getGitInfo(): { branch: string; sha: string } {
   try {

--- a/evals/helpers/html-report.ts
+++ b/evals/helpers/html-report.ts
@@ -26,7 +26,7 @@ function pct(a: number, b: number): string {
 }
 
 function shortenPath(p: string): string {
-  return p.replace(/\/tmp\/ct-eval-[^/]+\//, '');
+  return p.replace(/\/tmp\/ft-eval-[^/]+\//, '');
 }
 
 function formatFailureReason(t: TrialResult): string {

--- a/evals/helpers/repo-cache.ts
+++ b/evals/helpers/repo-cache.ts
@@ -28,7 +28,7 @@ let _cacheDir: string | undefined;
 /** Return the cache root directory, creating it if needed. */
 export function getRepoCacheDir(): string {
   if (!_cacheDir) {
-    _cacheDir = getEnv('EVALS_REPO_CACHE', '~/.context-tree/repo-cache')!;
+    _cacheDir = getEnv('EVALS_REPO_CACHE', '~/.first-tree/repo-cache')!;
     fs.mkdirSync(_cacheDir, { recursive: true });
   }
   return _cacheDir;

--- a/evals/helpers/repo-sandbox.ts
+++ b/evals/helpers/repo-sandbox.ts
@@ -5,10 +5,10 @@
  * is a full independent copy — patches from eval tasks are confined
  * to the sandbox and destroyed on cleanup.
  *
- * Single-repo layout:   /tmp/ct-eval-xxx/  (repo cloned at root)
- * Multi-repo layout:    /tmp/ct-eval-xxx/backend/
- *                       /tmp/ct-eval-xxx/web/
- *                       /tmp/ct-eval-xxx/mobile/
+ * Single-repo layout:   /tmp/ft-eval-xxx/  (repo cloned at root)
+ * Multi-repo layout:    /tmp/ft-eval-xxx/backend/
+ *                       /tmp/ft-eval-xxx/web/
+ *                       /tmp/ft-eval-xxx/mobile/
  */
 
 import { execSync } from 'node:child_process';
@@ -65,7 +65,7 @@ export async function createSandbox(
   condition: EvalCondition,
   treeConfig?: ContextTreeConfig,
 ): Promise<Sandbox> {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `ct-eval-${evalCase.id}-`));
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `ft-eval-${evalCase.id}-`));
   const isMultiRepo = evalCase.repos.length > 1;
 
   try {
@@ -88,7 +88,7 @@ export async function createSandbox(
       const primaryRepo = evalCase.repos[0];
       const repoName = defaultPath(primaryRepo.repo);
       const branch = `${repoName}/${primaryRepo.commit_sha.slice(0, 8)}`;
-      const treeTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ct-eval-tree-'));
+      const treeTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-eval-tree-'));
 
       try {
         process.stderr.write(`  Cloning context tree @ ${condition.tree_sha.slice(0, 8)} (${condition.label})...\n`);

--- a/evals/helpers/types.ts
+++ b/evals/helpers/types.ts
@@ -1,5 +1,5 @@
 /**
- * Core types for the context-tree eval harness.
+ * Core types for the first-tree eval harness.
  */
 
 /** A single repo to clone into the sandbox. */

--- a/evals/scripts/aggregate-report.ts
+++ b/evals/scripts/aggregate-report.ts
@@ -4,7 +4,7 @@
  *
  * Usage:
  *   npx tsx evals/scripts/aggregate-report.ts file1.json file2.json ...
- *   npx tsx evals/scripts/aggregate-report.ts ~/.context-tree/evals/feat-eval-phase1-2026-04-03-05*.json
+ *   npx tsx evals/scripts/aggregate-report.ts ~/.first-tree/evals/feat-eval-phase1-2026-04-03-05*.json
  *
  * Outputs an HTML file to the same directory as the first input file.
  */

--- a/evals/scripts/check-env.ts
+++ b/evals/scripts/check-env.ts
@@ -111,7 +111,7 @@ function checkCase(evalCase: EvalCase): CheckResult {
   }
 
   const ref = evalCase.repos[0];
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `ct-check-${evalCase.id}-`));
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `ft-check-${evalCase.id}-`));
 
   try {
     // --- Phase 1: Before fix (commit_sha) ---

--- a/evals/scripts/create-tree.ts
+++ b/evals/scripts/create-tree.ts
@@ -3,10 +3,10 @@
  *
  * Workflow:
  * 1. Clone code repo at commit (read-only reference)
- * 2. Install context-tree CLI globally (pnpm build && npm link)
+ * 2. Install first-tree CLI globally (pnpm build && npm link)
  * 3. Clone tree repo, create orphan branch, init as git repo
  * 4. Spawn Claude Code IN the tree repo with a prompt that points
- *    to the source code path — agent runs context-tree init and
+ *    to the source code path — agent runs first-tree init and
  *    populates the full tree
  * 5. Commit and push
  *
@@ -50,16 +50,16 @@ The source code repository is cloned at: ${codeDir}
 Read the source code from that path to understand the project structure. Do NOT modify anything in that directory.
 
 ## Your working directory
-You are working in a context tree repository. This is where the context tree will live. \`context-tree\` is a CLI tool that is already installed and available on your PATH.
+You are working in a context tree repository. This is where the context tree will live. \`first-tree\` is a CLI tool that is already installed and available on your PATH.
 
 ## Step 1: Learn about context trees
-Run \`context-tree help onboarding\` to understand what a context tree is, how it is structured, and the full setup workflow.
+Run \`first-tree help onboarding\` to understand what a context tree is, how it is structured, and the full setup workflow.
 
 ## Step 2: Initialize
-Run \`context-tree init --here\` in this directory. This bootstraps the framework, creates template files, and generates a task list in skills/first-tree/progress.md.
+Run \`first-tree init --here\` in this directory. This bootstraps the framework, creates template files, and generates a task list in .agents/skills/first-tree/progress.md.
 
 ## Step 3: Complete the task list
-Read skills/first-tree/progress.md and complete every task. Check off each task as you finish it by changing \`- [ ]\` to \`- [x]\`.
+Read .agents/skills/first-tree/progress.md and complete every task. Check off each task as you finish it by changing \`- [ ]\` to \`- [x]\`.
 
 ## Step 4: Populate the full tree
 When the task list asks whether to populate the tree, choose **Yes**. Then:
@@ -75,7 +75,7 @@ When the task list asks whether to populate the tree, choose **Yes**. Then:
 ## Rules
 - Do not ask the user any questions — make reasonable decisions autonomously.
 - When the progress file asks you to use AskUserQuestion, skip that step and make a reasonable choice yourself.
-- Run \`context-tree verify\` when done to confirm the tree is valid.
+- Run \`first-tree verify\` when done to confirm the tree is valid.
 - Ensure every directory that has content gets a NODE.md.
 - All file writes go in THIS directory (the tree repo), never in the source code directory.
 `;
@@ -108,7 +108,7 @@ export async function createTree(options: CreateTreeOptions): Promise<{ branch: 
     const codeDir = cloneCodeRepo(repo, commit);
     tmpdirs.push(codeDir);
 
-    // 2. Install context-tree CLI globally via npm link
+    // 2. Install first-tree CLI globally via npm link
     const cliDir = installCliAtVersion(cliVersion);
     tmpdirs.push(cliDir);
     const cliVer = getCliVersion(cliDir);
@@ -155,7 +155,7 @@ export async function createTree(options: CreateTreeOptions): Promise<{ branch: 
     process.stderr.write(`\nDone! Tree created:\n`);
     process.stderr.write(`  Branch: ${branch}\n`);
     process.stderr.write(`  Commit: ${sha}\n`);
-    process.stderr.write(`  CLI:    context-tree v${cliVer} (${cliVersion.slice(0, 7)})\n`);
+    process.stderr.write(`  CLI:    first-tree v${cliVer} (${cliVersion.slice(0, 7)})\n`);
 
     return { branch, sha };
   } finally {

--- a/evals/scripts/eval-prompt.txt
+++ b/evals/scripts/eval-prompt.txt
@@ -16,7 +16,7 @@ For each .yaml file in evals/cases/:
 3. If a test case FAILS, inspect the verify.sh script and the error output. If the verification script has bugs (wrong paths, incorrect assertions, missing dependencies), fix the verify.sh and re-run. Do NOT modify the eval harness code — only fix verify.sh scripts.
 
 4. After all cases are done, generate an aggregate HTML report:
-   npx tsx evals/scripts/aggregate-report.ts ~/.context-tree/evals/*.json
+   npx tsx evals/scripts/aggregate-report.ts ~/.first-tree/evals/*.json
 
 Process cases in this order (smaller/faster first):
 nanobot-exectool-regex, nanobot-streaming-metadata, pydantic-importstring-error, fastapi-optional-file-list, langchain-merge-parallel-tools, autogen-serialization-data-loss, autogen-provider-namespace-restriction, llamaindex-async-postprocess, llamaindex-run-id-passthrough, vercel-ai-oauth-trailing-slash, vercel-ai-error-code

--- a/evals/scripts/run-all-docker.sh
+++ b/evals/scripts/run-all-docker.sh
@@ -5,18 +5,18 @@
 #   bash evals/scripts/run-all-docker.sh
 #
 # Prerequisites:
-#   - Docker image built: docker build -t ct-eval -f evals/Dockerfile .
+#   - Docker image built: docker build -t ft-eval -f evals/Dockerfile .
 #   - gh auth login (for GH_TOKEN)
 #   - Claude Max plan authenticated (~/.claude/.credentials.json)
 
 set -euo pipefail
 
-IMAGE="${CT_EVAL_IMAGE:-ct-eval}"
+IMAGE="${FT_EVAL_IMAGE:-${CT_EVAL_IMAGE:-ft-eval}}"
 
 # Verify prerequisites
 if ! docker image inspect "$IMAGE" &>/dev/null; then
   echo "Docker image '$IMAGE' not found. Build it first:"
-  echo "  docker build -t ct-eval -f evals/Dockerfile ."
+  echo "  docker build -t ft-eval -f evals/Dockerfile ."
   exit 1
 fi
 
@@ -40,13 +40,13 @@ if [ -z "$CLAUDE_TOKEN" ]; then
 fi
 
 # Ensure output directory exists
-mkdir -p "$HOME/.context-tree/evals"
+mkdir -p "$HOME/.first-tree/evals"
 
-LOG_FILE="$HOME/.context-tree/evals/_run-$(date +%Y%m%d-%H%M%S).log"
+LOG_FILE="$HOME/.first-tree/evals/_run-$(date +%Y%m%d-%H%M%S).log"
 
 echo "Starting eval run in Docker..."
 echo "  Image: $IMAGE"
-echo "  Results: ~/.context-tree/evals/"
+echo "  Results: ~/.first-tree/evals/"
 echo "  Log: $LOG_FILE"
 echo ""
 
@@ -57,7 +57,7 @@ CREDS_B64=$(echo "$CLAUDE_CREDS_JSON" | base64 -w0)
 # Named volume persists ~/.claude across container restarts
 # Fix ownership on first use (volume is created as root)
 docker run --rm --user root \
-  -v ct-eval-claude-config:/home/eval/.claude \
+  -v ft-eval-claude-config:/home/eval/.claude \
   --entrypoint chown \
   "$IMAGE" \
   -R eval:eval /home/eval/.claude
@@ -66,8 +66,8 @@ docker run --rm -it \
   -e CLAUDE_CODE_OAUTH_TOKEN="$CLAUDE_TOKEN" \
   -e GH_TOKEN="$(gh auth token)" \
   -e _CREDS_B64="$CREDS_B64" \
-  -v ct-eval-claude-config:/home/eval/.claude \
-  -v "$HOME/.context-tree/evals:/home/eval/.context-tree/evals" \
+  -v ft-eval-claude-config:/home/eval/.claude \
+  -v "$HOME/.first-tree/evals:/home/eval/.first-tree/evals" \
   --entrypoint sh \
   "$IMAGE" \
   -c '

--- a/evals/scripts/run-eval.ts
+++ b/evals/scripts/run-eval.ts
@@ -146,7 +146,7 @@ if (evalResult.status !== 0) {
 
 console.log('\n═══ Step 4: Generating aggregate report ═══\n');
 
-const evalDir = getEnv('EVALS_STORE_DIR', '~/.context-tree/evals')!;
+const evalDir = getEnv('EVALS_STORE_DIR', '~/.first-tree/evals')!;
 if (!fs.existsSync(evalDir)) {
   console.error(`No eval results found in ${evalDir}`);
   process.exit(1);

--- a/evals/scripts/tree-manager.ts
+++ b/evals/scripts/tree-manager.ts
@@ -73,7 +73,7 @@ export function treeBranch(repo: string, commitSha: string): string {
  */
 export function treeCommitMessage(provenance: TreeProvenance): string {
   return [
-    `Generate tree with context-tree CLI @ ${provenance.cliCommit.slice(0, 7)}`,
+    `Generate tree with first-tree CLI @ ${provenance.cliCommit.slice(0, 7)}`,
     '',
     `repo: ${provenance.codeRepo}`,
     `code_commit: ${provenance.codeCommit}`,
@@ -146,7 +146,7 @@ export function preflight(treeRepo: string, codeRepo: string, codeSha: string): 
  * Returns the tmpdir path. Uses the repo cache to avoid redundant network clones.
  */
 export function cloneTreeRepo(treeRepo: string, branch?: string): string {
-  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ct-tree-repo-'));
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-tree-repo-'));
 
   if (branch) {
     try {
@@ -158,7 +158,7 @@ export function cloneTreeRepo(treeRepo: string, branch?: string): string {
     }
   }
 
-  const tmp2 = fs.mkdtempSync(path.join(os.tmpdir(), 'ct-tree-repo-'));
+  const tmp2 = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-tree-repo-'));
   cloneFromCache(treeRepo, tmp2);
   return tmp2;
 }
@@ -168,7 +168,7 @@ export function cloneTreeRepo(treeRepo: string, branch?: string): string {
  * Uses the repo cache to avoid redundant network clones.
  */
 export function cloneCodeRepo(codeRepo: string, commitSha: string): string {
-  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ct-code-repo-'));
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-code-repo-'));
 
   process.stderr.write(`Cloning ${codeRepo} @ ${commitSha.slice(0, 8)} (cached)...\n`);
   cloneFromCache(codeRepo, tmp, { commitSha });
@@ -176,15 +176,15 @@ export function cloneCodeRepo(codeRepo: string, commitSha: string): string {
 }
 
 /**
- * Install the context-tree CLI from a specific first-tree commit.
+ * Install the first-tree CLI from a specific first-tree commit.
  * Clones the first-tree repo at that commit, runs pnpm build && npm link
- * to make `context-tree` available globally.
+ * to make `first-tree` available globally.
  * Returns the path to the cloned first-tree directory.
  */
 export function installCliAtVersion(cliCommit: string): string {
-  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ct-cli-'));
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-cli-'));
 
-  process.stderr.write(`Installing context-tree CLI @ ${cliCommit.slice(0, 7)}...\n`);
+  process.stderr.write(`Installing first-tree CLI @ ${cliCommit.slice(0, 7)}...\n`);
   cloneFromCache(FIRST_TREE_SLUG, tmp, { commitSha: cliCommit });
 
   process.stderr.write('  Installing dependencies...\n');
@@ -204,7 +204,7 @@ export function installCliAtVersion(cliCommit: string): string {
 
   // Read CLI version from package.json
   const pkg = JSON.parse(fs.readFileSync(path.join(tmp, 'package.json'), 'utf-8'));
-  process.stderr.write(`  Installed context-tree v${pkg.version} (globally linked)\n`);
+  process.stderr.write(`  Installed first-tree v${pkg.version} (globally linked)\n`);
 
   return tmp;
 }
@@ -218,7 +218,7 @@ export function getCliVersion(cliDir: string): string {
 }
 
 /**
- * Prepare a tree repo directory so `context-tree init` can run in it.
+ * Prepare a tree repo directory so `first-tree init` can run in it.
  * After createOrphanBranch, the dir is a git repo but may have no commits.
  * We create an initial empty commit so git operations work normally.
  */
@@ -226,7 +226,7 @@ export function initBareTreeDir(treeDir: string): void {
   execSync('git commit --allow-empty -m "init"', {
     cwd: treeDir,
     stdio: 'pipe',
-    env: { ...process.env, GIT_AUTHOR_NAME: 'context-tree-eval', GIT_AUTHOR_EMAIL: 'eval@context-tree', GIT_COMMITTER_NAME: 'context-tree-eval', GIT_COMMITTER_EMAIL: 'eval@context-tree' },
+    env: { ...process.env, GIT_AUTHOR_NAME: 'first-tree-eval', GIT_AUTHOR_EMAIL: 'eval@first-tree', GIT_COMMITTER_NAME: 'first-tree-eval', GIT_COMMITTER_EMAIL: 'eval@first-tree' },
   });
 }
 
@@ -248,7 +248,7 @@ export function commitTree(treeDir: string, provenance: TreeProvenance): string 
   execSync(`git commit -m ${JSON.stringify(message)}`, {
     cwd: treeDir,
     stdio: 'pipe',
-    env: { ...process.env, GIT_AUTHOR_NAME: 'context-tree-eval', GIT_AUTHOR_EMAIL: 'eval@context-tree', GIT_COMMITTER_NAME: 'context-tree-eval', GIT_COMMITTER_EMAIL: 'eval@context-tree' },
+    env: { ...process.env, GIT_AUTHOR_NAME: 'first-tree-eval', GIT_AUTHOR_EMAIL: 'eval@first-tree', GIT_COMMITTER_NAME: 'first-tree-eval', GIT_COMMITTER_EMAIL: 'eval@first-tree' },
   });
 
   const sha = execSync('git rev-parse HEAD', { cwd: treeDir, encoding: 'utf-8' }).trim();
@@ -327,7 +327,7 @@ export function listBranchCommits(
   treeRepo: string,
   branch: string,
 ): Array<{ sha: string; message: string }> {
-  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ct-list-'));
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-list-'));
   try {
     cloneFromCache(treeRepo, tmp, { branch });
 

--- a/evals/scripts/update-tree.ts
+++ b/evals/scripts/update-tree.ts
@@ -40,16 +40,16 @@ The source code repository is cloned at: ${codeDir}
 Read the source code from that path to understand the project structure. Do NOT modify anything in that directory.
 
 ## Your working directory
-You are working in a context tree repository. This is where the context tree will live. \`context-tree\` is a CLI tool that is already installed and available on your PATH.
+You are working in a context tree repository. This is where the context tree will live. \`first-tree\` is a CLI tool that is already installed and available on your PATH.
 
 ## Step 1: Learn about context trees
-Run \`context-tree help onboarding\` to understand what a context tree is, how it is structured, and the full setup workflow.
+Run \`first-tree help onboarding\` to understand what a context tree is, how it is structured, and the full setup workflow.
 
 ## Step 2: Initialize
-Run \`context-tree init --here\` in this directory. This bootstraps the framework, creates template files, and generates a task list in skills/first-tree/progress.md.
+Run \`first-tree init --here\` in this directory. This bootstraps the framework, creates template files, and generates a task list in .agents/skills/first-tree/progress.md.
 
 ## Step 3: Complete the task list
-Read skills/first-tree/progress.md and complete every task. Check off each task as you finish it by changing \`- [ ]\` to \`- [x]\`.
+Read .agents/skills/first-tree/progress.md and complete every task. Check off each task as you finish it by changing \`- [ ]\` to \`- [x]\`.
 
 ## Step 4: Populate the full tree
 When the task list asks whether to populate the tree, choose **Yes**. Then:
@@ -65,7 +65,7 @@ When the task list asks whether to populate the tree, choose **Yes**. Then:
 ## Rules
 - Do not ask the user any questions — make reasonable decisions autonomously.
 - When the progress file asks you to use AskUserQuestion, skip that step and make a reasonable choice yourself.
-- Run \`context-tree verify\` when done to confirm the tree is valid.
+- Run \`first-tree verify\` when done to confirm the tree is valid.
 - Ensure every directory that has content gets a NODE.md.
 - All file writes go in THIS directory (the tree repo), never in the source code directory.
 `;
@@ -98,7 +98,7 @@ export async function updateTree(options: UpdateTreeOptions): Promise<{ branch: 
     const codeDir = cloneCodeRepo(repo, commit);
     tmpdirs.push(codeDir);
 
-    // 2. Install context-tree CLI globally via npm link
+    // 2. Install first-tree CLI globally via npm link
     const cliDir = installCliAtVersion(cliVersion);
     tmpdirs.push(cliDir);
     const cliVer = getCliVersion(cliDir);
@@ -149,7 +149,7 @@ export async function updateTree(options: UpdateTreeOptions): Promise<{ branch: 
     process.stderr.write(`\nDone! Tree updated:\n`);
     process.stderr.write(`  Branch: ${branch}\n`);
     process.stderr.write(`  Commit: ${sha}\n`);
-    process.stderr.write(`  CLI:    context-tree v${cliVer} (${cliVersion.slice(0, 7)})\n`);
+    process.stderr.write(`  CLI:    first-tree v${cliVer} (${cliVersion.slice(0, 7)})\n`);
 
     return { branch, sha };
   } finally {

--- a/evals/tests/tree-manager.test.ts
+++ b/evals/tests/tree-manager.test.ts
@@ -53,7 +53,7 @@ describe('treeCommitMessage', () => {
 
   it('starts with summary line', () => {
     const msg = treeCommitMessage(provenance);
-    expect(msg.split('\n')[0]).toBe('Generate tree with context-tree CLI @ abc123d');
+    expect(msg.split('\n')[0]).toBe('Generate tree with first-tree CLI @ abc123d');
   });
 
   it('includes all provenance fields', () => {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "url": "git+https://github.com/agent-team-foundation/first-tree.git"
   },
   "keywords": [
+    "first-tree",
     "context-tree",
     "cli",
     "agents",
@@ -19,7 +20,7 @@
   ],
   "type": "module",
   "bin": {
-    "context-tree": "./dist/cli.js"
+    "first-tree": "./dist/cli.js"
   },
   "imports": {
     "#skill/*": "./skills/first-tree/*",

--- a/skills/first-tree/SKILL.md
+++ b/skills/first-tree/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: first-tree
-description: Maintain the canonical `first-tree` skill and the thin `context-tree` CLI distributed by the `first-tree` npm package. Use when modifying `context-tree` commands (`init`, `publish`, `verify`, `upgrade`, `help onboarding`), the installed skill payload under `assets/framework/`, maintainer references, or the build, packaging, test, and CI wiring that supports the framework.
+description: Maintain the canonical `first-tree` skill and CLI distributed by the `first-tree` npm package. Use when modifying `first-tree` commands (`init`, `publish`, `verify`, `upgrade`, `help onboarding`), the installed skill payload under `assets/framework/`, maintainer references, or the build, packaging, test, and CI wiring that supports the framework.
 ---
 
 # First Tree
 
 Use this skill when the task depends on the exact behavior of the
-`context-tree` CLI or the installed `.agents/skills/first-tree/` and
-`.claude/skills/first-tree/` payloads that `context-tree init` ships to user
+`first-tree` CLI or the installed `.agents/skills/first-tree/` and
+`.claude/skills/first-tree/` payloads that `first-tree init` ships to user
 repos.
 
 ## Source Of Truth
@@ -18,7 +18,7 @@ repos.
   repos.
 - `engine/` holds the canonical framework and CLI behavior.
 - `scripts/` holds maintenance helpers for validating and running the skill.
-- In maintainer docs, use `context-tree` for the CLI, `skills/first-tree/` for
+- In maintainer docs, use `first-tree` for the CLI, `skills/first-tree/` for
   the bundled source path, and `.agents/skills/first-tree/` /
   `.claude/skills/first-tree/` for installed user-repo paths.
 
@@ -67,34 +67,34 @@ repos.
   the current repo keeps only the installed skill plus a
   `FIRST-TREE-SOURCE-INTEGRATION:` line in `AGENTS.md` and `CLAUDE.md`. Do not
   create `NODE.md`, `members/`, or tree-scoped `AGENTS.md` there.
-- `context-tree init` defaults to creating or reusing a sibling dedicated tree
+- `first-tree init` defaults to creating or reusing a sibling dedicated tree
   repo when invoked from a source/workspace repo. It installs the bundled skill
   into the source/workspace repo and scaffolds tree files only in the
   dedicated tree repo. Use `--here` to initialize the current repo in place
   when you are already inside the tree repo.
-- `context-tree publish --open-pr` is the default second-stage command after
+- `first-tree publish --open-pr` is the default second-stage command after
   `init` for source/workspace installs. Run it from the dedicated tree repo
   once the initial tree version is ready to push.
-- Never run `context-tree init --here` in a source/workspace repo unless the
+- Never run `first-tree init --here` in a source/workspace repo unless the
   user explicitly wants that repo itself to become the dedicated Context Tree.
   `--here` is for when you have already switched into the `*-context` repo.
-- `context-tree init` installs this skill into the target tree repo and
+- `first-tree init` installs this skill into the target tree repo and
   scaffolds `.agents/skills/first-tree/`, `.claude/skills/first-tree/`,
   `NODE.md`, `AGENTS.md`, and `members/NODE.md`.
-- The default source/workspace workflow is: run `context-tree init` from the
+- The default source/workspace workflow is: run `first-tree init` from the
   source repo, draft the first tree version in `<repo>-context`, then run
-  `context-tree publish --open-pr` from that dedicated tree repo.
-- After `context-tree publish` succeeds, treat the source/workspace repo's
+  `first-tree publish --open-pr` from that dedicated tree repo.
+- After `first-tree publish` succeeds, treat the source/workspace repo's
   submodule checkout as the canonical local working copy for the tree. The
   temporary sibling bootstrap checkout can be deleted when you no longer need
   it.
-- If the dedicated tree repo was initialized manually with `context-tree init --here`
+- If the dedicated tree repo was initialized manually with `first-tree init --here`
   and does not have bootstrap metadata yet, pass `--source-repo PATH` to
-  `context-tree publish`.
+  `first-tree publish`.
 - If permissions, auth, or local filesystem constraints block the dedicated
   repo workflow, stop and report the blocker. Do not fall back to in-place tree
   bootstrap in the source/workspace repo.
-- `context-tree upgrade` refreshes the installed skill from the copy bundled
+- `first-tree upgrade` refreshes the installed skill from the copy bundled
   with the currently running `first-tree` package. In a source/workspace repo
   it refreshes only the local skill plus the
   `FIRST-TREE-SOURCE-INTEGRATION:` line; upgrade the dedicated tree repo
@@ -114,8 +114,8 @@ repos.
 - Keep decision knowledge in the tree and execution detail in source systems.
 - Keep the skill as the only canonical knowledge source. The root CLI/package
   shell must not become a second source of framework semantics.
-- Keep the CLI name written as `context-tree` in maintainer and user-facing
-  docs so it is not confused with the `first-tree` package that ships it.
+- Keep the CLI name written as `first-tree` in maintainer and user-facing
+  docs so command examples stay aligned with the published package.
 - Keep normal `init` / `upgrade` flows self-contained. They must work from the
   skill bundled in the current package without cloning the source repo or
   relying on network access.

--- a/skills/first-tree/agents/openai.yaml
+++ b/skills/first-tree/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "First Tree"
-  short_description: "Maintain the First Tree skill and thin Context Tree CLI"
-  default_prompt: "Use $first-tree to maintain the canonical first-tree skill, its thin context-tree CLI, or its build, packaging, test, eval, and CI wiring. When a source/workspace repo installs first-tree, read references/source-workspace-installation.md first, keep that repo limited to local skill integration plus the FIRST-TREE-SOURCE-INTEGRATION marker lines, and keep all NODE.md/tree content only in a dedicated sibling *-context repo. Never choose context-tree init --here in the source/workspace repo unless the user explicitly wants that repo itself to become the tree."
+  short_description: "Maintain the First Tree skill and thin first-tree CLI"
+  default_prompt: "Use $first-tree to maintain the canonical first-tree skill, its thin first-tree CLI, or its build, packaging, test, eval, and CI wiring. When a source/workspace repo installs first-tree, read references/source-workspace-installation.md first, keep that repo limited to local skill integration plus the FIRST-TREE-SOURCE-INTEGRATION marker lines, and keep all NODE.md/tree content only in a dedicated sibling *-context repo. Never choose first-tree init --here in the source/workspace repo unless the user explicitly wants that repo itself to become the tree."

--- a/skills/first-tree/assets/framework/workflows/validate.yml
+++ b/skills/first-tree/assets/framework/workflows/validate.yml
@@ -16,4 +16,4 @@ jobs:
           node-version: "22"
 
       - name: Validate tree
-        run: npx -p first-tree context-tree verify
+        run: npx -p first-tree first-tree verify

--- a/skills/first-tree/engine/commands/help.ts
+++ b/skills/first-tree/engine/commands/help.ts
@@ -1,4 +1,4 @@
-const HELP_USAGE = `usage: context-tree help <topic>
+const HELP_USAGE = `usage: first-tree help <topic>
 
 Topics:
   onboarding   How to set up a context tree from scratch

--- a/skills/first-tree/engine/init.ts
+++ b/skills/first-tree/engine/init.ts
@@ -36,9 +36,9 @@ import { upsertSourceIntegrationFiles } from "#skill/engine/runtime/source-integ
  * all generated task text at once.
  */
 export const INTERACTIVE_TOOL = "AskUserQuestion";
-export const INIT_USAGE = `usage: context-tree init [--here] [--tree-name NAME] [--tree-path PATH]
+export const INIT_USAGE = `usage: first-tree init [--here] [--tree-name NAME] [--tree-path PATH]
 
-By default, running \`context-tree init\` inside a source or workspace repo installs
+By default, running \`first-tree init\` inside a source or workspace repo installs
 the first-tree skill in the current repo, updates \`AGENTS.md\` and \`CLAUDE.md\`
 with a \`${SOURCE_INTEGRATION_MARKER}\` line, and creates a sibling dedicated tree
 repo named \`<repo>-context\`.
@@ -123,7 +123,7 @@ export function formatTaskList(
       );
       lines.push("## Source Workspace Workflow");
       lines.push(
-        `- [ ] When this initial tree version is ready, run \`context-tree publish --open-pr\` from this dedicated tree repo. It will create or reuse the GitHub \`*-context\` repo, add it back to \`${context.sourceRepoName}\` as a git submodule, and open the source/workspace PR.`,
+        `- [ ] When this initial tree version is ready, run \`first-tree publish --open-pr\` from this dedicated tree repo. It will create or reuse the GitHub \`*-context\` repo, add it back to \`${context.sourceRepoName}\` as a git submodule, and open the source/workspace PR.`,
       );
       lines.push(
         `- [ ] After publish succeeds, treat the source/workspace repo's \`${context.sourceRepoName}\` submodule checkout as the canonical local working copy for this tree. The temporary sibling bootstrap repo can be deleted when you no longer need it.`,
@@ -156,14 +156,14 @@ export function formatTaskList(
   }
   lines.push("## Verification");
   lines.push(
-    "After completing the tasks above, run `context-tree verify` to confirm:",
+    "After completing the tasks above, run `first-tree verify` to confirm:",
   );
   lines.push(`- [ ] \`${FRAMEWORK_VERSION}\` exists`);
   lines.push("- [ ] Root NODE.md has valid frontmatter (title, owners)");
   lines.push(
     `- [ ] \`${AGENT_INSTRUCTIONS_FILE}\` is the only agent instructions file and has framework markers`,
   );
-  lines.push("- [ ] `context-tree verify` passes with no errors");
+  lines.push("- [ ] `first-tree verify` passes with no errors");
   lines.push("- [ ] At least one member node exists");
   lines.push("");
   lines.push("---");
@@ -171,7 +171,7 @@ export function formatTaskList(
   lines.push(
     "**Important:** As you complete each task, check it off in" +
       ` \`${INSTALLED_PROGRESS}\` by changing \`- [ ]\` to \`- [x]\`.` +
-      " Run `context-tree verify` when done — it will fail if any" +
+      " Run `first-tree verify` when done — it will fail if any" +
       " items remain unchecked.",
   );
   lines.push("");
@@ -205,9 +205,9 @@ export function runInit(repo?: Repo, options?: InitOptions): number {
   const r = initTarget.repo;
   if (options?.here && sourceRepo.isLikelySourceRepo() && !sourceRepo.looksLikeTreeRepo()) {
     console.log(
-      "Warning: `context-tree init --here` is initializing this source/workspace" +
+      "Warning: `first-tree init --here` is initializing this source/workspace" +
         " repo in place. This will create `NODE.md`, `members/`, and tree-scoped" +
-        ` ${AGENT_INSTRUCTIONS_FILE} here. Use plain \`context-tree init\` to create` +
+        ` ${AGENT_INSTRUCTIONS_FILE} here. Use plain \`first-tree init\` to create` +
         " a sibling dedicated tree repo instead.",
     );
     console.log();
@@ -415,7 +415,7 @@ function resolveInitTarget(
     return {
       ok: false,
       message:
-        "not a git repository. Run this from your source/workspace repo, or create a dedicated tree repo first:\n  git init\n  context-tree init --here",
+        "not a git repository. Run this from your source/workspace repo, or create a dedicated tree repo first:\n  git init\n  first-tree init --here",
     };
   }
 

--- a/skills/first-tree/engine/publish.ts
+++ b/skills/first-tree/engine/publish.ts
@@ -10,9 +10,9 @@ import {
   SKILL_ROOT,
 } from "#skill/engine/runtime/asset-loader.js";
 
-export const PUBLISH_USAGE = `usage: context-tree publish [--open-pr] [--tree-path PATH] [--source-repo PATH] [--submodule-path PATH] [--source-remote NAME]
+export const PUBLISH_USAGE = `usage: first-tree publish [--open-pr] [--tree-path PATH] [--source-repo PATH] [--submodule-path PATH] [--source-remote NAME]
 
-Run this from the dedicated tree repo after \`context-tree init\`. The command
+Run this from the dedicated tree repo after \`first-tree init\`. The command
 creates or reuses the GitHub \`*-context\` repo, pushes the current tree
 commit, adds that repo back to the source/workspace repo as a git submodule,
 and prepares the source-repo branch.
@@ -609,14 +609,14 @@ export function runPublish(repo?: Repo, options?: PublishOptions): number {
 
   if (treeRepo.hasSourceWorkspaceIntegration() && !treeRepo.looksLikeTreeRepo()) {
     console.error(
-      `Error: this repo only has the first-tree source/workspace integration installed. Run \`context-tree publish --tree-path ../${treeRepo.repoName()}-context\` or switch into the dedicated tree repo first.`,
+      `Error: this repo only has the first-tree source/workspace integration installed. Run \`first-tree publish --tree-path ../${treeRepo.repoName()}-context\` or switch into the dedicated tree repo first.`,
     );
     return 1;
   }
 
   if (!treeRepo.hasFramework() || !treeRepo.looksLikeTreeRepo()) {
     console.error(
-      "Error: `context-tree publish` must run from a dedicated tree repo (or use `--tree-path` to point at one). Run `context-tree init` first.",
+      "Error: `first-tree publish` must run from a dedicated tree repo (or use `--tree-path` to point at one). Run `first-tree init` first.",
     );
     return 1;
   }
@@ -624,7 +624,7 @@ export function runPublish(repo?: Repo, options?: PublishOptions): number {
   const sourceRepoRoot = resolveSourceRepoRoot(treeRepo, options);
   if (sourceRepoRoot === null) {
     console.error(
-      "Error: could not determine the source/workspace repo for this tree. Re-run `context-tree init` from the source repo first, or pass `--source-repo PATH`.",
+      "Error: could not determine the source/workspace repo for this tree. Re-run `first-tree init` from the source repo first, or pass `--source-repo PATH`.",
     );
     return 1;
   }
@@ -639,14 +639,14 @@ export function runPublish(repo?: Repo, options?: PublishOptions): number {
 
   if (sourceRepo.root === treeRepo.root) {
     console.error(
-      "Error: the source/workspace repo and dedicated tree repo resolved to the same path. `context-tree publish` expects two separate repos.",
+      "Error: the source/workspace repo and dedicated tree repo resolved to the same path. `first-tree publish` expects two separate repos.",
     );
     return 1;
   }
 
   if (!sourceRepo.hasCurrentInstalledSkill() || !sourceRepo.hasSourceWorkspaceIntegration()) {
     console.error(
-      "Error: the source/workspace repo does not have the first-tree source integration installed. Run `context-tree init` from the source/workspace repo first.",
+      "Error: the source/workspace repo does not have the first-tree source integration installed. Run `first-tree init` from the source/workspace repo first.",
     );
     return 1;
   }

--- a/skills/first-tree/engine/rules/framework.ts
+++ b/skills/first-tree/engine/rules/framework.ts
@@ -6,7 +6,7 @@ export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
   if (!repo.hasFramework()) {
     tasks.push(
-      `${installedSkillRootsDisplay()} not found — run \`context-tree init\` to install the framework skill bundled with the current \`first-tree\` package`,
+      `${installedSkillRootsDisplay()} not found — run \`first-tree init\` to install the framework skill bundled with the current \`first-tree\` package`,
     );
   }
   return { group: "Framework", order: 1, tasks };

--- a/skills/first-tree/engine/rules/populate-tree.ts
+++ b/skills/first-tree/engine/rules/populate-tree.ts
@@ -28,7 +28,7 @@ export function evaluate(repo: Repo): RuleResult {
 
   tasks.push(
     "After all domains are populated, update the root NODE.md to list every top-level domain with a one-line " +
-      "description. Ensure all NODE.md files pass `context-tree verify` — valid frontmatter, no placeholders, " +
+      "description. Ensure all NODE.md files pass `first-tree verify` — valid frontmatter, no placeholders, " +
       "and soft_links that resolve correctly.",
   );
 

--- a/skills/first-tree/engine/upgrade.ts
+++ b/skills/first-tree/engine/upgrade.ts
@@ -28,7 +28,7 @@ import {
   readSourceVersion,
 } from "#skill/engine/runtime/upgrader.js";
 
-export const UPGRADE_USAGE = `usage: context-tree upgrade [--tree-path PATH]
+export const UPGRADE_USAGE = `usage: first-tree upgrade [--tree-path PATH]
 
 Options:
   --tree-path PATH   Upgrade a tree repo from another working directory
@@ -54,6 +54,7 @@ function formatUpgradeTaskList(
     `- [ ] Re-copy any workflow updates you want from \`${FRAMEWORK_WORKFLOWS_DIR}/\` into \`.github/workflows/\``,
     `- [ ] Re-check any local agent setup that references \`${CLAUDE_SKILL_ROOT}/assets/framework/examples/\` or \`${CLAUDE_SKILL_ROOT}/assets/framework/helpers/\``,
     `- [ ] Re-check any repo scripts or workflow files that reference \`${SKILL_ROOT}/assets/framework/\``,
+    "- [ ] Replace any stale `context-tree` CLI command references in repo-specific docs, scripts, workflows, or agent config with `first-tree`",
     "",
   ];
 
@@ -97,13 +98,13 @@ function formatUpgradeTaskList(
   lines.push(
     "## Verification",
     `- [ ] \`${FRAMEWORK_VERSION}\` reads \`${packagedVersion}\``,
-    "- [ ] `context-tree verify` passes",
+    "- [ ] `first-tree verify` passes",
     "",
     "---",
     "",
     "**Important:** As you complete each task, check it off in" +
       ` \`${INSTALLED_PROGRESS}\` by changing \`- [ ]\` to \`- [x]\`.` +
-      " Run `context-tree verify` when done — it will fail if any" +
+      " Run `first-tree verify` when done — it will fail if any" +
       " items remain unchecked.",
     "",
   );
@@ -122,14 +123,14 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
 
   if (workingRepo.isLikelySourceRepo() && !workingRepo.looksLikeTreeRepo() && !workspaceOnlyIntegration) {
     console.error(
-      "Error: no installed framework skill found here. This looks like a source/workspace repo. Run `context-tree init` to create a dedicated tree repo, or pass `--tree-path` to upgrade an existing tree repo.",
+      "Error: no installed framework skill found here. This looks like a source/workspace repo. Run `first-tree init` to create a dedicated tree repo, or pass `--tree-path` to upgrade an existing tree repo.",
     );
     return 1;
   }
 
   if (!workingRepo.hasFramework()) {
     console.error(
-      "Error: no installed framework skill found. Run `context-tree init` first.",
+      "Error: no installed framework skill found. Run `first-tree init` first.",
     );
     return 1;
   }
@@ -137,7 +138,7 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
   const layout = workingRepo.frameworkLayout();
   if (layout === null) {
     console.error(
-      "Error: no installed framework skill found. Run `context-tree init` first.",
+      "Error: no installed framework skill found. Run `first-tree init` first.",
     );
     return 1;
   }
@@ -170,7 +171,7 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
     compareFrameworkVersions(localVersion, packagedVersion) > 0
   ) {
     console.log(
-      "The installed framework is newer than the skill bundled with this `first-tree` package. Install a newer package version before running `context-tree upgrade`.",
+      "The installed framework is newer than the skill bundled with this `first-tree` package. Install a newer package version before running `first-tree upgrade`.",
     );
     return 1;
   }
@@ -196,7 +197,7 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
           `Already up to date with the bundled skill (${FRAMEWORK_VERSION} = ${localVersion}).`,
         );
         console.log(
-          `This repo only carries source/workspace integration. Upgrade the dedicated tree repo separately with \`context-tree upgrade --tree-path ${sourceRepoTreePathHint}\`.`,
+          `This repo only carries source/workspace integration. Upgrade the dedicated tree repo separately with \`first-tree upgrade --tree-path ${sourceRepoTreePathHint}\`.`,
         );
         return 0;
       }
@@ -207,7 +208,7 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
         `Updated the ${SOURCE_INTEGRATION_MARKER} marker lines in ${changedFiles.map((file) => `\`${file}\``).join(" and ")}.`,
       );
       console.log(
-        `This repo only carries source/workspace integration. Upgrade the dedicated tree repo separately with \`context-tree upgrade --tree-path ${sourceRepoTreePathHint}\`.`,
+        `This repo only carries source/workspace integration. Upgrade the dedicated tree repo separately with \`first-tree upgrade --tree-path ${sourceRepoTreePathHint}\`.`,
       );
       return 0;
     }
@@ -233,7 +234,7 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
       );
     }
     console.log(
-      `This repo is not the Context Tree. Upgrade the dedicated tree repo separately with \`context-tree upgrade --tree-path ${sourceRepoTreePathHint}\`.`,
+      `This repo is not the Context Tree. Upgrade the dedicated tree repo separately with \`first-tree upgrade --tree-path ${sourceRepoTreePathHint}\`.`,
     );
     return 0;
   }

--- a/skills/first-tree/engine/verify.ts
+++ b/skills/first-tree/engine/verify.ts
@@ -8,7 +8,7 @@ import { runValidateMembers } from "#skill/engine/validators/members.js";
 import { runValidateNodes } from "#skill/engine/validators/nodes.js";
 
 const UNCHECKED_RE = /^- \[ \] (.+)$/gm;
-export const VERIFY_USAGE = `usage: context-tree verify [--tree-path PATH]
+export const VERIFY_USAGE = `usage: first-tree verify [--tree-path PATH]
 
 Options:
   --tree-path PATH   Verify a tree repo from another working directory
@@ -52,14 +52,14 @@ export function runVerify(repo?: Repo, nodeValidator?: NodeValidator): number {
 
   if (r.hasSourceWorkspaceIntegration() && !r.looksLikeTreeRepo()) {
     console.error(
-      `Error: this repo only has the first-tree source/workspace integration installed. Verify the dedicated tree repo instead, for example \`context-tree verify --tree-path ../${r.repoName()}-context\`.`,
+      `Error: this repo only has the first-tree source/workspace integration installed. Verify the dedicated tree repo instead, for example \`first-tree verify --tree-path ../${r.repoName()}-context\`.`,
     );
     return 1;
   }
 
   if (r.isLikelySourceRepo() && !r.looksLikeTreeRepo()) {
     console.error(
-      "Error: no installed framework skill found here. This looks like a source/workspace repo. Run `context-tree init` to create a dedicated tree repo, or pass `--tree-path` to verify an existing tree repo.",
+      "Error: no installed framework skill found here. This looks like a source/workspace repo. Run `first-tree init` to create a dedicated tree repo, or pass `--tree-path` to verify an existing tree repo.",
     );
     return 1;
   }

--- a/skills/first-tree/references/about.md
+++ b/skills/first-tree/references/about.md
@@ -5,7 +5,7 @@ owners: []
 
 # About Context Tree
 
-**context-tree.ai** — The living source of truth for your organization.
+**first-tree** — The living source of truth for your organization.
 
 ---
 

--- a/skills/first-tree/references/maintainer-architecture.md
+++ b/skills/first-tree/references/maintainer-architecture.md
@@ -5,7 +5,7 @@ This reference explains how to maintain the `first-tree` source repo itself.
 ## What This Repo Ships
 
 - One canonical skill: `skills/first-tree/`
-- One thin CLI package: the `context-tree` command distributed by the `first-tree`
+- One thin CLI package: the `first-tree` command distributed by the `first-tree`
   npm package
 - The published package carries that canonical skill directly; normal install
   and upgrade flows should not depend on cloning this source repo

--- a/skills/first-tree/references/maintainer-build-and-distribution.md
+++ b/skills/first-tree/references/maintainer-build-and-distribution.md
@@ -48,12 +48,12 @@ another skill reference, not only in the files themselves.
   package unless it becomes part of the user-facing framework contract.
 - If the CLI needs bundled knowledge or payload files, ship the canonical skill
   with the package rather than copying that information into root docs.
-- Normal `context-tree init` / `context-tree upgrade` flows must install from
+- Normal `first-tree init` / `first-tree upgrade` flows must install from
   the skill bundled in the running package, not by cloning the source repo.
 - Default dedicated-tree-repo creation must stay local-only. It may create a
   sibling git repo on disk, but it must not require remote repo creation or
   source-repo cloning.
-- `context-tree publish` is the explicit networked second-stage command for
+- `first-tree publish` is the explicit networked second-stage command for
   GitHub repo creation, submodule add-back, and optional source-repo PR
   opening. Keep that remote behavior there instead of expanding default `init`.
 - If you change anything that gets copied into user repos, bump

--- a/skills/first-tree/references/onboarding.md
+++ b/skills/first-tree/references/onboarding.md
@@ -55,18 +55,17 @@ Information an agent needs to **decide** on an approach — not to execute it.
 
 - A source/workspace Git repository, or an already-created dedicated tree repo
 - Node.js 18+
-- GitHub CLI (`gh`) if you want `context-tree publish` to create the remote
+- GitHub CLI (`gh`) if you want `first-tree publish` to create the remote
   `*-context` repo and open the source-repo PR for you
-- The npm package is `first-tree`, the installed CLI command is
-  `context-tree`.
-- `context-tree init` installs the framework skill into
+- The npm package and installed CLI command are both `first-tree`.
+- `first-tree init` installs the framework skill into
   `.agents/skills/first-tree/` and `.claude/skills/first-tree/`.
 - Use `npx first-tree init` for one-off runs, or `npm install -g first-tree`
-  to add the `context-tree` command to your PATH
+  to add the `first-tree` command to your PATH
 
 ### Step 1: Initialize
 
-Recommended workflow: run `context-tree init` from your source or workspace repo.
+Recommended workflow: run `first-tree init` from your source or workspace repo.
 The CLI will install the bundled skill in the current repo, update root
 `AGENTS.md` and `CLAUDE.md` with a `FIRST-TREE-SOURCE-INTEGRATION:` line, and
 create a sibling dedicated tree repo named `<repo>-context` by default. Tree
@@ -74,9 +73,9 @@ files are scaffolded only in the dedicated tree repo.
 
 ```bash
 cd my-org
-context-tree init
+first-tree init
 cd ../my-org-context
-context-tree publish --open-pr
+first-tree publish --open-pr
 ```
 
 If you already created a dedicated tree repo manually, initialize it in place:
@@ -84,7 +83,7 @@ If you already created a dedicated tree repo manually, initialize it in place:
 ```bash
 mkdir my-org-context && cd my-org-context
 git init
-context-tree init --here
+first-tree init --here
 ```
 
 Only use `--here` after you have already switched into the dedicated tree repo.
@@ -103,7 +102,7 @@ dedicated `*-context` repo.
 Default agent workflow after initialization:
 
 1. Draft the initial tree version in the dedicated `*-context` repo.
-2. Run `context-tree publish --open-pr` from that dedicated tree repo. It will
+2. Run `first-tree publish --open-pr` from that dedicated tree repo. It will
    create or reuse the GitHub `*-context` repo in the same owner/org as the
    source repo, add it back to the source/workspace repo as a `git submodule`,
    and open the source-repo PR.
@@ -131,20 +130,20 @@ As you complete each task, check it off in
 ### Step 3: Verify
 
 ```bash
-context-tree verify
+first-tree verify
 ```
 
 Or, from your source/workspace repo:
 
 ```bash
-context-tree verify --tree-path ../my-org-context
+first-tree verify --tree-path ../my-org-context
 ```
 
 This fails if any items in `.agents/skills/first-tree/progress.md` remain
 unchecked, and runs deterministic checks (valid frontmatter, node structure,
 member nodes exist).
 
-Do not run `context-tree verify` in the source/workspace repo itself. That repo
+Do not run `first-tree verify` in the source/workspace repo itself. That repo
 only carries the installed skill plus the
 `FIRST-TREE-SOURCE-INTEGRATION:` line.
 
@@ -183,11 +182,11 @@ The tree doesn't duplicate source code — it captures what connects things and 
 
 | Command | Description |
 |---------|-------------|
-| `context-tree init` | Install local source/workspace integration and create or refresh a dedicated tree repo. By default, running in a source/workspace repo creates a sibling `<repo>-context`; use `--here` only when you are already inside the dedicated tree repo. |
-| `context-tree publish` | Publish a dedicated tree repo to GitHub, add it back to the source/workspace repo as a submodule, and optionally open the source-repo PR. |
-| `context-tree verify` | Check the installed progress file for unchecked items + run deterministic validation. Use `--tree-path` when invoking from another working directory. |
-| `context-tree upgrade` | Refresh the installed framework skill from the currently running `first-tree` npm package and generate follow-up tasks. Use `--tree-path` when invoking from another working directory. |
-| `context-tree help onboarding` | Print this onboarding guide. |
+| `first-tree init` | Install local source/workspace integration and create or refresh a dedicated tree repo. By default, running in a source/workspace repo creates a sibling `<repo>-context`; use `--here` only when you are already inside the dedicated tree repo. |
+| `first-tree publish` | Publish a dedicated tree repo to GitHub, add it back to the source/workspace repo as a submodule, and optionally open the source-repo PR. |
+| `first-tree verify` | Check the installed progress file for unchecked items + run deterministic validation. Use `--tree-path` when invoking from another working directory. |
+| `first-tree upgrade` | Refresh the installed framework skill from the currently running `first-tree` npm package and generate follow-up tasks. Use `--tree-path` when invoking from another working directory. |
+| `first-tree help onboarding` | Print this onboarding guide. |
 
 ---
 
@@ -196,25 +195,25 @@ The tree doesn't duplicate source code — it captures what connects things and 
 When the framework updates:
 
 ```bash
-context-tree upgrade
+first-tree upgrade
 ```
 
-`context-tree upgrade` refreshes `.agents/skills/first-tree/` and
+`first-tree upgrade` refreshes `.agents/skills/first-tree/` and
 `.claude/skills/first-tree/` from the skill bundled with the currently running
 `first-tree` npm package, preserves your tree content, and generates follow-up
 tasks in `.agents/skills/first-tree/progress.md`.
 
-If you run `context-tree upgrade` in the source/workspace repo, it refreshes
+If you run `first-tree upgrade` in the source/workspace repo, it refreshes
 only the local installed skill plus the `FIRST-TREE-SOURCE-INTEGRATION:` lines.
-Run `context-tree upgrade --tree-path ../my-org-context` to upgrade the
+Run `first-tree upgrade --tree-path ../my-org-context` to upgrade the
 dedicated tree repo itself.
 
 If your repo still uses the older `skills/first-tree/` or `.context-tree/` layouts,
-`context-tree upgrade` will migrate it to the current installed layout first.
+`first-tree upgrade` will migrate it to the current installed layout first.
 
 To pick up a newer framework release, first run a newer package version, for
 example `npx first-tree@latest upgrade`, or update your global `first-tree`
-install before running `context-tree upgrade`.
+install before running `first-tree upgrade`.
 
 ---
 

--- a/skills/first-tree/references/source-workspace-installation.md
+++ b/skills/first-tree/references/source-workspace-installation.md
@@ -26,7 +26,7 @@ existing source or workspace repository.
 - Treat "install and use first-tree" in a source/workspace repo as a two-repo
   workflow: local integration in the current repo plus tree bootstrap in a
   sibling `*-context` repo.
-- Do not run `context-tree init --here` in the source/workspace repo unless the
+- Do not run `first-tree init --here` in the source/workspace repo unless the
   user explicitly says that repo itself should become the Context Tree.
 - If you cannot create the sibling repo locally, cannot push it to GitHub, or
   cannot add the submodule yet, pause and report the blocker. Do not fall back
@@ -38,11 +38,11 @@ existing source or workspace repository.
 When an agent is asked to install first-tree for a source/workspace repo, the
 default workflow is:
 
-1. Run `context-tree init` from the current source/workspace repo.
+1. Run `first-tree init` from the current source/workspace repo.
 2. Switch into the sibling dedicated tree repo named `<repo>-context`.
 3. Draft the first tree version from the real codebase, docs, and ownership
    signals.
-4. Run `context-tree publish --open-pr` from the dedicated tree repo. It will:
+4. Run `first-tree publish --open-pr` from the dedicated tree repo. It will:
    create or reuse the GitHub `*-context` repo in the same owner/org as the
    source repo, push the tree, add it back to the source/workspace repo as a
    `git submodule`, and open the source-repo PR.
@@ -50,15 +50,15 @@ default workflow is:
    canonical local working copy for the tree. The temporary sibling bootstrap
    checkout can be deleted when you no longer need it.
 
-If the dedicated tree repo was initialized manually with `context-tree init --here`
+If the dedicated tree repo was initialized manually with `first-tree init --here`
 and publish cannot infer the source repo, pass `--source-repo PATH`.
 
 ## Verification And Upgrade
 
-- Do not run `context-tree verify` in the source/workspace repo. Verify the
+- Do not run `first-tree verify` in the source/workspace repo. Verify the
   dedicated tree repo instead, for example
-  `context-tree verify --tree-path ../my-repo-context`.
-- Running `context-tree upgrade` in the source/workspace repo refreshes only
+  `first-tree verify --tree-path ../my-repo-context`.
+- Running `first-tree upgrade` in the source/workspace repo refreshes only
   the local installed skill plus the `FIRST-TREE-SOURCE-INTEGRATION:` lines.
-- Run `context-tree upgrade --tree-path ../my-repo-context` to upgrade the
+- Run `first-tree upgrade --tree-path ../my-repo-context` to upgrade the
   dedicated tree repo itself.

--- a/skills/first-tree/references/upgrade-contract.md
+++ b/skills/first-tree/references/upgrade-contract.md
@@ -59,7 +59,7 @@ For a dedicated tree repo, the tree content still lives outside the skill:
 - `NODE.md`
 - `AGENTS.md`
 - `members/`
-- `.agents/skills/first-tree/bootstrap.json` when `context-tree init` was run
+- `.agents/skills/first-tree/bootstrap.json` when `first-tree init` was run
   from a separate source/workspace repo and the publish workflow needs to
   remember that source repo path
 
@@ -70,7 +70,7 @@ skill discovery and hooks.
 
 ## Command Intent
 
-- `context-tree init`
+- `first-tree init`
   - when run in a source/workspace repo, creates or reuses a sibling dedicated
     tree repo by default
   - installs the skill into the source/workspace repo without creating tree
@@ -81,12 +81,12 @@ skill discovery and hooks.
   - renders top-level tree scaffolding only in the target tree repo
   - writes progress state only to the dedicated tree repo at
     `.agents/skills/first-tree/progress.md`
-- `context-tree verify`
+- `first-tree verify`
   - checks progress state from the installed skill
   - validates root/frontmatter/agent markers
   - runs node and member validators
   - must reject source/workspace repos that carry only local integration
-- `context-tree publish`
+- `first-tree publish`
   - is the explicit second-stage command for publishing a dedicated tree repo
     to GitHub after local bootstrap
   - reads dedicated-tree bootstrap metadata from
@@ -94,7 +94,7 @@ skill discovery and hooks.
   - may create or reuse the GitHub `*-context` repo, push tree commits, add it
     back to the source/workspace repo as a git submodule, and optionally open
     the source-repo PR
-- `context-tree upgrade`
+- `first-tree upgrade`
   - compares the installed skill payload version to the skill bundled with the
     currently running `first-tree` package
   - refreshes the installed skill payload without overwriting tree content
@@ -107,21 +107,21 @@ skill discovery and hooks.
 
 ## Compatibility Rules For Legacy Trees
 
-- `context-tree init` never creates a new `.context-tree/`.
-- `context-tree init --here` preserves the explicit in-place bootstrap path for
+- `first-tree init` never creates a new `.context-tree/`.
+- `first-tree init --here` preserves the explicit in-place bootstrap path for
   already-created tree repos.
 - Default dedicated-tree-repo creation is local-only. The CLI may create a new
   sibling git repo on disk, but it must not clone the source repo or depend on
   network access.
 - Source/workspace repos must never receive `NODE.md`, `members/`, or
   tree-scoped `AGENTS.md` from default init flows.
-- Normal `context-tree init` and `context-tree upgrade` flows do not clone the
+- Normal `first-tree init` and `first-tree upgrade` flows do not clone the
   source repo or require network access.
-- `context-tree verify` may still read a legacy
+- `first-tree verify` may still read a legacy
   `.claude/skills/first-tree/...`, `skills/first-tree/...`, or
   `.context-tree/...` layout in an existing user repo so the repo can be
   repaired or upgraded in place.
-- `context-tree upgrade` must migrate either legacy layout onto
+- `first-tree upgrade` must migrate either legacy layout onto
   `.agents/skills/first-tree/` and `.claude/skills/first-tree/`, and remove
   old skill directories afterward.
 - When both current and legacy layouts are present, prefer the

--- a/skills/first-tree/scripts/check-skill-sync.sh
+++ b/skills/first-tree/scripts/check-skill-sync.sh
@@ -105,7 +105,7 @@ if [[ -e "$SOURCE_DIR/evals" ]]; then
   exit 1
 fi
 
-require_file "$REPO_ROOT/evals/context-tree-eval.test.ts"
+require_file "$REPO_ROOT/evals/first-tree-eval.test.ts"
 require_file "$REPO_ROOT/evals/README.md"
 require_file "$REPO_ROOT/evals/helpers/case-loader.ts"
 require_file "$REPO_ROOT/evals/scripts/tree-manager.ts"

--- a/skills/first-tree/scripts/run-local-cli.sh
+++ b/skills/first-tree/scripts/run-local-cli.sh
@@ -25,11 +25,11 @@ if [[ -n "${REPO_ROOT}" ]]; then
   exec node dist/cli.js "$@"
 fi
 
-if command -v context-tree >/dev/null 2>&1; then
-  exec context-tree "$@"
+if command -v first-tree >/dev/null 2>&1; then
+  exec first-tree "$@"
 fi
 
-echo "Could not find a live first-tree checkout or a 'context-tree' binary on PATH." >&2
+echo "Could not find a live first-tree checkout or a 'first-tree' binary on PATH." >&2
 echo "Install the npm package 'first-tree' if you want the portable runner to invoke the CLI outside the repo." >&2
 echo "Read the onboarding guide at: ${INSTALL_GUIDE}" >&2
 exit 1

--- a/skills/first-tree/tests/init.test.ts
+++ b/skills/first-tree/tests/init.test.ts
@@ -73,7 +73,7 @@ describe("formatTaskList", () => {
     const groups = [{ group: "G", order: 1, tasks: ["t"] }];
     const output = formatTaskList(groups);
     expect(output).toContain("## Verification");
-    expect(output).toContain("context-tree verify");
+    expect(output).toContain("first-tree verify");
   });
 
   it("handles empty groups", () => {
@@ -89,7 +89,7 @@ describe("formatTaskList", () => {
       sourceRepoPath: "../ADHD",
     });
 
-    expect(output).toContain("context-tree publish --open-pr");
+    expect(output).toContain("first-tree publish --open-pr");
     expect(output).toContain("canonical local working copy");
   });
 });

--- a/skills/first-tree/tests/publish.test.ts
+++ b/skills/first-tree/tests/publish.test.ts
@@ -146,7 +146,7 @@ function createRunner(
 
 describe("parsePublishArgs", () => {
   it("documents the publish command", () => {
-    expect(PUBLISH_USAGE).toContain("context-tree publish");
+    expect(PUBLISH_USAGE).toContain("first-tree publish");
     expect(PUBLISH_USAGE).toContain("--open-pr");
     expect(PUBLISH_USAGE).toContain("--source-repo PATH");
   });

--- a/skills/first-tree/tests/skill-artifacts.test.ts
+++ b/skills/first-tree/tests/skill-artifacts.test.ts
@@ -39,7 +39,7 @@ describe("skill artifacts", () => {
     );
     expect(
       existsSync(
-        join(ROOT, "evals", "context-tree-eval.test.ts"),
+        join(ROOT, "evals", "first-tree-eval.test.ts"),
       ),
     ).toBe(true);
     expect(
@@ -219,7 +219,7 @@ describe("skill artifacts", () => {
 
     expect(read("README.md")).not.toContain("seed-tree");
     expect(read("AGENTS.md")).not.toContain("seed-tree");
-    expect(read("README.md")).toContain("Package Name vs Command");
+    expect(read("README.md")).toContain("Package And Command");
     expect(read("README.md")).toContain("Canonical Documentation");
     expect(read("README.md")).toContain("references/source-map.md");
     expect(read("README.md")).toContain("source-workspace-installation.md");
@@ -230,7 +230,7 @@ describe("skill artifacts", () => {
     expect(read("README.md")).toContain("dedicated tree repo");
     expect(read("README.md")).toContain("FIRST-TREE-SOURCE-INTEGRATION:");
     expect(read("README.md")).toContain("`first-tree` skill");
-    expect(read("README.md")).toContain("context-tree publish --open-pr");
+    expect(read("README.md")).toContain("first-tree publish --open-pr");
     expect(read("README.md")).toContain("canonical local working copy");
     expect(read("README.md")).toContain("Only use `--here` after you have already switched into the dedicated tree repo.");
     expect(read("AGENTS.md")).toContain("references/source-map.md");
@@ -244,14 +244,14 @@ describe("skill artifacts", () => {
     const onboarding = read("skills/first-tree/references/onboarding.md");
     expect(onboarding).toContain("npx first-tree init");
     expect(onboarding).toContain("npm install -g first-tree");
-    expect(onboarding).toContain("context-tree init --here");
-    expect(onboarding).toContain("installed CLI command is");
+    expect(onboarding).toContain("first-tree init --here");
+    expect(onboarding).toContain("installed CLI command are both `first-tree`");
     expect(onboarding).toContain("currently running `first-tree` npm package");
     expect(onboarding).toContain("npx first-tree@latest upgrade");
     expect(onboarding).toContain(".agents/skills/first-tree/");
     expect(onboarding).toContain(".claude/skills/first-tree/");
     expect(onboarding).toContain("FIRST-TREE-SOURCE-INTEGRATION:");
-    expect(onboarding).toContain("context-tree publish --open-pr");
+    expect(onboarding).toContain("first-tree publish --open-pr");
     expect(onboarding).toContain("source/workspace repo");
     expect(onboarding).toContain("git submodule");
     expect(onboarding).toContain("Only use `--here` after you have already switched into the dedicated tree repo.");
@@ -264,13 +264,13 @@ describe("skill artifacts", () => {
     expect(skillMd).toContain("maintainer-build-and-distribution.md");
     expect(skillMd).toContain("maintainer-testing.md");
     expect(skillMd).toContain("currently running `first-tree` package");
-    expect(skillMd).toContain("so it is not confused with the `first-tree`");
+    expect(skillMd).toContain("command examples stay aligned with the published package");
     expect(skillMd).toContain(".agents/skills/first-tree/");
     expect(skillMd).toContain(".claude/skills/first-tree/");
     expect(skillMd).toContain("source-workspace-installation.md");
     expect(skillMd).toContain("FIRST-TREE-SOURCE-INTEGRATION:");
-    expect(skillMd).toContain("context-tree publish --open-pr");
-    expect(skillMd).toContain("Never run `context-tree init --here` in a source/workspace repo");
+    expect(skillMd).toContain("first-tree publish --open-pr");
+    expect(skillMd).toContain("Never run `first-tree init --here` in a source/workspace repo");
     expect(skillMd).not.toContain("canonical eval harness");
 
     const sourceMap = read("skills/first-tree/references/source-map.md");
@@ -287,7 +287,7 @@ describe("skill artifacts", () => {
     expect(sourceMap).toContain("engine/runtime/asset-loader.ts");
     expect(sourceMap).toContain("tests/init.test.ts");
     expect(sourceMap).toContain("tests/thin-cli.test.ts");
-    expect(sourceMap).not.toContain("evals/context-tree-eval.test.ts");
+    expect(sourceMap).not.toContain("evals/first-tree-eval.test.ts");
     expect(sourceMap).toContain("package.json");
     expect(sourceMap).not.toContain("vitest.eval.config.ts");
     expect(sourceMap).toContain(".github/workflows/ci.yml");
@@ -297,9 +297,9 @@ describe("skill artifacts", () => {
     );
     expect(sourceWorkspaceInstall).toContain("FIRST-TREE-SOURCE-INTEGRATION:");
     expect(sourceWorkspaceInstall).toContain("git submodule");
-    expect(sourceWorkspaceInstall).toContain("context-tree publish --open-pr");
-    expect(sourceWorkspaceInstall).toContain("Do not run `context-tree verify`");
-    expect(sourceWorkspaceInstall).toContain("Do not run `context-tree init --here` in the source/workspace repo");
+    expect(sourceWorkspaceInstall).toContain("first-tree publish --open-pr");
+    expect(sourceWorkspaceInstall).toContain("Do not run `first-tree verify`");
+    expect(sourceWorkspaceInstall).toContain("Do not run `first-tree init --here` in the source/workspace repo");
 
     const maintainerArchitecture = read(
       "skills/first-tree/references/maintainer-architecture.md",
@@ -311,7 +311,7 @@ describe("skill artifacts", () => {
     const buildAndDistribution = read(
       "skills/first-tree/references/maintainer-build-and-distribution.md",
     );
-    expect(buildAndDistribution).toContain("context-tree publish");
+    expect(buildAndDistribution).toContain("first-tree publish");
   });
 
   it("keeps public OSS entrypoints and package metadata in place", () => {
@@ -323,7 +323,7 @@ describe("skill artifacts", () => {
       keywords?: string[];
     };
 
-    expect(read("README.md")).toContain("Package Name vs Command");
+    expect(read("README.md")).toContain("Package And Command");
     expect(read("README.md")).toContain("CONTRIBUTING.md");
     expect(read("README.md")).toContain("CODE_OF_CONDUCT.md");
     expect(read("README.md")).toContain("SECURITY.md");
@@ -365,7 +365,7 @@ describe("skill artifacts", () => {
       url: "git+https://github.com/agent-team-foundation/first-tree.git",
     });
     expect(pkg.keywords).toEqual(
-      expect.arrayContaining(["context-tree", "cli", "agents"]),
+      expect.arrayContaining(["first-tree", "cli", "agents"]),
     );
   });
 });

--- a/skills/first-tree/tests/thin-cli.test.ts
+++ b/skills/first-tree/tests/thin-cli.test.ts
@@ -40,15 +40,15 @@ afterEach(() => {
 
 describe("thin CLI shell", () => {
   it("documents the dedicated-repo meaning of --here", () => {
-    expect(USAGE).toContain("git init && context-tree init --here");
-    expect(USAGE).toContain("context-tree publish --open-pr");
+    expect(USAGE).toContain("git init && first-tree init --here");
+    expect(USAGE).toContain("first-tree publish --open-pr");
     expect(USAGE).toContain("`--here` is for when the current repo is already the dedicated tree repo.");
   });
 
   it("treats a symlinked npm bin path as direct execution", () => {
     const dir = makeTempDir();
     const target = join(dir, "cli.js");
-    const symlinkPath = join(dir, "context-tree");
+    const symlinkPath = join(dir, "first-tree");
 
     writeFileSync(target, "#!/usr/bin/env node\n");
     symlinkSync(target, symlinkPath);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,9 +3,9 @@
 import { realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-const USAGE = `usage: context-tree <command>
+const USAGE = `usage: first-tree <command>
 
-  New to context-tree? Run \`context-tree help onboarding\` first.
+  New to first-tree? Run \`first-tree help onboarding\` first.
 
 Commands:
   init      Install source/workspace integration and create or refresh a dedicated context tree repo
@@ -19,11 +19,11 @@ Options:
   --version    Show version number
 
 Common examples:
-  context-tree init
-  context-tree publish --open-pr
-  mkdir my-org-context && cd my-org-context && git init && context-tree init --here
-  context-tree verify --tree-path ../my-org-context
-  context-tree upgrade --tree-path ../my-org-context
+  first-tree init
+  first-tree publish --open-pr
+  mkdir my-org-context && cd my-org-context && git init && first-tree init --here
+  first-tree verify --tree-path ../my-org-context
+  first-tree upgrade --tree-path ../my-org-context
 
 Note:
   \`--here\` is for when the current repo is already the dedicated tree repo.

--- a/vitest.eval.config.ts
+++ b/vitest.eval.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['evals/context-tree-eval.test.ts'],
+    include: ['evals/first-tree-eval.test.ts'],
     testTimeout: 720_000,    // 12 min per test (10 min agent + setup/verify overhead)
     hookTimeout: 30_000,
     pool: 'forks',           // Process isolation for subprocess spawning


### PR DESCRIPTION
## Summary
- rename the published CLI command and all primary help/usage surfaces from `context-tree` to `first-tree`
- refresh README, maintainer docs, skill references, workflows, and eval harness text so command examples consistently use `first-tree`
- update tests, eval entrypoint naming, and maintainer scratch paths while keeping legacy `.context-tree/` upgrade compatibility notes intact

## Validation
- `pnpm validate:skill`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm pack --pack-destination <tmp>`