### PR TITLE
Fix stale inject-context hook migration

### DIFF
--- a/src/engine/runtime/adapters.ts
+++ b/src/engine/runtime/adapters.ts
@@ -17,6 +17,8 @@ const STALE_INJECT_CONTEXT_PATTERNS = [
   /\.claude\/skills\/first-tree\/assets\/framework\/helpers\/inject-tree-context\.sh/g,
   /skills\/first-tree\/assets\/framework\/helpers\/inject-tree-context\.sh/g,
   /\.context-tree\/helpers\/inject-tree-context\.sh/g,
+  /\.context-tree\/scripts\/inject-tree-context\.sh/g,
+  /\.scripts\/inject-tree-context\.sh/g,
 ];
 
 export function claudeCodeExampleCandidates(): string[] {
@@ -52,6 +54,10 @@ export function refreshInjectContextHook(
   for (const pattern of STALE_INJECT_CONTEXT_PATTERNS) {
     updated = updated.replace(pattern, INJECT_CONTEXT_COMMAND);
   }
+  updated = updated.replace(
+    /("command"\s*:\s*")(?:\.\/)?scripts\/inject-tree-context\.sh(")/g,
+    `$1${INJECT_CONTEXT_COMMAND}$2`,
+  );
   // Strip any leading "./" the legacy bash script started with so the
   // command runs cleanly.
   updated = updated.replace(

--- a/src/engine/upgrade.ts
+++ b/src/engine/upgrade.ts
@@ -206,6 +206,16 @@ function logTreeSourceRepoIndexSync(
   }
 }
 
+function logInjectContextHookRefresh(
+  hookRefresh: "updated" | "unchanged",
+): void {
+  if (hookRefresh === "updated") {
+    console.log(
+      "Updated `.claude/settings.json` SessionStart hook to use `npx -p first-tree first-tree inject-context --skip-version-check`.",
+    );
+  }
+}
+
 function formatUpgradeTaskList(
   repo: Repo,
   localVersion: string,
@@ -393,9 +403,10 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
       const changedFiles = updates
         .filter((update) => update.action !== "unchanged")
         .map((update) => update.file);
+      const hookRefresh = refreshInjectContextHook(workingRepo.root);
       const indexChanged =
         firstTreeIndex.action === "created" || firstTreeIndex.action === "updated";
-      if (changedFiles.length === 0 && !indexChanged) {
+      if (changedFiles.length === 0 && !indexChanged && hookRefresh === "unchanged") {
         if (firstTreeIndex.action === "skipped") {
           console.log(
             `Left \`${FIRST_TREE_INDEX_FILE}\` unchanged because it already contains unmanaged content.`,
@@ -422,6 +433,7 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
           `Left \`${FIRST_TREE_INDEX_FILE}\` unchanged because it already contains unmanaged content.`,
         );
       }
+      logInjectContextHookRefresh(hookRefresh);
       if (changedFiles.length > 0) {
         console.log(
           `Updated the ${SOURCE_INTEGRATION_MARKER} marker lines in ${changedFiles.map((file) => `\`${file}\``).join(" and ")}.`,
@@ -469,11 +481,7 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
     console.log(
       `Refreshed ${installedSkillRootsDisplay()} in this source/workspace repo.`,
     );
-    if (hookRefresh === "updated") {
-      console.log(
-        "Updated `.claude/settings.json` SessionStart hook to use `npx -p first-tree first-tree inject-context --skip-version-check`.",
-      );
-    }
+    logInjectContextHookRefresh(hookRefresh);
     if (refreshedWorkflows.length > 0) {
       console.log(
         `Overwrote shipped workflow files: ${refreshedWorkflows.map((f) => `\`.github/workflows/${f}\``).join(", ")}.`,
@@ -523,6 +531,7 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
       installedTreeSkillVersion !== null
       && missingInstalledRoots.length === 0
       && compareSkillVersions(installedTreeSkillVersion, packagedVersion) === 0;
+    const hookRefresh = refreshInjectContextHook(workingRepo.root);
 
     if (treeMetadataUpToDate && treeSkillUpToDate) {
       const sourceRepoIndex = syncTreeSourceRepoIndex(workingRepo.root);
@@ -531,6 +540,7 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
         `Already up to date with the bundled tree metadata and installed tree skill (${workingRepo.frameworkVersionPath()} = ${localVersion}).`,
       );
       logTreeSourceRepoIndexSync(sourceRepoIndex);
+      logInjectContextHookRefresh(hookRefresh);
       return 0;
     }
 
@@ -555,6 +565,7 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
     const sourceRepoIndex = syncTreeSourceRepoIndex(workingRepo.root);
     logTreeSourceRepoIndexSync(sourceRepoIndex);
     ensureSyncRunbook(workingRepo.root, sourceRoot);
+    logInjectContextHookRefresh(hookRefresh);
 
     const output = formatUpgradeTaskList(
       workingRepo,
@@ -573,9 +584,11 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
     missingInstalledRoots.length === 0 &&
     compareSkillVersions(localVersion, packagedVersion) === 0
   ) {
+    const hookRefresh = refreshInjectContextHook(workingRepo.root);
     console.log(
       `Already up to date with the bundled skill (${workingRepo.frameworkVersionPath()} = ${localVersion}).`,
     );
+    logInjectContextHookRefresh(hookRefresh);
     return 0;
   }
 
@@ -594,11 +607,7 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
   console.log(
     `Installed lightweight skill payload at ${installedSkillRootsDisplay()}.`,
   );
-  if (hookRefresh === "updated") {
-    console.log(
-      "Updated `.claude/settings.json` SessionStart hook to use `npx -p first-tree first-tree inject-context --skip-version-check`.",
-    );
-  }
+  logInjectContextHookRefresh(hookRefresh);
   if (refreshedWorkflows.length > 0) {
     console.log(
       `Overwrote shipped workflow files: ${refreshedWorkflows.map((f) => `\`.github/workflows/${f}\``).join(", ")}.`,

--- a/tests/upgrade.test.ts
+++ b/tests/upgrade.test.ts
@@ -1,5 +1,6 @@
 import {
   existsSync,
+  mkdirSync,
   lstatSync,
   readFileSync,
   readlinkSync,
@@ -45,6 +46,34 @@ function expectFirstTreeIndexSymlink(root: string): void {
   );
 }
 
+function writeStaleInjectContextSettings(
+  root: string,
+  command = ".context-tree/scripts/inject-tree-context.sh",
+): void {
+  mkdirSync(join(root, ".claude"), { recursive: true });
+  writeFileSync(
+    join(root, ".claude", "settings.json"),
+    JSON.stringify(
+      {
+        hooks: {
+          SessionStart: [
+            {
+              hooks: [
+                {
+                  type: "command",
+                  command,
+                },
+              ],
+            },
+          ],
+        },
+      },
+      null,
+      2,
+    ),
+  );
+}
+
 describe("runUpgrade", () => {
   it("migrates a legacy repo to the installed skill layout", () => {
     const repoDir = useTmpDir();
@@ -75,11 +104,12 @@ describe("runUpgrade", () => {
     );
   });
 
-  it("returns early when the installed skill already matches the packaged skill", () => {
+  it("returns early and refreshes a stale SessionStart hook when the installed skill already matches the packaged skill", () => {
     const repoDir = useTmpDir();
     const sourceDir = useTmpDir();
     makeFramework(repoDir.path, "0.2.0");
     makeSourceSkill(sourceDir.path, "0.2.0");
+    writeStaleInjectContextSettings(repoDir.path);
 
     const result = runUpgrade(new Repo(repoDir.path), {
       sourceRoot: sourceDir.path,
@@ -87,6 +117,11 @@ describe("runUpgrade", () => {
 
     expect(result).toBe(0);
     expect(existsSync(join(repoDir.path, INSTALLED_PROGRESS))).toBe(false);
+    expect(
+      readFileSync(join(repoDir.path, ".claude", "settings.json"), "utf-8"),
+    ).toContain(
+      "npx -p first-tree first-tree inject-context --skip-version-check",
+    );
   });
 
   it("migrates repos that still use the previous workspace skill path", () => {
@@ -215,6 +250,42 @@ describe("runUpgrade", () => {
     );
   });
 
+  it("refreshes a stale SessionStart hook even when a dedicated tree repo is already current", () => {
+    const repoDir = useTmpDir();
+    const sourceDir = useTmpDir();
+    makeTreeMetadata(repoDir.path, "0.2.0");
+    makeFramework(repoDir.path, "0.2.0");
+    makeAgentsMd(repoDir.path, { markers: true, userContent: true });
+    writeFileSync(
+      join(repoDir.path, "NODE.md"),
+      [
+        "---",
+        "title: Example Tree",
+        "owners: [alice]",
+        "---",
+        "",
+        "# Example Tree",
+        "",
+        "Context for the organization.",
+        "",
+      ].join("\n"),
+    );
+    writeStaleInjectContextSettings(repoDir.path);
+    makeSourceSkill(sourceDir.path, "0.2.0");
+
+    const result = runUpgrade(new Repo(repoDir.path), {
+      sourceRoot: sourceDir.path,
+    });
+
+    expect(result).toBe(0);
+    expect(existsSync(join(repoDir.path, TREE_PROGRESS))).toBe(false);
+    expect(
+      readFileSync(join(repoDir.path, ".claude", "settings.json"), "utf-8"),
+    ).toContain(
+      "npx -p first-tree first-tree inject-context --skip-version-check",
+    );
+  });
+
   it("refreshes source/workspace integration without writing tree progress", () => {
     const repoDir = useTmpDir();
     const sourceDir = useTmpDir();
@@ -258,7 +329,7 @@ describe("runUpgrade", () => {
     expect(existsSync(join(repoDir.path, INSTALLED_PROGRESS))).toBe(false);
   });
 
-  it("migrates a managed FIRST_TREE.md to a symlink even when the installed skill is already current", () => {
+  it("migrates a managed FIRST_TREE.md and refreshes a stale SessionStart hook even when the installed skill is already current", () => {
     const repoDir = useTmpDir();
     const sourceDir = useTmpDir();
     makeSourceRepo(repoDir.path);
@@ -282,6 +353,7 @@ describe("runUpgrade", () => {
         "",
       ].join("\n"),
     );
+    writeStaleInjectContextSettings(repoDir.path);
     makeSourceSkill(sourceDir.path, "0.2.0");
 
     const result = runUpgrade(new Repo(repoDir.path), {
@@ -291,6 +363,11 @@ describe("runUpgrade", () => {
     expect(result).toBe(0);
     expectFirstTreeIndexSymlink(repoDir.path);
     expect(existsSync(join(repoDir.path, INSTALLED_PROGRESS))).toBe(false);
+    expect(
+      readFileSync(join(repoDir.path, ".claude", "settings.json"), "utf-8"),
+    ).toContain(
+      "npx -p first-tree first-tree inject-context --skip-version-check",
+    );
   });
 
   it("preserves an existing legacy context binding in source/workspace integration", () => {

--- a/tests/wipe-and-refresh.test.ts
+++ b/tests/wipe-and-refresh.test.ts
@@ -99,6 +99,43 @@ describe("refreshInjectContextHook", () => {
     expect(updated).not.toContain("inject-tree-context.sh");
   });
 
+  it("replaces a stale .context-tree/scripts/inject-tree-context.sh hook command", () => {
+    const tmp = useTmpDir();
+    mkdirSync(join(tmp.path, ".claude"), { recursive: true });
+    writeFileSync(
+      join(tmp.path, ".claude", "settings.json"),
+      JSON.stringify(
+        {
+          hooks: {
+            SessionStart: [
+              {
+                hooks: [
+                  {
+                    type: "command",
+                    command: ".context-tree/scripts/inject-tree-context.sh",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const result = refreshInjectContextHook(tmp.path);
+    expect(result).toBe("updated");
+    const updated = readFileSync(
+      join(tmp.path, ".claude", "settings.json"),
+      "utf-8",
+    );
+    expect(updated).toContain(
+      "npx -p first-tree first-tree inject-context --skip-version-check",
+    );
+    expect(updated).not.toContain(".context-tree/scripts/inject-tree-context.sh");
+  });
+
   it("replaces a stale .claude/skills/.../inject-tree-context.sh path with the leading ./ stripped", () => {
     const tmp = useTmpDir();
     mkdirSync(join(tmp.path, ".claude"), { recursive: true });
@@ -131,6 +168,38 @@ describe("refreshInjectContextHook", () => {
       `"command":"npx -p first-tree first-tree inject-context --skip-version-check"`,
     );
     expect(updated).not.toContain("./npx");
+  });
+
+  it("replaces a stale scripts/inject-tree-context.sh hook command", () => {
+    const tmp = useTmpDir();
+    mkdirSync(join(tmp.path, ".claude"), { recursive: true });
+    writeFileSync(
+      join(tmp.path, ".claude", "settings.json"),
+      JSON.stringify({
+        hooks: {
+          SessionStart: [
+            {
+              hooks: [
+                {
+                  type: "command",
+                  command: "scripts/inject-tree-context.sh",
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+
+    const result = refreshInjectContextHook(tmp.path);
+    expect(result).toBe("updated");
+    const updated = readFileSync(
+      join(tmp.path, ".claude", "settings.json"),
+      "utf-8",
+    );
+    expect(updated).toContain(
+      `"command":"npx -p first-tree first-tree inject-context --skip-version-check"`,
+    );
   });
 
   it("returns unchanged when settings.json already uses the CLI command", () => {


### PR DESCRIPTION
## Summary
- recognize additional legacy SessionStart hook paths, including `.context-tree/scripts/inject-tree-context.sh`
- refresh stale hook commands even when `first-tree upgrade` otherwise exits as already up to date
- add regression coverage for source, workspace, and tree upgrade flows

## Testing
- `pnpm exec vitest run tests/wipe-and-refresh.test.ts tests/upgrade.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test` (still hits the existing `tests/cli-e2e.test.ts > runs the dedicated source-repo workflow through the CLI entrypoint` failure on base commit `8072800`)
