### PR TITLE
fix: tighten owner validation and stabilize cli e2e

### DIFF
--- a/src/engine/validators/nodes.ts
+++ b/src/engine/validators/nodes.ts
@@ -248,10 +248,19 @@ export function validateOwners(
   const raw = m[1].trim();
   if (!raw) return; // owners: [] is valid (inheritance)
 
-  const owners = raw
-    .split(",")
-    .map((o) => o.trim())
-    .filter(Boolean);
+  const ownerParts = raw.split(",").map((o) => o.trim());
+  // Allow a single trailing comma (last entry empty) but reject middle empty entries
+  const hasTrailingComma =
+    ownerParts.length > 0 && ownerParts[ownerParts.length - 1] === "";
+  const partsToCheck = hasTrailingComma ? ownerParts.slice(0, -1) : ownerParts;
+  const emptyCount = partsToCheck.filter((o) => !o).length;
+  if (emptyCount > 0) {
+    findings.error(
+      `${rel(path)}: owners list contains ${emptyCount} empty ${emptyCount === 1 ? "entry" : "entries"} between commas`,
+    );
+    return;
+  }
+  const owners = partsToCheck;
   if (owners.length === 0) {
     findings.error(`${rel(path)}: owners list contains only whitespace entries`);
     return;

--- a/tests/cli-e2e.test.ts
+++ b/tests/cli-e2e.test.ts
@@ -661,7 +661,7 @@ describe.sequential("CLI e2e smoke", () => {
     );
   });
 
-  it("publishes a tree and runs review in a fully mocked CLI environment", async () => {
+  it("publishes a tree and runs review in a fully mocked CLI environment", { timeout: 15000 }, async () => {
     const sandbox = useTmpDir();
     const sourceRoot = join(sandbox.path, "ADHD");
     const treeRoot = join(sandbox.path, "ADHD-tree");

--- a/tests/validate-nodes.test.ts
+++ b/tests/validate-nodes.test.ts
@@ -126,6 +126,37 @@ describe("validateOwners", () => {
     expect(f.errors).toHaveLength(1);
     expect(f.errors[0]).toContain("wildcard");
   });
+
+  it("rejects empty entries between commas", () => {
+    const tmp = useTmpDir();
+    const root = setup(tmp);
+    const p = write(root, "NODE.md", "---\nowners: [alice, , bob]\n---\n");
+    const fm = parseFrontmatter(p)!;
+    const f = new Findings();
+    validateOwners(fm, p, f);
+    expect(f.errors).toHaveLength(1);
+    expect(f.errors[0]).toContain("empty entry");
+  });
+
+  it("accepts trailing comma", () => {
+    const tmp = useTmpDir();
+    const root = setup(tmp);
+    const p = write(root, "NODE.md", "---\nowners: [alice,]\n---\n");
+    const fm = parseFrontmatter(p)!;
+    const f = new Findings();
+    validateOwners(fm, p, f);
+    expect(f.errors).toEqual([]);
+  });
+
+  it("accepts trailing comma with space", () => {
+    const tmp = useTmpDir();
+    const root = setup(tmp);
+    const p = write(root, "NODE.md", "---\nowners: [alice, bob, ]\n---\n");
+    const fm = parseFrontmatter(p)!;
+    const f = new Findings();
+    validateOwners(fm, p, f);
+    expect(f.errors).toEqual([]);
+  });
 });
 
 // --- validateFolders ---


### PR DESCRIPTION
## Summary
- reject malformed middle empty owner entries while still allowing trailing commas in node owners lists
- add focused owner validation regression coverage
- stabilize the mocked publish-and-review cli e2e by increasing timeout only for that slow test

## Validation
- `pnpm test tests/validate-nodes.test.ts`
- `pnpm test`
