### PR TITLE
fix: link first-tree entrypoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENT.md
+AGENTS.md

--- a/FIRST_TREE.md
+++ b/FIRST_TREE.md
@@ -1,0 +1,1 @@
+skills/first-tree/references/about.md

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ Do not use it inside the source/workspace repo unless you intentionally want
 that repo itself to become the Context Tree.
 
 - `first-tree init` installs `.agents/skills/first-tree/` and
-  `.claude/skills/first-tree/` plus `FIRST_TREE.md` in the current
+  `.claude/skills/first-tree/` plus a `FIRST_TREE.md` symlink to
+  `.agents/skills/first-tree/references/about.md` in the current
   source/workspace repo, appends a managed
   `FIRST-TREE-SOURCE-INTEGRATION:` section to root `AGENTS.md` and `CLAUDE.md`,
   then creates `NODE.md`, tree-scoped `AGENTS.md`, tree-scoped `CLAUDE.md`,
@@ -91,7 +92,7 @@ that repo itself to become the Context Tree.
   are complete.
 - `first-tree upgrade` refreshes the installed skill from the currently
   running `first-tree` npm package. In a source/workspace repo it refreshes
-  only the local installed skill, `FIRST_TREE.md`, plus the
+  only the local installed skill, the `FIRST_TREE.md` symlink, plus the
   `FIRST-TREE-SOURCE-INTEGRATION:` section; use `--tree-path` to upgrade the
   dedicated tree repo's `.first-tree/` metadata. To force the newest published
   package for a one-off upgrade, run `npx first-tree@latest upgrade`.

--- a/skills/first-tree/SKILL.md
+++ b/skills/first-tree/SKILL.md
@@ -70,9 +70,10 @@ repos.
   tree-scoped `AGENTS.md` / `CLAUDE.md` there.
 - `first-tree init` defaults to creating or reusing a sibling dedicated tree
   repo when invoked from a source/workspace repo. It installs the bundled skill
-  into the source/workspace repo, writes `FIRST_TREE.md` there, and scaffolds
-  tree files only in the dedicated tree repo. Use `--here` to initialize the
-  current repo in place when you are already inside the tree repo.
+  into the source/workspace repo, links `FIRST_TREE.md` to
+  `.agents/skills/first-tree/references/about.md` there, and scaffolds tree
+  files only in the dedicated tree repo. Use `--here` to initialize the current
+  repo in place when you are already inside the tree repo.
 - `first-tree publish --open-pr` is the default second-stage command after
   `init` for source/workspace installs. Run it from the dedicated tree repo
   once the initial tree version is ready to push.
@@ -118,7 +119,7 @@ repos.
   bootstrap in the source/workspace repo.
 - `first-tree upgrade` refreshes the installed skill from the copy bundled
   with the currently running `first-tree` package. In a source/workspace repo
-  it refreshes only the local skill, `FIRST_TREE.md`, plus the
+  it refreshes only the local skill, the `FIRST_TREE.md` symlink, plus the
   `FIRST-TREE-SOURCE-INTEGRATION:` section; upgrade the dedicated tree repo
   separately with `--tree-path`. Dedicated tree repos refresh only
   `.first-tree/`. To pick up a newer framework, run a newer package version

--- a/skills/first-tree/engine/init.ts
+++ b/skills/first-tree/engine/init.ts
@@ -59,7 +59,8 @@ export const INTERACTIVE_TOOL = "AskUserQuestion";
 export const INIT_USAGE = `usage: first-tree init [--here] [--seed-members contributors] [--tree-name NAME] [--tree-path PATH]
 
 By default, running \`first-tree init\` inside a source or workspace repo installs
-the first-tree skill in the current repo, writes \`FIRST_TREE.md\`, updates
+the first-tree skill in the current repo, links \`FIRST_TREE.md\` to the local
+\`about.md\` reference, updates
 \`AGENTS.md\` and \`CLAUDE.md\` with a managed \`${SOURCE_INTEGRATION_MARKER}\`
 section, and creates a sibling dedicated tree repo named \`<repo>-tree\`.
 Existing sibling \`*-context\` repos and existing local tree checkouts are
@@ -323,10 +324,7 @@ export function runInit(repo?: Repo, options?: InitOptions): number {
         );
         installSkill(resolvedSourceRoot, sourceRepo.root);
       }
-      const firstTreeIndex = upsertFirstTreeIndexFile(
-        sourceRepo.root,
-        initTarget.treeRepoName,
-      );
+      const firstTreeIndex = upsertFirstTreeIndexFile(sourceRepo.root);
       const updates = upsertSourceIntegrationFiles(
         sourceRepo.root,
         initTarget.treeRepoName,

--- a/skills/first-tree/engine/publish.ts
+++ b/skills/first-tree/engine/publish.ts
@@ -552,7 +552,7 @@ function buildPrBody(
     `Connect the published \`${treeRepoName}\` Context Tree back into this source/workspace repo.`,
     "",
     `- add \`${submodulePath}\` as the tracked Context Tree submodule`,
-    "- keep the local first-tree skill, FIRST_TREE.md entrypoint, and source integration marker lines in this repo",
+    "- keep the local first-tree skill, the FIRST_TREE.md symlink, and source integration marker lines in this repo",
     `- use \`${treeSlug}\` as the GitHub home for tree content`,
   ].join("\n");
 }

--- a/skills/first-tree/engine/runtime/source-integration.ts
+++ b/skills/first-tree/engine/runtime/source-integration.ts
@@ -1,4 +1,12 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import {
   FIRST_TREE_INDEX_FILE,
@@ -12,7 +20,10 @@ import {
 export type SourceIntegrationFile = (typeof SOURCE_INTEGRATION_FILES)[number];
 const FIRST_TREE_INDEX_BEGIN = "<!-- BEGIN FIRST-TREE INDEX -->";
 const FIRST_TREE_INDEX_END = "<!-- END FIRST-TREE INDEX -->";
-const REFERENCE_ROOT = SKILL_REFERENCES_DIR.replaceAll("\\", "/");
+export const FIRST_TREE_INDEX_SYMLINK_TARGET = join(
+  SKILL_REFERENCES_DIR,
+  "about.md",
+);
 
 export interface SourceIntegrationUpdate {
   action: "created" | "updated" | "unchanged";
@@ -65,30 +76,35 @@ export function hasSourceIntegrationMarker(text: string | null): boolean {
 
 export function upsertFirstTreeIndexFile(
   root: string,
-  treeRepoName?: string,
 ): FirstTreeIndexUpdate {
   const fullPath = join(root, FIRST_TREE_INDEX_FILE);
-  const exists = existsSync(fullPath);
-  const nextText = buildFirstTreeIndexFile(treeRepoName);
-  const current = exists ? readFileSync(fullPath, "utf-8") : null;
+  const existingType = detectFirstTreeIndexEntry(fullPath);
 
-  if (current === nextText) {
-    return { action: "unchanged", file: FIRST_TREE_INDEX_FILE };
+  if (existingType === "symlink") {
+    if (readlinkSync(fullPath) === FIRST_TREE_INDEX_SYMLINK_TARGET) {
+      return { action: "unchanged", file: FIRST_TREE_INDEX_FILE };
+    }
+    rmSync(fullPath, { force: true });
+    symlinkSync(FIRST_TREE_INDEX_SYMLINK_TARGET, fullPath);
+    return { action: "updated", file: FIRST_TREE_INDEX_FILE };
   }
 
-  if (
-    current !== null
-    && !current.includes(FIRST_TREE_INDEX_BEGIN)
-    && !current.includes(FIRST_TREE_INDEX_END)
-  ) {
+  if (existingType === "file") {
+    const current = readFileSync(fullPath, "utf-8");
+    if (!isManagedFirstTreeIndexFile(current)) {
+      return { action: "skipped", file: FIRST_TREE_INDEX_FILE };
+    }
+    rmSync(fullPath, { force: true });
+    symlinkSync(FIRST_TREE_INDEX_SYMLINK_TARGET, fullPath);
+    return { action: "updated", file: FIRST_TREE_INDEX_FILE };
+  }
+
+  if (existingType === "other") {
     return { action: "skipped", file: FIRST_TREE_INDEX_FILE };
   }
 
-  writeFileSync(fullPath, nextText);
-  return {
-    action: exists ? "updated" : "created",
-    file: FIRST_TREE_INDEX_FILE,
-  };
+  symlinkSync(FIRST_TREE_INDEX_SYMLINK_TARGET, fullPath);
+  return { action: "created", file: FIRST_TREE_INDEX_FILE };
 }
 
 export function upsertSourceIntegrationFiles(
@@ -168,31 +184,23 @@ function detectExistingSubmodulePath(text: string): string | null {
   return match?.[1] ?? null;
 }
 
-function buildFirstTreeIndexFile(treeRepoName?: string): string {
-  const lines = [
-    "# First Tree",
-    "",
-    FIRST_TREE_INDEX_BEGIN,
-    "Use this file as the local entrypoint for the installed `first-tree` workspace integration.",
-    "",
-    `- [About Context Tree](${REFERENCE_ROOT}/about.md)`,
-    `- [Onboarding](${REFERENCE_ROOT}/onboarding.md)`,
-    `- [Source/Workspace Installation Contract](${REFERENCE_ROOT}/source-workspace-installation.md)`,
-    "",
-  ];
-
-  if (treeRepoName) {
-    lines.push(
-      `The dedicated Context Tree for this workspace lives in the sibling \`${treeRepoName}\` repo/submodule. Keep durable decisions, rationale, and ownership there.`,
-      "",
-    );
+function detectFirstTreeIndexEntry(
+  fullPath: string,
+): "missing" | "file" | "symlink" | "other" {
+  try {
+    const stat = lstatSync(fullPath);
+    if (stat.isSymbolicLink()) {
+      return "symlink";
+    }
+    if (stat.isFile()) {
+      return "file";
+    }
+    return "other";
+  } catch {
+    return "missing";
   }
+}
 
-  lines.push(
-    "This file is managed by `first-tree init` and `first-tree upgrade`.",
-    FIRST_TREE_INDEX_END,
-    "",
-  );
-
-  return lines.join("\n");
+function isManagedFirstTreeIndexFile(text: string): boolean {
+  return text.includes(FIRST_TREE_INDEX_BEGIN) && text.includes(FIRST_TREE_INDEX_END);
 }

--- a/skills/first-tree/engine/upgrade.ts
+++ b/skills/first-tree/engine/upgrade.ts
@@ -212,10 +212,7 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
   );
 
   if (workspaceOnlyIntegration) {
-    const firstTreeIndex = upsertFirstTreeIndexFile(
-      workingRepo.root,
-      treeRepoName,
-    );
+    const firstTreeIndex = upsertFirstTreeIndexFile(workingRepo.root);
     if (
       layout === "skill" &&
       missingInstalledRoots.length === 0 &&

--- a/skills/first-tree/references/onboarding.md
+++ b/skills/first-tree/references/onboarding.md
@@ -67,8 +67,9 @@ Information an agent needs to **decide** on an approach — not to execute it.
 ### Step 1: Initialize
 
 Recommended workflow: run `first-tree init` from your source or workspace repo.
-The CLI will install the bundled skill in the current repo, update root
-`FIRST_TREE.md`, `AGENTS.md`, and `CLAUDE.md` with a managed
+The CLI will install the bundled skill in the current repo, create a root
+`FIRST_TREE.md` symlink to `.agents/skills/first-tree/references/about.md`,
+update `AGENTS.md` and `CLAUDE.md` with a managed
 `FIRST-TREE-SOURCE-INTEGRATION:` section, and create a sibling dedicated tree
 repo named `<repo>-tree` by default. If a sibling or bound `<repo>-context`
 already exists, `init` reuses it instead of renaming it. Tree files are
@@ -101,11 +102,11 @@ Do not use it inside the source/workspace repo unless you intentionally want
 that repo itself to become the Context Tree.
 
 From a source/workspace repo, `init` installs `.agents/skills/first-tree/`,
-`.claude/skills/first-tree/`, and `FIRST_TREE.md` only in that source repo.
-The dedicated tree repo keeps its local metadata under `.first-tree/`, renders
-scaffolding (`NODE.md`, `AGENTS.md`, `CLAUDE.md`, `members/NODE.md`), and
-generates a task list in `.first-tree/progress.md`. When
-`--seed-members contributors` is set, init also attempts to create
+`.claude/skills/first-tree/`, and the `FIRST_TREE.md` symlink only in that
+source repo. The dedicated tree repo keeps its local metadata under
+`.first-tree/`, renders scaffolding (`NODE.md`, `AGENTS.md`, `CLAUDE.md`,
+`members/NODE.md`), and generates a task list in `.first-tree/progress.md`.
+When `--seed-members contributors` is set, init also attempts to create
 `members/*/NODE.md` from GitHub contributor data and falls back to local git
 history if GitHub metadata is unavailable.
 
@@ -203,7 +204,7 @@ unchecked, and runs deterministic checks (valid frontmatter, node structure,
 member nodes exist).
 
 Do not run `first-tree verify` in the source/workspace repo itself. That repo
-only carries the installed skill, `FIRST_TREE.md`, plus the
+only carries the installed skill, the `FIRST_TREE.md` symlink, plus the
 `FIRST-TREE-SOURCE-INTEGRATION:` section.
 
 ### Step 4: Design Your Domains
@@ -262,7 +263,7 @@ the currently running `first-tree` npm package, preserves your tree content,
 and generates follow-up tasks.
 
 If you run `first-tree upgrade` in the source/workspace repo, it refreshes
-only the local installed skill, `FIRST_TREE.md`, plus the
+only the local installed skill, the `FIRST_TREE.md` symlink, plus the
 `FIRST-TREE-SOURCE-INTEGRATION:` section.
 Run `first-tree upgrade --tree-path ../my-org-tree` to upgrade the
 dedicated tree repo itself. If your source/workspace repo is already bound to

--- a/skills/first-tree/references/source-workspace-installation.md
+++ b/skills/first-tree/references/source-workspace-installation.md
@@ -13,8 +13,9 @@ existing source or workspace repository.
 - The current source/workspace repo is **not** the Context Tree.
 - The current source/workspace repo should carry only the installed
   `.agents/skills/first-tree/` and `.claude/skills/first-tree/` skill roots
-  plus `FIRST_TREE.md` and a managed `FIRST-TREE-SOURCE-INTEGRATION:` section
-  in root `AGENTS.md` and `CLAUDE.md`.
+  plus a `FIRST_TREE.md` symlink to
+  `.agents/skills/first-tree/references/about.md` and a managed
+  `FIRST-TREE-SOURCE-INTEGRATION:` section in root `AGENTS.md` and `CLAUDE.md`.
 - `NODE.md`, `members/`, and tree-scoped `AGENTS.md` / `CLAUDE.md` content
   belong only in a dedicated `*-tree` repo. Existing bound `*-context` repos
   are still supported and should be reused.
@@ -97,7 +98,7 @@ and publish cannot infer the source repo, pass `--source-repo PATH`.
   dedicated tree repo instead, for example
   `first-tree verify --tree-path ../my-repo-tree`.
 - Running `first-tree upgrade` in the source/workspace repo refreshes only
-  the local installed skill, `FIRST_TREE.md`, and the
+  the local installed skill, the `FIRST_TREE.md` symlink, and the
   `FIRST-TREE-SOURCE-INTEGRATION:` section.
 - Run `first-tree upgrade --tree-path ../my-repo-tree` to upgrade the
   dedicated tree repo itself. If the source/workspace repo is still bound to

--- a/skills/first-tree/references/upgrade-contract.md
+++ b/skills/first-tree/references/upgrade-contract.md
@@ -85,8 +85,8 @@ metadata directory:
     tree repo by default
   - installs the skill into the source/workspace repo without creating tree
     files there
-  - writes `FIRST_TREE.md` in the source/workspace repo as an easy entrypoint
-    to the installed references
+  - creates `FIRST_TREE.md` in the source/workspace repo as a symlink to the
+    installed `references/about.md` entrypoint
   - upserts the managed `FIRST-TREE-SOURCE-INTEGRATION:` section in root
     `AGENTS.md` and `CLAUDE.md`
   - does **not** install the skill into the target tree repo
@@ -114,7 +114,8 @@ metadata directory:
     currently running `first-tree` package
   - refreshes the current install metadata without overwriting tree content
   - when run in a source/workspace repo, refreshes only the local installed
-    skill, `FIRST_TREE.md`, plus the `FIRST-TREE-SOURCE-INTEGRATION:` section
+    skill, the `FIRST_TREE.md` symlink, plus the
+    `FIRST-TREE-SOURCE-INTEGRATION:` section
   - when run in a dedicated tree repo, refreshes only `.first-tree/`
   - migrates repos that still use the previous `skills/first-tree/` path onto
     `.agents/skills/first-tree/` and `.claude/skills/first-tree/`

--- a/skills/first-tree/tests/helpers.ts
+++ b/skills/first-tree/tests/helpers.ts
@@ -33,9 +33,14 @@ export function makeFramework(root: string, version = "0.1.0"): void {
     mkdirSync(join(root, skillRoot, "assets", "framework"), {
       recursive: true,
     });
+    mkdirSync(join(root, skillRoot, "references"), { recursive: true });
     writeFileSync(
       join(root, skillRoot, "SKILL.md"),
       "---\nname: first-tree\ndescription: installed\n---\n",
+    );
+    writeFileSync(
+      join(root, skillRoot, "references", "about.md"),
+      "# About Context Tree\n",
     );
   }
   writeFileSync(join(root, FRAMEWORK_VERSION), `${version}\n`);
@@ -87,6 +92,7 @@ export function makeSourceSkill(root: string, version = "0.2.0"): void {
   mkdirSync(join(skillRoot, "assets", "framework", "templates"), {
     recursive: true,
   });
+  mkdirSync(join(skillRoot, "references"), { recursive: true });
 
   writeFileSync(
     join(skillRoot, "SKILL.md"),
@@ -99,6 +105,10 @@ export function makeSourceSkill(root: string, version = "0.2.0"): void {
   writeFileSync(
     join(skillRoot, "assets", "framework", "manifest.json"),
     "{}\n",
+  );
+  writeFileSync(
+    join(skillRoot, "references", "about.md"),
+    "# About Context Tree\n",
   );
   writeFileSync(
     join(skillRoot, "assets", "framework", "VERSION"),

--- a/skills/first-tree/tests/init.test.ts
+++ b/skills/first-tree/tests/init.test.ts
@@ -1,5 +1,12 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
@@ -189,6 +196,14 @@ function escapeRegExp(text: string): string {
   return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function expectFirstTreeIndexSymlink(root: string): void {
+  const path = join(root, FIRST_TREE_INDEX_FILE);
+  expect(lstatSync(path).isSymbolicLink()).toBe(true);
+  expect(readlinkSync(path)).toBe(
+    join(".agents", "skills", "first-tree", "references", "about.md"),
+  );
+}
+
 describe("runInit", () => {
   it("errors when not a git repo", () => {
     const tmp = useTmpDir();
@@ -284,9 +299,7 @@ describe("runInit", () => {
     expect(
       readFileSync(join(sourceRepoDir.path, CLAUDE_INSTRUCTIONS_FILE), "utf-8"),
     ).toContain(buildSourceIntegrationBlock(basename(treeRepo)));
-    expect(
-      readFileSync(join(sourceRepoDir.path, FIRST_TREE_INDEX_FILE), "utf-8"),
-    ).toContain(".agents/skills/first-tree/references/about.md");
+    expectFirstTreeIndexSymlink(sourceRepoDir.path);
     expect(
       existsSync(join(treeRepo, ".agents", "skills", "first-tree", "SKILL.md")),
     ).toBe(false);
@@ -371,6 +384,33 @@ describe("runInit", () => {
     expect(
       readFileSync(join(sourceRepoDir.path, FIRST_TREE_INDEX_FILE), "utf-8"),
     ).toBe("# Custom entrypoint\n");
+  });
+
+  it("migrates a previously managed FIRST_TREE.md to a symlink", () => {
+    const sourceRepoDir = useTmpDir();
+    const sourceSkillDir = useTmpDir();
+    makeSourceRepo(sourceRepoDir.path);
+    makeSourceSkill(sourceSkillDir.path, "0.2.0");
+    writeFileSync(
+      join(sourceRepoDir.path, FIRST_TREE_INDEX_FILE),
+      [
+        "# First Tree",
+        "",
+        "<!-- BEGIN FIRST-TREE INDEX -->",
+        "legacy managed entrypoint",
+        "<!-- END FIRST-TREE INDEX -->",
+        "",
+      ].join("\n"),
+    );
+
+    expect(
+      runInit(new Repo(sourceRepoDir.path), {
+        sourceRoot: sourceSkillDir.path,
+        gitInitializer: fakeGitInitializer,
+      }),
+    ).toBe(0);
+
+    expectFirstTreeIndexSymlink(sourceRepoDir.path);
   });
 
   it("keeps supporting in-place init with --here", () => {

--- a/skills/first-tree/tests/skill-artifacts.test.ts
+++ b/skills/first-tree/tests/skill-artifacts.test.ts
@@ -1,5 +1,12 @@
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
@@ -38,6 +45,13 @@ describe("skill artifacts", () => {
       existsSync(join(ROOT, "skills", "first-tree", "engine", "member-seeding.ts")),
     ).toBe(true);
     expect(existsSync(join(ROOT, "AGENTS.md"))).toBe(true);
+    expect(existsSync(join(ROOT, "FIRST_TREE.md"))).toBe(true);
+    expect(lstatSync(join(ROOT, "CLAUDE.md")).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(join(ROOT, "CLAUDE.md"))).toBe("AGENTS.md");
+    expect(lstatSync(join(ROOT, "FIRST_TREE.md")).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(join(ROOT, "FIRST_TREE.md"))).toBe(
+      "skills/first-tree/references/about.md",
+    );
     expect(existsSync(join(ROOT, "skills", "first-tree", "tests", "init.test.ts"))).toBe(
       true,
     );

--- a/skills/first-tree/tests/upgrade.test.ts
+++ b/skills/first-tree/tests/upgrade.test.ts
@@ -1,4 +1,10 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  readFileSync,
+  readlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { basename, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { Repo } from "#skill/engine/repo.js";
@@ -26,6 +32,14 @@ import {
   makeTreeMetadata,
   useTmpDir,
 } from "./helpers.js";
+
+function expectFirstTreeIndexSymlink(root: string): void {
+  const path = join(root, FIRST_TREE_INDEX_FILE);
+  expect(lstatSync(path).isSymbolicLink()).toBe(true);
+  expect(readlinkSync(path)).toBe(
+    join(".agents", "skills", "first-tree", "references", "about.md"),
+  );
+}
 
 describe("runUpgrade", () => {
   it("migrates a legacy repo to the installed skill layout", () => {
@@ -160,9 +174,42 @@ describe("runUpgrade", () => {
     expect(readFileSync(join(repoDir.path, CLAUDE_INSTRUCTIONS_FILE), "utf-8")).toContain(
       expectedBlock,
     );
-    expect(readFileSync(join(repoDir.path, FIRST_TREE_INDEX_FILE), "utf-8")).toContain(
-      ".agents/skills/first-tree/references/about.md",
+    expectFirstTreeIndexSymlink(repoDir.path);
+    expect(existsSync(join(repoDir.path, INSTALLED_PROGRESS))).toBe(false);
+  });
+
+  it("migrates a managed FIRST_TREE.md to a symlink even when the installed skill is already current", () => {
+    const repoDir = useTmpDir();
+    const sourceDir = useTmpDir();
+    makeSourceRepo(repoDir.path);
+    makeFramework(repoDir.path, "0.2.0");
+    writeFileSync(
+      join(repoDir.path, AGENT_INSTRUCTIONS_FILE),
+      `${SOURCE_INTEGRATION_MARKER} old text\n`,
     );
+    writeFileSync(
+      join(repoDir.path, CLAUDE_INSTRUCTIONS_FILE),
+      `${SOURCE_INTEGRATION_MARKER} old text\n`,
+    );
+    writeFileSync(
+      join(repoDir.path, FIRST_TREE_INDEX_FILE),
+      [
+        "# First Tree",
+        "",
+        "<!-- BEGIN FIRST-TREE INDEX -->",
+        "legacy managed entrypoint",
+        "<!-- END FIRST-TREE INDEX -->",
+        "",
+      ].join("\n"),
+    );
+    makeSourceSkill(sourceDir.path, "0.2.0");
+
+    const result = runUpgrade(new Repo(repoDir.path), {
+      sourceRoot: sourceDir.path,
+    });
+
+    expect(result).toBe(0);
+    expectFirstTreeIndexSymlink(repoDir.path);
     expect(existsSync(join(repoDir.path, INSTALLED_PROGRESS))).toBe(false);
   });
 


### PR DESCRIPTION
## Summary
- fix the repo-root `CLAUDE.md` symlink to point at `AGENTS.md`
- add a repo-root `FIRST_TREE.md` symlink to `skills/first-tree/references/about.md`
- change `first-tree init` and `first-tree upgrade` to maintain `FIRST_TREE.md` as a symlink instead of a generated markdown index
- update docs and tests for the new symlink behavior

## Validation
- `pnpm typecheck`
- `pnpm validate:skill`
- `pnpm test`