### PR TITLE
fix(sync): harden proposal branch generation

### DIFF
--- a/src/engine/sync.ts
+++ b/src/engine/sync.ts
@@ -7,9 +7,10 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
-import { basename, dirname, join, relative, resolve } from "node:path";
+import { join, relative, resolve } from "node:path";
 import { promisify } from "node:util";
 import { Repo } from "#engine/repo.js";
+import { runVerify } from "#engine/verify.js";
 import {
   TREE_RUNTIME_ROOT,
 } from "#engine/runtime/asset-loader.js";
@@ -19,6 +20,7 @@ import {
   writeTreeBinding,
   type TreeBindingState,
 } from "#engine/runtime/binding-state.js";
+import { resolveNodeOwners } from "../../assets/framework/helpers/generate-codeowners.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -64,6 +66,7 @@ export type ShellRun = (
 export interface SyncDeps {
   shellRun?: ShellRun;
   now?: () => Date;
+  verifyTree?: (treeRoot: string) => number | Promise<number>;
 }
 
 async function defaultShellRun(
@@ -141,16 +144,20 @@ const SCAN_SKIP_DIRS = new Set([
 const FRONTMATTER_RE = /^---\s*\n(.*?)\n---/s;
 const TITLE_RE = /^title:\s*['"]?(.+?)['"]?\s*$/m;
 const OWNERS_RE = /^owners:\s*\[([^\]]*)\]/m;
+const GITHUB_RE = /^github:\s*['"]?(.+?)['"]?\s*$/m;
+const LEADING_FRONTMATTER_RE = /^---\s*\r?\n[\s\S]*?\r?\n---(?:\s*\r?\n)?/;
 
 function parseNodeFrontmatter(text: string): {
   title: string | undefined;
   owners: string[] | undefined;
+  github: string | undefined;
 } {
   const match = text.match(FRONTMATTER_RE);
-  if (!match) return { title: undefined, owners: undefined };
+  if (!match) return { title: undefined, owners: undefined, github: undefined };
   const fm = match[1];
   const titleMatch = fm.match(TITLE_RE);
   const ownersMatch = fm.match(OWNERS_RE);
+  const githubMatch = fm.match(GITHUB_RE);
   const title = titleMatch ? titleMatch[1].trim() : undefined;
   let owners: string[] | undefined;
   if (ownersMatch) {
@@ -159,7 +166,8 @@ function parseNodeFrontmatter(text: string): {
       ? []
       : raw.split(",").map((o) => o.trim()).filter(Boolean);
   }
-  return { title, owners };
+  const github = githubMatch ? githubMatch[1].trim() : undefined;
+  return { title, owners, github };
 }
 
 export function scanTreeNodes(root: string): TreeNodeSummary[] {
@@ -205,6 +213,94 @@ export function scanTreeNodes(root: string): TreeNodeSummary[] {
   return results.sort((a, b) => a.path.localeCompare(b.path));
 }
 
+function normalizeGitHubLogin(value: string): string {
+  return value.trim().replace(/^@+/, "").toLowerCase();
+}
+
+function sanitizeSuggestedNodeBodyMarkdown(markdown: string): string {
+  const trimmed = markdown.trim();
+  if (trimmed === "") return trimmed;
+  const withoutFrontmatter = trimmed.replace(LEADING_FRONTMATTER_RE, "").trim();
+  return withoutFrontmatter === "" ? trimmed : withoutFrontmatter;
+}
+
+function findExistingMemberDirByAuthorLogin(
+  treeRoot: string,
+  authorLogin: string | null,
+): string | null {
+  if (!authorLogin) return null;
+  const normalizedAuthor = normalizeGitHubLogin(authorLogin);
+  if (normalizedAuthor === "") return null;
+  const membersRoot = join(treeRoot, "members");
+  if (!existsSync(membersRoot)) return null;
+
+  const matches: string[] = [];
+  const walk = (dir: string): void => {
+    const nodePath = join(dir, "NODE.md");
+    if (existsSync(nodePath)) {
+      try {
+        const text = readFileSync(nodePath, "utf-8");
+        const { owners, github } = parseNodeFrontmatter(text);
+        const matchesAuthor =
+          (owners ?? []).some((owner) => normalizeGitHubLogin(owner) === normalizedAuthor)
+          || (github ? normalizeGitHubLogin(github) === normalizedAuthor : false);
+        if (matchesAuthor) {
+          matches.push(relative(treeRoot, dir).split("\\").join("/"));
+        }
+      } catch {
+        // ignore unreadable member nodes
+      }
+    }
+
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.startsWith(".")) continue;
+      const child = join(dir, entry);
+      try {
+        if (!statSync(child).isDirectory()) continue;
+      } catch {
+        continue;
+      }
+      walk(child);
+    }
+  };
+
+  walk(membersRoot);
+  matches.sort((a, b) => {
+    const depthDiff = a.split("/").length - b.split("/").length;
+    return depthDiff !== 0 ? depthDiff : a.localeCompare(b);
+  });
+  return matches[0] ?? null;
+}
+
+function resolveProposalOwners(
+  treeRoot: string,
+  targetDir: string,
+  authorLogin: string | null,
+): string[] {
+  const combined = [...resolveNodeOwners(targetDir, treeRoot, new Map())];
+  if (authorLogin) {
+    combined.push(authorLogin);
+  }
+
+  const seen = new Set<string>();
+  const resolved: string[] = [];
+  for (const owner of combined) {
+    const cleaned = owner.replace(/^@+/, "").trim();
+    if (cleaned === "") continue;
+    const normalized = normalizeGitHubLogin(cleaned);
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    resolved.push(cleaned);
+  }
+  return resolved;
+}
+
 interface CommitSummary {
   sha: string;
   shortSha: string;
@@ -219,6 +315,7 @@ interface MergedPr {
   title: string;
   mergedAt: string;
   mergeCommitSha: string | null;
+  authorLogin: string | null;
 }
 
 interface DriftReport {
@@ -245,6 +342,7 @@ interface ClassificationItem {
 interface ProposalGroup {
   sourcePrNumber: number | null;
   sourcePrTitle: string | null;
+  sourcePrAuthorLogin: string | null;
   proposals: ClassificationItem[];
   proposalPaths: string[];
 }
@@ -484,6 +582,7 @@ async function fetchMergedPrs(
       items?: Array<{
         number?: number;
         title?: string;
+        user?: { login?: string };
         pull_request?: { merged_at?: string; merge_commit_sha?: string };
       }>;
     };
@@ -494,6 +593,7 @@ async function fetchMergedPrs(
         title: item.title!,
         mergedAt: item.pull_request?.merged_at ?? "",
         mergeCommitSha: item.pull_request?.merge_commit_sha ?? null,
+        authorLogin: item.user?.login?.trim() ?? null,
       }));
   } catch {
     return [];
@@ -575,10 +675,12 @@ Return a JSON array. Each element represents one area that needs a NEW tree node
   "target_node_path": null,
   "rationale": "one sentence explaining why the tree needs this node",
   "suggested_node_title": "Human-readable title for the node",
-  "suggested_node_body_markdown": "Draft NODE.md body content (2-5 paragraphs)"
+  "suggested_node_body_markdown": "Draft NODE.md body content ONLY (2-5 paragraphs, no YAML frontmatter)"
 }
 
 For TREE_OK items, only path, type, and rationale are required (other fields can be empty strings).
+
+IMPORTANT: \`suggested_node_body_markdown\` must contain body content only. Do NOT include YAML frontmatter or code fences.
 
 Return a JSON array only, no prose.`;
   const CLAUDE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes per classification
@@ -697,6 +799,7 @@ function writeProposalFile(
   const dir = join(treeRoot, TREE_RUNTIME_ROOT, "proposals", sourceId);
   mkdirSync(dir, { recursive: true });
   const filePath = join(dir, `${slug}.md`);
+  const body = sanitizeSuggestedNodeBodyMarkdown(item.suggested_node_body_markdown);
   const frontmatter = [
     "---",
     `type: ${item.type}`,
@@ -707,44 +810,8 @@ function writeProposalFile(
     "---",
     "",
   ].join("\n");
-  writeFileSync(filePath, `${frontmatter}${item.suggested_node_body_markdown}\n`);
+  writeFileSync(filePath, `${frontmatter}${body}\n`);
   return filePath;
-}
-
-function extractOwnersFromCodeowners(
-  treeRoot: string,
-  targetPath: string,
-): string[] {
-  const candidates = [
-    join(treeRoot, "CODEOWNERS"),
-    join(treeRoot, ".github", "CODEOWNERS"),
-    join(treeRoot, "docs", "CODEOWNERS"),
-  ];
-  for (const candidate of candidates) {
-    if (!existsSync(candidate)) continue;
-    let text;
-    try {
-      text = readFileSync(candidate, "utf-8");
-    } catch {
-      continue;
-    }
-    const matches: string[] = [];
-    for (const rawLine of text.split("\n")) {
-      const line = rawLine.trim();
-      if (line === "" || line.startsWith("#")) continue;
-      const parts = line.split(/\s+/);
-      if (parts.length < 2) continue;
-      const pattern = parts[0];
-      if (
-        pattern === "*"
-        || targetPath.startsWith(pattern.replace(/^\//, "").replace(/\/$/, ""))
-      ) {
-        matches.push(...parts.slice(1).map(s => s.replace(/^@+/, '')));
-      }
-    }
-    if (matches.length > 0) return matches;
-  }
-  return [];
 }
 
 async function ghAuthOk(shellRun: ShellRun): Promise<boolean> {
@@ -824,6 +891,7 @@ async function prepareProposalGroup(
   drift: DriftReport,
   group: ProposalGroup,
   baseRef: string,
+  verifyTree: (treeRoot: string) => number | Promise<number>,
 ): Promise<PreparedProposalGroup | null> {
   const shortSha = drift.toSha.slice(0, 7);
   const branchSuffix = group.sourcePrNumber !== null
@@ -878,12 +946,27 @@ async function prepareProposalGroup(
       let dirSegment = proposal.path === "(root)" ? "misc" : proposal.path;
       // Strip trailing /NODE.md if the AI included it in the path
       dirSegment = dirSegment.replace(/\/NODE\.md$/i, "").replace(/^NODE\.md$/i, "misc");
+      if (dirSegment.startsWith("members/")) {
+        const existingMemberDir = findExistingMemberDirByAuthorLogin(
+          treeRoot,
+          group.sourcePrAuthorLogin,
+        );
+        if (existingMemberDir) {
+          dirSegment = existingMemberDir;
+        }
+      }
       const absDir = join(treeRoot, dirSegment);
       mkdirSync(absDir, { recursive: true });
-      const owners = [...new Set(extractOwnersFromCodeowners(treeRoot, dirSegment))];
+      const owners = resolveProposalOwners(
+        treeRoot,
+        absDir,
+        group.sourcePrAuthorLogin,
+      );
       const title = proposal.suggested_node_title;
       const capitalizedTitle = title.charAt(0).toUpperCase() + title.slice(1);
-      const body = proposal.suggested_node_body_markdown;
+      const body = sanitizeSuggestedNodeBodyMarkdown(
+        proposal.suggested_node_body_markdown,
+      );
       const nodePath = join(absDir, "NODE.md");
       // Only write if NODE.md doesn't already exist (don't overwrite human-authored nodes)
       if (!existsSync(nodePath)) {
@@ -941,6 +1024,18 @@ async function prepareProposalGroup(
   if (commitResult.code !== 0) {
     console.error(`\u274C git commit failed: ${commitResult.stderr.trim()}`);
     return null;
+  }
+
+  const verifyCode = await verifyTree(treeRoot);
+  if (verifyCode !== 0) {
+    return {
+      branch,
+      prTitle,
+      prBody: "",
+      group,
+      skipped: true,
+      skipReason: "first-tree verify failed",
+    };
   }
 
   const bodyLines = [
@@ -1083,6 +1178,7 @@ export async function runSync(
 ): Promise<number> {
   const shellRun = deps.shellRun ?? defaultShellRun;
   const now = deps.now ?? (() => new Date());
+  const verifyTree = deps.verifyTree ?? ((root: string) => runVerify(new Repo(root)));
   const repo = new Repo(treeRoot);
 
   if (!repo.looksLikeTreeRepo()) {
@@ -1248,7 +1344,13 @@ export async function runSync(
     // Classify per merged PR (not per batch) so each source PR → one tree PR
     const prsToClassify = drift.mergedPrs.length > 0
       ? drift.mergedPrs
-      : [{ number: 0, title: "unlinked commits", mergeCommitSha: null }];
+      : [{
+          number: 0,
+          title: "unlinked commits",
+          mergeCommitSha: null,
+          mergedAt: "",
+          authorLogin: null,
+        }];
 
     // Phase 1: Classify all PRs in parallel (up to CONCURRENCY at a time)
     interface ClassifiedPr {
@@ -1348,6 +1450,7 @@ export async function runSync(
           const group: ProposalGroup = {
             sourcePrNumber: pr.number > 0 ? pr.number : null,
             sourcePrTitle: pr.number > 0 ? pr.title : null,
+            sourcePrAuthorLogin: pr.authorLogin,
             proposals: filtered,
             proposalPaths: written,
           };
@@ -1358,6 +1461,7 @@ export async function runSync(
             drift,
             group,
             originalRef,
+            verifyTree,
           );
           if (prepared === null) {
             // Fatal error during preparation

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -546,7 +546,7 @@ describe("sync -- PR labeling", () => {
     const code = await runSync(
       tmp.path,
       { source: undefined, propose: false, apply: true, dryRun: true },
-      { shellRun },
+      { shellRun, verifyTree: () => 0 },
     );
     expect(code).toBe(0);
     expect(checkoutCommands).toEqual([
@@ -702,7 +702,7 @@ describe("sync -- PR labeling", () => {
     const code = await runSync(
       tmp.path,
       { source: undefined, propose: false, apply: true, dryRun: false },
-      { shellRun },
+      { shellRun, verifyTree: () => 0 },
     );
 
     expect(code).toBe(1);
@@ -796,14 +796,439 @@ describe("sync -- PR labeling", () => {
     const code = await runSync(
       tmp.path,
       { source: undefined, propose: false, apply: true, dryRun: false },
-      { shellRun },
+      { shellRun, verifyTree: () => 0 },
     );
     expect(code).toBe(0);
     expect(labelArgsCaptured.join(" ")).toContain("first-tree:sync");
     expect(labelArgsCaptured.join(" ")).not.toContain("auto-merge");
     const nodeText = readFileSync(join(tmp.path, "pkg-a", "NODE.md"), "utf-8");
-    expect(nodeText).toContain("owners: [alice, bob]");
+    expect(nodeText).toContain("owners: [alice]");
     expect(nodeText).not.toContain("@alice");
+  });
+
+  it("asks Claude for body-only markdown without YAML frontmatter", async () => {
+    const tmp = useTmpDir();
+    makeTreeShell(tmp.path);
+    const fromSha = "aa".repeat(20);
+    const toSha = "bb".repeat(20);
+    writeTreeBinding(tmp.path, "source-prompt", {
+      bindingMode: "standalone-source",
+      entrypoint: "/repos/source",
+      lastReconciledSourceCommit: fromSha,
+      remoteUrl: "https://github.com/alice/source.git",
+      rootKind: "git-repo",
+      scope: "repo",
+      sourceId: "source-prompt",
+      sourceName: "source",
+      sourceRootPath: "../source",
+      treeMode: "dedicated",
+      treeRepoName: "tree",
+    });
+
+    let claudePrompt = "";
+    const shellRun: ShellRun = async (command, args) => {
+      if (command === "gh" && args[0] === "auth") return okAuth();
+      if (command === "claude" && args[0] === "--version") return claudeVersionOk();
+      if (command === "gh" && args[0] === "api") {
+        const path = args[1] ?? "";
+        if (path === "/repos/alice/source/commits/HEAD") {
+          return { stdout: `${toSha}\n`, stderr: "", code: 0 };
+        }
+        if (path.startsWith("/repos/alice/source/compare/")) {
+          return {
+            stdout: JSON.stringify({
+              commits: [{
+                sha: "1".repeat(40),
+                commit: {
+                  message: "feat(pkg-a): add docs",
+                  author: { name: "alice", date: "2026-04-01T00:00:00Z" },
+                },
+                files: [{ filename: "pkg-a/x.ts" }],
+              }],
+            }),
+            stderr: "",
+            code: 0,
+          };
+        }
+        if (path.startsWith("search/issues")) {
+          return { stdout: JSON.stringify({ items: [] }), stderr: "", code: 0 };
+        }
+      }
+      if (command === "claude" && args[0] === "-p") {
+        claudePrompt = args.at(-1) ?? "";
+        return {
+          stdout: JSON.stringify([{
+            path: "pkg-a",
+            type: "TREE_OK",
+            target_node_path: null,
+            rationale: "Already documented",
+            suggested_node_title: "",
+            suggested_node_body_markdown: "",
+          }]),
+          stderr: "",
+          code: 0,
+        };
+      }
+      return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
+    };
+
+    const code = await runSync(
+      tmp.path,
+      { source: undefined, propose: true, apply: false, dryRun: false },
+      { shellRun },
+    );
+
+    expect(code).toBe(0);
+    expect(claudePrompt).toContain("body content ONLY");
+    expect(claudePrompt).toContain("Do NOT include YAML frontmatter");
+  });
+
+  it("strips Claude frontmatter and inherits parent owners plus PR author", async () => {
+    const tmp = useTmpDir();
+    makeTreeShell(tmp.path);
+    mkdirSync(join(tmp.path, "engineering"), { recursive: true });
+    writeFileSync(
+      join(tmp.path, "engineering", "NODE.md"),
+      "---\ntitle: Engineering\nowners: [core-team, review-lead]\n---\n# Engineering\n",
+    );
+    const fromSha = "cc".repeat(20);
+    const toSha = "dd".repeat(20);
+    writeTreeBinding(tmp.path, "source-owners", {
+      bindingMode: "standalone-source",
+      entrypoint: "/repos/source",
+      lastReconciledSourceCommit: fromSha,
+      remoteUrl: "https://github.com/alice/source.git",
+      rootKind: "git-repo",
+      scope: "repo",
+      sourceId: "source-owners",
+      sourceName: "source",
+      sourceRootPath: "../source",
+      treeMode: "dedicated",
+      treeRepoName: "tree",
+    });
+
+    const shellRun: ShellRun = async (command, args) => {
+      if (command === "gh" && args[0] === "auth") return okAuth();
+      if (command === "claude" && args[0] === "--version") return claudeVersionOk();
+      if (command === "gh" && args[0] === "api") {
+        const path = args[1] ?? "";
+        if (path === "/repos/alice/source/commits/HEAD") {
+          return { stdout: `${toSha}\n`, stderr: "", code: 0 };
+        }
+        if (path.startsWith("/repos/alice/source/compare/")) {
+          return {
+            stdout: JSON.stringify({
+              commits: [{
+                sha: "1".repeat(40),
+                commit: {
+                  message: "feat(backend): add worker (#101)",
+                  author: { name: "dev", date: "2026-04-01T00:00:00Z" },
+                },
+                files: [{ filename: "engineering/backend/worker.ts" }],
+              }],
+            }),
+            stderr: "",
+            code: 0,
+          };
+        }
+        if (path.startsWith("search/issues")) {
+          return {
+            stdout: JSON.stringify({
+              items: [{
+                number: 101,
+                title: "feat(backend): add worker",
+                user: { login: "external-dev" },
+                pull_request: {
+                  merged_at: "2026-04-01T00:00:00Z",
+                  merge_commit_sha: "1".repeat(40),
+                },
+              }],
+            }),
+            stderr: "",
+            code: 0,
+          };
+        }
+      }
+      if (command === "gh" && args[0] === "pr" && args[1] === "list") {
+        return { stdout: "[]", stderr: "", code: 0 };
+      }
+      if (command === "claude" && args[0] === "-p") {
+        return {
+          stdout: JSON.stringify([{
+            path: "engineering/backend",
+            type: "TREE_MISS",
+            target_node_path: null,
+            rationale: "Backend worker is new knowledge",
+            suggested_node_title: "backend",
+            suggested_node_body_markdown: [
+              "---",
+              'title: "Backend"',
+              "owners: [wrong-owner]",
+              "soft_links: [/engineering]",
+              "---",
+              "",
+              "# Backend",
+              "",
+              "New worker details.",
+            ].join("\n"),
+          }]),
+          stderr: "",
+          code: 0,
+        };
+      }
+      if (command === "git") {
+        if (args[0] === "symbolic-ref") {
+          return { stdout: "main\n", stderr: "", code: 0 };
+        }
+        if (args.includes("diff") && args.includes("--cached") && args.includes("--quiet")) {
+          return { stdout: "", stderr: "", code: 1 };
+        }
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
+    };
+
+    const code = await runSync(
+      tmp.path,
+      { source: undefined, propose: false, apply: true, dryRun: true },
+      { shellRun, verifyTree: () => 0 },
+    );
+
+    expect(code).toBe(0);
+    const nodeText = readFileSync(join(tmp.path, "engineering", "backend", "NODE.md"), "utf-8");
+    expect(nodeText).toContain("owners: [core-team, review-lead, external-dev]");
+    expect(nodeText.match(/^---$/gm)?.length).toBe(2);
+    expect(nodeText).not.toContain("soft_links: [/engineering]");
+    expect(nodeText).toContain("# Backend");
+  });
+
+  it("reuses an existing member node when the PR author is already in members", async () => {
+    const tmp = useTmpDir();
+    makeTreeShell(tmp.path);
+    mkdirSync(join(tmp.path, "members", "dotta"), { recursive: true });
+    writeFileSync(
+      join(tmp.path, "members", "NODE.md"),
+      "---\ntitle: Members\nowners: []\n---\n# Members\n",
+    );
+    writeFileSync(
+      join(tmp.path, "members", "dotta", "NODE.md"),
+      [
+        "---",
+        'title: "Dotta"',
+        "owners: [cryppadotta]",
+        "github: cryppadotta",
+        'type: "human"',
+        'role: "Engineer"',
+        "domains:",
+        '  - "backend"',
+        "---",
+        "",
+        "# Dotta",
+      ].join("\n"),
+    );
+    const fromSha = "ee".repeat(20);
+    const toSha = "ff".repeat(20);
+    writeTreeBinding(tmp.path, "source-members", {
+      bindingMode: "standalone-source",
+      entrypoint: "/repos/source",
+      lastReconciledSourceCommit: fromSha,
+      remoteUrl: "https://github.com/alice/source.git",
+      rootKind: "git-repo",
+      scope: "repo",
+      sourceId: "source-members",
+      sourceName: "source",
+      sourceRootPath: "../source",
+      treeMode: "dedicated",
+      treeRepoName: "tree",
+    });
+
+    const shellRun: ShellRun = async (command, args) => {
+      if (command === "gh" && args[0] === "auth") return okAuth();
+      if (command === "claude" && args[0] === "--version") return claudeVersionOk();
+      if (command === "gh" && args[0] === "api") {
+        const path = args[1] ?? "";
+        if (path === "/repos/alice/source/commits/HEAD") {
+          return { stdout: `${toSha}\n`, stderr: "", code: 0 };
+        }
+        if (path.startsWith("/repos/alice/source/compare/")) {
+          return {
+            stdout: JSON.stringify({
+              commits: [{
+                sha: "2".repeat(40),
+                commit: {
+                  message: "docs(member): update bio (#102)",
+                  author: { name: "cryppadotta", date: "2026-04-02T00:00:00Z" },
+                },
+                files: [{ filename: "README.md" }],
+              }],
+            }),
+            stderr: "",
+            code: 0,
+          };
+        }
+        if (path.startsWith("search/issues")) {
+          return {
+            stdout: JSON.stringify({
+              items: [{
+                number: 102,
+                title: "docs(member): update bio",
+                user: { login: "cryppadotta" },
+                pull_request: {
+                  merged_at: "2026-04-02T00:00:00Z",
+                  merge_commit_sha: "2".repeat(40),
+                },
+              }],
+            }),
+            stderr: "",
+            code: 0,
+          };
+        }
+      }
+      if (command === "gh" && args[0] === "pr" && args[1] === "list") {
+        return { stdout: "[]", stderr: "", code: 0 };
+      }
+      if (command === "claude" && args[0] === "-p") {
+        return {
+          stdout: JSON.stringify([{
+            path: "members/cryppadotta",
+            type: "TREE_MISS",
+            target_node_path: null,
+            rationale: "Member node missing",
+            suggested_node_title: "cryppadotta",
+            suggested_node_body_markdown: "# cryppadotta",
+          }]),
+          stderr: "",
+          code: 0,
+        };
+      }
+      if (command === "git") {
+        if (args[0] === "symbolic-ref") {
+          return { stdout: "main\n", stderr: "", code: 0 };
+        }
+        if (args.includes("diff") && args.includes("--cached") && args.includes("--quiet")) {
+          return { stdout: "", stderr: "", code: 0 };
+        }
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
+    };
+
+    const code = await runSync(
+      tmp.path,
+      { source: undefined, propose: false, apply: true, dryRun: true },
+      { shellRun, verifyTree: () => 0 },
+    );
+
+    expect(code).toBe(0);
+    expect(existsSync(join(tmp.path, "members", "cryppadotta", "NODE.md"))).toBe(false);
+    expect(readFileSync(join(tmp.path, "members", "dotta", "NODE.md"), "utf-8")).toContain(
+      "owners: [cryppadotta]",
+    );
+  });
+
+  it("skips pushing PR branches that fail first-tree verify", async () => {
+    const tmp = useTmpDir();
+    makeTreeShell(tmp.path);
+    const fromSha = "11".repeat(20);
+    const toSha = "22".repeat(20);
+    writeTreeBinding(tmp.path, "source-verify", {
+      bindingMode: "standalone-source",
+      entrypoint: "/repos/source",
+      lastReconciledSourceCommit: fromSha,
+      remoteUrl: "https://github.com/alice/source.git",
+      rootKind: "git-repo",
+      scope: "repo",
+      sourceId: "source-verify",
+      sourceName: "source",
+      sourceRootPath: "../source",
+      treeMode: "dedicated",
+      treeRepoName: "tree",
+    });
+
+    const prCreateCalls: string[][] = [];
+    const shellRun: ShellRun = async (command, args) => {
+      if (command === "gh" && args[0] === "auth") return okAuth();
+      if (command === "claude" && args[0] === "--version") return claudeVersionOk();
+      if (command === "gh" && args[0] === "api") {
+        const path = args[1] ?? "";
+        if (path === "/repos/alice/source/commits/HEAD") {
+          return { stdout: `${toSha}\n`, stderr: "", code: 0 };
+        }
+        if (path.startsWith("/repos/alice/source/compare/")) {
+          return {
+            stdout: JSON.stringify({
+              commits: [{
+                sha: "3".repeat(40),
+                commit: {
+                  message: "feat(pkg-a): add thing (#103)",
+                  author: { name: "alice", date: "2026-04-03T00:00:00Z" },
+                },
+                files: [{ filename: "pkg-a/x.ts" }],
+              }],
+            }),
+            stderr: "",
+            code: 0,
+          };
+        }
+        if (path.startsWith("search/issues")) {
+          return {
+            stdout: JSON.stringify({
+              items: [{
+                number: 103,
+                title: "feat(pkg-a): add thing",
+                user: { login: "alice" },
+                pull_request: {
+                  merged_at: "2026-04-03T00:00:00Z",
+                  merge_commit_sha: "3".repeat(40),
+                },
+              }],
+            }),
+            stderr: "",
+            code: 0,
+          };
+        }
+      }
+      if (command === "gh" && args[0] === "pr" && args[1] === "list") {
+        return { stdout: "[]", stderr: "", code: 0 };
+      }
+      if (command === "gh" && args[0] === "pr" && args[1] === "create") {
+        prCreateCalls.push([...args]);
+        return { stdout: "https://github.com/x/y/pull/103", stderr: "", code: 0 };
+      }
+      if (command === "claude" && args[0] === "-p") {
+        return {
+          stdout: JSON.stringify([{
+            path: "pkg-a",
+            type: "TREE_MISS",
+            target_node_path: null,
+            rationale: "Need pkg-a node",
+            suggested_node_title: "pkg-a",
+            suggested_node_body_markdown: "# pkg-a",
+          }]),
+          stderr: "",
+          code: 0,
+        };
+      }
+      if (command === "git") {
+        if (args[0] === "symbolic-ref") {
+          return { stdout: "main\n", stderr: "", code: 0 };
+        }
+        if (args.includes("diff") && args.includes("--cached") && args.includes("--quiet")) {
+          return { stdout: "", stderr: "", code: 1 };
+        }
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
+    };
+
+    const code = await runSync(
+      tmp.path,
+      { source: undefined, propose: false, apply: true, dryRun: false },
+      { shellRun, verifyTree: () => 1 },
+    );
+
+    expect(code).toBe(0);
+    expect(prCreateCalls).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Summary
- strip any Claude-generated YAML frontmatter before writing proposal or NODE content
- resolve new node owners from the nearest parent NODE and append the source PR author when available
- reuse existing member nodes for the same GitHub login instead of creating duplicate member directories
- run a verify gate per generated sync branch and skip branches that fail validation
- tighten the Claude prompt so `suggested_node_body_markdown` is body-only markdown

## Testing
- pnpm exec vitest run tests/sync.test.ts
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm validate:skill
- pnpm pack

Closes #97
