### PR TITLE
fix: stop binding codebases as tree submodules by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ The CLI:
 - installs the bundled `first-tree` skill in that tree repo if it is missing
 - scaffolds the dedicated tree repo there
 - writes binding metadata locally and in the tree repo
-- syncs the bound codebase repo into the tree repo under `.first-tree/submodules/`
 
 ### Existing Shared Tree
 
@@ -97,7 +96,7 @@ first-tree init --tree-path ../org-context --tree-mode shared
 
 If the tree is remote-only, pass `--tree-url`; `bind` / `init` will clone a
 local checkout, ensure the tree repo has the bundled skill installed, and then
-write the binding metadata plus the hidden tree-side codebase submodule.
+write the binding metadata in both locations.
 
 ### Workspace Root + Shared Tree
 
@@ -116,8 +115,7 @@ first-tree init --scope workspace --sync-members
 
 The workspace root gets its own local skill integration plus
 `.first-tree/workspace.json`. Each discovered child repo is then bound as a
-`workspace-member` to the same tree via `first-tree workspace sync`, and the
-tree repo keeps each bound child repo under `.first-tree/submodules/`.
+`workspace-member` to the same tree via `first-tree workspace sync`.
 
 ### Explicit Tree Bootstrap
 
@@ -160,7 +158,6 @@ folder before modifying anything. It reports:
     tree.json                # .first-tree/tree.json
     bindings/                # .first-tree/bindings/
       <source-id>.json
-    submodules/              # hidden codebase-repo mirrors tracked as git submodules
     bootstrap.json           # legacy compatibility for older publish flows
   NODE.md
   AGENTS.md
@@ -173,8 +170,9 @@ folder before modifying anything. It reports:
 The source/workspace root is not the tree. It should never contain `NODE.md`,
 `members/`, or tree-scoped `AGENTS.md` / `CLAUDE.md`.
 
-The tree repo keeps any bound codebase repos under `.first-tree/submodules/`
-so they do not become visible tree domains during validation.
+The tree repo stores binding metadata in `.first-tree/bindings/`, while
+source/workspace roots keep local checkout guidance in `.first-tree/local-tree.json`
+plus their own source/workspace binding state.
 
 ## Commands
 

--- a/docs/maintainer-architecture.md
+++ b/docs/maintainer-architecture.md
@@ -14,8 +14,6 @@ Bindings are stored in:
 
 - source/workspace roots: `.first-tree/source.json` and `.first-tree/workspace.json`
 - tree repos: `.first-tree/tree.json` and `.first-tree/bindings/<source-id>.json`
-- tree repos also keep hidden git-backed codebase mirrors under
-  `.first-tree/submodules/`
 
 That replaces the old one-source-at-a-time mental model that depended too
 heavily on one mutable bootstrap file.
@@ -33,8 +31,8 @@ heavily on one mutable bootstrap file.
 - keep `.agents/skills/first-tree/` and `.claude/skills/first-tree/` as alias
   symlinks in this source repo
 - keep source/workspace roots free of tree content
-- keep tree-side codebase mirrors hidden under `.first-tree/submodules/` so
-  validators never treat them as visible tree domains
+- keep tree-side metadata limited to `.first-tree/tree.json` and
+  `.first-tree/bindings/`
 - keep shared-tree behavior expressed through bindings, not heuristics alone
 - update docs, code, and tests together whenever the binding schema changes
 

--- a/skills/first-tree/SKILL.md
+++ b/skills/first-tree/SKILL.md
@@ -76,8 +76,7 @@ Default onboarding workflow:
    child repos bind to the same shared tree.
 
 During `bind` / `init`, the CLI also ensures the tree repo has the bundled
-`first-tree` skill installed and mirrors each git-backed bound codebase under
-`.first-tree/submodules/` in the tree repo.
+`first-tree` skill installed and refreshes binding metadata in both locations.
 
 ## CLI Commands
 

--- a/skills/first-tree/references/onboarding.md
+++ b/skills/first-tree/references/onboarding.md
@@ -72,7 +72,6 @@ The CLI will:
 - install the bundled `first-tree` skill in that tree repo if it is missing
 - scaffold the tree repo there
 - write binding metadata in both the source repo and the tree repo
-- sync the bound codebase repo into the tree repo under `.first-tree/submodules/`
 
 ### Case B: Single Repo + Existing Shared Tree
 
@@ -102,7 +101,6 @@ first-tree bind --tree-url git@github.com:acme/org-context.git --tree-mode share
 - write `.first-tree/source.json`
 - refresh `.first-tree/local-tree.json`
 - write `.first-tree/tree.json` and `.first-tree/bindings/<source-id>.json`
-- sync the bound codebase repo into the tree repo under `.first-tree/submodules/`
 
 ### Case C: Workspace Root + Shared Tree
 
@@ -121,8 +119,7 @@ first-tree init --scope workspace --tree-path ../org-context --tree-mode shared 
 
 The workspace root gets local integration plus `.first-tree/workspace.json`.
 Then `first-tree workspace sync` binds every discovered child repo as a
-`workspace-member` to that same shared tree and syncs each bound child repo
-into the tree repo under `.first-tree/submodules/`.
+`workspace-member` to that same shared tree.
 
 ### Case D: Explicit Tree Bootstrap
 

--- a/skills/first-tree/references/source-workspace-installation.md
+++ b/skills/first-tree/references/source-workspace-installation.md
@@ -21,8 +21,8 @@ workspace repo, or non-git workspace folder.
 - `NODE.md`, `members/`, and tree-scoped `AGENTS.md` / `CLAUDE.md` belong only
   in the tree repo.
 - The tree repo keeps its own installed skill under `.agents/skills/first-tree/`
-  and `.claude/skills/first-tree`, plus tree metadata under `.first-tree/tree.json`,
-  `.first-tree/bindings/`, and hidden codebase mirrors under `.first-tree/submodules/`.
+  and `.claude/skills/first-tree`, plus tree metadata under `.first-tree/tree.json`
+  and `.first-tree/bindings/`.
 
 ## Binding Modes
 
@@ -56,9 +56,6 @@ workspace repo, or non-git workspace folder.
     tree.json
     bindings/
       <source-id>.json
-    submodules/
-      repos/
-      workspaces/
     bootstrap.json          # legacy compatibility
   NODE.md
   AGENTS.md
@@ -80,9 +77,9 @@ When an agent is asked to install `first-tree`:
 Do not recreate a new sibling tree repo when the user already has a shared tree
 they want to keep using.
 
-Whenever a git-backed source repo is bound, also keep its checkout mirrored in
-the tree repo under `.first-tree/submodules/`. These hidden submodules are for
-tree-side code/context access and should not become visible Context Tree domains.
+Whenever a git-backed source/workspace root is bound, keep the binding metadata
+pointing at the tree checkout and published tree URL. Do not create hidden
+codebase mirrors in the tree repo by default.
 
 ## Workspace Rule
 

--- a/skills/first-tree/references/upgrade-contract.md
+++ b/skills/first-tree/references/upgrade-contract.md
@@ -51,9 +51,6 @@ In a tree repo, `first-tree init tree` produces:
   tree.json
   bindings/
     <source-id>.json
-  submodules/
-    repos/
-    workspaces/
   bootstrap.json          # legacy compatibility
 NODE.md
 AGENTS.md
@@ -83,7 +80,6 @@ metadata such as `.first-tree/VERSION` plus the installed tree-repo skill.
 - user-authored content outside the managed framework markers
 - source/workspace binding metadata
 - local checkout guidance in `.first-tree/local-tree.json`
-- hidden tree-side codebase submodule paths in `.first-tree/submodules/`
 
 ## Command Intent
 
@@ -114,5 +110,5 @@ metadata such as `.first-tree/VERSION` plus the installed tree-repo skill.
 - workspace child repos should share one tree, not create many parallel trees
 - shared tree bindings should live in `.first-tree/bindings/`, not in a single
   overwrite-prone bootstrap file
-- tree-side codebase submodules should live under `.first-tree/submodules/` so
-  validators do not treat them as visible tree domains
+- source/workspace roots should keep referencing the tree through binding
+  metadata and `.first-tree/local-tree.json`

--- a/src/engine/bind.ts
+++ b/src/engine/bind.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
-import { basename, dirname, join, relative, resolve } from "node:path";
+import { existsSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
 import { Repo } from "#engine/repo.js";
 import {
   buildStableSourceId,
@@ -8,7 +8,6 @@ import {
   deriveDefaultEntrypoint,
   readTreeState,
   readWorkspaceState,
-  slugifyToken,
   type BoundTreeReference,
   type RootKind,
   type SourceBindingMode,
@@ -24,9 +23,6 @@ import {
   copyCanonicalSkill,
   resolveBundledPackageRoot,
 } from "#engine/runtime/installer.js";
-import {
-  TREE_SUBMODULES_DIR,
-} from "#engine/runtime/asset-loader.js";
 import {
   readLocalTreeConfig,
   upsertLocalTreeConfig,
@@ -66,12 +62,6 @@ Options:
 
 interface CommandRunOptions {
   cwd: string;
-}
-
-interface TreeSubmoduleSyncResult {
-  action: "created" | "skipped" | "unchanged" | "updated";
-  path?: string;
-  reason?: string;
 }
 
 type CommandRunner = (
@@ -275,175 +265,6 @@ function installSkillIfNeeded(
   return "reused";
 }
 
-function readGitmodules(root: string): Map<string, string | null> {
-  const entries = new Map<string, string | null>();
-  let currentPath: string | null = null;
-
-  try {
-    const text = readFileSync(join(root, ".gitmodules"), "utf-8");
-    for (const line of text.split(/\r?\n/u)) {
-      const pathMatch = line.match(/^\s*path\s*=\s*(.+?)\s*$/u);
-      if (pathMatch?.[1]) {
-        currentPath = pathMatch[1].trim();
-        entries.set(currentPath, null);
-        continue;
-      }
-
-      const urlMatch = line.match(/^\s*url\s*=\s*(.+?)\s*$/u);
-      if (currentPath !== null && urlMatch?.[1]) {
-        entries.set(currentPath, urlMatch[1].trim());
-      }
-    }
-  } catch {
-    return entries;
-  }
-
-  return entries;
-}
-
-function buildTreeSubmodulePath(
-  sourceRepo: Repo,
-  bindingMode: SourceBindingMode,
-  workspaceId?: string,
-  workspaceRootPath?: string,
-): string {
-  if (bindingMode === "workspace-member" && workspaceId && workspaceRootPath) {
-    const relativePath = relative(workspaceRootPath, sourceRepo.root);
-    const segments = relativePath
-      .split(/[\\/]+/u)
-      .filter(Boolean)
-      .map((segment) => slugifyToken(segment));
-    return join(
-      TREE_SUBMODULES_DIR,
-      "workspaces",
-      slugifyToken(workspaceId),
-      ...segments,
-    );
-  }
-
-  if (bindingMode === "workspace-root" && workspaceId) {
-    return join(
-      TREE_SUBMODULES_DIR,
-      "workspaces",
-      slugifyToken(workspaceId),
-      "__workspace_root__",
-    );
-  }
-
-  return join(TREE_SUBMODULES_DIR, "repos", slugifyToken(sourceRepo.repoName()));
-}
-
-function resolveTreeSubmoduleUrl(
-  runner: CommandRunner,
-  sourceRepo: Repo,
-  treeRepo: Repo,
-): { requiresFileProtocol: boolean; url: string } | null {
-  const remoteUrl = readGitRemoteUrl(runner, sourceRepo.root);
-  if (remoteUrl !== null) {
-    return {
-      requiresFileProtocol: false,
-      url: remoteUrl,
-    };
-  }
-
-  if (commandOutput(runner, sourceRepo.root, ["rev-parse", "--verify", "HEAD"]) === null) {
-    return null;
-  }
-
-  return {
-    requiresFileProtocol: true,
-    url: relativeRepoPath(treeRepo.root, sourceRepo.root),
-  };
-}
-
-function syncTreeSubmodule(
-  runner: CommandRunner,
-  sourceRepo: Repo,
-  treeRepo: Repo,
-  bindingMode: SourceBindingMode,
-  workspaceId?: string,
-  workspaceRootPath?: string,
-): TreeSubmoduleSyncResult {
-  if (!sourceRepo.isGitRepo()) {
-    return {
-      action: "skipped",
-      reason: "the bound source/workspace root is not a git repository",
-    };
-  }
-
-  const submodulePath = buildTreeSubmodulePath(
-    sourceRepo,
-    bindingMode,
-    workspaceId,
-    workspaceRootPath,
-  );
-  const desiredUrl = resolveTreeSubmoduleUrl(runner, sourceRepo, treeRepo);
-  if (desiredUrl === null) {
-    return {
-      action: "skipped",
-      path: submodulePath,
-      reason:
-        "the bound source repo does not have a commit or remote yet, so git cannot add it as a submodule",
-    };
-  }
-
-  const existingUrl = readGitmodules(treeRepo.root).get(submodulePath);
-  const gitPrefix = desiredUrl.requiresFileProtocol
-    ? ["-c", "protocol.file.allow=always"]
-    : [];
-
-  try {
-    if (existingUrl === desiredUrl.url) {
-      return {
-        action: "unchanged",
-        path: submodulePath,
-      };
-    }
-
-    if (existingUrl === undefined) {
-      runner(
-        "git",
-        [
-          ...gitPrefix,
-          "submodule",
-          "add",
-          "--force",
-          desiredUrl.url,
-          submodulePath,
-        ],
-        { cwd: treeRepo.root },
-      );
-      return {
-        action: "created",
-        path: submodulePath,
-      };
-    }
-
-    runner(
-      "git",
-      [
-        ...gitPrefix,
-        "submodule",
-        "set-url",
-        "--",
-        submodulePath,
-        desiredUrl.url,
-      ],
-      { cwd: treeRepo.root },
-    );
-    return {
-      action: "updated",
-      path: submodulePath,
-    };
-  } catch (err) {
-    return {
-      action: "skipped",
-      path: submodulePath,
-      reason: err instanceof Error ? err.message : "unknown git error",
-    };
-  }
-}
-
 export function parseBindArgs(
   args: string[],
 ): ParsedBindArgs | { error: string } {
@@ -587,14 +408,6 @@ export function runBind(repo?: Repo, options?: BindOptions): number {
       treeResolution.treeRepo,
       sourceRoot,
     );
-    const submoduleSync = syncTreeSubmodule(
-      runner,
-      sourceRepo,
-      treeResolution.treeRepo,
-      bindingMode,
-      workspaceId,
-      workspaceRootPath,
-    );
 
     const firstTreeIndex = upsertFirstTreeIndexFile(sourceRepo.root);
     const gitIgnore = upsertLocalTreeGitIgnore(sourceRepo.root);
@@ -651,7 +464,6 @@ export function runBind(repo?: Repo, options?: BindOptions): number {
       sourceId,
       sourceName: sourceRepo.repoName(),
       sourceRootPath: relativeRepoPath(treeResolution.treeRepo.root, sourceRepo.root),
-      submodulePath: submoduleSync.path,
       treeMode,
       treeRepoName: treeResolution.treeRepoName,
       workspaceId,
@@ -720,25 +532,6 @@ export function runBind(repo?: Repo, options?: BindOptions): number {
       console.log(`  Updated ${changedFiles.join(" and ")}.`);
     } else {
       console.log("  Source integration instructions were already current.");
-    }
-    if (submoduleSync.action === "created") {
-      console.log(
-        `  Added tree submodule \`${submoduleSync.path}\` for this codebase repo.`,
-      );
-    } else if (submoduleSync.action === "updated") {
-      console.log(
-        `  Updated tree submodule \`${submoduleSync.path}\` for this codebase repo.`,
-      );
-    } else if (submoduleSync.action === "unchanged") {
-      console.log(
-        `  Reused existing tree submodule \`${submoduleSync.path}\` for this codebase repo.`,
-      );
-    } else if (submoduleSync.path) {
-      console.log(
-        `  Skipped tree submodule sync for \`${submoduleSync.path}\`: ${submoduleSync.reason}.`,
-      );
-    } else {
-      console.log(`  Skipped tree submodule sync: ${submoduleSync.reason}.`);
     }
     console.log("  Wrote source and tree binding metadata.");
     return 0;

--- a/src/engine/runtime/binding-state.ts
+++ b/src/engine/runtime/binding-state.ts
@@ -81,7 +81,6 @@ export interface TreeBindingState {
   sourceId: string;
   sourceName: string;
   sourceRootPath: string;
-  submodulePath?: string;
   treeMode: TreeMode;
   treeRepoName: string;
   workspaceId?: string;
@@ -347,9 +346,6 @@ export function readTreeBinding(
   if (parsed.remoteUrl !== undefined && typeof parsed.remoteUrl !== "string") {
     return null;
   }
-  if (parsed.submodulePath !== undefined && typeof parsed.submodulePath !== "string") {
-    return null;
-  }
   if (parsed.workspaceId !== undefined && typeof parsed.workspaceId !== "string") {
     return null;
   }
@@ -370,7 +366,6 @@ export function readTreeBinding(
     sourceId: parsed.sourceId,
     sourceName: parsed.sourceName,
     sourceRootPath: parsed.sourceRootPath,
-    submodulePath: parsed.submodulePath,
     treeMode: parsed.treeMode,
     treeRepoName: parsed.treeRepoName,
     workspaceId: parsed.workspaceId,

--- a/tests/bind.test.ts
+++ b/tests/bind.test.ts
@@ -7,11 +7,12 @@ import {
   readSourceState,
   readTreeBinding,
   readTreeState,
+  treeBindingPath,
 } from "#engine/runtime/binding-state.js";
 import { makeGitRepo, makeSourceRepo, makeSourceSkill, makeTreeMetadata, useTmpDir } from "./helpers.js";
 
 describe("runBind", () => {
-  it("installs the tree-repo skill and adds a codebase submodule when binding", () => {
+  it("installs the tree-repo skill without creating a codebase submodule", () => {
     const sandbox = useTmpDir();
     const sourceBundle = useTmpDir();
     const sourceRoot = join(sandbox.path, "product-repo");
@@ -30,6 +31,7 @@ describe("runBind", () => {
     });
 
     const sourceState = readSourceState(sourceRoot);
+    const treeBinding = readTreeBinding(treeRoot, sourceState!.sourceId);
     expect(result).toBe(0);
     expect(sourceState?.bindingMode).toBe("shared-source");
     expect(readTreeState(treeRoot)?.treeRepoName).toBe("org-context");
@@ -39,14 +41,12 @@ describe("runBind", () => {
     expect(existsSync(join(treeRoot, ".claude", "skills", "first-tree", "SKILL.md"))).toBe(
       true,
     );
-    expect(readTreeBinding(treeRoot, sourceState!.sourceId)?.submodulePath).toBe(
-      ".first-tree/submodules/repos/product-repo",
-    );
-    expect(readFileSync(join(treeRoot, ".gitmodules"), "utf-8")).toContain(
-      ".first-tree/submodules/repos/product-repo",
-    );
-    expect(readFileSync(join(treeRoot, ".gitmodules"), "utf-8")).toContain(
-      "url = ../product-repo",
-    );
+    expect(treeBinding?.sourceName).toBe("product-repo");
+    expect(existsSync(join(treeRoot, ".gitmodules"))).toBe(false);
+    expect(
+      JSON.parse(
+        readFileSync(treeBindingPath(treeRoot, sourceState!.sourceId), "utf-8"),
+      ),
+    ).not.toHaveProperty("submodulePath");
   });
 });

--- a/tests/cli-e2e.test.ts
+++ b/tests/cli-e2e.test.ts
@@ -501,9 +501,7 @@ describe.sequential("CLI e2e smoke", () => {
     expect(sourceState?.bindingMode).toBe("standalone-source");
     expect(readLocalTreeConfig(sourceRoot)?.treeRepoName).toBe("product-repo-tree");
     expect(readTreeState(treeRoot)?.treeRepoName).toBe("product-repo-tree");
-    expect(readTreeBinding(treeRoot, sourceState!.sourceId)?.submodulePath).toBe(
-      ".first-tree/submodules/repos/product-repo",
-    );
+    expect(readTreeBinding(treeRoot, sourceState!.sourceId)).not.toBeNull();
     expect(readFileSync(join(sourceRoot, AGENT_INSTRUCTIONS_FILE), "utf-8")).toContain(
       "FIRST-TREE-SOURCE-INTEGRATION",
     );
@@ -512,12 +510,6 @@ describe.sequential("CLI e2e smoke", () => {
     );
     expect(readFileSync(join(sourceRoot, FIRST_TREE_INDEX_FILE), "utf-8")).toContain(
       "About Context Tree",
-    );
-    expect(readFileSync(join(treeRoot, ".gitmodules"), "utf-8")).toContain(
-      ".first-tree/submodules/repos/product-repo",
-    );
-    expect(readFileSync(join(treeRoot, ".gitmodules"), "utf-8")).toContain(
-      "url = ../product-repo",
     );
     expect(readFileSync(join(treeRoot, ".agents", "skills", "first-tree", "SKILL.md"), "utf-8")).toContain(
       "name: first-tree",
@@ -648,12 +640,6 @@ describe.sequential("CLI e2e smoke", () => {
         "FIRST-TREE-SOURCE-INTEGRATION",
       );
     }
-    expect(readFileSync(join(treeRoot, ".gitmodules"), "utf-8")).toContain(
-      ".first-tree/submodules/workspaces/workspace-root/apps/app-one",
-    );
-    expect(readFileSync(join(treeRoot, ".gitmodules"), "utf-8")).toContain(
-      ".first-tree/submodules/workspaces/workspace-root/services/service-two",
-    );
 
     makeSourceRepo(childThree);
     const workspaceSync = await runCliCaptured(workspaceRoot, [
@@ -800,11 +786,5 @@ describe.sequential("CLI e2e smoke", () => {
     expect(readSourceState(workspaceRoot)?.rootKind).toBe("git-repo");
     expect(readSourceState(childRepo)?.bindingMode).toBe("workspace-member");
     expect(readTreeBinding(treeRoot, readSourceState(childRepo)!.sourceId)).not.toBeNull();
-    expect(readFileSync(join(treeRoot, ".gitmodules"), "utf-8")).toContain(
-      ".first-tree/submodules/workspaces/git-workspace/__workspace_root__",
-    );
-    expect(readFileSync(join(treeRoot, ".gitmodules"), "utf-8")).toContain(
-      ".first-tree/submodules/workspaces/git-workspace/packages/feature-repo",
-    );
   });
 });

--- a/tests/skill-artifacts.test.ts
+++ b/tests/skill-artifacts.test.ts
@@ -56,7 +56,7 @@ describe("skill artifacts", () => {
     expect(readlinkSync(join(ROOT, "CLAUDE.md"))).toBe("AGENTS.md");
     expect(lstatSync(join(ROOT, "FIRST_TREE.md")).isSymbolicLink()).toBe(true);
     expect(readlinkSync(join(ROOT, "FIRST_TREE.md"))).toBe(
-      "skills/first-tree/references/about.md",
+      ".agents/skills/first-tree/references/about.md",
     );
     expect(lstatSync(join(ROOT, ".agents", "skills", "first-tree")).isSymbolicLink()).toBe(true);
     expect(readlinkSync(join(ROOT, ".agents", "skills", "first-tree"))).toBe(
@@ -215,7 +215,7 @@ describe("skill artifacts", () => {
     expect(read("README.md")).toContain(".first-tree/workspace.json");
     expect(read("README.md")).toContain(".first-tree/tree.json");
     expect(read("README.md")).toContain(".first-tree/bindings/");
-    expect(read("README.md")).toContain(".first-tree/submodules/");
+    expect(read("README.md")).not.toContain(".first-tree/submodules/");
     expect(read("README.md")).toContain("`first-tree` skill");
     expect(read("README.md")).toContain("first-tree publish");
     expect(read("README.md")).toContain("<repo>-tree");
@@ -242,6 +242,7 @@ describe("skill artifacts", () => {
     expect(onboarding).toContain(".first-tree/workspace.json");
     expect(onboarding).toContain(".first-tree/tree.json");
     expect(onboarding).toContain(".first-tree/bindings/");
+    expect(onboarding).not.toContain(".first-tree/submodules/");
     expect(onboarding).toContain("<repo>-tree");
     expect(onboarding).toContain("first-tree init tree --here");
     expect(onboarding).toContain("shared tree");
@@ -277,6 +278,7 @@ describe("skill artifacts", () => {
     expect(skillMd).toContain("After Every Task");
     expect(skillMd).toContain("npx -p first-tree first-tree");
     expect(skillMd).toContain("--skip-version-check");
+    expect(skillMd).not.toContain(".first-tree/submodules/");
 
     const sourceMap = read("docs/source-map.md");
     expect(sourceMap).not.toContain("repo-snapshot");
@@ -306,7 +308,7 @@ describe("skill artifacts", () => {
     expect(sourceWorkspaceInstall).toContain(".first-tree/workspace.json");
     expect(sourceWorkspaceInstall).toContain(".first-tree/tree.json");
     expect(sourceWorkspaceInstall).toContain(".first-tree/bindings/");
-    expect(sourceWorkspaceInstall).toContain(".first-tree/submodules/");
+    expect(sourceWorkspaceInstall).not.toContain(".first-tree/submodules/");
     expect(sourceWorkspaceInstall).toContain("workspace-member");
     expect(sourceWorkspaceInstall).toContain("first-tree workspace sync");
     expect(sourceWorkspaceInstall).toContain("first-tree publish");
@@ -329,7 +331,12 @@ describe("skill artifacts", () => {
     expect(maintainerArchitecture).toContain("tree repo");
     expect(maintainerArchitecture).toContain("binding");
     expect(maintainerArchitecture).toContain(".first-tree/bindings/");
-    expect(maintainerArchitecture).toContain(".first-tree/submodules/");
+    expect(maintainerArchitecture).not.toContain(".first-tree/submodules/");
+
+    const upgradeContract = read(
+      "skills/first-tree/references/upgrade-contract.md",
+    );
+    expect(upgradeContract).not.toContain(".first-tree/submodules/");
 
     const buildAndDistribution = read(
       "docs/maintainer-build-and-distribution.md",


### PR DESCRIPTION
## Summary
- stop `first-tree bind` from auto-creating tree-side submodules for bound codebases
- keep the tree-repo skill install behavior while restoring URL-and-binding-metadata defaults
- update docs and tests to describe bindings without hidden `.first-tree/submodules/` mirrors

## Validation
- pnpm validate:skill
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm pack