### PR TITLE
fix(bind): populate remoteUrl from source repo's git remote

### DIFF
--- a/src/engine/bind.ts
+++ b/src/engine/bind.ts
@@ -642,10 +642,13 @@ export function runBind(repo?: Repo, options?: BindOptions): number {
       treeMode,
       treeRepoName: treeResolution.treeRepoName,
     });
+    const sourceRemoteUrl = sourceRepo.isGitRepo()
+      ? readGitRemoteUrl(runner, sourceRepo.root)
+      : null;
     writeTreeBinding(treeResolution.treeRepo.root, sourceId, {
       bindingMode,
       entrypoint,
-      remoteUrl,
+      remoteUrl: sourceRemoteUrl ?? undefined,
       rootKind,
       scope,
       sourceId,


### PR DESCRIPTION
## Summary

- `writeTreeBinding` was using the tree repo's URL for the binding's `remoteUrl` field instead of the source repo's `origin` remote
- This left `remoteUrl` undefined for any source whose tree had no published URL
- Now reads `git remote get-url origin` from the source repo and writes it into the binding

Closes #80

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test --exclude 'tests/skill-artifacts.test.ts'` — 318/318 passing
- [x] `pnpm build` — clean

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)