### PR TITLE
docs: clarify first-tree-all skill sync path

### DIFF
--- a/skills/first-tree/SKILL.md
+++ b/skills/first-tree/SKILL.md
@@ -53,6 +53,12 @@ repos.
   thin CLI shell, not as a tree repo.
 - Keep command behavior, validator behavior, shipped assets, maintainer
   references, and package shell aligned.
+- If the task is to refresh the `first-tree-all` workspace mirror skill, treat
+  that as a maintainer sync step, not as normal `first-tree upgrade` behavior.
+  From the `first-tree-all` superproject, update the `first-tree` submodule
+  from `https://github.com/agent-team-foundation/first-tree` and repoint the
+  root `.agents/skills/first-tree` and `.claude/skills/first-tree` mirrors;
+  prefer `bash scripts/sync-first-tree-skill.sh --remote`.
 - If root README/AGENTS/CI text explains something non-obvious, migrate that
   information into `references/` and trim the root file back down.
 - If you change runtime assets or skill references, run `pnpm validate:skill`.
@@ -142,6 +148,10 @@ repos.
 - Keep normal `init` / `upgrade` flows self-contained. They must work from the
   skill bundled in the current package without cloning the source repo or
   relying on network access.
+- Keep workspace-level mirror sync separate from runtime install/upgrade
+  behavior. A `first-tree-all` maintainer may explicitly update the
+  `first-tree` submodule from GitHub and repoint root mirror symlinks, but that
+  is not a requirement for routine skill use in source/workspace repos.
 - Make upgrade behavior explicit. If you change installed paths, update
   `references/upgrade-contract.md`, task text, and tests together.
 

--- a/skills/first-tree/references/maintainer-build-and-distribution.md
+++ b/skills/first-tree/references/maintainer-build-and-distribution.md
@@ -50,6 +50,12 @@ another skill reference, not only in the files themselves.
   with the package rather than copying that information into root docs.
 - Normal `first-tree init` / `first-tree upgrade` flows must install from
   the skill bundled in the running package, not by cloning the source repo.
+- In the `first-tree-all` superproject, refreshing the root mirror skill is a
+  separate maintainer sync step: update the `first-tree` submodule from
+  `https://github.com/agent-team-foundation/first-tree` and repoint the root
+  `.agents/skills/first-tree` / `.claude/skills/first-tree` symlinks there;
+  prefer `bash scripts/sync-first-tree-skill.sh --remote` instead of changing
+  the runtime install/upgrade contract.
 - Default dedicated-tree-repo creation must stay local-only. It may create a
   sibling git repo on disk, but it must not require remote repo creation or
   source-repo cloning.


### PR DESCRIPTION
## Summary
- document that first-tree-all mirror-skill refreshes should pull from the canonical first-tree repo
- point maintainers to `bash scripts/sync-first-tree-skill.sh --remote` for that sync flow
- keep the normal bundled package upgrade contract unchanged

## Validation
- pnpm validate:skill