### PR TITLE
chore: initialize shared first-tree binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ Thumbs.db
 node_modules/
 dist/
 *.tsbuildinfo
+.first-tree/local-tree.json
+.first-tree/tmp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,20 +65,25 @@ npx tsx evals/scripts/run-eval.ts --trials 3 --cases pydantic-importstring-error
 ```
 
 <!-- BEGIN FIRST-TREE-SOURCE-INTEGRATION -->
-FIRST-TREE-SOURCE-INTEGRATION: dedicated tree repo `ADHD-tree`
-FIRST-TREE-TREE-REPO-URL: `https://github.com/agent-team-foundation/first-tree-context.git`
+FIRST-TREE-SOURCE-INTEGRATION: workspace member bound to shared tree repo `first-tree-context`
+FIRST-TREE-TREE-REPO: `ADHD-tree`
+FIRST-TREE-TREE-MODE: `shared`
+FIRST-TREE-BINDING-MODE: `workspace-member`
+FIRST-TREE-TREE-REPO-URL: `https://github.com/agent-team-foundation/first-tree-context`
+FIRST-TREE-ENTRYPOINT: `/workspaces/first-tree-all/repos/first-tree`
+FIRST-TREE-WORKSPACE-ID: `first-tree-all`
 FIRST-TREE-LOCAL-TREE-CONFIG: `.first-tree/local-tree.json`
 
-This repo is a source/workspace repo. Keep all Context Tree files only in the dedicated `first-tree-context` repo.
+This repo is a workspace member. Keep all Context Tree files only in the shared `first-tree-context` repo and follow the workspace root's binding for shared context updates in workspace `first-tree-all`.
 
 Before every task:
 - Read `.first-tree/local-tree.json` first. If it exists, resolve its `localPath` value from this repo root and treat that checkout as the canonical local tree repo.
 - If that configured checkout exists locally, update it before you read anything else.
-- If the configured checkout is missing, clone a temporary working copy from `https://github.com/agent-team-foundation/first-tree-context.git` into `.first-tree/tmp/first-tree-context/`, use it for the current task, and delete it before you finish.
+- If the configured checkout is missing, clone a temporary working copy from `https://github.com/agent-team-foundation/first-tree-context` into `.first-tree/tmp/first-tree-context/`, use it for the current task, and delete it before you finish.
 - Never commit `.first-tree/local-tree.json` or anything under `.first-tree/tmp/` to this repo. They are local-only workspace state.
 
 After every task:
 - Always ask whether the tree needs updating.
-- If the task changed decisions, constraints, rationale, or ownership, open a PR in the tree repo first. Then open the source/workspace code PR.
+- If the task changed decisions, constraints, rationale, ownership, or shared workspace relationships, open a PR in the tree repo first. Then open the source/workspace code PR.
 - If the task changed only implementation details, skip the tree PR and open only the source/workspace code PR.
 <!-- END FIRST-TREE-SOURCE-INTEGRATION -->

--- a/FIRST_TREE.md
+++ b/FIRST_TREE.md
@@ -1,1 +1,1 @@
-skills/first-tree/references/about.md
+.agents/skills/first-tree/references/about.md


### PR DESCRIPTION
## Summary
- install the latest first-tree source integration in this repo
- bind this repo to the shared first-tree-context tree
- add the managed local-tree guidance files

## Verification
- config/doc-only change; no repo-specific build run