### PR TITLE
fix: keep init onboarding credential-free

### DIFF
--- a/skills/first-tree/references/onboarding.md
+++ b/skills/first-tree/references/onboarding.md
@@ -158,9 +158,14 @@ to the current state of the repo. Complete each task:
 - Optionally configure agent integration in the source/workspace repo (for
   Claude Code, the installed hook assets live under
   `.claude/skills/first-tree/`)
-- Copy any validation workflows you want from the source/workspace repo's
+- Copy any deterministic validation workflows you want from the
+  source/workspace repo's
   `.agents/skills/first-tree/assets/framework/workflows/` directory into the
   tree repo's `.github/workflows/`
+
+Core onboarding should stay credential-free. Do not ask the user for model API
+keys during `first-tree init`; treat any model-backed PR review automation as a
+separate manual follow-up after the tree scaffold is in place.
 
 As you complete each task, check it off in
 `.first-tree/progress.md` by changing `- [ ]` to `- [x]`.

--- a/src/engine/rules/ci-validation.ts
+++ b/src/engine/rules/ci-validation.ts
@@ -1,6 +1,5 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
-import { INTERACTIVE_TOOL } from "#engine/init.js";
 import type { Repo } from "#engine/repo.js";
 import type { RuleResult } from "#engine/rules/index.js";
 
@@ -9,7 +8,6 @@ const BUNDLED_WORKFLOW_SOURCE = "the bundled first-tree workflow templates";
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
   let hasValidation = false;
-  let hasPrReview = false;
   let hasCodeowners = false;
   const workflowsDir = join(repo.root, ".github", "workflows");
   try {
@@ -26,9 +24,6 @@ export function evaluate(repo: Repo): RuleResult {
           ) {
             hasValidation = true;
           }
-          if (content.includes("run-review")) {
-            hasPrReview = true;
-          }
           if (content.includes("generate-codeowners")) {
             hasCodeowners = true;
           }
@@ -43,25 +38,6 @@ export function evaluate(repo: Repo): RuleResult {
   if (!hasValidation) {
     tasks.push(
       `No validation workflow found — copy \`validate.yml\` from ${BUNDLED_WORKFLOW_SOURCE} to \`.github/workflows/validate.yml\``,
-    );
-  }
-  if (!hasPrReview) {
-    tasks.push(
-      `Use ${INTERACTIVE_TOOL} to ask whether the user wants AI-powered PR reviews. Options:\n` +
-      "  1. **OpenRouter** — use an OpenRouter API key\n" +
-      "  2. **Claude API** — use a Claude API key directly\n" +
-      "  3. **Skip** — do not set up PR reviews\n" +
-      "If (1): copy `pr-review.yml` from the bundled first-tree workflow templates to `.github/workflows/pr-review.yml` as-is; the repo secret name is `OPENROUTER_API_KEY`. " +
-      "If (2): copy the workflow and replace the `env` block with `ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}`, remove the `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, and `ANTHROPIC_DEFAULT_SONNET_MODEL` lines; the repo secret name is `ANTHROPIC_API_KEY`. " +
-      "If (3): skip this and the next task.",
-    );
-    tasks.push(
-      `Use ${INTERACTIVE_TOOL} to ask how the user wants to configure the API secret. Options:\n` +
-      "  1. **Set it now** — provide the key and the agent will run `gh secret set <SECRET_NAME> --body <KEY>`\n" +
-      "  2. **I'll do it myself** — the agent will show manual instructions\n" +
-      "If (1): ask the user to provide the key, then run `gh secret set` with the secret name from the previous step. " +
-      "If (2): tell the user to go to their repo → Settings → Secrets and variables → Actions → New repository secret, and create the secret with the name from the previous step. " +
-      "Skip this task if the user chose Skip in the previous step.",
     );
   }
   if (!hasCodeowners) {

--- a/tests/rules.test.ts
+++ b/tests/rules.test.ts
@@ -245,26 +245,24 @@ describe("ciValidation rule", () => {
     const tmp = useTmpDir();
     const repo = new Repo(tmp.path);
     const result = ciValidation.evaluate(repo);
-    expect(result.tasks).toHaveLength(4);
+    expect(result.tasks).toHaveLength(2);
     expect(result.tasks[0]).toContain("validation workflow");
     expect(result.tasks[0]).toContain("validate.yml");
     expect(result.tasks[0]).toContain("bundled first-tree workflow templates");
-    expect(result.tasks[1]).toContain("PR reviews");
-    expect(result.tasks[2]).toContain("API secret");
-    expect(result.tasks[3]).toContain("CODEOWNERS");
+    expect(result.tasks[1]).toContain("CODEOWNERS");
   });
 
-  it("reports workflow without validate or pr-review", () => {
+  it("reports workflow without validate or codeowners", () => {
     const tmp = useTmpDir();
     const wfDir = join(tmp.path, ".github", "workflows");
     mkdirSync(wfDir, { recursive: true });
     writeFileSync(join(wfDir, "ci.yml"), "name: CI\non: push\njobs: {}\n");
     const repo = new Repo(tmp.path);
     const result = ciValidation.evaluate(repo);
-    expect(result.tasks).toHaveLength(4);
+    expect(result.tasks).toHaveLength(2);
   });
 
-  it("passes validation but reports missing pr-review and codeowners", () => {
+  it("passes validation but reports missing codeowners", () => {
     const tmp = useTmpDir();
     const wfDir = join(tmp.path, ".github", "workflows");
     mkdirSync(wfDir, { recursive: true });
@@ -274,13 +272,11 @@ describe("ciValidation rule", () => {
     );
     const repo = new Repo(tmp.path);
     const result = ciValidation.evaluate(repo);
-    expect(result.tasks).toHaveLength(3);
-    expect(result.tasks[0]).toContain("PR reviews");
-    expect(result.tasks[1]).toContain("API secret");
-    expect(result.tasks[2]).toContain("CODEOWNERS");
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]).toContain("CODEOWNERS");
   });
 
-  it("passes pr-review but reports missing validation and codeowners", () => {
+  it("ignores pr-review workflow for core onboarding", () => {
     const tmp = useTmpDir();
     const wfDir = join(tmp.path, ".github", "workflows");
     mkdirSync(wfDir, { recursive: true });
@@ -295,7 +291,7 @@ describe("ciValidation rule", () => {
     expect(result.tasks[1]).toContain("CODEOWNERS");
   });
 
-  it("passes with validate and pr-review but reports missing codeowners", () => {
+  it("passes with validate and pr-review but still only reports missing codeowners", () => {
     const tmp = useTmpDir();
     const wfDir = join(tmp.path, ".github", "workflows");
     mkdirSync(wfDir, { recursive: true });
@@ -334,24 +330,15 @@ describe("ciValidation rule", () => {
     expect(result.tasks).toEqual([]);
   });
 
-  it("pr-review task presents numbered options", () => {
+  it("does not ask init users to configure PR reviews or API secrets", () => {
     const tmp = useTmpDir();
     const repo = new Repo(tmp.path);
     const result = ciValidation.evaluate(repo);
-    const prTask = result.tasks.find((t) => t.includes("PR review"));
-    expect(prTask).toContain("OpenRouter");
-    expect(prTask).toContain("Claude API");
-    expect(prTask).toContain("Skip");
-  });
-
-  it("secret task presents options for gh CLI or manual setup", () => {
-    const tmp = useTmpDir();
-    const repo = new Repo(tmp.path);
-    const result = ciValidation.evaluate(repo);
-    const secretTask = result.tasks.find((t) => t.includes("API secret"));
-    expect(secretTask).toContain("Set it now");
-    expect(secretTask).toContain("I'll do it myself");
-    expect(secretTask).toContain("gh secret set");
+    expect(result.tasks.join("\n")).not.toContain("PR review");
+    expect(result.tasks.join("\n")).not.toContain("API secret");
+    expect(result.tasks.join("\n")).not.toContain("OpenRouter");
+    expect(result.tasks.join("\n")).not.toContain("Claude API");
+    expect(result.tasks.join("\n")).not.toContain("gh secret set");
   });
 });
 


### PR DESCRIPTION
## Summary
- remove init-time PR review and API secret prompts from the CI/Validation checklist
- document that first-tree init core onboarding must stay credential-free
- lock the behavior with rule tests

## Validation
- pnpm validate:skill
- pnpm typecheck
- pnpm build
- pnpm test -- tests/rules.test.ts