### PR TITLE
perf(sync): parallelize apply phase (git push + gh pr create)

### DIFF
--- a/src/engine/sync.ts
+++ b/src/engine/sync.ts
@@ -776,15 +776,28 @@ async function runGenerateCodeownersForTree(treeRoot: string): Promise<void> {
   }
 }
 
-async function applyProposalGroup(
+/** Result of preparing a proposal group (branch created, files committed locally). */
+interface PreparedProposalGroup {
+  branch: string;
+  prTitle: string;
+  prBody: string;
+  group: ProposalGroup;
+  skipped: boolean;
+  skipReason?: string;
+}
+
+/**
+ * Phase 1: Prepare a proposal group by creating a branch and committing locally.
+ * This must be done sequentially because git checkout requires exclusive access.
+ * Returns the branch name and PR metadata for the push/create phase.
+ */
+async function prepareProposalGroup(
   shellRun: ShellRun,
   treeRoot: string,
   binding: TreeBindingState,
   drift: DriftReport,
   group: ProposalGroup,
-  dryRun: boolean,
-  now: () => Date,
-): Promise<boolean> {
+): Promise<PreparedProposalGroup | null> {
   const shortSha = drift.toSha.slice(0, 7);
   const branchSuffix = group.sourcePrNumber !== null
     ? `pr${group.sourcePrNumber}`
@@ -805,8 +818,14 @@ async function applyProposalGroup(
       try {
         const parsed = JSON.parse(existingPr.stdout) as Array<{ number: number }>;
         if (parsed.length > 0) {
-          console.log(`\u23ED PR for source PR #${group.sourcePrNumber} already exists \u2014 skipping`);
-          return true;
+          return {
+            branch,
+            prTitle,
+            prBody: "",
+            group,
+            skipped: true,
+            skipReason: `PR for source PR #${group.sourcePrNumber} already exists`,
+          };
         }
       } catch {
         // ignore parse errors and continue
@@ -821,7 +840,7 @@ async function applyProposalGroup(
     console.error(
       `\u274C could not create branch ${branch}: ${branchCreate.stderr.trim()}`,
     );
-    return false;
+    return null;
   }
 
   // Write nodes directly to real tree paths (not drift/)
@@ -857,8 +876,14 @@ async function applyProposalGroup(
   }
 
   if (writtenFiles.length === 0) {
-    console.log(`  \u23ED No new files to commit for this PR — skipping.`);
-    return true;
+    return {
+      branch,
+      prTitle,
+      prBody: "",
+      group,
+      skipped: true,
+      skipReason: "No new files to commit",
+    };
   }
 
   // NOTE: Only stage the specific NODE.md files this PR created.
@@ -871,8 +896,14 @@ async function applyProposalGroup(
   const stagingCheck = await shellRun("git", ["diff", "--cached", "--quiet"], { cwd: treeRoot });
   if (stagingCheck.code === 0) {
     // Nothing staged — files already existed or were already committed
-    console.log(`  \u23ED Nothing new to commit for this PR — skipping.`);
-    return true;
+    return {
+      branch,
+      prTitle,
+      prBody: "",
+      group,
+      skipped: true,
+      skipReason: "Nothing new to commit",
+    };
   }
   const commitMessage = group.sourcePrNumber !== null
     ? `chore(sync): ${binding.sourceId} PR#${group.sourcePrNumber} to ${shortSha}`
@@ -882,22 +913,7 @@ async function applyProposalGroup(
   });
   if (commitResult.code !== 0) {
     console.error(`\u274C git commit failed: ${commitResult.stderr.trim()}`);
-    return false;
-  }
-
-  if (dryRun) {
-    console.log(
-      `(dry-run) would push ${branch} and open PR titled "${prTitle}"`,
-    );
-    return true;
-  }
-
-  const pushResult = await shellRun("git", ["push", "origin", "HEAD"], {
-    cwd: treeRoot,
-  });
-  if (pushResult.code !== 0) {
-    console.error(`\u274C git push failed: ${pushResult.stderr.trim()}`);
-    return false;
+    return null;
   }
 
   const bodyLines = [
@@ -918,9 +934,38 @@ async function applyProposalGroup(
     ),
   ];
 
+  return {
+    branch,
+    prTitle,
+    prBody: bodyLines.join("\n"),
+    group,
+    skipped: false,
+  };
+}
+
+/**
+ * Phase 2: Push branches and create PRs.
+ * This can be parallelized because each branch is independent.
+ */
+async function pushAndCreatePr(
+  shellRun: ShellRun,
+  treeRoot: string,
+  prepared: PreparedProposalGroup,
+): Promise<{ success: boolean; prUrl?: string; error?: string }> {
+  const { branch, prTitle, prBody } = prepared;
+
+  // Push the branch
+  const pushResult = await shellRun("git", ["push", "origin", branch], {
+    cwd: treeRoot,
+  });
+  if (pushResult.code !== 0) {
+    return { success: false, error: `git push failed: ${pushResult.stderr.trim()}` };
+  }
+
+  // Create the PR
   const prCreate = await shellRun(
     "gh",
-    ["pr", "create", "--title", prTitle, "--body", bodyLines.join("\n")],
+    ["pr", "create", "--head", branch, "--title", prTitle, "--body", prBody],
     { cwd: treeRoot },
   );
   if (prCreate.code !== 0) {
@@ -929,18 +974,14 @@ async function applyProposalGroup(
       stderr.toLowerCase().includes("already exists")
       || stderr.toLowerCase().includes("a pull request for branch")
     ) {
-      console.log(
-        `\u23ED PR for branch ${branch} already exists \u2014 skipping create, leaving the existing one.`,
-      );
-      return true;
+      return { success: true, prUrl: `(existing PR for ${branch})` };
     }
-    console.error(`\u274C gh pr create failed: ${stderr}`);
-    return false;
+    return { success: false, error: `gh pr create failed: ${stderr}` };
   }
   const prUrl = prCreate.stdout.trim();
 
+  // Add labels (best effort, don't fail if this doesn't work)
   const labels = ["first-tree:sync"];
-  // Pre-create labels if they don't exist (ignore errors — may lack permission)
   for (const label of labels) {
     await shellRun(
       "gh",
@@ -949,16 +990,63 @@ async function applyProposalGroup(
     );
   }
   const labelArgs = labels.flatMap((l) => ["--add-label", l]);
-  const labelResult = await shellRun(
-    "gh",
-    ["pr", "edit", prUrl, ...labelArgs],
-    { cwd: treeRoot },
-  );
-  if (labelResult.code !== 0) {
-    console.error(`\u26A0 gh pr edit (add label) failed: ${labelResult.stderr.trim()}`);
+  await shellRun("gh", ["pr", "edit", prUrl, ...labelArgs], { cwd: treeRoot });
+
+  return { success: true, prUrl };
+}
+
+/**
+ * Run push and PR creation in parallel with concurrency limit and rate-limit backoff.
+ */
+async function pushAndCreatePrsParallel(
+  shellRun: ShellRun,
+  treeRoot: string,
+  preparedGroups: PreparedProposalGroup[],
+  concurrency: number,
+): Promise<{ successes: number; failures: number; prUrls: string[] }> {
+  const results: { success: boolean; prUrl?: string; error?: string }[] = [];
+  const prUrls: string[] = [];
+
+  for (let i = 0; i < preparedGroups.length; i += concurrency) {
+    const batch = preparedGroups.slice(i, i + concurrency);
+    const batchResults = await Promise.all(
+      batch.map(async (prepared) => {
+        const MAX_RETRIES = 2;
+        for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+          const result = await pushAndCreatePr(shellRun, treeRoot, prepared);
+          if (result.success) return result;
+
+          // Check for rate limiting
+          const isRateLimit = result.error?.includes("429") ||
+            result.error?.toLowerCase().includes("rate") ||
+            result.error?.toLowerCase().includes("too many");
+          if (isRateLimit && attempt < MAX_RETRIES) {
+            const waitSec = (attempt + 1) * 10;
+            console.log(`  \u26A0 Rate limited. Retrying in ${waitSec}s... (attempt ${attempt + 2}/${MAX_RETRIES + 1})`);
+            await new Promise((resolve) => setTimeout(resolve, waitSec * 1000));
+            continue;
+          }
+          return result;
+        }
+        return { success: false, error: "Max retries exceeded" };
+      }),
+    );
+    results.push(...batchResults);
   }
-  console.log(`\u2713 opened PR ${prUrl}`);
-  return true;
+
+  let successes = 0;
+  let failures = 0;
+  for (const result of results) {
+    if (result.success) {
+      successes++;
+      if (result.prUrl) prUrls.push(result.prUrl);
+    } else {
+      failures++;
+      console.error(`\u274C ${result.error}`);
+    }
+  }
+
+  return { successes, failures, prUrls };
 }
 
 export async function runSync(
@@ -1209,78 +1297,122 @@ export async function runSync(
       `\u2713 ${drift.binding.sourceId}: ${totalProposals} total proposal(s) across ${prsToClassify.length} source PR(s)`,
     );
 
-    // Phase 2: Apply sequentially (git operations can't be parallel)
-    // Each PR needs its own branch/commit/push cycle — this is inherently serial.
+    // Phase 2: Apply with parallelized push + PR creation
+    // Branch creation and commits must be sequential, but push and PR create can be parallel.
     if (flags.apply) {
-      const applyCount = classifiedPrs.filter((c) => c.filtered.length > 0).length;
-      console.log(
-        `\nApplying ${applyCount} tree PR(s) sequentially (git push per PR, ~8s each)...`,
-      );
-      for (const { pr, filtered, written } of classifiedPrs) {
-        if (filtered.length === 0) continue;
-        const group: ProposalGroup = {
-          sourcePrNumber: pr.number > 0 ? pr.number : null,
-          sourcePrTitle: pr.number > 0 ? pr.title : null,
-          proposals: filtered,
-          proposalPaths: written,
-        };
-        const ok = await applyProposalGroup(
-          shellRun,
-          repo.root,
-          drift.binding,
-          drift,
-          group,
-          flags.dryRun,
-          now,
+      const APPLY_CONCURRENCY = 5; // Concurrency for push + PR create (avoid rate limits)
+      const groupsToApply = classifiedPrs.filter((c) => c.filtered.length > 0);
+      const applyCount = groupsToApply.length;
+
+      if (applyCount === 0) {
+        console.log("\nNo tree PRs to apply.");
+      } else {
+        // Phase 2a: Prepare all branches sequentially (git checkout requires exclusive access)
+        console.log(
+          `\nPreparing ${applyCount} tree PR(s) (creating branches, committing locally)...`,
         );
-        if (!ok) return 1;
-        await shellRun("git", ["checkout", "-"], { cwd: repo.root });
-      }
+        const preparedGroups: PreparedProposalGroup[] = [];
+        const originalBranch = (await shellRun("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd: repo.root })).stdout.trim();
 
-      // Open a housekeeping PR: pin the binding + regenerate CODEOWNERS
-      // This is the ONLY PR that touches the binding file and CODEOWNERS,
-      // avoiding cascade merge conflicts between individual sync PRs.
-      if (!flags.dryRun && applyCount > 0) {
-        console.log("\nOpening housekeeping PR (binding pin + CODEOWNERS)...");
-        const hkBranch = `first-tree/sync-${drift.binding.sourceId}-housekeeping`;
-        await shellRun("git", ["checkout", "-B", hkBranch], { cwd: repo.root });
-
-        // Pin the binding to the latest synced commit
-        writeTreeBinding(repo.root, drift.binding.sourceId, {
-          ...drift.binding,
-          lastReconciledSourceCommit: drift.toSha,
-          lastReconciledAt: now().toISOString(),
-        });
-
-        // Regenerate CODEOWNERS
-        await runGenerateCodeownersForTree(repo.root);
-
-        await shellRun("git", ["add", "-A"], { cwd: repo.root });
-        const hkDiff = await shellRun("git", ["diff", "--cached", "--quiet"], { cwd: repo.root });
-        if (hkDiff.code !== 0) {
-          await shellRun("git", ["commit", "-m", `chore(sync): pin ${drift.binding.sourceId} to ${drift.toSha.slice(0, 7)} + regenerate CODEOWNERS`], { cwd: repo.root });
-          await shellRun("git", ["push", "origin", "HEAD"], { cwd: repo.root });
-          const hkPr = await shellRun("gh", [
-            "pr", "create",
-            "--title", `chore(sync): housekeeping for ${drift.binding.sourceId}`,
-            "--body", [
-              "Housekeeping PR — pins the sync bookmark and regenerates CODEOWNERS.",
-              "",
-              "**Merge this AFTER all sync PRs are merged.**",
-              "",
-              `Pins \`lastReconciledSourceCommit\` to \`${drift.toSha.slice(0, 7)}\`.`,
-            ].join("\n"),
-          ], { cwd: repo.root });
-          if (hkPr.code === 0) {
-            console.log(`\u2713 Housekeeping PR opened: ${hkPr.stdout.trim()}`);
-            console.log("  Merge this AFTER all other sync PRs are merged.");
+        for (const { pr, filtered, written } of groupsToApply) {
+          const group: ProposalGroup = {
+            sourcePrNumber: pr.number > 0 ? pr.number : null,
+            sourcePrTitle: pr.number > 0 ? pr.title : null,
+            proposals: filtered,
+            proposalPaths: written,
+          };
+          const prepared = await prepareProposalGroup(
+            shellRun,
+            repo.root,
+            drift.binding,
+            drift,
+            group,
+          );
+          if (prepared === null) {
+            // Fatal error during preparation
+            return 1;
           }
-        } else {
-          console.log("  No changes for housekeeping PR.");
+          if (prepared.skipped) {
+            console.log(`  \u23ED ${prepared.branch}: ${prepared.skipReason}`);
+          } else {
+            console.log(`  \u2713 ${prepared.branch}: ready for push`);
+            preparedGroups.push(prepared);
+          }
         }
-        await shellRun("git", ["checkout", "-"], { cwd: repo.root });
-      } else if (flags.dryRun && applyCount > 0) {
-        console.log(`\n(dry-run) would open housekeeping PR to pin binding to ${drift.toSha.slice(0, 7)} + regenerate CODEOWNERS`);
+
+        // Return to original branch before parallel operations
+        await shellRun("git", ["checkout", originalBranch], { cwd: repo.root });
+
+        if (flags.dryRun) {
+          console.log(`\n(dry-run) would push ${preparedGroups.length} branch(es) and open PRs`);
+          for (const prepared of preparedGroups) {
+            console.log(`  - ${prepared.branch}: "${prepared.prTitle}"`);
+          }
+        } else if (preparedGroups.length > 0) {
+          // Phase 2b: Push and create PRs in parallel
+          console.log(
+            `\nPushing ${preparedGroups.length} branch(es) and creating PRs (concurrency: ${APPLY_CONCURRENCY})...`,
+          );
+          const { successes, failures, prUrls } = await pushAndCreatePrsParallel(
+            shellRun,
+            repo.root,
+            preparedGroups,
+            APPLY_CONCURRENCY,
+          );
+          console.log(`\u2713 Push/PR phase complete: ${successes} succeeded, ${failures} failed`);
+          for (const prUrl of prUrls) {
+            console.log(`  - ${prUrl}`);
+          }
+          if (failures > 0) {
+            console.error(`\u26A0 ${failures} PR(s) failed to create. Check errors above.`);
+          }
+        }
+
+        // Open a housekeeping PR: pin the binding + regenerate CODEOWNERS
+        // This is the ONLY PR that touches the binding file and CODEOWNERS,
+        // avoiding cascade merge conflicts between individual sync PRs.
+        if (!flags.dryRun && preparedGroups.length > 0) {
+          console.log("\nOpening housekeeping PR (binding pin + CODEOWNERS)...");
+          const hkBranch = `first-tree/sync-${drift.binding.sourceId}-housekeeping`;
+          await shellRun("git", ["checkout", "-B", hkBranch], { cwd: repo.root });
+
+          // Pin the binding to the latest synced commit
+          writeTreeBinding(repo.root, drift.binding.sourceId, {
+            ...drift.binding,
+            lastReconciledSourceCommit: drift.toSha,
+            lastReconciledAt: now().toISOString(),
+          });
+
+          // Regenerate CODEOWNERS
+          await runGenerateCodeownersForTree(repo.root);
+
+          await shellRun("git", ["add", "-A"], { cwd: repo.root });
+          const hkDiff = await shellRun("git", ["diff", "--cached", "--quiet"], { cwd: repo.root });
+          if (hkDiff.code !== 0) {
+            await shellRun("git", ["commit", "-m", `chore(sync): pin ${drift.binding.sourceId} to ${drift.toSha.slice(0, 7)} + regenerate CODEOWNERS`], { cwd: repo.root });
+            await shellRun("git", ["push", "origin", "HEAD"], { cwd: repo.root });
+            const hkPr = await shellRun("gh", [
+              "pr", "create",
+              "--title", `chore(sync): housekeeping for ${drift.binding.sourceId}`,
+              "--body", [
+                "Housekeeping PR — pins the sync bookmark and regenerates CODEOWNERS.",
+                "",
+                "**Merge this AFTER all sync PRs are merged.**",
+                "",
+                `Pins \`lastReconciledSourceCommit\` to \`${drift.toSha.slice(0, 7)}\`.`,
+              ].join("\n"),
+            ], { cwd: repo.root });
+            if (hkPr.code === 0) {
+              console.log(`\u2713 Housekeeping PR opened: ${hkPr.stdout.trim()}`);
+              console.log("  Merge this AFTER all other sync PRs are merged.");
+            }
+          } else {
+            console.log("  No changes for housekeeping PR.");
+          }
+          await shellRun("git", ["checkout", "-"], { cwd: repo.root });
+        } else if (flags.dryRun && preparedGroups.length > 0) {
+          console.log(`\n(dry-run) would open housekeeping PR to pin binding to ${drift.toSha.slice(0, 7)} + regenerate CODEOWNERS`);
+        }
       }
     }
   }

--- a/src/engine/sync.ts
+++ b/src/engine/sync.ts
@@ -1400,6 +1400,7 @@ export async function runSync(
           }
           if (failures > 0) {
             console.error(`\u26A0 ${failures} PR(s) failed to create. Check errors above.`);
+            return 1;
           }
         }
 

--- a/src/engine/sync.ts
+++ b/src/engine/sync.ts
@@ -776,6 +776,32 @@ async function runGenerateCodeownersForTree(treeRoot: string): Promise<void> {
   }
 }
 
+async function resolveStableCheckoutRef(
+  shellRun: ShellRun,
+  treeRoot: string,
+): Promise<string | null> {
+  const branchResult = await shellRun("git", ["symbolic-ref", "--quiet", "--short", "HEAD"], {
+    cwd: treeRoot,
+  });
+  const branchName = branchResult.stdout.trim();
+  if (branchResult.code === 0 && branchName !== "") {
+    return branchName;
+  }
+
+  const headResult = await shellRun("git", ["rev-parse", "HEAD"], {
+    cwd: treeRoot,
+  });
+  const headSha = headResult.stdout.trim();
+  if (headResult.code === 0 && headSha !== "") {
+    return headSha;
+  }
+
+  console.error(
+    "\u274C could not determine the original git checkout for sync apply.",
+  );
+  return null;
+}
+
 /** Result of preparing a proposal group (branch created, files committed locally). */
 interface PreparedProposalGroup {
   branch: string;
@@ -797,6 +823,7 @@ async function prepareProposalGroup(
   binding: TreeBindingState,
   drift: DriftReport,
   group: ProposalGroup,
+  baseRef: string,
 ): Promise<PreparedProposalGroup | null> {
   const shortSha = drift.toSha.slice(0, 7);
   const branchSuffix = group.sourcePrNumber !== null
@@ -833,7 +860,7 @@ async function prepareProposalGroup(
     }
   }
 
-  const branchCreate = await shellRun("git", ["checkout", "-B", branch], {
+  const branchCreate = await shellRun("git", ["checkout", "-B", branch, baseRef], {
     cwd: treeRoot,
   });
   if (branchCreate.code !== 0) {
@@ -1312,7 +1339,10 @@ export async function runSync(
           `\nPreparing ${applyCount} tree PR(s) (creating branches, committing locally)...`,
         );
         const preparedGroups: PreparedProposalGroup[] = [];
-        const originalBranch = (await shellRun("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd: repo.root })).stdout.trim();
+        const originalRef = await resolveStableCheckoutRef(shellRun, repo.root);
+        if (originalRef === null) {
+          return 1;
+        }
 
         for (const { pr, filtered, written } of groupsToApply) {
           const group: ProposalGroup = {
@@ -1327,6 +1357,7 @@ export async function runSync(
             drift.binding,
             drift,
             group,
+            originalRef,
           );
           if (prepared === null) {
             // Fatal error during preparation
@@ -1341,7 +1372,11 @@ export async function runSync(
         }
 
         // Return to original branch before parallel operations
-        await shellRun("git", ["checkout", originalBranch], { cwd: repo.root });
+        const restoreResult = await shellRun("git", ["checkout", originalRef], { cwd: repo.root });
+        if (restoreResult.code !== 0) {
+          console.error(`\u274C could not return to ${originalRef}: ${restoreResult.stderr.trim()}`);
+          return 1;
+        }
 
         if (flags.dryRun) {
           console.log(`\n(dry-run) would push ${preparedGroups.length} branch(es) and open PRs`);
@@ -1374,7 +1409,11 @@ export async function runSync(
         if (!flags.dryRun && preparedGroups.length > 0) {
           console.log("\nOpening housekeeping PR (binding pin + CODEOWNERS)...");
           const hkBranch = `first-tree/sync-${drift.binding.sourceId}-housekeeping`;
-          await shellRun("git", ["checkout", "-B", hkBranch], { cwd: repo.root });
+          const hkCheckout = await shellRun("git", ["checkout", "-B", hkBranch, originalRef], { cwd: repo.root });
+          if (hkCheckout.code !== 0) {
+            console.error(`\u274C could not create housekeeping branch ${hkBranch}: ${hkCheckout.stderr.trim()}`);
+            return 1;
+          }
 
           // Pin the binding to the latest synced commit
           writeTreeBinding(repo.root, drift.binding.sourceId, {
@@ -1409,7 +1448,11 @@ export async function runSync(
           } else {
             console.log("  No changes for housekeeping PR.");
           }
-          await shellRun("git", ["checkout", "-"], { cwd: repo.root });
+          const restoreAfterHousekeeping = await shellRun("git", ["checkout", originalRef], { cwd: repo.root });
+          if (restoreAfterHousekeeping.code !== 0) {
+            console.error(`\u274C could not return to ${originalRef}: ${restoreAfterHousekeeping.stderr.trim()}`);
+            return 1;
+          }
         } else if (flags.dryRun && preparedGroups.length > 0) {
           console.log(`\n(dry-run) would open housekeeping PR to pin binding to ${drift.toSha.slice(0, 7)} + regenerate CODEOWNERS`);
         }

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -413,6 +413,149 @@ describe("sync -- default run", () => {
 });
 
 describe("sync -- PR labeling", () => {
+  it("apply prepares every sync branch from the original ref", async () => {
+    const tmp = useTmpDir();
+    makeTreeShell(tmp.path);
+    mkdirSync(join(tmp.path, ".github"), { recursive: true });
+    writeFileSync(
+      join(tmp.path, ".github", "CODEOWNERS"),
+      "/pkg-a/ @alice\n/pkg-b/ @bob\n",
+    );
+    const fromSha = "aa".repeat(20);
+    const toSha = "bb".repeat(20);
+    writeTreeBinding(tmp.path, "source-parallel", {
+      bindingMode: "standalone-source",
+      entrypoint: "/repos/source",
+      lastReconciledSourceCommit: fromSha,
+      remoteUrl: "https://github.com/alice/source.git",
+      rootKind: "git-repo",
+      scope: "repo",
+      sourceId: "source-parallel",
+      sourceName: "source",
+      sourceRootPath: "../source",
+      treeMode: "dedicated",
+      treeRepoName: "tree",
+    });
+    const checkoutCommands: string[][] = [];
+    let classifyCall = 0;
+    const shellRun: ShellRun = async (command, args) => {
+      if (command === "gh" && args[0] === "auth") return okAuth();
+      if (command === "claude" && args[0] === "--version") return claudeVersionOk();
+      if (command === "gh" && args[0] === "api") {
+        const path = args[1] ?? "";
+        if (path === "/repos/alice/source/commits/HEAD") {
+          return { stdout: `${toSha}\n`, stderr: "", code: 0 };
+        }
+        if (path.startsWith("/repos/alice/source/compare/")) {
+          return {
+            stdout: JSON.stringify({
+              commits: [
+                {
+                  sha: "1".repeat(40),
+                  commit: {
+                    message: "feat(pkg-a): add thing (#101)",
+                    author: { name: "a", date: "2026-04-01T00:00:00Z" },
+                  },
+                  files: [{ filename: "pkg-a/x.ts" }],
+                },
+                {
+                  sha: "2".repeat(40),
+                  commit: {
+                    message: "feat(pkg-b): add thing (#102)",
+                    author: { name: "b", date: "2026-04-02T00:00:00Z" },
+                  },
+                  files: [{ filename: "pkg-b/y.ts" }],
+                },
+              ],
+            }),
+            stderr: "",
+            code: 0,
+          };
+        }
+        if (path.startsWith("search/issues")) {
+          return {
+            stdout: JSON.stringify({
+              items: [
+                {
+                  number: 101,
+                  title: "feat(pkg-a): add thing",
+                  pull_request: {
+                    merged_at: "2026-04-01T00:00:00Z",
+                    merge_commit_sha: "1".repeat(40),
+                  },
+                },
+                {
+                  number: 102,
+                  title: "feat(pkg-b): add thing",
+                  pull_request: {
+                    merged_at: "2026-04-02T00:00:00Z",
+                    merge_commit_sha: "2".repeat(40),
+                  },
+                },
+              ],
+            }),
+            stderr: "",
+            code: 0,
+          };
+        }
+      }
+      if (command === "gh" && args[0] === "pr" && args[1] === "list") {
+        return { stdout: "[]", stderr: "", code: 0 };
+      }
+      if (command === "claude" && args[0] === "-p") {
+        classifyCall += 1;
+        return {
+          stdout: JSON.stringify([
+            classifyCall === 1
+              ? {
+                  path: "pkg-a",
+                  type: "TREE_MISS",
+                  target_node_path: null,
+                  rationale: "No node for pkg-a",
+                  suggested_node_title: "pkg-a",
+                  suggested_node_body_markdown: "# pkg-a",
+                }
+              : {
+                  path: "pkg-b",
+                  type: "TREE_MISS",
+                  target_node_path: null,
+                  rationale: "No node for pkg-b",
+                  suggested_node_title: "pkg-b",
+                  suggested_node_body_markdown: "# pkg-b",
+                },
+          ]),
+          stderr: "",
+          code: 0,
+        };
+      }
+      if (command === "git") {
+        if (args[0] === "symbolic-ref") {
+          return { stdout: "main\n", stderr: "", code: 0 };
+        }
+        if (args[0] === "checkout") {
+          checkoutCommands.push([...args]);
+          return { stdout: "", stderr: "", code: 0 };
+        }
+        if (args.includes("diff") && args.includes("--cached") && args.includes("--quiet")) {
+          return { stdout: "", stderr: "", code: 1 };
+        }
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
+    };
+    const code = await runSync(
+      tmp.path,
+      { source: undefined, propose: false, apply: true, dryRun: true },
+      { shellRun },
+    );
+    expect(code).toBe(0);
+    expect(checkoutCommands).toEqual([
+      ["checkout", "-B", "first-tree/sync-source-parallel-pr101", "main"],
+      ["checkout", "-B", "first-tree/sync-source-parallel-pr102", "main"],
+      ["checkout", "main"],
+    ]);
+  });
+
   it("apply labels PR with first-tree:sync only, never auto-merge", async () => {
     const tmp = useTmpDir();
     makeTreeShell(tmp.path);
@@ -476,6 +619,9 @@ describe("sync -- PR labeling", () => {
         return { stdout: classifyResponse, stderr: "", code: 0 };
       }
       if (command === "git") {
+        if (args[0] === "symbolic-ref") {
+          return { stdout: "main\n", stderr: "", code: 0 };
+        }
         // diff --cached --quiet: exit 1 = has staged changes (simulate successful staging)
         if (args.includes("diff") && args.includes("--cached") && args.includes("--quiet")) {
           return { stdout: "", stderr: "", code: 1 };

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -556,6 +556,162 @@ describe("sync -- PR labeling", () => {
     ]);
   });
 
+  it("does not open housekeeping after a partial parallel apply failure", async () => {
+    const tmp = useTmpDir();
+    makeTreeShell(tmp.path);
+    mkdirSync(join(tmp.path, ".github"), { recursive: true });
+    writeFileSync(
+      join(tmp.path, ".github", "CODEOWNERS"),
+      "/pkg-a/ @alice\n/pkg-b/ @bob\n",
+    );
+    const fromSha = "aa".repeat(20);
+    const toSha = "bb".repeat(20);
+    writeTreeBinding(tmp.path, "source-parallel", {
+      bindingMode: "standalone-source",
+      entrypoint: "/repos/source",
+      lastReconciledSourceCommit: fromSha,
+      remoteUrl: "https://github.com/alice/source.git",
+      rootKind: "git-repo",
+      scope: "repo",
+      sourceId: "source-parallel",
+      sourceName: "source",
+      sourceRootPath: "../source",
+      treeMode: "dedicated",
+      treeRepoName: "tree",
+    });
+    const prCreateCalls: string[][] = [];
+    let classifyCall = 0;
+    const shellRun: ShellRun = async (command, args) => {
+      if (command === "gh" && args[0] === "auth") return okAuth();
+      if (command === "claude" && args[0] === "--version") return claudeVersionOk();
+      if (command === "gh" && args[0] === "api") {
+        const path = args[1] ?? "";
+        if (path === "/repos/alice/source/commits/HEAD") {
+          return { stdout: `${toSha}\n`, stderr: "", code: 0 };
+        }
+        if (path.startsWith("/repos/alice/source/compare/")) {
+          return {
+            stdout: JSON.stringify({
+              commits: [
+                {
+                  sha: "1".repeat(40),
+                  commit: {
+                    message: "feat(pkg-a): add thing (#101)",
+                    author: { name: "a", date: "2026-04-01T00:00:00Z" },
+                  },
+                  files: [{ filename: "pkg-a/x.ts" }],
+                },
+                {
+                  sha: "2".repeat(40),
+                  commit: {
+                    message: "feat(pkg-b): add thing (#102)",
+                    author: { name: "b", date: "2026-04-02T00:00:00Z" },
+                  },
+                  files: [{ filename: "pkg-b/y.ts" }],
+                },
+              ],
+            }),
+            stderr: "",
+            code: 0,
+          };
+        }
+        if (path.startsWith("search/issues")) {
+          return {
+            stdout: JSON.stringify({
+              items: [
+                {
+                  number: 101,
+                  title: "feat(pkg-a): add thing",
+                  pull_request: {
+                    merged_at: "2026-04-01T00:00:00Z",
+                    merge_commit_sha: "1".repeat(40),
+                  },
+                },
+                {
+                  number: 102,
+                  title: "feat(pkg-b): add thing",
+                  pull_request: {
+                    merged_at: "2026-04-02T00:00:00Z",
+                    merge_commit_sha: "2".repeat(40),
+                  },
+                },
+              ],
+            }),
+            stderr: "",
+            code: 0,
+          };
+        }
+      }
+      if (command === "gh" && args[0] === "pr" && args[1] === "list") {
+        return { stdout: "[]", stderr: "", code: 0 };
+      }
+      if (command === "gh" && args[0] === "pr" && args[1] === "create") {
+        prCreateCalls.push([...args]);
+        return { stdout: "https://github.com/x/y/pull/101\n", stderr: "", code: 0 };
+      }
+      if (command === "gh" && args[0] === "pr" && args[1] === "edit") {
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      if (command === "gh" && args[0] === "label") {
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      if (command === "claude" && args[0] === "-p") {
+        classifyCall += 1;
+        return {
+          stdout: JSON.stringify([
+            classifyCall === 1
+              ? {
+                  path: "pkg-a",
+                  type: "TREE_MISS",
+                  target_node_path: null,
+                  rationale: "No node for pkg-a",
+                  suggested_node_title: "pkg-a",
+                  suggested_node_body_markdown: "# pkg-a",
+                }
+              : {
+                  path: "pkg-b",
+                  type: "TREE_MISS",
+                  target_node_path: null,
+                  rationale: "No node for pkg-b",
+                  suggested_node_title: "pkg-b",
+                  suggested_node_body_markdown: "# pkg-b",
+                },
+          ]),
+          stderr: "",
+          code: 0,
+        };
+      }
+      if (command === "git") {
+        if (args[0] === "symbolic-ref") {
+          return { stdout: "main\n", stderr: "", code: 0 };
+        }
+        if (args[0] === "checkout") {
+          return { stdout: "", stderr: "", code: 0 };
+        }
+        if (args[0] === "push" && args[2] === "first-tree/sync-source-parallel-pr102") {
+          return { stdout: "", stderr: "push failed", code: 1 };
+        }
+        if (args.includes("diff") && args.includes("--cached") && args.includes("--quiet")) {
+          return { stdout: "", stderr: "", code: 1 };
+        }
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
+    };
+
+    const code = await runSync(
+      tmp.path,
+      { source: undefined, propose: false, apply: true, dryRun: false },
+      { shellRun },
+    );
+
+    expect(code).toBe(1);
+    expect(readTreeBinding(tmp.path, "source-parallel")?.lastReconciledSourceCommit).toBe(fromSha);
+    expect(
+      prCreateCalls.some((args) => args.includes("chore(sync): housekeeping for source-parallel")),
+    ).toBe(false);
+  });
+
   it("apply labels PR with first-tree:sync only, never auto-merge", async () => {
     const tmp = useTmpDir();
     makeTreeShell(tmp.path);


### PR DESCRIPTION
## Summary

Parallelizes the apply phase of `sync --apply` to reduce time from ~8 min to ~2-3 min for 55 PRs:

- Split `applyProposalGroup` into two phases:
  - `prepareProposalGroup`: Creates branch, writes files, commits locally (sequential - git checkout requires exclusive access)
  - `pushAndCreatePr`: Pushes branch and creates PR (parallelizable)
- Run push + PR creation in parallel with concurrency 5 and rate-limit backoff

## Test plan

- [x] All 376 existing tests pass
- [x] Typecheck passes
- [x] Build succeeds
- [ ] Manual test with a real sync run (recommended before merge)

Fixes #93

🤖 Generated with [Claude Code](https://claude.ai/code)