### PR TITLE
fix: expose canonical skill through local aliases

### DIFF
--- a/.agents/skills/first-tree
+++ b/.agents/skills/first-tree
@@ -1,0 +1,1 @@
+../../skills/first-tree

--- a/.claude/skills/first-tree
+++ b/.claude/skills/first-tree
@@ -1,0 +1,1 @@
+../../.agents/skills/first-tree

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,9 @@ This repo ships the canonical `first-tree` skill plus a thin
 
 - Treat `skills/first-tree/` as the only canonical source of
   framework knowledge.
+- The tracked `.agents/skills/first-tree` and `.claude/skills/first-tree`
+  entries in this repo are local alias symlinks for agent discovery; edit
+  `skills/first-tree/`, not the aliases.
 - Use `first-tree` for both the npm package and CLI command, and
   `skills/first-tree/` when you mean the bundled skill path.
 - Keep source/workspace installs limited to local skill integration; `NODE.md`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,14 @@ Naming note:
 - `first-tree` is the npm package name.
 - `first-tree` is also the installed CLI command.
 - `skills/first-tree/` is the bundled skill path inside this repo.
+- This source repo also tracks `.agents/skills/first-tree/` and
+  `.claude/skills/first-tree/` as symlink aliases back to
+  `skills/first-tree/` for local agent discovery.
 - User trees install that payload into `.agents/skills/first-tree/` and
   `.claude/skills/first-tree/`.
 
 Most changes should land in the canonical skill under `skills/first-tree/`,
-not in root-level prose or ad hoc helper files.
+not in the local alias paths, root-level prose, or ad hoc helper files.
 
 ## Before You Change Anything
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ runtime.
 - The installed skill directories inside a user tree are
   `.agents/skills/first-tree/` and `.claude/skills/first-tree/` in a
   source/workspace repo.
+- In this source repo, those same two paths are tracked symlink aliases back
+  to `skills/first-tree/` so local agents can resolve the latest bundled skill
+  without a copied mirror.
 - Dedicated tree repos keep their local CLI metadata under `.first-tree/`.
 - The published package keeps its bundled canonical source under
   `skills/first-tree/`.
@@ -144,6 +147,8 @@ runtime.
   bundled skill.
 - `skills/first-tree/` is the canonical source for framework behavior, shipped
   templates, maintainer references, and validation logic.
+- `.agents/skills/first-tree/` and `.claude/skills/first-tree/` in this repo
+  are local symlink entrypoints to that canonical source for agent tooling.
 - `first-tree init` installs that bundled skill into `.agents/skills/first-tree/`
   and `.claude/skills/first-tree/` inside source/workspace repos, and writes
   `.first-tree/` metadata only inside dedicated tree repos.

--- a/skills/first-tree/SKILL.md
+++ b/skills/first-tree/SKILL.md
@@ -13,6 +13,9 @@ repos.
 ## Source Of Truth
 
 - `skills/first-tree/` is the only canonical copy.
+- In this source repo, `.agents/skills/first-tree/` and
+  `.claude/skills/first-tree/` are tracked symlink aliases back to that
+  canonical copy for local agent discovery.
 - `references/` holds the explanatory docs the skill should load on demand.
 - `assets/framework/` holds the runtime payload that gets installed into user
   repos.

--- a/skills/first-tree/engine/runtime/installer.ts
+++ b/skills/first-tree/engine/runtime/installer.ts
@@ -9,7 +9,7 @@ import {
   symlinkSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, join, relative } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   BUNDLED_SKILL_ROOT,
@@ -75,21 +75,26 @@ export function readCanonicalFrameworkVersion(sourceRoot: string): string {
 
 export function copyCanonicalSkill(sourceRoot: string, targetRoot: string): void {
   const src = resolveCanonicalSkillRoot(sourceRoot);
+  const sourceRepoSkillRoot = join(targetRoot, BUNDLED_SKILL_ROOT);
+  const useSourceRepoAliases = resolve(sourceRepoSkillRoot) === resolve(src);
   for (const relPath of [
     ...INSTALLED_SKILL_ROOTS,
-    LEGACY_REPO_SKILL_ROOT,
+    ...(useSourceRepoAliases ? [] : [LEGACY_REPO_SKILL_ROOT]),
   ]) {
     const fullPath = join(targetRoot, relPath);
     if (existsSync(fullPath) || isSymlink(fullPath)) {
       rmSync(fullPath, { recursive: true, force: true });
     }
   }
-  // Copy to the canonical location (.agents/skills/first-tree)
   const primaryDst = join(targetRoot, SKILL_ROOT);
   mkdirSync(dirname(primaryDst), { recursive: true });
-  cpSync(src, primaryDst, { recursive: true });
+  if (useSourceRepoAliases) {
+    const relTarget = relative(dirname(primaryDst), src);
+    symlinkSync(relTarget, primaryDst);
+  } else {
+    cpSync(src, primaryDst, { recursive: true });
+  }
 
-  // Symlink .claude/skills/first-tree → .agents/skills/first-tree
   const symlinkDst = join(targetRoot, CLAUDE_SKILL_ROOT);
   mkdirSync(dirname(symlinkDst), { recursive: true });
   const relTarget = relative(dirname(symlinkDst), primaryDst);

--- a/skills/first-tree/references/maintainer-architecture.md
+++ b/skills/first-tree/references/maintainer-architecture.md
@@ -5,6 +5,9 @@ This reference explains how to maintain the `first-tree` source repo itself.
 ## What This Repo Ships
 
 - One canonical skill: `skills/first-tree/`
+- One pair of tracked local alias entrypoints:
+  `.agents/skills/first-tree/` and `.claude/skills/first-tree/`, both
+  symlinked back to `skills/first-tree/` in this repo
 - One thin CLI package: the `first-tree` command distributed by the `first-tree`
   npm package
 - The published package carries that canonical skill directly; normal install
@@ -37,6 +40,8 @@ and should be preserved.
 ## Non-Negotiables
 
 - Treat `skills/first-tree/` as the only canonical source.
+- Keep `.agents/skills/first-tree/` and `.claude/skills/first-tree/` as
+  symlink aliases only; do not turn them into copied mirrors in this repo.
 - If a maintainer needs information to safely change behavior, move that
   information into `references/`; do not leave it only in root `README.md`,
   `AGENTS.md`, CI comments, or PR descriptions.

--- a/skills/first-tree/references/source-map.md
+++ b/skills/first-tree/references/source-map.md
@@ -91,7 +91,9 @@ not become the only place important maintainer knowledge lives.
 ## Compatibility Notes
 
 - The source repo intentionally contains no root `.context-tree/`, `docs/`,
-  mirror skills, or bundled repo snapshot.
+  copied mirror skills, or bundled repo snapshot. The only allowed alias
+  entrypoints are the tracked symlinks at `.agents/skills/first-tree/` and
+  `.claude/skills/first-tree/`.
 - Legacy `.context-tree/...` paths still matter only for migrating existing
   user repos; the compatibility logic lives in
   `engine/runtime/asset-loader.ts` and `engine/upgrade.ts`.

--- a/skills/first-tree/references/upgrade-contract.md
+++ b/skills/first-tree/references/upgrade-contract.md
@@ -10,8 +10,11 @@ rules we keep for legacy `skills/first-tree/` and `.context-tree/` repos.
 - `assets/framework/` contains the shipped runtime payload.
 - The distributable `first-tree` package must carry the canonical skill inside
   the package itself.
-- The source repo does not keep a root `.context-tree/`, `docs/`, mirror skill
-  directories, or a bundled repo snapshot.
+- The source repo does not keep a root `.context-tree/`, `docs/`, copied
+  mirror skill directories, or a bundled repo snapshot.
+- The only source-repo aliases allowed outside `skills/first-tree/` are the
+  tracked symlinks at `.agents/skills/first-tree/` and
+  `.claude/skills/first-tree/`, both pointing back to the canonical source.
 
 ## Installed Layout
 
@@ -49,6 +52,12 @@ The current installed layout in a source/workspace repo is:
           helpers/
 FIRST_TREE.md
 ```
+
+Inside the `first-tree` source repo itself, `.agents/skills/first-tree/` and
+`.claude/skills/first-tree/` are tracked symlink aliases back to
+`skills/first-tree/` for local agent discovery. User repos still receive the
+installed layout above as local integration, with the canonical payload rooted
+under `.agents/skills/first-tree/`.
 
 For a source/workspace repo, the local integration stops there. It should also
 carry a managed `FIRST-TREE-SOURCE-INTEGRATION:` section in root `AGENTS.md`

--- a/skills/first-tree/scripts/check-skill-sync.sh
+++ b/skills/first-tree/scripts/check-skill-sync.sh
@@ -24,6 +24,22 @@ require_file() {
   fi
 }
 
+require_symlink_target() {
+  local path="$1"
+  local expected="$2"
+  if [[ ! -L "$path" ]]; then
+    echo "Missing symlink: $path" >&2
+    exit 1
+  fi
+
+  local actual
+  actual="$(readlink "$path")"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "Unexpected symlink target for $path: expected $expected, got $actual" >&2
+    exit 1
+  fi
+}
+
 REPO_ROOT="$(find_repo_root || true)"
 SOURCE_DIR=""
 if [[ -n "$REPO_ROOT" ]]; then
@@ -88,11 +104,22 @@ require_file "$SOURCE_DIR/assets/framework/helpers/run-review.ts"
 require_file "$SOURCE_DIR/assets/framework/helpers/summarize-progress.js"
 require_file "$SOURCE_DIR/assets/framework/helpers/inject-tree-context.sh"
 
+if [[ -e "$SOURCE_DIR/evals" ]]; then
+  echo "Skill should not contain repo-only eval tooling." >&2
+  exit 1
+fi
+
+require_file "$REPO_ROOT/evals/first-tree-eval.test.ts"
+require_file "$REPO_ROOT/evals/README.md"
+require_file "$REPO_ROOT/evals/helpers/case-loader.ts"
+require_file "$REPO_ROOT/evals/scripts/tree-manager.ts"
+require_file "$REPO_ROOT/evals/tests/eval-helpers.test.ts"
+require_symlink_target "$REPO_ROOT/.agents/skills/first-tree" "../../skills/first-tree"
+require_symlink_target "$REPO_ROOT/.claude/skills/first-tree" "../../.agents/skills/first-tree"
+
 # Check for legacy artifacts that should not be committed.
 # Use git ls-files to ignore untracked local files (e.g. .claude/settings.local.json).
 for legacy_path in \
-  ".agents" \
-  ".claude" \
   ".context-tree" \
   "docs" \
   "tests" \
@@ -104,16 +131,13 @@ do
   fi
 done
 
-if [[ -e "$SOURCE_DIR/evals" ]]; then
-  echo "Skill should not contain repo-only eval tooling." >&2
+tracked_aliases="$(git -C "$REPO_ROOT" ls-files .agents .claude)"
+expected_aliases=$'.agents/skills/first-tree\n.claude/skills/first-tree'
+if [[ -n "$tracked_aliases" && "$tracked_aliases" != "$expected_aliases" ]]; then
+  echo "Tracked .agents/.claude entries are out of sync with the expected local skill aliases." >&2
+  printf 'Expected:\n%s\nGot:\n%s\n' "$expected_aliases" "$tracked_aliases" >&2
   exit 1
 fi
-
-require_file "$REPO_ROOT/evals/first-tree-eval.test.ts"
-require_file "$REPO_ROOT/evals/README.md"
-require_file "$REPO_ROOT/evals/helpers/case-loader.ts"
-require_file "$REPO_ROOT/evals/scripts/tree-manager.ts"
-require_file "$REPO_ROOT/evals/tests/eval-helpers.test.ts"
 
 if grep -q '"#docs/\*"' "$REPO_ROOT/package.json"; then
   echo "package.json still exposes the legacy #docs import alias." >&2

--- a/skills/first-tree/tests/skill-artifacts.test.ts
+++ b/skills/first-tree/tests/skill-artifacts.test.ts
@@ -14,17 +14,20 @@ import { parse } from "yaml";
 
 const ROOT = process.cwd();
 
-/** Check if a path has any tracked files in git (handles dirs and files). */
-function isTrackedInGit(relativePath: string): boolean {
-  const result = spawnSync("git", ["ls-files", relativePath], {
+function trackedEntriesInGit(...relativePaths: string[]): string[] {
+  const result = spawnSync("git", ["ls-files", ...relativePaths], {
     cwd: ROOT,
     stdio: "pipe",
   });
-  return (result.stdout?.toString().trim().length ?? 0) > 0;
+  return result.stdout
+    ?.toString()
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean) ?? [];
 }
 
 describe("skill artifacts", () => {
-  it("keeps only the canonical skill in the source repo", () => {
+  it("keeps one canonical skill plus local alias entrypoints in the source repo", () => {
     expect(existsSync(join(ROOT, "skills", "first-tree", "SKILL.md"))).toBe(true);
     expect(existsSync(join(ROOT, "skills", "first-tree", "references", "onboarding.md"))).toBe(true);
     expect(
@@ -46,11 +49,21 @@ describe("skill artifacts", () => {
     ).toBe(true);
     expect(existsSync(join(ROOT, "AGENTS.md"))).toBe(true);
     expect(existsSync(join(ROOT, "FIRST_TREE.md"))).toBe(true);
+    expect(existsSync(join(ROOT, ".agents", "skills", "first-tree", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(ROOT, ".claude", "skills", "first-tree", "SKILL.md"))).toBe(true);
     expect(lstatSync(join(ROOT, "CLAUDE.md")).isSymbolicLink()).toBe(true);
     expect(readlinkSync(join(ROOT, "CLAUDE.md"))).toBe("AGENTS.md");
     expect(lstatSync(join(ROOT, "FIRST_TREE.md")).isSymbolicLink()).toBe(true);
     expect(readlinkSync(join(ROOT, "FIRST_TREE.md"))).toBe(
       "skills/first-tree/references/about.md",
+    );
+    expect(lstatSync(join(ROOT, ".agents", "skills", "first-tree")).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(join(ROOT, ".agents", "skills", "first-tree"))).toBe(
+      "../../skills/first-tree",
+    );
+    expect(lstatSync(join(ROOT, ".claude", "skills", "first-tree")).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(join(ROOT, ".claude", "skills", "first-tree"))).toBe(
+      "../../.agents/skills/first-tree",
     );
     expect(existsSync(join(ROOT, "skills", "first-tree", "tests", "init.test.ts"))).toBe(
       true,
@@ -155,13 +168,17 @@ describe("skill artifacts", () => {
         ),
       ),
     ).toBe(true);
-    // Legacy artifacts must not be tracked in git (untracked local files are OK)
-    expect(isTrackedInGit(".agents")).toBe(false);
-    expect(isTrackedInGit(".claude")).toBe(false);
-    expect(isTrackedInGit(".context-tree")).toBe(false);
+    expect(
+      trackedEntriesInGit(".agents", ".claude").filter(
+        (entry) =>
+          entry !== ".agents/skills/first-tree"
+          && entry !== ".claude/skills/first-tree",
+      ),
+    ).toEqual([]);
+    expect(trackedEntriesInGit(".context-tree")).toEqual([]);
     expect(existsSync(join(ROOT, "AGENT.md"))).toBe(false);
-    expect(isTrackedInGit("docs")).toBe(false);
-    expect(isTrackedInGit("tests")).toBe(false);
+    expect(trackedEntriesInGit("docs")).toEqual([]);
+    expect(trackedEntriesInGit("tests")).toEqual([]);
     expect(existsSync(join(ROOT, "evals"))).toBe(true);
     expect(existsSync(join(ROOT, "src", "commands"))).toBe(false);
     expect(existsSync(join(ROOT, "src", "runtime"))).toBe(false);

--- a/skills/first-tree/tests/upgrade.test.ts
+++ b/skills/first-tree/tests/upgrade.test.ts
@@ -9,6 +9,7 @@ import { basename, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { Repo } from "#skill/engine/repo.js";
 import { runUpgrade } from "#skill/engine/upgrade.js";
+import { copyCanonicalSkill } from "#skill/engine/runtime/installer.js";
 import {
   AGENT_INSTRUCTIONS_FILE,
   CLAUDE_INSTRUCTIONS_FILE,
@@ -124,6 +125,29 @@ describe("runUpgrade", () => {
     makeSourceRepo(repoDir.path);
     const result = runUpgrade(new Repo(repoDir.path));
     expect(result).toBe(1);
+  });
+
+  it("keeps source-repo aliases pointed at the canonical skill when installing locally", () => {
+    const repoDir = useTmpDir();
+    makeSourceRepo(repoDir.path);
+    makeSourceSkill(repoDir.path, "0.2.0");
+
+    copyCanonicalSkill(repoDir.path, repoDir.path);
+
+    expect(existsSync(join(repoDir.path, "skills", "first-tree", "SKILL.md"))).toBe(true);
+    expect(lstatSync(join(repoDir.path, ".agents", "skills", "first-tree")).isSymbolicLink()).toBe(
+      true,
+    );
+    expect(readlinkSync(join(repoDir.path, ".agents", "skills", "first-tree"))).toBe(
+      "../../skills/first-tree",
+    );
+    expect(lstatSync(join(repoDir.path, ".claude", "skills", "first-tree")).isSymbolicLink()).toBe(
+      true,
+    );
+    expect(readlinkSync(join(repoDir.path, ".claude", "skills", "first-tree"))).toBe(
+      "../../.agents/skills/first-tree",
+    );
+    expect(readFileSync(join(repoDir.path, FRAMEWORK_VERSION), "utf-8").trim()).toBe("0.2.0");
   });
 
   it("refreshes a dedicated tree repo without reinstalling the skill", () => {


### PR DESCRIPTION
## Summary
- add tracked .agents/.claude skill symlink entrypoints that point back to skills/first-tree
- preserve those aliases when refreshing the source repo skill locally
- document and validate the alias contract in tests and maintainer docs

## Testing
- pnpm validate:skill
- pnpm typecheck
- pnpm test
- pnpm build