### PR TITLE
Improve PR review context loading

### DIFF
--- a/assets/framework/helpers/run-review.ts
+++ b/assets/framework/helpers/run-review.ts
@@ -8,8 +8,14 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 
 const CLAUDE_BIN = join(homedir(), ".local", "bin", "claude");
@@ -18,6 +24,7 @@ const MAX_ATTEMPTS = 3;
 // though retries are cheap in practice due to cached context via --continue.
 const MAX_BUDGET_USD = 0.5;
 const AGENT_INSTRUCTIONS_PATHS = ["AGENTS.md", "AGENT.md"] as const;
+const DEFAULT_PR_METADATA_PATH = "/tmp/pr-metadata.json";
 
 function resolveAgentInstructionsPath(): string {
   for (const candidate of AGENT_INSTRUCTIONS_PATHS) {
@@ -34,7 +41,13 @@ function resolveAgentInstructionsPath(): string {
 export function buildPrompt(
   diffPath: string,
   reviewPromptPath: string,
+  options: PrepareReviewWorkspaceOptions = {},
 ): string {
+  const reviewWorkspace = prepareReviewWorkspace(diffPath, {
+    prMetadataPath: options.prMetadataPath ?? DEFAULT_PR_METADATA_PATH,
+    prMetadata: options.prMetadata,
+    workspaceRoot: options.workspaceRoot,
+  });
   const parts: string[] = [];
   const agentInstructionsPath = resolveAgentInstructionsPath();
   const files: [string, string][] = [
@@ -46,9 +59,251 @@ export function buildPrompt(
     const content = readFileSync(path, "utf-8");
     parts.push(`## ${heading}\n\n${content}`);
   }
-  const diff = readFileSync(diffPath, "utf-8");
-  parts.push(`## PR Diff\n\n\`\`\`\n${diff}\`\`\``);
+  parts.push(
+    [
+      "## PR Review Context",
+      "",
+      "You are running inside a checked-out Context Tree repo with local file and shell access.",
+      "Do not load the entire raw diff unless it is absolutely necessary.",
+      "Start from the PR overview and changed-file manifest below, then inspect only the",
+      "per-file patches and tree files needed to reach your review.",
+      "",
+      renderPrOverview(reviewWorkspace.metadata),
+      "",
+      "## Changed Files Manifest",
+      "",
+      reviewWorkspace.manifestMarkdown,
+      "",
+      "## On-Demand Evidence",
+      "",
+      `- Structured manifest JSON: \`${reviewWorkspace.manifestPath}\``,
+      `- Per-file patch directory: \`${reviewWorkspace.patchesDir}\``,
+      `- Full raw diff (use only if required): \`${reviewWorkspace.fullDiffPath}\``,
+    ].join("\n"),
+  );
   return parts.join("\n\n");
+}
+
+export interface PrMetadataFile {
+  path: string;
+  additions?: number;
+  deletions?: number;
+}
+
+export interface PrMetadata {
+  url?: string;
+  title?: string;
+  body?: string;
+  files?: PrMetadataFile[];
+}
+
+export interface DiffSection {
+  oldPath: string;
+  newPath: string;
+  path: string;
+  patch: string;
+}
+
+export interface ReviewWorkspaceFile extends PrMetadataFile {
+  oldPath?: string;
+  newPath?: string;
+  patchPath?: string;
+}
+
+interface ReviewWorkspaceManifest {
+  pr: {
+    url?: string;
+    title?: string;
+    body?: string;
+    metadataPath?: string;
+  };
+  files: ReviewWorkspaceFile[];
+  fullDiffPath: string;
+}
+
+export interface ReviewWorkspace {
+  rootDir: string;
+  patchesDir: string;
+  manifestPath: string;
+  manifestMarkdown: string;
+  fullDiffPath: string;
+  metadata: PrMetadata | null;
+  files: ReviewWorkspaceFile[];
+}
+
+interface PrepareReviewWorkspaceOptions {
+  prMetadataPath?: string;
+  prMetadata?: PrMetadata | null;
+  workspaceRoot?: string;
+}
+
+function readPrMetadata(path: string): PrMetadata | null {
+  if (!existsSync(path)) {
+    return null;
+  }
+
+  try {
+    const raw = readFileSync(path, "utf-8");
+    return JSON.parse(raw) as PrMetadata;
+  } catch {
+    return null;
+  }
+}
+
+function parseDiffHeader(line: string): { oldPath: string; newPath: string } | null {
+  const match = line.match(/^diff --git a\/(.+?) b\/(.+)$/);
+  if (!match) {
+    return null;
+  }
+  return {
+    oldPath: match[1],
+    newPath: match[2],
+  };
+}
+
+export function splitDiffByFile(diffText: string): DiffSection[] {
+  const sections: DiffSection[] = [];
+  const lines = diffText.split("\n");
+  let currentHeader: { oldPath: string; newPath: string } | null = null;
+  let currentLines: string[] = [];
+
+  const flush = () => {
+    if (!currentHeader || currentLines.length === 0) {
+      currentHeader = null;
+      currentLines = [];
+      return;
+    }
+
+    sections.push({
+      oldPath: currentHeader.oldPath,
+      newPath: currentHeader.newPath,
+      path: currentHeader.newPath === "/dev/null" ? currentHeader.oldPath : currentHeader.newPath,
+      patch: currentLines.join("\n"),
+    });
+    currentHeader = null;
+    currentLines = [];
+  };
+
+  for (const line of lines) {
+    if (line.startsWith("diff --git ")) {
+      flush();
+      currentHeader = parseDiffHeader(line);
+      currentLines = [line];
+      continue;
+    }
+
+    if (currentHeader) {
+      currentLines.push(line);
+    }
+  }
+
+  flush();
+  return sections;
+}
+
+function sanitizePatchFilename(path: string, index: number): string {
+  const cleaned = path.replace(/[^A-Za-z0-9._-]+/g, "__").replace(/^_+|_+$/g, "");
+  return `${String(index).padStart(4, "0")}-${cleaned || "file"}.diff`;
+}
+
+function renderPrOverview(metadata: PrMetadata | null): string {
+  if (!metadata) {
+    return "## PR Overview\n\n- PR metadata file was not available. Use the changed-file manifest below.";
+  }
+
+  const lines = ["## PR Overview", ""];
+  if (metadata.url) {
+    lines.push(`- URL: ${metadata.url}`);
+  }
+  if (metadata.title) {
+    lines.push(`- Title: ${metadata.title}`);
+  }
+  if (metadata.body) {
+    lines.push(`- Body: ${metadata.body}`);
+  }
+  if (metadata.files?.length) {
+    lines.push(`- Changed files: ${metadata.files.length}`);
+  }
+
+  return lines.join("\n");
+}
+
+function renderManifestMarkdown(files: ReviewWorkspaceFile[]): string {
+  if (files.length === 0) {
+    return "- No changed files were reported.";
+  }
+
+  return files
+    .map((file) => {
+      const counts =
+        typeof file.additions === "number" || typeof file.deletions === "number"
+          ? ` (+${file.additions ?? 0} / -${file.deletions ?? 0})`
+          : "";
+      const patchRef = file.patchPath ? ` -> \`${file.patchPath}\`` : "";
+      return `- \`${file.path}\`${counts}${patchRef}`;
+    })
+    .join("\n");
+}
+
+export function prepareReviewWorkspace(
+  diffPath: string,
+  options: PrepareReviewWorkspaceOptions = {},
+): ReviewWorkspace {
+  const prMetadata =
+    options.prMetadata ??
+    (options.prMetadataPath ? readPrMetadata(options.prMetadataPath) : null) ??
+    readPrMetadata(DEFAULT_PR_METADATA_PATH);
+  const diffText = readFileSync(diffPath, "utf-8");
+  const sections = splitDiffByFile(diffText);
+  const rootDir =
+    options.workspaceRoot ?? mkdtempSync(join(tmpdir(), "first-tree-review-"));
+  const patchesDir = join(rootDir, "patches");
+  mkdirSync(patchesDir, { recursive: true });
+
+  const patchPathByKey = new Map<string, string>();
+  for (const [index, section] of sections.entries()) {
+    const patchPath = join(patchesDir, sanitizePatchFilename(section.path, index));
+    writeFileSync(patchPath, section.patch);
+    patchPathByKey.set(section.path, patchPath);
+    patchPathByKey.set(section.oldPath, patchPath);
+    patchPathByKey.set(section.newPath, patchPath);
+  }
+
+  const files: ReviewWorkspaceFile[] =
+    prMetadata?.files && prMetadata.files.length > 0
+      ? prMetadata.files.map((file) => ({
+          ...file,
+          patchPath: patchPathByKey.get(file.path),
+        }))
+      : sections.map((section) => ({
+          path: section.path,
+          oldPath: section.oldPath,
+          newPath: section.newPath,
+          patchPath: patchPathByKey.get(section.path),
+        }));
+
+  const manifestPath = join(rootDir, "manifest.json");
+  const manifest: ReviewWorkspaceManifest = {
+    pr: {
+      url: prMetadata?.url,
+      title: prMetadata?.title,
+      body: prMetadata?.body,
+      metadataPath: options.prMetadataPath ?? (prMetadata ? DEFAULT_PR_METADATA_PATH : undefined),
+    },
+    files,
+    fullDiffPath: diffPath,
+  };
+  writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+
+  return {
+    rootDir,
+    patchesDir,
+    manifestPath,
+    manifestMarkdown: renderManifestMarkdown(files),
+    fullDiffPath: diffPath,
+    metadata: prMetadata,
+    files,
+  };
 }
 
 export function extractStreamText(jsonl: string): string {

--- a/assets/framework/workflows/pr-review.yml
+++ b/assets/framework/workflows/pr-review.yml
@@ -42,6 +42,7 @@ jobs:
           PR_NUMBER=${{ github.event.pull_request.number || github.event.issue.number }}
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           gh pr diff "$PR_NUMBER" > /tmp/pr-diff.txt
+          gh pr view "$PR_NUMBER" --json url,title,body,files > /tmp/pr-metadata.json
           gh pr view "$PR_NUMBER" --json headRefOid -q .headRefOid > /tmp/pr-head-sha.txt
 
       - name: Run Claude review

--- a/tests/run-review.test.ts
+++ b/tests/run-review.test.ts
@@ -1,7 +1,13 @@
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  buildPrompt,
   extractStreamText,
   extractReviewJson,
+  prepareReviewWorkspace,
+  splitDiffByFile,
 } from "../assets/framework/helpers/run-review.js";
 
 // --- extractStreamText ---
@@ -151,5 +157,128 @@ describe("extractReviewJson", () => {
     expect(
       extractReviewJson('{"verdict": "", "summary": "Empty"}'),
     ).toBeNull();
+  });
+});
+
+// --- splitDiffByFile ---
+
+describe("splitDiffByFile", () => {
+  it("splits a multi-file diff into per-file sections", () => {
+    const diff = [
+      "diff --git a/foo.md b/foo.md",
+      "index 1111111..2222222 100644",
+      "--- a/foo.md",
+      "+++ b/foo.md",
+      "@@ -1 +1 @@",
+      "-old",
+      "+new",
+      "diff --git a/bar/NODE.md b/bar/NODE.md",
+      "index 3333333..4444444 100644",
+      "--- a/bar/NODE.md",
+      "+++ b/bar/NODE.md",
+      "@@ -1 +1 @@",
+      "-old node",
+      "+new node",
+    ].join("\n");
+
+    const sections = splitDiffByFile(diff);
+    expect(sections).toHaveLength(2);
+    expect(sections[0].path).toBe("foo.md");
+    expect(sections[0].patch).toContain("+new");
+    expect(sections[1].path).toBe("bar/NODE.md");
+    expect(sections[1].patch).toContain("+new node");
+  });
+});
+
+// --- prepareReviewWorkspace / buildPrompt ---
+
+describe("review workspace preparation", () => {
+  it("writes manifest and per-file patches for on-demand inspection", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "first-tree-review-test-"));
+    const diffPath = join(tempDir, "pr.diff");
+    const metadataPath = join(tempDir, "pr-metadata.json");
+    const workspaceRoot = join(tempDir, "workspace");
+
+    writeFileSync(
+      diffPath,
+      [
+        "diff --git a/foo.md b/foo.md",
+        "index 1111111..2222222 100644",
+        "--- a/foo.md",
+        "+++ b/foo.md",
+        "@@ -1 +1 @@",
+        "-old",
+        "+new",
+      ].join("\n"),
+    );
+    writeFileSync(
+      metadataPath,
+      JSON.stringify({
+        url: "https://github.com/example/repo/pull/1",
+        title: "Review me",
+        files: [{ path: "foo.md", additions: 1, deletions: 1 }],
+      }),
+    );
+
+    const workspace = prepareReviewWorkspace(diffPath, {
+      prMetadataPath: metadataPath,
+      workspaceRoot,
+    });
+
+    expect(workspace.files).toHaveLength(1);
+    expect(workspace.files[0].patchPath).toBeDefined();
+    expect(readFileSync(workspace.manifestPath, "utf-8")).toContain(
+      "https://github.com/example/repo/pull/1",
+    );
+    expect(readFileSync(workspace.files[0].patchPath!, "utf-8")).toContain(
+      "diff --git a/foo.md b/foo.md",
+    );
+  });
+
+  it("keeps the raw diff out of the initial prompt", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "first-tree-review-prompt-"));
+    const diffPath = join(tempDir, "pr.diff");
+    const metadataPath = join(tempDir, "pr-metadata.json");
+    const reviewPromptPath = join(tempDir, "review.md");
+    const workspaceRoot = join(tempDir, "workspace");
+    const uniqueDiffMarker = "UNIQUE_DIFF_MARKER_FOR_PROMPT";
+    const originalCwd = process.cwd();
+
+    writeFileSync(join(tempDir, "AGENTS.md"), "# Instructions\n\nFollow the tree rules.");
+    writeFileSync(join(tempDir, "NODE.md"), "---\ntitle: Root\nowners: [*]\n---\n\n# Root");
+    writeFileSync(reviewPromptPath, "Return ONLY JSON.");
+    writeFileSync(
+      diffPath,
+      [
+        "diff --git a/foo.md b/foo.md",
+        "index 1111111..2222222 100644",
+        "--- a/foo.md",
+        "+++ b/foo.md",
+        "@@ -1 +1 @@",
+        `+${uniqueDiffMarker}`,
+      ].join("\n"),
+    );
+    writeFileSync(
+      metadataPath,
+      JSON.stringify({
+        url: "https://github.com/example/repo/pull/1",
+        title: "Prompt check",
+        files: [{ path: "foo.md", additions: 1, deletions: 0 }],
+      }),
+    );
+
+    process.chdir(tempDir);
+    try {
+      const prompt = buildPrompt(diffPath, reviewPromptPath, {
+        prMetadataPath: metadataPath,
+        workspaceRoot,
+      });
+
+      expect(prompt).toContain("https://github.com/example/repo/pull/1");
+      expect(prompt).toContain("Structured manifest JSON");
+      expect(prompt).not.toContain(uniqueDiffMarker);
+    } finally {
+      process.chdir(originalCwd);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- stop embedding the full PR diff in the initial Claude review prompt
- generate a lightweight review workspace with PR metadata, a changed-file manifest, and per-file patch files for on-demand inspection
- add workflow metadata output plus tests that lock in the new prompt behavior

## Verification
- pnpm test tests/run-review.test.ts
- pnpm typecheck
- pnpm build