### PR TITLE
feat: install tree-repo skill and sync bound codebases

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,14 @@ first-tree init
 
 The CLI:
 
-- installs `.agents/skills/first-tree/` and `.claude/skills/first-tree/`
+- installs `.agents/skills/first-tree/` and `.claude/skills/first-tree/` in the source/workspace root
 - adds `FIRST_TREE.md`
 - updates `AGENTS.md` / `CLAUDE.md`
 - creates or reuses a sibling `<repo>-tree` checkout
+- installs the bundled `first-tree` skill in that tree repo if it is missing
 - scaffolds the dedicated tree repo there
 - writes binding metadata locally and in the tree repo
+- syncs the bound codebase repo into the tree repo under `.first-tree/submodules/`
 
 ### Existing Shared Tree
 
@@ -94,7 +96,8 @@ first-tree init --tree-path ../org-context --tree-mode shared
 ```
 
 If the tree is remote-only, pass `--tree-url`; `bind` / `init` will clone a
-local checkout and then write the binding metadata.
+local checkout, ensure the tree repo has the bundled skill installed, and then
+write the binding metadata plus the hidden tree-side codebase submodule.
 
 ### Workspace Root + Shared Tree
 
@@ -113,7 +116,8 @@ first-tree init --scope workspace --sync-members
 
 The workspace root gets its own local skill integration plus
 `.first-tree/workspace.json`. Each discovered child repo is then bound as a
-`workspace-member` to the same tree via `first-tree workspace sync`.
+`workspace-member` to the same tree via `first-tree workspace sync`, and the
+tree repo keeps each bound child repo under `.first-tree/submodules/`.
 
 ### Explicit Tree Bootstrap
 
@@ -148,12 +152,15 @@ folder before modifying anything. It reports:
   ... source code or workspace folders ...
 
 <tree-repo>/
+  .agents/skills/first-tree/
+  .claude/skills/first-tree
   .first-tree/
     VERSION
     progress.md
     tree.json                # .first-tree/tree.json
     bindings/                # .first-tree/bindings/
       <source-id>.json
+    submodules/              # hidden codebase-repo mirrors tracked as git submodules
     bootstrap.json           # legacy compatibility for older publish flows
   NODE.md
   AGENTS.md
@@ -165,6 +172,9 @@ folder before modifying anything. It reports:
 
 The source/workspace root is not the tree. It should never contain `NODE.md`,
 `members/`, or tree-scoped `AGENTS.md` / `CLAUDE.md`.
+
+The tree repo keeps any bound codebase repos under `.first-tree/submodules/`
+so they do not become visible tree domains during validation.
 
 ## Commands
 

--- a/docs/maintainer-architecture.md
+++ b/docs/maintainer-architecture.md
@@ -14,6 +14,8 @@ Bindings are stored in:
 
 - source/workspace roots: `.first-tree/source.json` and `.first-tree/workspace.json`
 - tree repos: `.first-tree/tree.json` and `.first-tree/bindings/<source-id>.json`
+- tree repos also keep hidden git-backed codebase mirrors under
+  `.first-tree/submodules/`
 
 That replaces the old one-source-at-a-time mental model that depended too
 heavily on one mutable bootstrap file.
@@ -31,6 +33,8 @@ heavily on one mutable bootstrap file.
 - keep `.agents/skills/first-tree/` and `.claude/skills/first-tree/` as alias
   symlinks in this source repo
 - keep source/workspace roots free of tree content
+- keep tree-side codebase mirrors hidden under `.first-tree/submodules/` so
+  validators never treat them as visible tree domains
 - keep shared-tree behavior expressed through bindings, not heuristics alone
 - update docs, code, and tests together whenever the binding schema changes
 

--- a/skills/first-tree/SKILL.md
+++ b/skills/first-tree/SKILL.md
@@ -75,6 +75,10 @@ Default onboarding workflow:
 5. If the current root is a workspace, run `first-tree workspace sync` so all
    child repos bind to the same shared tree.
 
+During `bind` / `init`, the CLI also ensures the tree repo has the bundled
+`first-tree` skill installed and mirrors each git-backed bound codebase under
+`.first-tree/submodules/` in the tree repo.
+
 ## CLI Commands
 
 | Command | Purpose |

--- a/skills/first-tree/references/onboarding.md
+++ b/skills/first-tree/references/onboarding.md
@@ -65,12 +65,14 @@ first-tree init
 
 The CLI will:
 
-- install `.agents/skills/first-tree/` and `.claude/skills/first-tree/`
+- install `.agents/skills/first-tree/` and `.claude/skills/first-tree/` in the source/workspace root
 - create `FIRST_TREE.md`
 - refresh `AGENTS.md` and `CLAUDE.md`
 - create or reuse a sibling `<repo>-tree` checkout
+- install the bundled `first-tree` skill in that tree repo if it is missing
 - scaffold the tree repo there
 - write binding metadata in both the source repo and the tree repo
+- sync the bound codebase repo into the tree repo under `.first-tree/submodules/`
 
 ### Case B: Single Repo + Existing Shared Tree
 
@@ -95,10 +97,12 @@ first-tree bind --tree-url git@github.com:acme/org-context.git --tree-mode share
 `bind` will clone a local checkout if needed, then:
 
 - install local skill integration in the current repo
+- install the bundled `first-tree` skill in the tree repo if it is missing
 - refresh `AGENTS.md` and `CLAUDE.md`
 - write `.first-tree/source.json`
 - refresh `.first-tree/local-tree.json`
 - write `.first-tree/tree.json` and `.first-tree/bindings/<source-id>.json`
+- sync the bound codebase repo into the tree repo under `.first-tree/submodules/`
 
 ### Case C: Workspace Root + Shared Tree
 
@@ -117,7 +121,8 @@ first-tree init --scope workspace --tree-path ../org-context --tree-mode shared 
 
 The workspace root gets local integration plus `.first-tree/workspace.json`.
 Then `first-tree workspace sync` binds every discovered child repo as a
-`workspace-member` to that same shared tree.
+`workspace-member` to that same shared tree and syncs each bound child repo
+into the tree repo under `.first-tree/submodules/`.
 
 ### Case D: Explicit Tree Bootstrap
 

--- a/skills/first-tree/references/source-workspace-installation.md
+++ b/skills/first-tree/references/source-workspace-installation.md
@@ -20,8 +20,9 @@ workspace repo, or non-git workspace folder.
   - `.first-tree/workspace.json` when the root is a workspace
 - `NODE.md`, `members/`, and tree-scoped `AGENTS.md` / `CLAUDE.md` belong only
   in the tree repo.
-- The tree repo keeps its own metadata under `.first-tree/tree.json` and
-  `.first-tree/bindings/`.
+- The tree repo keeps its own installed skill under `.agents/skills/first-tree/`
+  and `.claude/skills/first-tree`, plus tree metadata under `.first-tree/tree.json`,
+  `.first-tree/bindings/`, and hidden codebase mirrors under `.first-tree/submodules/`.
 
 ## Binding Modes
 
@@ -47,12 +48,17 @@ workspace repo, or non-git workspace folder.
     workspace.json          # workspace roots only
 
 <tree-repo>/
+  .agents/skills/first-tree/
+  .claude/skills/first-tree
   .first-tree/
     VERSION
     progress.md
     tree.json
     bindings/
       <source-id>.json
+    submodules/
+      repos/
+      workspaces/
     bootstrap.json          # legacy compatibility
   NODE.md
   AGENTS.md
@@ -74,6 +80,10 @@ When an agent is asked to install `first-tree`:
 Do not recreate a new sibling tree repo when the user already has a shared tree
 they want to keep using.
 
+Whenever a git-backed source repo is bound, also keep its checkout mirrored in
+the tree repo under `.first-tree/submodules/`. These hidden submodules are for
+tree-side code/context access and should not become visible Context Tree domains.
+
 ## Workspace Rule
 
 If the current root contains many child repos or submodules:
@@ -90,7 +100,8 @@ package folders that are not repos do not get repo-level binding metadata.
 - Verify the tree repo with `first-tree verify`.
 - Use `first-tree upgrade` in a source/workspace root to refresh local
   integration.
-- Use `first-tree upgrade --tree-path ...` to refresh the tree repo metadata.
+- Use `first-tree upgrade --tree-path ...` to refresh the tree repo metadata
+  plus its installed tree-repo skill.
 
 ## Publish Rule
 

--- a/skills/first-tree/references/upgrade-contract.md
+++ b/skills/first-tree/references/upgrade-contract.md
@@ -43,12 +43,17 @@ CLAUDE.md
 In a tree repo, `first-tree init tree` produces:
 
 ```text
+.agents/skills/first-tree/
+.claude/skills/first-tree
 .first-tree/
   VERSION
   progress.md
   tree.json
   bindings/
     <source-id>.json
+  submodules/
+    repos/
+    workspaces/
   bootstrap.json          # legacy compatibility
 NODE.md
 AGENTS.md
@@ -69,8 +74,8 @@ members/
 6. preserves `.first-tree/local-tree.json`, `.first-tree/source.json`, and
    `.first-tree/workspace.json`
 
-`first-tree upgrade --tree-path ...` in a tree repo refreshes only tree-side
-metadata such as `.first-tree/VERSION`.
+`first-tree upgrade --tree-path ...` in a tree repo refreshes tree-side
+metadata such as `.first-tree/VERSION` plus the installed tree-repo skill.
 
 ## What Gets Preserved
 
@@ -78,6 +83,7 @@ metadata such as `.first-tree/VERSION`.
 - user-authored content outside the managed framework markers
 - source/workspace binding metadata
 - local checkout guidance in `.first-tree/local-tree.json`
+- hidden tree-side codebase submodule paths in `.first-tree/submodules/`
 
 ## Command Intent
 
@@ -108,3 +114,5 @@ metadata such as `.first-tree/VERSION`.
 - workspace child repos should share one tree, not create many parallel trees
 - shared tree bindings should live in `.first-tree/bindings/`, not in a single
   overwrite-prone bootstrap file
+- tree-side codebase submodules should live under `.first-tree/submodules/` so
+  validators do not treat them as visible tree domains

--- a/src/engine/bind.ts
+++ b/src/engine/bind.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { basename, dirname, join, resolve } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { basename, dirname, join, relative, resolve } from "node:path";
 import { Repo } from "#engine/repo.js";
 import {
   buildStableSourceId,
@@ -8,6 +8,7 @@ import {
   deriveDefaultEntrypoint,
   readTreeState,
   readWorkspaceState,
+  slugifyToken,
   type BoundTreeReference,
   type RootKind,
   type SourceBindingMode,
@@ -24,14 +25,14 @@ import {
   resolveBundledPackageRoot,
 } from "#engine/runtime/installer.js";
 import {
+  TREE_SUBMODULES_DIR,
+} from "#engine/runtime/asset-loader.js";
+import {
   readLocalTreeConfig,
   upsertLocalTreeConfig,
   upsertLocalTreeGitIgnore,
 } from "#engine/runtime/local-tree-config.js";
-import {
-  upsertFirstTreeIndexFile,
-  upsertSourceIntegrationFiles,
-} from "#engine/runtime/source-integration.js";
+import { upsertFirstTreeIndexFile, upsertSourceIntegrationFiles } from "#engine/runtime/source-integration.js";
 import { relativeRepoPath } from "#engine/dedicated-tree.js";
 
 export const BIND_USAGE = `usage: first-tree bind [--tree-path PATH | --tree-url URL] [--tree-mode dedicated|shared] [--mode standalone-source|shared-source|workspace-root|workspace-member] [--workspace-id ID] [--workspace-root PATH] [--entrypoint PATH]
@@ -44,6 +45,8 @@ What it does:
   3. Writes .first-tree/source.json and refreshes .first-tree/local-tree.json
   4. Writes .first-tree/tree.json and .first-tree/bindings/<source-id>.json
      in the target tree repo when a local tree checkout is available
+  5. Ensures the target tree repo also has the first-tree skill installed
+  6. Syncs the bound codebase repo into the tree repo under .first-tree/submodules/
 
 Typical examples:
   first-tree bind --tree-path ../org-context --tree-mode shared
@@ -63,6 +66,12 @@ Options:
 
 interface CommandRunOptions {
   cwd: string;
+}
+
+interface TreeSubmoduleSyncResult {
+  action: "created" | "skipped" | "unchanged" | "updated";
+  path?: string;
+  reason?: string;
 }
 
 type CommandRunner = (
@@ -256,14 +265,182 @@ function ensureTreeCheckout(
 }
 
 function installSkillIfNeeded(
-  sourceRepo: Repo,
+  targetRepo: Repo,
   sourceRoot: string,
-): void {
-  if (!sourceRepo.hasCurrentInstalledSkill()) {
-    copyCanonicalSkill(sourceRoot, sourceRepo.root);
-    console.log("  Installed the bundled first-tree skill locally.");
-  } else {
-    console.log("  Reused the existing installed first-tree skill.");
+): "installed" | "reused" {
+  if (!targetRepo.hasCurrentInstalledSkill()) {
+    copyCanonicalSkill(sourceRoot, targetRepo.root);
+    return "installed";
+  }
+  return "reused";
+}
+
+function readGitmodules(root: string): Map<string, string | null> {
+  const entries = new Map<string, string | null>();
+  let currentPath: string | null = null;
+
+  try {
+    const text = readFileSync(join(root, ".gitmodules"), "utf-8");
+    for (const line of text.split(/\r?\n/u)) {
+      const pathMatch = line.match(/^\s*path\s*=\s*(.+?)\s*$/u);
+      if (pathMatch?.[1]) {
+        currentPath = pathMatch[1].trim();
+        entries.set(currentPath, null);
+        continue;
+      }
+
+      const urlMatch = line.match(/^\s*url\s*=\s*(.+?)\s*$/u);
+      if (currentPath !== null && urlMatch?.[1]) {
+        entries.set(currentPath, urlMatch[1].trim());
+      }
+    }
+  } catch {
+    return entries;
+  }
+
+  return entries;
+}
+
+function buildTreeSubmodulePath(
+  sourceRepo: Repo,
+  bindingMode: SourceBindingMode,
+  workspaceId?: string,
+  workspaceRootPath?: string,
+): string {
+  if (bindingMode === "workspace-member" && workspaceId && workspaceRootPath) {
+    const relativePath = relative(workspaceRootPath, sourceRepo.root);
+    const segments = relativePath
+      .split(/[\\/]+/u)
+      .filter(Boolean)
+      .map((segment) => slugifyToken(segment));
+    return join(
+      TREE_SUBMODULES_DIR,
+      "workspaces",
+      slugifyToken(workspaceId),
+      ...segments,
+    );
+  }
+
+  if (bindingMode === "workspace-root" && workspaceId) {
+    return join(
+      TREE_SUBMODULES_DIR,
+      "workspaces",
+      slugifyToken(workspaceId),
+      "__workspace_root__",
+    );
+  }
+
+  return join(TREE_SUBMODULES_DIR, "repos", slugifyToken(sourceRepo.repoName()));
+}
+
+function resolveTreeSubmoduleUrl(
+  runner: CommandRunner,
+  sourceRepo: Repo,
+  treeRepo: Repo,
+): { requiresFileProtocol: boolean; url: string } | null {
+  const remoteUrl = readGitRemoteUrl(runner, sourceRepo.root);
+  if (remoteUrl !== null) {
+    return {
+      requiresFileProtocol: false,
+      url: remoteUrl,
+    };
+  }
+
+  if (commandOutput(runner, sourceRepo.root, ["rev-parse", "--verify", "HEAD"]) === null) {
+    return null;
+  }
+
+  return {
+    requiresFileProtocol: true,
+    url: relativeRepoPath(treeRepo.root, sourceRepo.root),
+  };
+}
+
+function syncTreeSubmodule(
+  runner: CommandRunner,
+  sourceRepo: Repo,
+  treeRepo: Repo,
+  bindingMode: SourceBindingMode,
+  workspaceId?: string,
+  workspaceRootPath?: string,
+): TreeSubmoduleSyncResult {
+  if (!sourceRepo.isGitRepo()) {
+    return {
+      action: "skipped",
+      reason: "the bound source/workspace root is not a git repository",
+    };
+  }
+
+  const submodulePath = buildTreeSubmodulePath(
+    sourceRepo,
+    bindingMode,
+    workspaceId,
+    workspaceRootPath,
+  );
+  const desiredUrl = resolveTreeSubmoduleUrl(runner, sourceRepo, treeRepo);
+  if (desiredUrl === null) {
+    return {
+      action: "skipped",
+      path: submodulePath,
+      reason:
+        "the bound source repo does not have a commit or remote yet, so git cannot add it as a submodule",
+    };
+  }
+
+  const existingUrl = readGitmodules(treeRepo.root).get(submodulePath);
+  const gitPrefix = desiredUrl.requiresFileProtocol
+    ? ["-c", "protocol.file.allow=always"]
+    : [];
+
+  try {
+    if (existingUrl === desiredUrl.url) {
+      return {
+        action: "unchanged",
+        path: submodulePath,
+      };
+    }
+
+    if (existingUrl === undefined) {
+      runner(
+        "git",
+        [
+          ...gitPrefix,
+          "submodule",
+          "add",
+          "--force",
+          desiredUrl.url,
+          submodulePath,
+        ],
+        { cwd: treeRepo.root },
+      );
+      return {
+        action: "created",
+        path: submodulePath,
+      };
+    }
+
+    runner(
+      "git",
+      [
+        ...gitPrefix,
+        "submodule",
+        "set-url",
+        "--",
+        submodulePath,
+        desiredUrl.url,
+      ],
+      { cwd: treeRepo.root },
+    );
+    return {
+      action: "updated",
+      path: submodulePath,
+    };
+  } catch (err) {
+    return {
+      action: "skipped",
+      path: submodulePath,
+      reason: err instanceof Error ? err.message : "unknown git error",
+    };
   }
 }
 
@@ -405,7 +582,19 @@ export function runBind(repo?: Repo, options?: BindOptions): number {
     console.log(`  Binding mode:          ${bindingMode}`);
     console.log(`  Tree mode:             ${treeMode}\n`);
 
-    installSkillIfNeeded(sourceRepo, sourceRoot);
+    const sourceSkillAction = installSkillIfNeeded(sourceRepo, sourceRoot);
+    const treeSkillAction = installSkillIfNeeded(
+      treeResolution.treeRepo,
+      sourceRoot,
+    );
+    const submoduleSync = syncTreeSubmodule(
+      runner,
+      sourceRepo,
+      treeResolution.treeRepo,
+      bindingMode,
+      workspaceId,
+      workspaceRootPath,
+    );
 
     const firstTreeIndex = upsertFirstTreeIndexFile(sourceRepo.root);
     const gitIgnore = upsertLocalTreeGitIgnore(sourceRepo.root);
@@ -462,6 +651,7 @@ export function runBind(repo?: Repo, options?: BindOptions): number {
       sourceId,
       sourceName: sourceRepo.repoName(),
       sourceRootPath: relativeRepoPath(treeResolution.treeRepo.root, sourceRepo.root),
+      submodulePath: submoduleSync.path,
       treeMode,
       treeRepoName: treeResolution.treeRepoName,
       workspaceId,
@@ -503,6 +693,16 @@ export function runBind(repo?: Repo, options?: BindOptions): number {
     } else if (firstTreeIndex.action === "updated") {
       console.log("  Updated FIRST_TREE.md.");
     }
+    if (sourceSkillAction === "installed") {
+      console.log("  Installed the bundled first-tree skill locally.");
+    } else {
+      console.log("  Reused the existing installed first-tree skill locally.");
+    }
+    if (treeSkillAction === "installed") {
+      console.log("  Installed the bundled first-tree skill in the tree repo.");
+    } else {
+      console.log("  Reused the existing first-tree skill in the tree repo.");
+    }
     if (gitIgnore.action === "created") {
       console.log("  Created .gitignore entries for first-tree local state.");
     } else if (gitIgnore.action === "updated") {
@@ -520,6 +720,25 @@ export function runBind(repo?: Repo, options?: BindOptions): number {
       console.log(`  Updated ${changedFiles.join(" and ")}.`);
     } else {
       console.log("  Source integration instructions were already current.");
+    }
+    if (submoduleSync.action === "created") {
+      console.log(
+        `  Added tree submodule \`${submoduleSync.path}\` for this codebase repo.`,
+      );
+    } else if (submoduleSync.action === "updated") {
+      console.log(
+        `  Updated tree submodule \`${submoduleSync.path}\` for this codebase repo.`,
+      );
+    } else if (submoduleSync.action === "unchanged") {
+      console.log(
+        `  Reused existing tree submodule \`${submoduleSync.path}\` for this codebase repo.`,
+      );
+    } else if (submoduleSync.path) {
+      console.log(
+        `  Skipped tree submodule sync for \`${submoduleSync.path}\`: ${submoduleSync.reason}.`,
+      );
+    } else {
+      console.log(`  Skipped tree submodule sync: ${submoduleSync.reason}.`);
     }
     console.log("  Wrote source and tree binding metadata.");
     return 0;

--- a/src/engine/init.ts
+++ b/src/engine/init.ts
@@ -46,6 +46,7 @@ import {
   LOCAL_TREE_CONFIG,
   installedSkillRootsDisplay,
   SOURCE_INTEGRATION_MARKER,
+  TREE_VERSION,
 } from "#engine/runtime/asset-loader.js";
 import {
   readLocalTreeConfig,
@@ -420,20 +421,35 @@ export function runInit(repo?: Repo, options?: InitOptions): number {
 
   try {
     const resolvedSourceRoot = resolveSourceRoot();
+    if (!r.hasCurrentInstalledSkill()) {
+      console.log("Installing the first-tree skill into the tree repo...");
+      installSkill(resolvedSourceRoot, r.root);
+    } else {
+      console.log("Reusing the existing first-tree skill in the tree repo.");
+    }
+    console.log();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error(`Error: ${message}`);
+    return 1;
+  }
+
+  try {
+    const resolvedSourceRoot = resolveSourceRoot();
     const frameworkDir = resolveCanonicalFrameworkRoot(resolvedSourceRoot);
     const bundledSkillVersion = readSkillVersion(resolvedSourceRoot);
-    const layout = r.frameworkLayout();
+    const hadTreeMetadata = r.pathExists(TREE_VERSION);
 
-    if (layout === null || layout === "tree") {
+    if (!hadTreeMetadata) {
       console.log(
         "Bootstrapping dedicated tree metadata from the bundled first-tree package...",
       );
-      writeTreeRuntimeVersion(r.root, bundledSkillVersion);
     } else {
       console.log(
         "Reusing the existing tree framework layout and filling any missing scaffold files...",
       );
     }
+    writeTreeRuntimeVersion(r.root, bundledSkillVersion);
 
     renderTemplates(frameworkDir, r.root);
     console.log();

--- a/src/engine/runtime/asset-loader.ts
+++ b/src/engine/runtime/asset-loader.ts
@@ -13,6 +13,7 @@ export const TREE_PROGRESS = join(TREE_RUNTIME_ROOT, "progress.md");
 export const TREE_BOOTSTRAP_STATE = join(TREE_RUNTIME_ROOT, "bootstrap.json");
 export const TREE_STATE = join(TREE_RUNTIME_ROOT, "tree.json");
 export const TREE_BINDINGS_DIR = join(TREE_RUNTIME_ROOT, "bindings");
+export const TREE_SUBMODULES_DIR = join(TREE_RUNTIME_ROOT, "submodules");
 export const LOCAL_TREE_CONFIG = join(TREE_RUNTIME_ROOT, "local-tree.json");
 export const LOCAL_TREE_TEMP_ROOT = join(TREE_RUNTIME_ROOT, "tmp");
 export const SOURCE_STATE = join(TREE_RUNTIME_ROOT, "source.json");
@@ -247,6 +248,9 @@ export function resolveFirstExistingPath(
 }
 
 export function detectFrameworkLayout(root: string): FrameworkLayout | null {
+  if (pathExists(root, TREE_VERSION)) {
+    return "tree";
+  }
   if (
     pathExists(root, join(SKILL_ROOT, "SKILL.md")) &&
     pathExists(root, INSTALLED_SKILL_VERSION) &&
@@ -256,9 +260,6 @@ export function detectFrameworkLayout(root: string): FrameworkLayout | null {
   }
   if (pathExists(root, FRAMEWORK_VERSION)) {
     return "skill";
-  }
-  if (pathExists(root, TREE_VERSION)) {
-    return "tree";
   }
   if (pathExists(root, CLAUDE_FRAMEWORK_VERSION)) {
     return "claude-skill";

--- a/src/engine/runtime/binding-state.ts
+++ b/src/engine/runtime/binding-state.ts
@@ -81,6 +81,7 @@ export interface TreeBindingState {
   sourceId: string;
   sourceName: string;
   sourceRootPath: string;
+  submodulePath?: string;
   treeMode: TreeMode;
   treeRepoName: string;
   workspaceId?: string;
@@ -346,6 +347,9 @@ export function readTreeBinding(
   if (parsed.remoteUrl !== undefined && typeof parsed.remoteUrl !== "string") {
     return null;
   }
+  if (parsed.submodulePath !== undefined && typeof parsed.submodulePath !== "string") {
+    return null;
+  }
   if (parsed.workspaceId !== undefined && typeof parsed.workspaceId !== "string") {
     return null;
   }
@@ -366,6 +370,7 @@ export function readTreeBinding(
     sourceId: parsed.sourceId,
     sourceName: parsed.sourceName,
     sourceRootPath: parsed.sourceRootPath,
+    submodulePath: parsed.submodulePath,
     treeMode: parsed.treeMode,
     treeRepoName: parsed.treeRepoName,
     workspaceId: parsed.workspaceId,

--- a/src/engine/upgrade.ts
+++ b/src/engine/upgrade.ts
@@ -12,6 +12,7 @@ import {
   AGENT_INSTRUCTIONS_FILE,
   CLAUDE_INSTRUCTIONS_FILE,
   FIRST_TREE_INDEX_FILE,
+  INSTALLED_SKILL_VERSION,
   LEGACY_AGENT_INSTRUCTIONS_FILE,
   LEGACY_REPO_SKILL_ROOT,
   SOURCE_INTEGRATION_MARKER,
@@ -40,7 +41,6 @@ import {
 } from "#engine/runtime/local-tree-config.js";
 import {
   compareSkillVersions,
-  extractMajorMinor,
   readBundledSkillVersion,
 } from "#engine/runtime/upgrader.js";
 
@@ -58,8 +58,9 @@ In a source/workspace repo: refreshes only the local installed skill, the
 section in AGENTS.md/CLAUDE.md. The dedicated tree repo must be upgraded
 separately with \`--tree-path\`.
 
-In a dedicated tree repo: refreshes \`.first-tree/VERSION\` and emits a task
-list for the maintainer.
+In a dedicated tree repo: refreshes \`.first-tree/VERSION\`, refreshes the
+installed tree-repo skill when present, and emits a task list for the
+maintainer.
 
 Migrates legacy layouts (\`.context-tree/\`, \`skills/first-tree/\`) onto the
 modern \`.agents/skills/first-tree/\` path. To pick up a newer skill version,
@@ -156,6 +157,7 @@ function formatUpgradeTaskList(
   if (layout === "tree") {
     lines.push(
       "## Tree Metadata",
+      `- [ ] Confirm the tree-repo skill at ${installedSkillRootsDisplay()} still resolves correctly after the refresh`,
       "- [ ] Replace any stale `context-tree` CLI command references in repo-specific docs, scripts, workflows, or agent config with `first-tree`",
       "",
     );
@@ -438,17 +440,50 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
   }
 
   if (layout === "tree") {
-    if (compareSkillVersions(localVersion, packagedVersion) === 0) {
+    const installedTreeSkillVersion =
+      workingRepo.readFile(INSTALLED_SKILL_VERSION)?.trim() ?? null;
+    if (
+      installedTreeSkillVersion !== null
+      && compareSkillVersions(installedTreeSkillVersion, packagedVersion) > 0
+    ) {
       console.log(
-        `Already up to date with the bundled tree metadata (${workingRepo.frameworkVersionPath()} = ${localVersion}).`,
+        "The installed tree-repo skill is newer than the skill bundled with this `first-tree` package. Install a newer package version before running `first-tree upgrade`.",
+      );
+      return 1;
+    }
+
+    const treeMetadataUpToDate =
+      compareSkillVersions(localVersion, packagedVersion) === 0;
+    const treeSkillUpToDate =
+      installedTreeSkillVersion !== null
+      && missingInstalledRoots.length === 0
+      && compareSkillVersions(installedTreeSkillVersion, packagedVersion) === 0;
+
+    if (treeMetadataUpToDate && treeSkillUpToDate) {
+      console.log(
+        `Already up to date with the bundled tree metadata and installed tree skill (${workingRepo.frameworkVersionPath()} = ${localVersion}).`,
       );
       return 0;
     }
 
-    writeTreeRuntimeVersion(workingRepo.root, packagedVersion);
-    console.log(
-      `Refreshed dedicated tree metadata at \`${workingRepo.frameworkVersionPath()}\`.`,
-    );
+    if (!treeMetadataUpToDate) {
+      writeTreeRuntimeVersion(workingRepo.root, packagedVersion);
+      console.log(
+        `Refreshed dedicated tree metadata at \`${workingRepo.frameworkVersionPath()}\`.`,
+      );
+    }
+    if (!treeSkillUpToDate) {
+      const wipedPaths = wipeInstalledSkill(workingRepo.root);
+      copyCanonicalSkill(sourceRoot, workingRepo.root);
+      if (wipedPaths.length > 0) {
+        console.log(
+          `Wiped previous tree skill installation: ${wipedPaths.map((p) => `\`${p}/\``).join(", ")}.`,
+        );
+      }
+      console.log(
+        `Refreshed tree-repo skill payload at ${installedSkillRootsDisplay()}.`,
+      );
+    }
 
     const output = formatUpgradeTaskList(
       workingRepo,

--- a/src/engine/workspace.ts
+++ b/src/engine/workspace.ts
@@ -1,6 +1,7 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
 import { Repo } from "#engine/repo.js";
+import { TREE_SUBMODULES_DIR } from "#engine/runtime/asset-loader.js";
 
 export type WorkspaceRepoKind = "git-submodule" | "nested-git-repo";
 
@@ -36,7 +37,10 @@ function parseGitmodules(root: string): string[] {
     const text = readFileSync(join(root, ".gitmodules"), "utf-8");
     return [...text.matchAll(/^\s*path\s*=\s*(.+?)\s*$/gm)]
       .map((match) => match[1]?.trim())
-      .filter((value): value is string => Boolean(value));
+      .filter(
+        (value): value is string =>
+          Boolean(value) && !value.startsWith(`${TREE_SUBMODULES_DIR}/`),
+      );
   } catch {
     return [];
   }

--- a/tests/asset-loader.test.ts
+++ b/tests/asset-loader.test.ts
@@ -53,6 +53,20 @@ describe("asset-loader", () => {
     ).toBe(TREE_VERSION);
   });
 
+  it("still prefers the dedicated tree layout when the tree repo also has an installed skill", () => {
+    const tmp = useTmpDir();
+    mkdirSync(join(tmp.path, ".agents", "skills", "first-tree"), {
+      recursive: true,
+    });
+    mkdirSync(join(tmp.path, ".first-tree"), { recursive: true });
+    writeFileSync(join(tmp.path, INSTALLED_PROGRESS), "installed");
+    writeFileSync(join(tmp.path, TREE_VERSION), "0.2.0\n");
+    writeFileSync(join(tmp.path, ".agents", "skills", "first-tree", "SKILL.md"), "skill\n");
+    writeFileSync(join(tmp.path, ".agents", "skills", "first-tree", "VERSION"), "0.2.0\n");
+
+    expect(detectFrameworkLayout(tmp.path)).toBe("tree");
+  });
+
   it("detects the previous workspace skill path before older layouts", () => {
     const tmp = useTmpDir();
     mkdirSync(join(tmp.path, "skills", "first-tree", "assets", "framework"), {

--- a/tests/bind.test.ts
+++ b/tests/bind.test.ts
@@ -1,0 +1,52 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+import { runBind } from "#engine/bind.js";
+import { Repo } from "#engine/repo.js";
+import {
+  readSourceState,
+  readTreeBinding,
+  readTreeState,
+} from "#engine/runtime/binding-state.js";
+import { makeGitRepo, makeSourceRepo, makeSourceSkill, makeTreeMetadata, useTmpDir } from "./helpers.js";
+
+describe("runBind", () => {
+  it("installs the tree-repo skill and adds a codebase submodule when binding", () => {
+    const sandbox = useTmpDir();
+    const sourceBundle = useTmpDir();
+    const sourceRoot = join(sandbox.path, "product-repo");
+    const treeRoot = join(sandbox.path, "org-context");
+
+    makeSourceRepo(sourceRoot);
+    makeGitRepo(treeRoot);
+    makeTreeMetadata(treeRoot, "0.1.0");
+    makeSourceSkill(sourceBundle.path, "0.2.0");
+
+    const result = runBind(new Repo(sourceRoot), {
+      currentCwd: sourceRoot,
+      sourceRoot: sourceBundle.path,
+      treeMode: "shared",
+      treePath: relative(sourceRoot, treeRoot),
+    });
+
+    const sourceState = readSourceState(sourceRoot);
+    expect(result).toBe(0);
+    expect(sourceState?.bindingMode).toBe("shared-source");
+    expect(readTreeState(treeRoot)?.treeRepoName).toBe("org-context");
+    expect(existsSync(join(treeRoot, ".agents", "skills", "first-tree", "SKILL.md"))).toBe(
+      true,
+    );
+    expect(existsSync(join(treeRoot, ".claude", "skills", "first-tree", "SKILL.md"))).toBe(
+      true,
+    );
+    expect(readTreeBinding(treeRoot, sourceState!.sourceId)?.submodulePath).toBe(
+      ".first-tree/submodules/repos/product-repo",
+    );
+    expect(readFileSync(join(treeRoot, ".gitmodules"), "utf-8")).toContain(
+      ".first-tree/submodules/repos/product-repo",
+    );
+    expect(readFileSync(join(treeRoot, ".gitmodules"), "utf-8")).toContain(
+      "url = ../product-repo",
+    );
+  });
+});

--- a/tests/cli-e2e.test.ts
+++ b/tests/cli-e2e.test.ts
@@ -497,9 +497,13 @@ describe.sequential("CLI e2e smoke", () => {
     expect(initResult.code).toBe(0);
 
     const treeRoot = join(sandbox.path, "product-repo-tree");
-    expect(readSourceState(sourceRoot)?.bindingMode).toBe("standalone-source");
+    const sourceState = readSourceState(sourceRoot);
+    expect(sourceState?.bindingMode).toBe("standalone-source");
     expect(readLocalTreeConfig(sourceRoot)?.treeRepoName).toBe("product-repo-tree");
     expect(readTreeState(treeRoot)?.treeRepoName).toBe("product-repo-tree");
+    expect(readTreeBinding(treeRoot, sourceState!.sourceId)?.submodulePath).toBe(
+      ".first-tree/submodules/repos/product-repo",
+    );
     expect(readFileSync(join(sourceRoot, AGENT_INSTRUCTIONS_FILE), "utf-8")).toContain(
       "FIRST-TREE-SOURCE-INTEGRATION",
     );
@@ -508,6 +512,15 @@ describe.sequential("CLI e2e smoke", () => {
     );
     expect(readFileSync(join(sourceRoot, FIRST_TREE_INDEX_FILE), "utf-8")).toContain(
       "About Context Tree",
+    );
+    expect(readFileSync(join(treeRoot, ".gitmodules"), "utf-8")).toContain(
+      ".first-tree/submodules/repos/product-repo",
+    );
+    expect(readFileSync(join(treeRoot, ".gitmodules"), "utf-8")).toContain(
+      "url = ../product-repo",
+    );
+    expect(readFileSync(join(treeRoot, ".agents", "skills", "first-tree", "SKILL.md"), "utf-8")).toContain(
+      "name: first-tree",
     );
 
     const inspectAfter = await runCliCaptured(treeRoot, [
@@ -622,6 +635,9 @@ describe.sequential("CLI e2e smoke", () => {
     expect(workspaceState?.members).toHaveLength(2);
     expect(workspaceSourceState?.rootKind).toBe("folder");
     expect(readLocalTreeConfig(workspaceRoot)?.treeMode).toBe("shared");
+    expect(readFileSync(join(treeRoot, ".agents", "skills", "first-tree", "SKILL.md"), "utf-8")).toContain(
+      "name: first-tree",
+    );
 
     for (const childRoot of [childOne, childTwo]) {
       const childSourceState = readSourceState(childRoot);
@@ -632,6 +648,12 @@ describe.sequential("CLI e2e smoke", () => {
         "FIRST-TREE-SOURCE-INTEGRATION",
       );
     }
+    expect(readFileSync(join(treeRoot, ".gitmodules"), "utf-8")).toContain(
+      ".first-tree/submodules/workspaces/workspace-root/apps/app-one",
+    );
+    expect(readFileSync(join(treeRoot, ".gitmodules"), "utf-8")).toContain(
+      ".first-tree/submodules/workspaces/workspace-root/services/service-two",
+    );
 
     makeSourceRepo(childThree);
     const workspaceSync = await runCliCaptured(workspaceRoot, [
@@ -778,5 +800,11 @@ describe.sequential("CLI e2e smoke", () => {
     expect(readSourceState(workspaceRoot)?.rootKind).toBe("git-repo");
     expect(readSourceState(childRepo)?.bindingMode).toBe("workspace-member");
     expect(readTreeBinding(treeRoot, readSourceState(childRepo)!.sourceId)).not.toBeNull();
+    expect(readFileSync(join(treeRoot, ".gitmodules"), "utf-8")).toContain(
+      ".first-tree/submodules/workspaces/git-workspace/__workspace_root__",
+    );
+    expect(readFileSync(join(treeRoot, ".gitmodules"), "utf-8")).toContain(
+      ".first-tree/submodules/workspaces/git-workspace/packages/feature-repo",
+    );
   });
 });

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -50,7 +51,34 @@ export function makeTreeMetadata(root: string, version = "0.1.0"): void {
 }
 
 export function makeGitRepo(root: string): void {
-  mkdirSync(join(root, ".git"), { recursive: true });
+  mkdirSync(root, { recursive: true });
+  execFileSync("git", ["init"], {
+    cwd: root,
+    stdio: "ignore",
+  });
+}
+
+function commitWorkingTree(root: string, message: string): void {
+  execFileSync("git", ["add", "-A"], {
+    cwd: root,
+    stdio: "ignore",
+  });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.email=first-tree-tests@example.com",
+      "-c",
+      "user.name=First Tree Tests",
+      "commit",
+      "-m",
+      message,
+    ],
+    {
+      cwd: root,
+      stdio: "ignore",
+    },
+  );
 }
 
 export function makeSourceRepo(root: string): void {
@@ -61,6 +89,7 @@ export function makeSourceRepo(root: string): void {
     JSON.stringify({ name: "example-source-repo" }, null, 2),
   );
   writeFileSync(join(root, "src", "index.ts"), "export const ready = true;\n");
+  commitWorkingTree(root, "Initial source repo");
 }
 
 export function makeLegacyFramework(root: string, version = "0.1.0"): void {

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -194,10 +194,10 @@ describe("runInit", () => {
     expect(ret).toBe(0);
     expect(
       existsSync(join(repoDir.path, ".agents", "skills", "first-tree", "SKILL.md")),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       existsSync(join(repoDir.path, ".claude", "skills", "first-tree", "SKILL.md")),
-    ).toBe(false);
+    ).toBe(true);
     expect(readFileSync(join(repoDir.path, TREE_VERSION), "utf-8").trim()).toBe("0.2.0");
     expect(existsSync(join(repoDir.path, "NODE.md"))).toBe(true);
     expect(existsSync(join(repoDir.path, AGENT_INSTRUCTIONS_FILE))).toBe(true);
@@ -282,10 +282,10 @@ describe("runInit", () => {
     });
     expect(
       existsSync(join(treeRepo, ".agents", "skills", "first-tree", "SKILL.md")),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       existsSync(join(treeRepo, ".claude", "skills", "first-tree", "SKILL.md")),
-    ).toBe(false);
+    ).toBe(true);
     expect(existsSync(join(treeRepo, "NODE.md"))).toBe(true);
     expect(existsSync(join(treeRepo, AGENT_INSTRUCTIONS_FILE))).toBe(true);
     expect(existsSync(join(treeRepo, CLAUDE_INSTRUCTIONS_FILE))).toBe(true);
@@ -451,7 +451,7 @@ describe("runInit", () => {
     expect(existsSync(join(sourceRepoDir.path, "members", "NODE.md"))).toBe(true);
     expect(existsSync(join(sourceRepoDir.path, TREE_PROGRESS))).toBe(true);
     expect(existsSync(join(sourceRepoDir.path, ".agents", "skills", "first-tree", "SKILL.md"))).toBe(
-      false,
+      true,
     );
   });
 

--- a/tests/repo.test.ts
+++ b/tests/repo.test.ts
@@ -267,6 +267,16 @@ describe("path preferences", () => {
     expect(repo.frameworkVersionPath()).toBe(TREE_VERSION);
   });
 
+  it("keeps preferring dedicated tree metadata even when the tree repo also has an installed skill", () => {
+    const tmp = useTmpDir();
+    makeTreeMetadata(tmp.path);
+    makeFramework(tmp.path);
+    const repo = new Repo(tmp.path);
+    expect(repo.frameworkLayout()).toBe("tree");
+    expect(repo.preferredProgressPath()).toBe(TREE_PROGRESS);
+    expect(repo.frameworkVersionPath()).toBe(TREE_VERSION);
+  });
+
   it("switches path preferences for repos using the previous workspace skill path", () => {
     const tmp = useTmpDir();
     makeLegacyRepoFramework(tmp.path);

--- a/tests/skill-artifacts.test.ts
+++ b/tests/skill-artifacts.test.ts
@@ -215,6 +215,7 @@ describe("skill artifacts", () => {
     expect(read("README.md")).toContain(".first-tree/workspace.json");
     expect(read("README.md")).toContain(".first-tree/tree.json");
     expect(read("README.md")).toContain(".first-tree/bindings/");
+    expect(read("README.md")).toContain(".first-tree/submodules/");
     expect(read("README.md")).toContain("`first-tree` skill");
     expect(read("README.md")).toContain("first-tree publish");
     expect(read("README.md")).toContain("<repo>-tree");
@@ -305,6 +306,7 @@ describe("skill artifacts", () => {
     expect(sourceWorkspaceInstall).toContain(".first-tree/workspace.json");
     expect(sourceWorkspaceInstall).toContain(".first-tree/tree.json");
     expect(sourceWorkspaceInstall).toContain(".first-tree/bindings/");
+    expect(sourceWorkspaceInstall).toContain(".first-tree/submodules/");
     expect(sourceWorkspaceInstall).toContain("workspace-member");
     expect(sourceWorkspaceInstall).toContain("first-tree workspace sync");
     expect(sourceWorkspaceInstall).toContain("first-tree publish");
@@ -327,6 +329,7 @@ describe("skill artifacts", () => {
     expect(maintainerArchitecture).toContain("tree repo");
     expect(maintainerArchitecture).toContain("binding");
     expect(maintainerArchitecture).toContain(".first-tree/bindings/");
+    expect(maintainerArchitecture).toContain(".first-tree/submodules/");
 
     const buildAndDistribution = read(
       "docs/maintainer-build-and-distribution.md",

--- a/tests/upgrade.test.ts
+++ b/tests/upgrade.test.ts
@@ -151,7 +151,7 @@ describe("runUpgrade", () => {
     expect(readFileSync(join(repoDir.path, INSTALLED_SKILL_VERSION), "utf-8").trim()).toBe("0.2.0");
   });
 
-  it("refreshes a dedicated tree repo without reinstalling the skill", () => {
+  it("refreshes a dedicated tree repo and installs the tree-repo skill", () => {
     const repoDir = useTmpDir();
     const sourceDir = useTmpDir();
     makeTreeMetadata(repoDir.path, "0.1.0");
@@ -164,7 +164,12 @@ describe("runUpgrade", () => {
 
     expect(result).toBe(0);
     expect(readFileSync(join(repoDir.path, TREE_VERSION), "utf-8").trim()).toBe("0.2.0");
-    expect(existsSync(join(repoDir.path, ".agents", "skills", "first-tree"))).toBe(false);
+    expect(existsSync(join(repoDir.path, ".agents", "skills", "first-tree", "SKILL.md"))).toBe(
+      true,
+    );
+    expect(existsSync(join(repoDir.path, ".claude", "skills", "first-tree", "SKILL.md"))).toBe(
+      true,
+    );
     expect(readFileSync(join(repoDir.path, TREE_PROGRESS), "utf-8")).toContain(
       ".first-tree/VERSION",
     );


### PR DESCRIPTION
## Summary
- install the bundled first-tree skill into the tree repo during init/bind/upgrade when needed
- mirror each git-backed bound codebase into the tree repo under `.first-tree/submodules/`
- keep tree detection, workspace discovery, docs, and tests aligned with the new contract

## Verification
- pnpm typecheck
- pnpm test
- pnpm build