### PR TITLE
fix: declare bin entry explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "markdown"
   ],
   "type": "module",
-  "bin": "dist/cli.js",
+  "bin": {
+    "first-tree": "dist/cli.js"
+  },
   "imports": {
     "#engine/*": "./src/engine/*",
     "#skill/*": "./skills/first-tree/*",


### PR DESCRIPTION
## Summary
- change `package.json` `bin` from a shorthand string to an explicit object
- remove the npm publish auto-correction warning for the package bin entry
- keep the published CLI entrypoint unchanged as `first-tree -> dist/cli.js`

## Testing
- pnpm validate:skill
- pnpm typecheck
- pnpm test
- pnpm pack