### PR TITLE
fix: skip gitignored source skill artifacts on publish

### DIFF
--- a/src/engine/publish.ts
+++ b/src/engine/publish.ts
@@ -513,9 +513,24 @@ function commitSourceIntegration(
       ".gitignore",
     ].filter((path) => existsSync(join(sourceRepo.root, path))),
   ].filter((path, index, items) => items.indexOf(path) === index);
+  const stageablePaths = resolveStageableManagedPaths(
+    runner,
+    sourceRepo,
+    managedPaths,
+  );
 
-  runner("git", ["add", "--", ...managedPaths], { cwd: sourceRepo.root });
-  if (!hasIndexedChanges(runner, sourceRepo.root, managedPaths)) {
+  if (stageablePaths.skippedPaths.length > 0) {
+    console.log(
+      `  Skipped gitignored source skill artifacts: ${stageablePaths.skippedPaths.map((path) => `\`${path}\``).join(", ")}.`,
+    );
+  }
+
+  if (stageablePaths.paths.length === 0) {
+    return false;
+  }
+
+  runner("git", ["add", "--", ...stageablePaths.paths], { cwd: sourceRepo.root });
+  if (!hasIndexedChanges(runner, sourceRepo.root, stageablePaths.paths)) {
     return false;
   }
   runner(
@@ -525,11 +540,63 @@ function commitSourceIntegration(
       "-m",
       `chore: connect ${treeRepoName} context tree`,
       "--",
-      ...managedPaths,
+      ...stageablePaths.paths,
     ],
     { cwd: sourceRepo.root },
   );
   return true;
+}
+
+function resolveStageableManagedPaths(
+  runner: CommandRunner,
+  sourceRepo: Repo,
+  managedPaths: string[],
+): { paths: string[]; skippedPaths: string[] } {
+  const skippedPaths = new Set<string>();
+  const skillBundlePaths = [
+    SKILL_ROOT,
+    CLAUDE_SKILL_ROOT,
+    FIRST_TREE_INDEX_FILE,
+  ].filter((path) => managedPaths.includes(path));
+
+  // FIRST_TREE.md and .claude/skills/first-tree are symlink views into the
+  // canonical .agents/skills/first-tree bundle, so stage them only when the
+  // canonical skill root itself can be added to git.
+  if (
+    skillBundlePaths.includes(SKILL_ROOT)
+    && pathIsGitIgnored(runner, sourceRepo.root, SKILL_ROOT)
+  ) {
+    for (const path of skillBundlePaths) {
+      skippedPaths.add(path);
+    }
+  }
+
+  for (const path of managedPaths) {
+    if (skippedPaths.has(path)) {
+      continue;
+    }
+    if (pathIsGitIgnored(runner, sourceRepo.root, path)) {
+      skippedPaths.add(path);
+    }
+  }
+
+  return {
+    paths: managedPaths.filter((path) => !skippedPaths.has(path)),
+    skippedPaths: managedPaths.filter((path) => skippedPaths.has(path)),
+  };
+}
+
+function pathIsGitIgnored(
+  runner: CommandRunner,
+  root: string,
+  relPath: string,
+): boolean {
+  return commandSucceeds(
+    runner,
+    "git",
+    ["check-ignore", "-q", "--", relPath],
+    root,
+  );
 }
 
 function ensureTreeRemotePublished(

--- a/tests/publish.test.ts
+++ b/tests/publish.test.ts
@@ -12,9 +12,15 @@ import { writeBootstrapState } from "#engine/runtime/bootstrap.js";
 import {
   AGENT_INSTRUCTIONS_FILE,
   CLAUDE_INSTRUCTIONS_FILE,
+  CLAUDE_SKILL_ROOT,
+  FIRST_TREE_INDEX_FILE,
   LOCAL_TREE_CONFIG,
+  SKILL_ROOT,
 } from "#engine/runtime/asset-loader.js";
-import { buildSourceIntegrationBlock } from "#engine/runtime/source-integration.js";
+import {
+  buildSourceIntegrationBlock,
+  upsertFirstTreeIndexFile,
+} from "#engine/runtime/source-integration.js";
 import {
   makeAgentsMd,
   makeClaudeMd,
@@ -57,9 +63,11 @@ function createRunner(
   sourceRoot: string,
   treeRoot: string,
   treeRepoName: string,
+  options?: { ignoredPaths?: string[] },
 ): { calls: RecordedCommand[]; runner: CommandRunner } {
   const calls: RecordedCommand[] = [];
   let treeOriginExists = false;
+  const ignoredPaths = new Set(options?.ignoredPaths ?? []);
   const runner: CommandRunner = (command, args, options) => {
     calls.push({ command, args, cwd: options.cwd });
 
@@ -101,6 +109,18 @@ function createRunner(
       && args[2] === "--quiet"
     ) {
       throw new Error("changes present");
+    }
+
+    if (
+      command === "git"
+      && args[0] === "check-ignore"
+      && args[1] === "-q"
+    ) {
+      const relPath = args.at(-1);
+      if (relPath && ignoredPaths.has(relPath)) {
+        return "";
+      }
+      throw new Error("not ignored");
     }
 
     if (command === "git" && args[0] === "branch" && args[1] === "--show-current") {
@@ -275,6 +295,45 @@ describe("runPublish", () => {
       treeRepoName: "ADHD-tree",
       treeRepoUrl: "git@github.com:acme/ADHD-tree.git",
     });
+  });
+
+  it("skips source skill artifacts when the source repo ignores /.agents/", () => {
+    const rootDir = useTmpDir();
+    const sourceRoot = join(rootDir.path, "ADHD");
+    const treeRoot = join(rootDir.path, "ADHD-tree");
+
+    makeSourceRepo(sourceRoot);
+    makeFramework(sourceRoot, "0.2.0");
+    makeSourceIntegration(sourceRoot);
+    upsertFirstTreeIndexFile(sourceRoot);
+    makeTreeRepo(treeRoot);
+    writeBootstrapState(treeRoot, {
+      sourceRepoName: "ADHD",
+      sourceRepoPath: relative(treeRoot, sourceRoot),
+      treeRepoName: "ADHD-tree",
+    });
+
+    const { calls, runner } = createRunner(sourceRoot, treeRoot, "ADHD-tree", {
+      ignoredPaths: [SKILL_ROOT],
+    });
+    const result = runPublish(new Repo(treeRoot), {
+      commandRunner: runner,
+    });
+
+    expect(result).toBe(0);
+    const sourceGitAdd = calls.find(
+      (call) =>
+        call.command === "git"
+        && call.cwd === sourceRoot
+        && call.args[0] === "add",
+    );
+    expect(sourceGitAdd).toBeDefined();
+    expect(sourceGitAdd?.args).not.toContain(SKILL_ROOT);
+    expect(sourceGitAdd?.args).not.toContain(CLAUDE_SKILL_ROOT);
+    expect(sourceGitAdd?.args).not.toContain(FIRST_TREE_INDEX_FILE);
+    expect(sourceGitAdd?.args).toContain(AGENT_INSTRUCTIONS_FILE);
+    expect(sourceGitAdd?.args).toContain(CLAUDE_INSTRUCTIONS_FILE);
+    expect(sourceGitAdd?.args).toContain(".gitignore");
   });
 
   it("still infers the source repo from a legacy context repo name", () => {


### PR DESCRIPTION
## Summary
- skip source skill artifacts during `first-tree publish` when their canonical `.agents/skills/first-tree` path is gitignored
- avoid staging `FIRST_TREE.md` and `.claude/skills/first-tree` when they would become broken symlinks without the canonical skill bundle
- add a regression test for source repos that ignore `/.agents/`

## Testing
- pnpm typecheck
- pnpm test

Fixes #71