### PR TITLE
chore: onboard local first-tree skill

### DIFF
--- a/.agents/skills/first-tree
+++ b/.agents/skills/first-tree
@@ -1,0 +1,1 @@
+../../skills/first-tree

--- a/.claude/skills/first-tree
+++ b/.claude/skills/first-tree
@@ -1,0 +1,1 @@
+../../skills/first-tree

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,3 +48,19 @@ npx tsx evals/scripts/check-env.ts --cases nanobot-exectool-regex
 # Run evals with multiple trials
 npx tsx evals/scripts/run-eval.ts --trials 3 --cases pydantic-importstring-error
 ```
+
+<!-- BEGIN FIRST-TREE-SOURCE-INTEGRATION -->
+FIRST-TREE-SOURCE-INTEGRATION:
+
+This repo is a source/workspace repo. Keep all Context Tree files only in the dedicated `first-tree-context` repo/submodule.
+
+Before every task:
+- If this workspace already tracks the Context Tree as a git submodule, sync submodules to the commits recorded by the current superproject and read the tracked tree first (preferred path: `first-tree-context/`).
+- If that submodule directory exists but is not initialized locally, initialize only that submodule; do not update every submodule in the workspace.
+- If the tree has not been published back to this workspace as a tracked submodule yet, work from the sibling dedicated `first-tree-context` bootstrap repo instead.
+
+After every task:
+- Always ask whether the tree needs updating.
+- If the task changed decisions, constraints, rationale, or ownership, open a PR in the tree repo first. Then update this repo's Context Tree submodule pointer and open the source/workspace code PR.
+- If the task changed only implementation details, skip the tree PR and open only the source/workspace code PR.
+<!-- END FIRST-TREE-SOURCE-INTEGRATION -->

--- a/FIRST_TREE.md
+++ b/FIRST_TREE.md
@@ -1,1 +1,1 @@
-skills/first-tree/references/about.md
+.agents/skills/first-tree/references/about.md


### PR DESCRIPTION
## Summary
- add source-repo first-tree skill symlinks under .agents and .claude
- point FIRST_TREE.md at the standard installed-skill about.md entrypoint
- append the managed FIRST-TREE-SOURCE-INTEGRATION block and bind it to first-tree-context

## Validation
- verified the symlinks resolve to the canonical skills/first-tree payload
- did not run pnpm checks because this change only updates local onboarding/docs/symlinks