### PR TITLE
chore: align shared tree binding metadata

### DIFF
--- a/.first-tree/source.json
+++ b/.first-tree/source.json
@@ -1,0 +1,18 @@
+{
+  "bindingMode": "workspace-member",
+  "rootKind": "git-repo",
+  "scope": "workspace",
+  "sourceId": "first-tree-b27f27a6",
+  "sourceName": "first-tree",
+  "tree": {
+    "entrypoint": "/workspaces/first-tree-all/repos/first-tree",
+    "localPath": "../first-tree-context",
+    "remoteUrl": "https://github.com/agent-team-foundation/first-tree-context",
+    "treeId": "first-tree-context",
+    "treeMode": "shared",
+    "treeRepoName": "first-tree-context"
+  },
+  "workspaceId": "first-tree-all",
+  "workspaceRootPath": "..",
+  "schemaVersion": 1
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Local first-tree scratch data
-.first-tree/
+.first-tree/*
+!.first-tree/source.json
 
 # IDE
 .idea/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,8 +65,8 @@ npx tsx evals/scripts/run-eval.ts --trials 3 --cases pydantic-importstring-error
 ```
 
 <!-- BEGIN FIRST-TREE-SOURCE-INTEGRATION -->
-FIRST-TREE-SOURCE-INTEGRATION: workspace member bound to shared tree repo `ADHD-tree`
-FIRST-TREE-TREE-REPO: `ADHD-tree`
+FIRST-TREE-SOURCE-INTEGRATION: workspace member bound to shared tree repo `first-tree-context`
+FIRST-TREE-TREE-REPO: `first-tree-context`
 FIRST-TREE-TREE-MODE: `shared`
 FIRST-TREE-BINDING-MODE: `workspace-member`
 FIRST-TREE-TREE-REPO-URL: `https://github.com/agent-team-foundation/first-tree-context`
@@ -74,12 +74,12 @@ FIRST-TREE-ENTRYPOINT: `/workspaces/first-tree-all/repos/first-tree`
 FIRST-TREE-WORKSPACE-ID: `first-tree-all`
 FIRST-TREE-LOCAL-TREE-CONFIG: `.first-tree/local-tree.json`
 
-This repo is a workspace member. Keep all Context Tree files only in the shared `ADHD-tree` repo and follow the workspace root's binding for shared context updates in workspace `first-tree-all`.
+This repo is a workspace member. Keep all Context Tree files only in the shared `first-tree-context` repo and follow the workspace root's binding for shared context updates in workspace `first-tree-all`.
 
 Before every task:
 - Read `.first-tree/local-tree.json` first. If it exists, resolve its `localPath` value from this repo root and treat that checkout as the canonical local tree repo.
 - If that configured checkout exists locally, update it before you read anything else.
-- If the configured checkout is missing, clone a temporary working copy from `https://github.com/agent-team-foundation/first-tree-context` into `.first-tree/tmp/ADHD-tree/`, use it for the current task, and delete it before you finish.
+- If the configured checkout is missing, clone a temporary working copy from `https://github.com/agent-team-foundation/first-tree-context` into `.first-tree/tmp/first-tree-context/`, use it for the current task, and delete it before you finish.
 - Never commit `.first-tree/local-tree.json` or anything under `.first-tree/tmp/` to this repo. They are local-only workspace state.
 
 After every task:


### PR DESCRIPTION
## Summary
- replace the stale `ADHD-tree` workspace-member references with `first-tree-context`
- start tracking the committed `.first-tree/source.json` workspace binding metadata required by the latest first-tree contract
- keep this repo aligned with shared-tree PR #116

## Verification
- `npx -p first-tree first-tree inspect --json --skip-version-check`