### PR TITLE
fix: unify CLI version with framework VERSION file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - run: pnpm version:check
+
       - run: pnpm validate:skill
 
       - run: pnpm typecheck

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-tree",
-  "version": "0.1.0",
+  "version": "0.2.4",
   "description": "CLI tools for Context Tree — the living source of truth for your organization.",
   "homepage": "https://github.com/agent-team-foundation/first-tree#readme",
   "bugs": {
@@ -30,6 +30,8 @@
     "skills/first-tree"
   ],
   "scripts": {
+    "version:sync": "node scripts/sync-version.js",
+    "prebuild": "node scripts/sync-version.js",
     "build": "tsdown",
     "prepack": "pnpm build",
     "test": "vitest run",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   ],
   "scripts": {
     "version:sync": "node scripts/sync-version.js",
+    "version:check": "node scripts/sync-version.js --check",
     "prebuild": "node scripts/sync-version.js",
     "build": "tsdown",
     "prepack": "pnpm build",

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+/**
+ * Sync the version from skills/first-tree/assets/framework/VERSION into package.json.
+ * Run automatically via the prepack script so npm always sees the canonical version.
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const versionFile = join(root, "skills/first-tree/assets/framework/VERSION");
+const pkgFile = join(root, "package.json");
+
+const version = readFileSync(versionFile, "utf-8").trim();
+const pkg = JSON.parse(readFileSync(pkgFile, "utf-8"));
+
+if (pkg.version !== version) {
+  pkg.version = version;
+  writeFileSync(pkgFile, JSON.stringify(pkg, null, 2) + "\n");
+  console.log(`package.json version synced to ${version}`);
+} else {
+  console.log(`package.json version already ${version}`);
+}

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -1,11 +1,16 @@
 #!/usr/bin/env node
 /**
  * Sync the version from skills/first-tree/assets/framework/VERSION into package.json.
- * Run automatically via the prepack script so npm always sees the canonical version.
+ *
+ * Usage:
+ *   node scripts/sync-version.js          # write package.json if out of sync
+ *   node scripts/sync-version.js --check  # exit 1 if out of sync (CI mode)
  */
 import { readFileSync, writeFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+
+const check = process.argv.includes("--check");
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const versionFile = join(root, "skills/first-tree/assets/framework/VERSION");
@@ -14,10 +19,15 @@ const pkgFile = join(root, "package.json");
 const version = readFileSync(versionFile, "utf-8").trim();
 const pkg = JSON.parse(readFileSync(pkgFile, "utf-8"));
 
-if (pkg.version !== version) {
+if (pkg.version === version) {
+  console.log(`package.json version already ${version}`);
+} else if (check) {
+  console.error(
+    `Version mismatch: package.json has ${pkg.version}, VERSION has ${version}. Run \`pnpm version:sync\` to fix.`,
+  );
+  process.exit(1);
+} else {
   pkg.version = version;
   writeFileSync(pkgFile, JSON.stringify(pkg, null, 2) + "\n");
   console.log(`package.json version synced to ${version}`);
-} else {
-  console.log(`package.json version already ${version}`);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 
 const USAGE = `usage: first-tree <command>
 
+  This CLI is designed for agents, not humans. Let your agent handle it.
   New to first-tree? Run \`first-tree help onboarding\` first.
 
 Commands:
@@ -62,10 +63,9 @@ export async function runCli(
   }
 
   if (args[0] === "--version" || args[0] === "-v") {
-    const { createRequire } = await import("node:module");
-    const require = createRequire(import.meta.url);
-    const pkg = require("../package.json") as { version: string };
-    write(pkg.version);
+    const { resolveBundledPackageRoot, readCanonicalFrameworkVersion } =
+      await import("#skill/engine/runtime/installer.js");
+    write(readCanonicalFrameworkVersion(resolveBundledPackageRoot()));
     return 0;
   }
 


### PR DESCRIPTION
## Summary
- Make `skills/first-tree/assets/framework/VERSION` the single source of truth for the version
- CLI `--version` now reads from the VERSION file instead of `package.json`
- Added `scripts/sync-version.js` that runs on `prebuild` to keep `package.json` in sync
- Added agent-first note to CLI help output

## Test plan
- [x] `first-tree --version` returns `0.2.4` (matches VERSION file)
- [x] `pnpm build` auto-syncs `package.json` version
- [x] All 274 tests pass
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)