### PR TITLE
docs: move maintainer knowledge into Context Tree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,10 +7,10 @@ for what gets shipped.
 
 ## Start Here
 
-1. `docs/source-map.md` — index of every maintainer-facing file
+1. `docs/source-map.md` — maintainer entrypoint; it points to canonical Context Tree nodes first, then local implementation notes
 2. `skills/first-tree/SKILL.md` — the user-facing skill payload (read this so
    you understand what ships to user repos)
-3. The specific maintainer reference linked from the source map
+3. The specific Context Tree node or repo-local maintainer reference linked from the source map
 4. `skills/first-tree/references/source-workspace-installation.md` for the
    user-facing install contract (also shipped to user repos)
 
@@ -23,7 +23,9 @@ for what gets shipped.
   - `skills/first-tree/` is the lightweight skill payload that gets copied
     verbatim to user repos via `copyCanonicalSkill`. It contains only
     `SKILL.md`, `VERSION`, and `references/` (user-facing references only).
-  - `docs/` holds maintainer-only references (source-map, maintainer-*)
+  - `docs/` holds source-repo implementation notes and file maps; canonical
+    design/architecture decisions belong in the bound Context Tree under
+    `first-tree-skill-cli/`
   - `tests/` holds the test suite
 - The tracked `.agents/skills/first-tree` and `.claude/skills/first-tree`
   entries in this repo are local alias symlinks for agent discovery; edit
@@ -35,6 +37,9 @@ for what gets shipped.
 - Keep source/workspace installs limited to local skill integration; `NODE.md`,
   `members/`, and tree-scoped `AGENTS.md` belong only in a dedicated
   `*-context` repo. See `skills/first-tree/references/source-workspace-installation.md`.
+- When a maintainer note becomes decision-grade knowledge other repos should
+  discover, move it into `first-tree-context/first-tree-skill-cli/` and leave a
+  thin repo-local pointer in `docs/`.
 - Keep shipped runtime assets generic.
 
 ## Validation

--- a/README.md
+++ b/README.md
@@ -206,8 +206,11 @@ plus their own source/workspace binding state.
 ## Canonical Documentation
 
 User-facing references ship in `skills/first-tree/references/` and are copied
-to user repos via `first-tree init` / `first-tree bind`. Maintainer-only
-references live in `docs/` and never ship.
+to user repos via `first-tree init` / `first-tree bind`.
+
+Canonical design and architecture knowledge for this project lives in the bound
+Context Tree under `first-tree-skill-cli/`. Repo-local maintainer notes in
+`docs/` are implementation-only and never ship.
 
 - User-facing overview: `skills/first-tree/references/whitepaper.md`
 - User onboarding: `skills/first-tree/references/onboarding.md`
@@ -215,6 +218,8 @@ references live in `docs/` and never ship.
   `skills/first-tree/references/source-workspace-installation.md`
 - Upgrade and layout contract:
   `skills/first-tree/references/upgrade-contract.md`
+- Canonical architecture node: `first-tree-skill-cli/repo-architecture.md`
+- Canonical sync design node: `first-tree-skill-cli/sync.md`
 - Maintainer entrypoint: `docs/source-map.md`
 
 ## Developing This Repo

--- a/docs/design-sync.md
+++ b/docs/design-sync.md
@@ -1,170 +1,22 @@
-# Design: `first-tree sync`
+# `first-tree sync`
 
-> Authoritative design document for the sync feature.
-> Last updated: 2026-04-10
+Authoritative decision node: `first-tree-skill-cli/sync.md` in the bound
+Context Tree.
 
-## Overview
+This repo-local file is intentionally thin. It tracks only source-repo
+implementation touchpoints that do not belong in the tree.
 
-`first-tree sync` detects when a Context Tree has drifted from the source repo(s) it describes, classifies each change using AI, and opens targeted pull requests to bring the tree back in line.
+## Local Implementation Touchpoints
 
-The goal is to keep trees current so downstream consumers (like gardener) operate on accurate context. Without sync, trees rot silently as the source code evolves.
+- `src/engine/sync.ts` — core detect/propose/apply implementation
+- `src/engine/commands/sync.ts` — CLI adapter
+- `tests/sync.test.ts` — sync behavior coverage
+- `assets/framework/claude-commands/first-tree-sync*.md` — installed runbooks
+  and schedule payload
 
-## How it works — three phases
+## Change Checklist
 
-Sync runs in three progressive phases. Each phase includes all the work of the previous one.
-
-### 1. Detect (default, no flags)
-
-Check each bound source repo for new merged PRs since the last sync pin. Print a summary of what changed and how far the tree has drifted.
-
-This is safe to run at any time — it is read-only and makes no changes.
-
-### 2. Propose (`--propose`)
-
-Detect + classify each source PR against the tree using AI. For every merged source PR, a Claude call determines whether the tree needs updating. Results are written to `.first-tree/proposals/`.
-
-### 3. Apply (`--apply`)
-
-Propose + create one tree PR per source PR, labeled `first-tree:sync` and left open for human review.
-
-## Key design decisions
-
-### One source PR maps to one tree PR
-
-Tree PRs are not bundled. Each tree PR has clear scope, gets routed to the right owner via CODEOWNERS, and can be merged independently. This makes review tractable and rollback trivial.
-
-### AI is required — no deterministic fallback
-
-Classification requires the `claude` CLI. If it is not on PATH, sync exits with code 1 and prints install instructions. The reasoning: a bad tree update is worse than no tree update. Quality over availability.
-
-### Classification is per-PR, not per-batch
-
-Each merged source PR gets its own Claude call. This keeps the context window small, produces cleaner verdicts, and naturally maps to the one-PR-per-source-PR output model.
-
-### No auto-merge — PRs require human review
-
-Sync PRs are never auto-merged. Every PR is labeled `first-tree:sync` and left open for human review. A future review agent may be added to assist, but the final merge decision is always human.
-
-### First run traces history
-
-On first run (no existing sync pin), sync does not silently pin to HEAD. Instead it walks up to 500 commits back (or 6 months, whichever comes first) and generates proposals for the full history. The pin is only recorded after a successful apply.
-
-### Only already-bound sources are processed
-
-New repos must be bound first via `first-tree bind` or `first-tree workspace sync`. Auto-discovery of new source repos is not in scope for this feature.
-
-### Multi-source support
-
-A shared tree can bind multiple source repos. Each source gets its own `lastReconciledSourceCommit` pin stored in `.first-tree/bindings/<sourceId>.json`.
-
-## Classification logic
-
-For each merged source PR, the AI returns one of two verdicts:
-
-| Verdict | Meaning | Action |
-|---|---|---|
-| **TREE_OK** | The tree already covers this change | No tree PR opened |
-| **TREE_MISS** | The tree has no coverage for this area | New node proposed |
-
-There is intentionally no TREE_STALE verdict. Since gardener is required on the source repo, every merged PR has already passed context-fit review before merge. A merged PR cannot contradict the tree — if it did, gardener would have flagged it pre-merge. The only question sync asks is: "did this PR introduce new knowledge the tree hasn't captured yet?"
-
-The classification prompt biases toward TREE_MISS. A sparse tree (missing context) is more dangerous than a detailed one (extra context), because downstream consumers make worse decisions with gaps than with redundancy.
-
-The AI evaluates the overall picture of each PR, not individual commits within it.
-
-## End-to-end flow
-
-Using the paperclip project as an example:
-
-```
-paperclip repo gets PRs merged
-  -> sync schedule detects drift (hourly)
-  -> AI classifies each merged PR against tree nodes
-  -> one tree PR opened per source PR
-  -> CI checks (typecheck, test, build, verify)
-  -> gardener reviews for context-fit
-  -> node owner approves
-  -> squash merge -> tree is current
-```
-
-## Schedule and automation
-
-Four commands manage the automation lifecycle:
-
-| Command | What it does |
-|---|---|
-| `first-tree-sync-start` | Verifies bindings, gardener, MCP connector. Creates cloud schedule + local loop. |
-| `first-tree-sync-stop` | Disables cloud schedule, stops local loop. |
-| `first-tree-sync-schedule.md` | Coordinator runbook — runs sync then gardener in one slot to avoid rate-limit conflicts. |
-| `first-tree-sync-loop.md` | `/loop` wrapper for the local path. |
-
-**Dual-path execution:**
-
-- **Local path:** Uses the `claude` CLI directly for classification.
-- **Cloud path:** Uses an agent-as-classifier since the `claude` CLI is not available in cloud sandboxes.
-
-## File layout
-
-When sync is installed in a tree repo, these files are added:
-
-```
-.claude/commands/
-  first-tree-sync.md           <- main runbook (dual-path: local gh + cloud MCP)
-  first-tree-sync-schedule.md  <- coordinator: sync then gardener
-  first-tree-sync-start.md     <- start automation
-  first-tree-sync-stop.md      <- stop automation
-  first-tree-sync-loop.md      <- /loop wrapper
-```
-
-## Apply output structure
-
-When `--apply` runs, it produces the following artifacts in the tree repo:
-
-- **TREE_MISS proposals** create a new `NODE.md` under `drift/<sourceId>/<path>/`.
-- Intermediate directories receive auto-generated `NODE.md` files.
-- The `drift/` directory is added to the root `NODE.md` domain listing.
-- `generate-codeowners` runs after writing nodes to keep ownership in sync.
-- Labels (`first-tree:sync`) are pre-created via `gh label create --force`.
-
-## Schema changes
-
-`BoundTreeReference` and `TreeBindingState` gained two new optional fields:
-
-```typescript
-lastReconciledSourceCommit?: string  // SHA the tree was last synced to
-lastReconciledAt?: string            // ISO 8601 timestamp
-```
-
-Schema version bumped from 1 to 2. Version 1 files continue to parse correctly — the new fields are `undefined`, which all code paths handle gracefully.
-
-## Relationship to gardener
-
-Sync and gardener are complementary but independent:
-
-- **Sync** proposes tree updates (opens PRs).
-- **Gardener** reviews tree PRs for context-fit (reviews and approves).
-
-Sync does not depend on gardener's code. Gardener reviews sync PRs for context-fit when installed on the tree repo, but sync operates independently.
-
-When both are installed, the coordinator runbook (`first-tree-sync-schedule.md`) runs them in sequence within a single schedule slot, avoiding rate-limit conflicts.
-
-## Roadmap: GitHub Bot mode (not current focus)
-
-The current implementation runs locally via Claude Code (CLI + schedule). A future GitHub Bot mode would make onboarding a one-click "Install" button on GitHub Marketplace, matching the Greptile experience.
-
-**Two modes, same core logic:**
-- Local mode: `claude -p` for AI, `gh` CLI for GitHub (current)
-- Bot mode: `@anthropic-ai/sdk` for AI, Octokit for GitHub (future)
-
-**Likely runtime:** GitHub Actions for gardener (fast, event-driven), Modal/Lambda for sync (long-running, bursty). GitHub App webhook triggers both.
-
-**Why it matters for adoption:** No Claude Code subscription required, no MCP connector config, no `/schedule` setup. Just install the GitHub App and it works.
-
-This is on the roadmap but not blocking the current local-mode work.
-
-## Known limitations
-
-1. **Cloud classification quality.** The cloud schedule path uses the agent itself as classifier (no `claude` CLI in sandbox). Classification quality may differ from the local path.
-2. **History trace cap.** First-run history walk stops at 500 commits or 6 months, whichever comes first.
-3. **Commit-to-PR matching.** Uses heuristics (merge commit SHA, PR number mentions in commit messages). Some commits may land in an "unlinked" group that requires manual triage.
-4. **Code owner review not enforced by default.** The `require_code_owner_review` branch protection rule is not set automatically. Repo admins must enable it if owner review is a hard gate.
+- If product behavior, invariants, or classification rules change, update
+  `first-tree-skill-cli/sync.md`.
+- If installation surfaces or shipped runbooks change, update the runtime asset
+  files here plus the relevant packaging/test docs in this repo.

--- a/docs/maintainer-architecture.md
+++ b/docs/maintainer-architecture.md
@@ -1,50 +1,28 @@
 # Maintainer Architecture
 
-This repo ships one canonical skill plus one thin CLI package.
+Authoritative decision node: `first-tree-skill-cli/repo-architecture.md` in
+the bound Context Tree.
 
-## Core Model
+This file is source-repo-local. It maps the tree's architectural decisions onto
+the files maintainers edit in this repo.
 
-The user-facing system is now built around three explicit objects:
+## Local Responsibility Map
 
-1. `source/workspace root`
-2. `tree repo`
-3. `binding`
+| Path | Local responsibility |
+| --- | --- |
+| `skills/first-tree/` | Canonical skill payload that ships verbatim to user repos |
+| `assets/framework/` | Runtime assets installed or refreshed by the CLI |
+| `src/engine/` | Command behavior, binding logic, verification, publish, and sync orchestration |
+| `tests/` | Repo-local validation surface |
+| Root package files | Packaging, build, and shell entrypoints |
 
-Bindings are stored in:
+## Local Guardrails
 
-- source/workspace roots: `.first-tree/source.json` (includes workspace members for workspace roots)
-- tree repos: `.first-tree/tree.json` and `.first-tree/bindings/<source-id>.json`
-
-The tree repo may also generate a human/agent-facing `source-repos.md` index
-from those bindings, but the JSON files remain the canonical machine-readable
-source of truth.
-
-That replaces the old one-source-at-a-time mental model that depended too
-heavily on one mutable bootstrap file.
-
-## Canonical Layers
-
-1. `skills/first-tree/` owns user knowledge.
-2. `assets/framework/` owns shipped runtime assets.
-3. `src/engine/` owns behavior.
-4. `tests/` own the main validation surface.
-5. root package files own only packaging / shell concerns.
-
-## Non-Negotiables
-
-- keep `.agents/skills/first-tree/` and `.claude/skills/first-tree/` as alias
-  symlinks in this source repo
-- keep source/workspace roots free of tree content
-- keep canonical tree-side metadata limited to `.first-tree/tree.json` and
-  `.first-tree/bindings/`; any root-level repo index must be derived from those
-  files instead of becoming a second source of truth
-- keep shared-tree behavior expressed through bindings, not heuristics alone
-- update docs, code, and tests together whenever the binding schema changes
-
-## End-State Target
-
-- `inspect` classifies before mutating
-- `bind` owns source/tree connection
-- `init` is a high-level wrapper, not the only place where all logic lives
-- `workspace sync` handles member repos explicitly
-- `publish` treats the tree repo as primary and refreshes local bindings second
+- Keep `.agents/skills/first-tree/` and `.claude/skills/first-tree/` as alias
+  symlinks; edit `skills/first-tree/`, not the aliases.
+- Keep source/workspace repos free of tree content; tree nodes belong in the
+  bound Context Tree repo.
+- Treat `source-repos.md` as generated output; tree-side truth still lives in
+  `.first-tree/tree.json` and `.first-tree/bindings/`.
+- When the binding schema or install contract changes, update the tree node,
+  source docs, code, and tests together.

--- a/docs/maintainer-build-and-distribution.md
+++ b/docs/maintainer-build-and-distribution.md
@@ -1,7 +1,10 @@
 # Build And Distribution
 
-Use this reference when touching package wiring, release behavior, or the
-distributable contract of `first-tree`.
+Authoritative decision node: `first-tree-skill-cli/build-and-distribution.md`
+in the bound Context Tree.
+
+Use this local reference when touching package wiring, build surfaces, or the
+release checklist in this repo.
 
 ## Fast Validation
 
@@ -23,11 +26,9 @@ run:
 pnpm pack
 ```
 
-Inspect the tarball contents before merging packaging changes. The distribution
-must be able to carry the canonical skill and the thin CLI shell without
-requiring repo-local prose.
+Inspect the tarball contents before merging packaging changes.
 
-## Build Responsibilities
+## Local Packaging Surfaces
 
 - `package.json` defines package metadata, scripts, and import aliases.
 - `tsconfig.json` defines TypeScript compile boundaries.
@@ -35,28 +36,13 @@ requiring repo-local prose.
 - `vitest.config.ts` defines unit-test entrypoints, and
   `vitest.eval.config.ts` defines the repo-only maintainer eval entrypoint.
 - `.github/workflows/ci.yml` is the thin CI shell for repo validation.
+- `assets/framework/VERSION` marks the shipped framework payload version.
 
-These files are shell surfaces. Their meaning must be documented here or in
-another skill reference, not only in the files themselves.
+## Release Checklist
 
-## Distribution Rules
-
-- Do not introduce a second copy of the framework outside the skill.
-- `package.json` must ship `skills/first-tree/` in the published
-  package alongside the thin CLI build output.
-- Keep repo-only developer tooling such as root `evals/` out of the published
-  package unless it becomes part of the user-facing framework contract.
-- If the CLI needs bundled knowledge or payload files, ship the canonical skill
-  with the package rather than copying that information into root docs.
-- Normal `first-tree init` / `first-tree upgrade` flows must install from
-  the skill bundled in the running package, not by cloning the source repo.
-- Default dedicated-tree-repo creation must stay local-only. It may create a
-  sibling git repo on disk, but it must not require remote repo creation or
-  source-repo cloning.
-- `first-tree publish` is the explicit networked second-stage command for
-  GitHub repo creation, local binding refresh, and optional single-source PR
-  opening. Keep that remote behavior there instead of expanding default `init`.
-- If you change anything that gets copied into user repos, bump
-  `assets/framework/VERSION` and keep the upgrade task text in sync.
-- If packaging changes alter what gets installed into user repos, update
-  `references/upgrade-contract.md`, tests, and validation commands together.
+- If package contents or install/upgrade behavior changed, run `pnpm pack`.
+- Inspect the tarball to confirm it includes `dist/`, `skills/first-tree/`, and
+  `assets/`, while excluding repo-only sources such as `docs/`, `tests/`,
+  `src/`, and `evals/`.
+- If you changed anything copied into user repos, bump
+  `assets/framework/VERSION` and sync the upgrade docs/tests in the same change.

--- a/docs/maintainer-testing.md
+++ b/docs/maintainer-testing.md
@@ -1,7 +1,10 @@
 # Testing
 
-Use this reference when validating framework behavior or changing the testing
-surface.
+Authoritative decision node: `first-tree-skill-cli/validation-surface.md` in
+the bound Context Tree.
+
+Use this local reference when you need the concrete commands and file
+entrypoints for validating work in this source repo.
 
 ## Core Checks
 
@@ -30,14 +33,14 @@ Examples:
 
 ```bash
 pnpm test:e2e
-pnpm test -- skills/first-tree/tests/rules.test.ts
-pnpm test -- skills/first-tree/tests/verify.test.ts
-pnpm test -- skills/first-tree/tests/skill-artifacts.test.ts
-pnpm test -- skills/first-tree/tests/thin-cli.test.ts
+pnpm test -- tests/skill-artifacts.test.ts
+pnpm test -- tests/thin-cli.test.ts
+pnpm test -- tests/verify.test.ts
+pnpm test -- tests/sync.test.ts
 ```
 
 If a future refactor changes these paths again, keep the command semantics and
-coverage expectations documented here.
+coverage expectations aligned with the tree node.
 
 ## Packaging Check
 
@@ -57,7 +60,6 @@ source repo. Use `evals/README.md` when you need to run or update it.
 
 ## Change Discipline
 
-- Update this reference whenever core test entrypoints or packaging boundaries
-  change.
-- If a maintainer would need oral history to know which checks matter, that
-  knowledge belongs here.
+- Update this local reference whenever concrete test entrypoints change.
+- If the validation philosophy or coverage contract changes, update the tree
+  node first and then sync this file.

--- a/docs/maintainer-thin-cli.md
+++ b/docs/maintainer-thin-cli.md
@@ -1,6 +1,10 @@
 # Thin CLI Shell
 
-Use this reference when changing the root CLI/package shell.
+Authoritative decision node: `first-tree-skill-cli/thin-cli-shell.md` in the
+bound Context Tree.
+
+Use this local reference when changing `src/cli.ts` or the command adapters in
+`src/engine/commands/`.
 
 ## Shell Responsibilities
 
@@ -8,7 +12,8 @@ The shell should:
 
 - parse commands and flags
 - expose help and version
-- dispatch into `src/engine/`
+- handle `--skip-version-check`
+- dispatch into `src/engine/commands/`
 - stay thin
 
 ## Current CLI Surface
@@ -22,16 +27,26 @@ Top-level user commands:
 - `publish`
 - `verify`
 - `upgrade`
+- `sync`
 - `review`
 - `generate-codeowners`
+- `invite`
+- `join`
 - `inject-context`
 - `help`
 
+## Local Touchpoints
+
+- `src/cli.ts` — usage text, global flags, and dispatch
+- `src/engine/commands/*.ts` — thin command adapters
+- `tests/thin-cli.test.ts` — direct CLI smoke coverage
+- `tests/cli-e2e.test.ts` — end-to-end command workflow coverage
+
 ## Rules For Shell Changes
 
-- keep onboarding semantics in the skill references, not only in `src/cli.ts`
-- if `inspect` / `bind` / `workspace sync` / `publish` behavior changes, update
-  `skills/first-tree/references/onboarding.md`,
-  `skills/first-tree/references/source-workspace-installation.md`, and
-  `skills/first-tree/references/upgrade-contract.md`
-- keep root prose short; detailed operational knowledge belongs in the skill
+- Keep onboarding semantics in the skill references and tree nodes, not only in
+  `src/cli.ts`.
+- If command behavior changes, update the relevant tree node and shipped
+  reference docs before relying on the code to explain it.
+- Keep root prose short; detailed implementation notes belong here, while
+  decision-grade operational knowledge belongs in the tree.

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -1,19 +1,28 @@
 # Context Tree Source Map
 
-This is the maintainer reading index for the current `first-tree` architecture.
+This is the maintainer entrypoint for the `first-tree` source repo.
+
+Read canonical decisions from the bound Context Tree first. Use the repo-local
+docs below only for source-repo implementation details.
 
 ## Read First
 
 | Path | Why it matters |
 | --- | --- |
+| `first-tree-skill-cli/repo-architecture.md` | Canonical layer model plus the boundary between tree knowledge and source-repo docs |
+| `first-tree-skill-cli/thin-cli-shell.md` | Command-surface contract for the thin CLI shell |
+| `first-tree-skill-cli/build-and-distribution.md` | Packaging and release invariants |
+| `first-tree-skill-cli/validation-surface.md` | Validation philosophy and coverage expectations |
+| `first-tree-skill-cli/sync.md` | Authoritative product/architecture context for `first-tree sync` |
 | `skills/first-tree/SKILL.md` | User-facing skill workflow |
 | `skills/first-tree/references/onboarding.md` | Repo, shared-tree, and workspace onboarding model |
 | `skills/first-tree/references/source-workspace-installation.md` | Binding model and source/workspace contract |
 | `skills/first-tree/references/upgrade-contract.md` | Installed layout and upgrade invariants |
-| `docs/maintainer-architecture.md` | High-level maintainer model |
-| `docs/maintainer-thin-cli.md` | Thin CLI shell responsibilities |
-| `docs/maintainer-build-and-distribution.md` | Build, pack, and publish contract |
-| `docs/maintainer-testing.md` | Validation workflow |
+| `docs/maintainer-architecture.md` | Local file-level architecture map for this source repo |
+| `docs/maintainer-thin-cli.md` | Implementation touchpoints for `src/cli.ts` and command adapters |
+| `docs/maintainer-build-and-distribution.md` | Packaging surfaces and release checklist in this repo |
+| `docs/maintainer-testing.md` | Concrete validation commands and targeted test entrypoints |
+| `docs/design-sync.md` | Local implementation touchpoints for the sync feature |
 
 ## Runtime Payload
 
@@ -39,6 +48,7 @@ This is the maintainer reading index for the current `first-tree` architecture.
 | `src/engine/publish.ts` | Tree publish flow and local source refresh |
 | `src/engine/upgrade.ts` | Installed-skill / tree upgrade behavior |
 | `src/engine/verify.ts` | Tree verification |
+| `src/engine/sync.ts` | Drift detection, proposal generation, and apply flow |
 | `src/engine/runtime/binding-state.ts` | `source.json`, `tree.json`, and `bindings/` schema |
 | `src/engine/runtime/local-tree-config.ts` | Local tree config helpers (delegates to `source.json`) |
 | `src/engine/runtime/source-repo-index.ts` | Generated `source-repos.md` index plus root tree repo guidance |
@@ -52,6 +62,7 @@ This is the maintainer reading index for the current `first-tree` architecture.
 | `tests/init.test.ts` | Tree bootstrap and init wrapper behavior |
 | `tests/cli-e2e.test.ts` | End-to-end CLI smoke coverage across repo, workspace, publish, and review workflows |
 | `tests/publish.test.ts` | Publish orchestration |
+| `tests/sync.test.ts` | Sync behavior and apply flow |
 | `tests/thin-cli.test.ts` | Thin CLI smoke coverage |
 | `tests/skill-artifacts.test.ts` | Skill export and doc integrity |
 | `tests/upgrade.test.ts` | Upgrade behavior |
@@ -59,6 +70,9 @@ This is the maintainer reading index for the current `first-tree` architecture.
 
 ## Notes
 
+- Keep decision-grade knowledge in the bound Context Tree under
+  `first-tree-skill-cli/`.
 - Keep root `README.md` and `AGENTS.md` short and distribution-focused.
 - Keep shipped user knowledge in `skills/first-tree/references/`.
-- Keep runtime metadata changes synchronized across docs, tests, and code.
+- Keep runtime metadata changes synchronized across tree nodes, local docs,
+  tests, and code.

--- a/scripts/check-skill-sync.sh
+++ b/scripts/check-skill-sync.sh
@@ -56,8 +56,9 @@ for forbidden in engine assets tests scripts agents; do
   fi
 done
 
-# Maintainer docs moved to top-level docs/.
+# Source-repo maintainer docs live in top-level docs/.
 require_file "$REPO_ROOT/docs/source-map.md"
+require_file "$REPO_ROOT/docs/design-sync.md"
 require_file "$REPO_ROOT/docs/maintainer-architecture.md"
 require_file "$REPO_ROOT/docs/maintainer-thin-cli.md"
 require_file "$REPO_ROOT/docs/maintainer-build-and-distribution.md"

--- a/tests/skill-artifacts.test.ts
+++ b/tests/skill-artifacts.test.ts
@@ -104,6 +104,9 @@ describe("skill artifacts", () => {
       existsSync(join(ROOT, "docs", "maintainer-testing.md")),
     ).toBe(true);
     expect(
+      existsSync(join(ROOT, "docs", "design-sync.md")),
+    ).toBe(true);
+    expect(
       trackedEntriesInGit(".agents", ".claude").filter(
         (entry) =>
           entry !== ".agents/skills/first-tree"
@@ -202,6 +205,8 @@ describe("skill artifacts", () => {
     expect(read("README.md")).toContain("Canonical Documentation");
     expect(read("README.md")).toContain("docs/source-map.md");
     expect(read("README.md")).toContain("source-workspace-installation.md");
+    expect(read("README.md")).toContain("first-tree-skill-cli/repo-architecture.md");
+    expect(read("README.md")).toContain("first-tree-skill-cli/sync.md");
     expect(read("README.md")).toContain("skills/first-tree/");
     expect(read("README.md")).toContain(".agents/skills/first-tree/");
     expect(read("README.md")).toContain(".claude/skills/first-tree/");
@@ -222,6 +227,7 @@ describe("skill artifacts", () => {
     expect(read("README.md")).toContain("first-tree init tree --here");
     expect(read("AGENTS.md")).toContain("docs/source-map.md");
     expect(read("AGENTS.md")).toContain("source-workspace-installation.md");
+    expect(read("AGENTS.md")).toContain("first-tree-skill-cli/");
     expect(read("AGENTS.md")).toContain("bundled skill payload path");
     expect(read("AGENTS.md")).not.toContain("### Running evals");
     expect(read("AGENTS.md")).not.toContain("EVALS_TREE_REPO");
@@ -281,16 +287,24 @@ describe("skill artifacts", () => {
     const sourceMap = read("docs/source-map.md");
     expect(sourceMap).not.toContain("repo-snapshot");
     expect(sourceMap).not.toContain("sync-skill-artifacts.sh");
+    expect(sourceMap).toContain("first-tree-skill-cli/repo-architecture.md");
+    expect(sourceMap).toContain("first-tree-skill-cli/thin-cli-shell.md");
+    expect(sourceMap).toContain("first-tree-skill-cli/build-and-distribution.md");
+    expect(sourceMap).toContain("first-tree-skill-cli/validation-surface.md");
+    expect(sourceMap).toContain("first-tree-skill-cli/sync.md");
     expect(sourceMap).toContain("source-workspace-installation.md");
+    expect(sourceMap).toContain("docs/design-sync.md");
     expect(sourceMap).toContain("maintainer-architecture.md");
     expect(sourceMap).toContain("maintainer-thin-cli.md");
     expect(sourceMap).toContain("maintainer-build-and-distribution.md");
     expect(sourceMap).toContain("maintainer-testing.md");
     expect(sourceMap).toContain("src/engine/publish.ts");
+    expect(sourceMap).toContain("src/engine/sync.ts");
     expect(sourceMap).toContain("src/engine/inspect.ts");
     expect(sourceMap).toContain("src/engine/bind.ts");
     expect(sourceMap).toContain("src/engine/workspace-sync.ts");
     expect(sourceMap).toContain("tests/publish.test.ts");
+    expect(sourceMap).toContain("tests/sync.test.ts");
     expect(sourceMap).toContain("src/engine/runtime/binding-state.ts");
     expect(sourceMap).toContain("src/engine/runtime/local-tree-config.ts"); // still exists, delegates to source.json
     expect(sourceMap).toContain("src/engine/runtime/source-repo-index.ts");
@@ -325,9 +339,11 @@ describe("skill artifacts", () => {
     const maintainerArchitecture = read(
       "docs/maintainer-architecture.md",
     );
-    expect(maintainerArchitecture).toContain("source/workspace root");
-    expect(maintainerArchitecture).toContain("tree repo");
-    expect(maintainerArchitecture).toContain("binding");
+    expect(maintainerArchitecture).toContain("first-tree-skill-cli/repo-architecture.md");
+    expect(maintainerArchitecture).toContain("skills/first-tree/");
+    expect(maintainerArchitecture).toContain("assets/framework/");
+    expect(maintainerArchitecture).toContain("src/engine/");
+    expect(maintainerArchitecture).toContain("tests/");
     expect(maintainerArchitecture).toContain(".first-tree/bindings/");
     expect(maintainerArchitecture).toContain("source-repos.md");
     expect(maintainerArchitecture).not.toContain(".first-tree/submodules/");
@@ -340,7 +356,14 @@ describe("skill artifacts", () => {
     const buildAndDistribution = read(
       "docs/maintainer-build-and-distribution.md",
     );
-    expect(buildAndDistribution).toContain("first-tree publish");
+    expect(buildAndDistribution).toContain("first-tree-skill-cli/build-and-distribution.md");
+    expect(buildAndDistribution).toContain("pnpm pack");
+    expect(buildAndDistribution).toContain("assets/framework/VERSION");
+
+    const designSync = read("docs/design-sync.md");
+    expect(designSync).toContain("first-tree-skill-cli/sync.md");
+    expect(designSync).toContain("src/engine/sync.ts");
+    expect(designSync).toContain("tests/sync.test.ts");
   });
 
   it("keeps public OSS entrypoints and package metadata in place", () => {


### PR DESCRIPTION
## Summary
- rewrite the local maintainer docs so they point to the shared Context Tree for canonical decisions and keep only source-repo implementation notes
- update README and AGENTS to make the tree-vs-source-doc boundary explicit
- extend maintainer validation so the local docs/tests enforce the new documentation split

## Validation
- `pnpm validate:skill`
- `pnpm typecheck`
- `pnpm test -- tests/skill-artifacts.test.ts`
- `pnpm build`
- `node dist/cli.js verify --tree-path ../first-tree-context`

## Related
- tree PR: agent-team-foundation/first-tree-context#133

Closes #100