### PR TITLE
fix: detect duplicate agent placeholder blocks

### DIFF
--- a/src/engine/repo.ts
+++ b/src/engine/repo.ts
@@ -90,6 +90,22 @@ const SOURCE_DIR_HINTS = new Set([
 
 export const FRAMEWORK_BEGIN_MARKER = "<!-- BEGIN CONTEXT-TREE FRAMEWORK";
 export const FRAMEWORK_END_MARKER = "<!-- END CONTEXT-TREE FRAMEWORK -->";
+export const PROJECT_SPECIFIC_INSTRUCTIONS_HEADER =
+  "# Project-Specific Instructions";
+export const PROJECT_SPECIFIC_INSTRUCTIONS_PLACEHOLDER =
+  "<!-- Add your project-specific agent instructions below this line. -->";
+const PROJECT_SPECIFIC_PLACEHOLDER_RE =
+  /# Project-Specific Instructions\s*\n(?:\s*\n)*<!-- Add your project-specific agent instructions below this line\. -->/g;
+
+export function countProjectSpecificPlaceholderBlocks(text: string): number {
+  const normalized = text.replaceAll("\r\n", "\n");
+  const markerIndex = normalized.indexOf(FRAMEWORK_END_MARKER);
+  const searchText =
+    markerIndex >= 0
+      ? normalized.slice(markerIndex + FRAMEWORK_END_MARKER.length)
+      : normalized;
+  return searchText.match(PROJECT_SPECIFIC_PLACEHOLDER_RE)?.length ?? 0;
+}
 
 export interface Frontmatter {
   title?: string;

--- a/src/engine/rules/agent-instructions.ts
+++ b/src/engine/rules/agent-instructions.ts
@@ -1,4 +1,8 @@
-import { FRAMEWORK_END_MARKER } from "#engine/repo.js";
+import {
+  countProjectSpecificPlaceholderBlocks,
+  FRAMEWORK_END_MARKER,
+  PROJECT_SPECIFIC_INSTRUCTIONS_HEADER,
+} from "#engine/repo.js";
 import type { Repo } from "#engine/repo.js";
 import type { RuleResult } from "#engine/rules/index.js";
 import {
@@ -46,6 +50,11 @@ export function evaluate(repo: Repo): RuleResult {
     );
   } else {
     const text = repo.readAgentInstructions() ?? "";
+    if (countProjectSpecificPlaceholderBlocks(text) > 1) {
+      tasks.push(
+        `Remove duplicate \`${PROJECT_SPECIFIC_INSTRUCTIONS_HEADER}\` placeholder blocks from ${AGENT_INSTRUCTIONS_FILE}; keep only one copy of the template section`,
+      );
+    }
     const afterMarker = text.split(FRAMEWORK_END_MARKER);
     if (afterMarker.length > 1) {
       const userSection = afterMarker[1].trim();
@@ -72,6 +81,11 @@ export function evaluate(repo: Repo): RuleResult {
         `\`${CLAUDE_INSTRUCTIONS_FILE}\` exists but is missing framework markers — add \`<!-- BEGIN CONTEXT-TREE FRAMEWORK -->\` and \`<!-- END CONTEXT-TREE FRAMEWORK -->\` sections`,
       );
     } else {
+      if (countProjectSpecificPlaceholderBlocks(claudeText) > 1) {
+        tasks.push(
+          `Remove duplicate \`${PROJECT_SPECIFIC_INSTRUCTIONS_HEADER}\` placeholder blocks from ${CLAUDE_INSTRUCTIONS_FILE}; keep only one copy of the template section`,
+        );
+      }
       const afterMarker = claudeText.split(FRAMEWORK_END_MARKER);
       if (afterMarker.length > 1) {
         const userSection = afterMarker[1].trim();

--- a/src/engine/runtime/source-repo-index.ts
+++ b/src/engine/runtime/source-repo-index.ts
@@ -39,6 +39,11 @@ export function syncTreeSourceRepoIndex(treeRoot: string): SourceRepoIndexSyncRe
 
 export function buildSourceRepoIndex(bindings: TreeBindingState[]): string {
   const lines = [
+    "---",
+    'title: "Source Repos"',
+    "owners: []",
+    "---",
+    "",
     "# Source Repos",
     "",
     "Generated from `.first-tree/bindings/*.json`. This is the quickest index of the source/workspace repos described by this Context Tree. The binding JSON files remain the canonical machine-readable source of truth.",

--- a/src/engine/verify.ts
+++ b/src/engine/verify.ts
@@ -1,6 +1,10 @@
 import { resolve } from "node:path";
 import { formatDedicatedTreePathExample } from "#engine/dedicated-tree.js";
-import { Repo } from "#engine/repo.js";
+import {
+  countProjectSpecificPlaceholderBlocks,
+  PROJECT_SPECIFIC_INSTRUCTIONS_HEADER,
+  Repo,
+} from "#engine/repo.js";
 import {
   AGENT_INSTRUCTIONS_FILE,
   CLAUDE_INSTRUCTIONS_FILE,
@@ -124,11 +128,33 @@ export function runVerify(repo?: Repo, nodeValidator?: NodeValidator): number {
   const hasCanonicalAgentInstructions = r.hasCanonicalAgentInstructionsFile();
   const hasLegacyAgentInstructions = r.hasLegacyAgentInstructionsFile();
   const hasClaudeInstructions = r.hasClaudeInstructionsFile();
+  const duplicatePlaceholderFiles: string[] = [];
+  const agentInstructionsText = r.readAgentInstructions();
+  if (
+    hasCanonicalAgentInstructions
+    && agentInstructionsText !== null
+    && countProjectSpecificPlaceholderBlocks(agentInstructionsText) > 1
+  ) {
+    duplicatePlaceholderFiles.push(AGENT_INSTRUCTIONS_FILE);
+  }
+  const claudeInstructionsText = r.readClaudeInstructions();
+  if (
+    hasClaudeInstructions
+    && claudeInstructionsText !== null
+    && countProjectSpecificPlaceholderBlocks(claudeInstructionsText) > 1
+  ) {
+    duplicatePlaceholderFiles.push(CLAUDE_INSTRUCTIONS_FILE);
+  }
   if (hasLegacyAgentInstructions) {
     const followUp = hasCanonicalAgentInstructions
       ? `Remove legacy \`${LEGACY_AGENT_INSTRUCTIONS_FILE}\` after confirming its contents are in \`${AGENT_INSTRUCTIONS_FILE}\`.`
       : `Rename \`${LEGACY_AGENT_INSTRUCTIONS_FILE}\` to \`${AGENT_INSTRUCTIONS_FILE}\`.`;
     console.log(`  Legacy agent instructions detected. ${followUp}\n`);
+  }
+  if (duplicatePlaceholderFiles.length > 0) {
+    console.log(
+      `  Duplicate \`${PROJECT_SPECIFIC_INSTRUCTIONS_HEADER}\` placeholder blocks detected in ${duplicatePlaceholderFiles.map((file) => `\`${file}\``).join(" and ")}. Keep only one copy of the template section in each file.\n`,
+    );
   }
   allPassed = check(
     `${AGENT_INSTRUCTIONS_FILE} is canonical and both ${AGENT_INSTRUCTIONS_FILE}/${CLAUDE_INSTRUCTIONS_FILE} have framework markers`,
@@ -136,7 +162,8 @@ export function runVerify(repo?: Repo, nodeValidator?: NodeValidator): number {
       !hasLegacyAgentInstructions &&
       r.hasAgentInstructionsMarkers() &&
       hasClaudeInstructions &&
-      r.hasClaudeInstructionsMarkers(),
+      r.hasClaudeInstructionsMarkers() &&
+      duplicatePlaceholderFiles.length === 0,
   ) && allPassed;
 
   // 4. Node validation

--- a/tests/repo.test.ts
+++ b/tests/repo.test.ts
@@ -1,7 +1,10 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { Repo } from "#engine/repo.js";
+import {
+  countProjectSpecificPlaceholderBlocks,
+  Repo,
+} from "#engine/repo.js";
 import {
   AGENT_INSTRUCTIONS_FILE,
   CLAUDE_INSTALLED_PROGRESS,
@@ -120,6 +123,48 @@ describe("frontmatter", () => {
     const tmp = useTmpDir();
     const repo = new Repo(tmp.path);
     expect(repo.frontmatter("NODE.md")).toBeNull();
+  });
+});
+
+// --- project-specific placeholder detection ---
+
+describe("countProjectSpecificPlaceholderBlocks", () => {
+  it("counts duplicate placeholder blocks after the framework marker", () => {
+    const text = [
+      "<!-- BEGIN CONTEXT-TREE FRAMEWORK -->",
+      "framework stuff",
+      "<!-- END CONTEXT-TREE FRAMEWORK -->",
+      "",
+      "# Project-Specific Instructions",
+      "",
+      "<!-- Add your project-specific agent instructions below this line. -->",
+      "",
+      "# Project-Specific Instructions",
+      "",
+      "<!-- Add your project-specific agent instructions below this line. -->",
+      "",
+    ].join("\n");
+
+    expect(countProjectSpecificPlaceholderBlocks(text)).toBe(2);
+  });
+
+  it("ignores placeholder text before the framework marker", () => {
+    const text = [
+      "# Project-Specific Instructions",
+      "",
+      "<!-- Add your project-specific agent instructions below this line. -->",
+      "",
+      "<!-- BEGIN CONTEXT-TREE FRAMEWORK -->",
+      "framework stuff",
+      "<!-- END CONTEXT-TREE FRAMEWORK -->",
+      "",
+      "# Project-Specific Instructions",
+      "",
+      "<!-- Add your project-specific agent instructions below this line. -->",
+      "",
+    ].join("\n");
+
+    expect(countProjectSpecificPlaceholderBlocks(text)).toBe(1);
   });
 });
 

--- a/tests/rules.test.ts
+++ b/tests/rules.test.ts
@@ -151,6 +151,60 @@ describe("agentInstructions rule", () => {
     expect(result.tasks.some((t) => t.toLowerCase().includes("project-specific"))).toBe(true);
   });
 
+  it("reports duplicate placeholder blocks in AGENTS.md", () => {
+    const tmp = useTmpDir();
+    writeFileSync(
+      join(tmp.path, "AGENTS.md"),
+      [
+        "<!-- BEGIN CONTEXT-TREE FRAMEWORK -->",
+        "framework stuff",
+        "<!-- END CONTEXT-TREE FRAMEWORK -->",
+        "",
+        "# Project-Specific Instructions",
+        "",
+        "<!-- Add your project-specific agent instructions below this line. -->",
+        "",
+        "# Project-Specific Instructions",
+        "",
+        "<!-- Add your project-specific agent instructions below this line. -->",
+        "",
+      ].join("\n"),
+    );
+    makeClaudeMd(tmp.path, { markers: true, userContent: true });
+    const repo = new Repo(tmp.path);
+    const result = agentInstructions.evaluate(repo);
+    expect(result.tasks.some((t) => t.includes("duplicate") && t.includes("AGENTS.md"))).toBe(
+      true,
+    );
+  });
+
+  it("reports duplicate placeholder blocks in CLAUDE.md", () => {
+    const tmp = useTmpDir();
+    makeAgentsMd(tmp.path, { markers: true, userContent: true });
+    writeFileSync(
+      join(tmp.path, "CLAUDE.md"),
+      [
+        "<!-- BEGIN CONTEXT-TREE FRAMEWORK -->",
+        "framework stuff",
+        "<!-- END CONTEXT-TREE FRAMEWORK -->",
+        "",
+        "# Project-Specific Instructions",
+        "",
+        "<!-- Add your project-specific agent instructions below this line. -->",
+        "",
+        "# Project-Specific Instructions",
+        "",
+        "<!-- Add your project-specific agent instructions below this line. -->",
+        "",
+      ].join("\n"),
+    );
+    const repo = new Repo(tmp.path);
+    const result = agentInstructions.evaluate(repo);
+    expect(result.tasks.some((t) => t.includes("duplicate") && t.includes("CLAUDE.md"))).toBe(
+      true,
+    );
+  });
+
   it("reports missing CLAUDE.md", () => {
     const tmp = useTmpDir();
     makeAgentsMd(tmp.path, { markers: true, userContent: true });

--- a/tests/source-repo-index.test.ts
+++ b/tests/source-repo-index.test.ts
@@ -75,6 +75,8 @@ describe("syncTreeSourceRepoIndex", () => {
     const agents = readFileSync(join(treeDir.path, "AGENTS.md"), "utf-8");
 
     expect(result.indexAction).toBe("created");
+    expect(sourceRepos).toContain('title: "Source Repos"');
+    expect(sourceRepos).toContain("owners: []");
     expect(sourceRepos).toContain("[acme/alpha](https://github.com/acme/alpha)");
     expect(sourceRepos).toContain(
       "[acme/platform-workspace](https://github.com/acme/platform-workspace)",

--- a/tests/verify.test.ts
+++ b/tests/verify.test.ts
@@ -251,6 +251,30 @@ describe("runVerify failing", () => {
     expect(ret).toBe(1);
   });
 
+  it("fails when AGENTS.md contains duplicate placeholder blocks", () => {
+    const tmp = useTmpDir();
+    buildFullRepo(tmp.path);
+    writeFileSync(
+      join(tmp.path, AGENT_INSTRUCTIONS_FILE),
+      [
+        "<!-- BEGIN CONTEXT-TREE FRAMEWORK -->",
+        "framework stuff",
+        "<!-- END CONTEXT-TREE FRAMEWORK -->",
+        "",
+        "# Project-Specific Instructions",
+        "",
+        "<!-- Add your project-specific agent instructions below this line. -->",
+        "",
+        "# Project-Specific Instructions",
+        "",
+        "<!-- Add your project-specific agent instructions below this line. -->",
+        "",
+      ].join("\n"),
+    );
+    const repo = new Repo(tmp.path);
+    expect(runVerify(repo, passValidator)).toBe(1);
+  });
+
   it("fails when legacy AGENT.md remains alongside AGENTS.md", () => {
     const tmp = useTmpDir();
     buildFullRepo(tmp.path);


### PR DESCRIPTION
## Summary
- detect repeated `# Project-Specific Instructions` placeholder blocks in `AGENTS.md` / `CLAUDE.md`
- surface the duplication both in the agent-instructions rule output and in `first-tree verify`
- add targeted test coverage for repo helpers, rules, and verify behavior
- add frontmatter to generated `source-repos.md` so the current full test suite stays green

## Verification
- `pnpm exec vitest run tests/source-repo-index.test.ts tests/cli-e2e.test.ts tests/repo.test.ts tests/rules.test.ts tests/verify.test.ts`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
