### PR TITLE
feat: inject tree-first cross-repo session context

### DIFF
--- a/assets/framework/examples/codex/config.toml
+++ b/assets/framework/examples/codex/config.toml
@@ -1,0 +1,2 @@
+[features]
+codex_hooks = true

--- a/assets/framework/examples/codex/hooks.json
+++ b/assets/framework/examples/codex/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx -p first-tree first-tree inject-context --skip-version-check",
+            "statusMessage": "Loading First Tree context"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,7 +21,7 @@ Commands:
   generate-codeowners   Generate .github/CODEOWNERS from tree ownership
   invite                Invite a new member to the Context Tree
   join                  Accept an invite and join a Context Tree
-  inject-context        Output Claude Code SessionStart hook payload from NODE.md
+  inject-context        Output tree-first SessionStart hook payload for Claude/Codex
   help                  Show help for a topic (e.g. \`help onboarding\`)
 
 Options:

--- a/src/engine/bind.ts
+++ b/src/engine/bind.ts
@@ -23,6 +23,10 @@ import {
   copyCanonicalSkill,
   resolveBundledPackageRoot,
 } from "#engine/runtime/installer.js";
+import {
+  ensureAgentContextHooks,
+  formatAgentContextHookMessages,
+} from "#engine/runtime/adapters.js";
 import { syncTreeSourceRepoIndex } from "#engine/runtime/source-repo-index.js";
 import {
   upsertLocalTreeGitIgnore,
@@ -421,6 +425,7 @@ export function runBind(repo?: Repo, options?: BindOptions): number {
         workspaceId,
       },
     );
+    const sourceAgentHooks = ensureAgentContextHooks(sourceRepo.root);
     writeSourceState(sourceRepo.root, {
       bindingMode,
       rootKind,
@@ -462,6 +467,7 @@ export function runBind(repo?: Repo, options?: BindOptions): number {
         ? relativeRepoPath(treeResolution.treeRepo.root, workspaceRootPath)
         : undefined,
     });
+    const treeAgentHooks = ensureAgentContextHooks(treeResolution.treeRepo.root);
     const sourceRepoIndex = syncTreeSourceRepoIndex(treeResolution.treeRepo.root);
 
     if (bindingMode === "workspace-member" && workspaceId && workspaceRootPath) {
@@ -530,6 +536,12 @@ export function runBind(repo?: Repo, options?: BindOptions): number {
       console.log(`  Updated ${changedFiles.join(" and ")}.`);
     } else {
       console.log("  Source integration instructions were already current.");
+    }
+    for (const message of formatAgentContextHookMessages(sourceAgentHooks)) {
+      console.log(`  ${message}`);
+    }
+    for (const message of formatAgentContextHookMessages(treeAgentHooks)) {
+      console.log(`  ${message}`);
     }
     console.log("  Wrote source and tree binding metadata.");
     return 0;

--- a/src/engine/commands/inject-context.ts
+++ b/src/engine/commands/inject-context.ts
@@ -1,15 +1,15 @@
-import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { buildTreeFirstContextBundle } from "#engine/runtime/tree-first-context.js";
 
 export const INJECT_CONTEXT_USAGE = `usage: first-tree inject-context
 
-Output a Claude Code SessionStart hook payload that injects the root NODE.md
-content as additional session context. Reads NODE.md from the current working
-directory.
+Output a SessionStart hook payload that injects tree-first cross-repo context.
+When the current working directory is a bound source/workspace root, the
+command resolves the canonical tree checkout, reads the tree root NODE.md,
+and appends a bindings-derived repo index. Tree repos still work directly.
 
-Intended to be wired into \`.claude/settings.json\` as the SessionStart hook
-command. Use \`--skip-version-check\` (the global flag) to avoid the npm
-registry check on every session start.
+Intended to be wired into Claude Code and Codex SessionStart hooks. Use
+\`--skip-version-check\` (the global flag) to avoid the npm registry check
+on every session start.
 
 Options:
   --help         Show this help message
@@ -21,17 +21,16 @@ export function runInjectContext(args: string[] = []): number {
     return 0;
   }
 
-  const nodeMdPath = join(process.cwd(), "NODE.md");
-  if (!existsSync(nodeMdPath)) {
+  const bundle = buildTreeFirstContextBundle(process.cwd());
+  if (bundle === null) {
     // Silent no-op: emit empty payload so the hook doesn't fail
     return 0;
   }
 
-  const content = readFileSync(nodeMdPath, "utf-8");
   const payload = {
     hookSpecificOutput: {
       hookEventName: "SessionStart",
-      additionalContext: content,
+      additionalContext: bundle.additionalContext,
     },
   };
   console.log(JSON.stringify(payload));

--- a/src/engine/init.ts
+++ b/src/engine/init.ts
@@ -55,6 +55,10 @@ import {
   upsertFirstTreeIndexFile,
   upsertSourceIntegrationFiles,
 } from "#engine/runtime/source-integration.js";
+import {
+  ensureAgentContextHooks,
+  formatAgentContextHookMessages,
+} from "#engine/runtime/adapters.js";
 import { runWorkspaceSync } from "#engine/workspace-sync.js";
 
 /**
@@ -402,6 +406,10 @@ export function runInit(repo?: Repo, options?: InitOptions): number {
       installSkill(resolvedSourceRoot, r.root);
     } else {
       console.log("Reusing the existing first-tree skill in the tree repo.");
+    }
+    const treeAgentHooks = ensureAgentContextHooks(r.root);
+    for (const message of formatAgentContextHookMessages(treeAgentHooks)) {
+      console.log(`  ${message}`);
     }
     console.log();
   } catch (err) {

--- a/src/engine/inspect.ts
+++ b/src/engine/inspect.ts
@@ -5,6 +5,7 @@ import {
   readTreeState,
   readWorkspaceState,
 } from "#engine/runtime/binding-state.js";
+import { inspectAgentContextHooks } from "#engine/runtime/adapters.js";
 import { readLocalTreeConfig } from "#engine/runtime/local-tree-config.js";
 import { discoverWorkspaceRepos } from "#engine/workspace.js";
 
@@ -33,6 +34,7 @@ export interface InspectionResult {
     | "workspace-folder"
     | "workspace-repo";
   currentCwd: string;
+  agentContextHooks: ReturnType<typeof inspectAgentContextHooks>;
   hasSourceIntegration: boolean;
   root: string;
   rootKind: "folder" | "git-repo";
@@ -61,6 +63,7 @@ export function inspectRepo(repo?: Repo): InspectionResult {
   }
 
   return {
+    agentContextHooks: inspectAgentContextHooks(workingRepo.root),
     childRepos,
     classification,
     currentCwd: resolve(process.cwd()),
@@ -99,6 +102,10 @@ export function runInspect(repo?: Repo, json = false): number {
       console.log(`  - ${childRepo.relativePath} (${childRepo.kind})`);
     }
   }
+  console.log();
+  console.log(`  Claude hook:    ${inspection.agentContextHooks.claudeSettings}`);
+  console.log(`  Codex config:   ${inspection.agentContextHooks.codexConfig}`);
+  console.log(`  Codex hooks:    ${inspection.agentContextHooks.codexHooks}`);
   return 0;
 }
 

--- a/src/engine/inspect.ts
+++ b/src/engine/inspect.ts
@@ -5,7 +5,11 @@ import {
   readTreeState,
   readWorkspaceState,
 } from "#engine/runtime/binding-state.js";
-import { inspectAgentContextHooks } from "#engine/runtime/adapters.js";
+import {
+  formatAgentContextHookDriftMessages,
+  inspectAgentContextHookReport,
+  inspectAgentContextHooks,
+} from "#engine/runtime/adapters.js";
 import { readLocalTreeConfig } from "#engine/runtime/local-tree-config.js";
 import { discoverWorkspaceRepos } from "#engine/workspace.js";
 
@@ -18,6 +22,7 @@ Output includes:
   - whether the root looks like a tree repo, source repo, or workspace root
   - discovered child repos / submodules for workspace onboarding
   - any existing first-tree binding metadata
+  - managed Claude Code / Codex agent context hook health
 
 Options:
   --json   Emit machine-readable JSON
@@ -35,6 +40,7 @@ export interface InspectionResult {
     | "workspace-repo";
   currentCwd: string;
   agentContextHooks: ReturnType<typeof inspectAgentContextHooks>;
+  agentContextHookReport: ReturnType<typeof inspectAgentContextHookReport>;
   hasSourceIntegration: boolean;
   root: string;
   rootKind: "folder" | "git-repo";
@@ -48,6 +54,7 @@ export function inspectRepo(repo?: Repo): InspectionResult {
   const workingRepo = repo ?? new Repo();
   const childRepos = discoverWorkspaceRepos(workingRepo.root);
   const rootKind = workingRepo.isGitRepo() ? "git-repo" : "folder";
+  const agentContextHookReport = inspectAgentContextHookReport(workingRepo.root);
 
   let classification: InspectionResult["classification"];
   if (workingRepo.looksLikeTreeRepo()) {
@@ -63,7 +70,8 @@ export function inspectRepo(repo?: Repo): InspectionResult {
   }
 
   return {
-    agentContextHooks: inspectAgentContextHooks(workingRepo.root),
+    agentContextHooks: agentContextHookReport.health,
+    agentContextHookReport,
     childRepos,
     classification,
     currentCwd: resolve(process.cwd()),
@@ -103,9 +111,20 @@ export function runInspect(repo?: Repo, json = false): number {
     }
   }
   console.log();
+  console.log(`  Hook health:    ${inspection.agentContextHookReport.overall}`);
   console.log(`  Claude hook:    ${inspection.agentContextHooks.claudeSettings}`);
   console.log(`  Codex config:   ${inspection.agentContextHooks.codexConfig}`);
   console.log(`  Codex hooks:    ${inspection.agentContextHooks.codexHooks}`);
+  if (inspection.agentContextHookReport.overall !== "current") {
+    console.log();
+    console.log("  Agent context drift:");
+    for (const message of formatAgentContextHookDriftMessages(
+      inspection.agentContextHookReport,
+    )) {
+      console.log(`    - ${message}`);
+    }
+    console.log(`  Repair hint:    ${inspection.agentContextHookReport.repairHint}`);
+  }
   return 0;
 }
 

--- a/src/engine/publish.ts
+++ b/src/engine/publish.ts
@@ -21,6 +21,13 @@ import {
 } from "#engine/runtime/local-tree-config.js";
 import { upsertSourceIntegrationFiles } from "#engine/runtime/source-integration.js";
 import {
+  ensureAgentContextHooks,
+  formatAgentContextHookMessages,
+  CODEX_CONFIG_PATH,
+  CODEX_HOOKS_PATH,
+  CLAUDE_SETTINGS_PATH,
+} from "#engine/runtime/adapters.js";
+import {
   AGENT_INSTRUCTIONS_FILE,
   CLAUDE_INSTRUCTIONS_FILE,
   CLAUDE_SKILL_ROOT,
@@ -468,6 +475,7 @@ function updateSourceWorkspaceIntegration(
   treeRepoUrl: string,
   localTreeRoot: string,
 ): {
+  agentHookActions: ReturnType<typeof ensureAgentContextHooks>;
   gitIgnoreAction: "created" | "updated" | "unchanged";
   sourceStateAction: "created" | "updated" | "unchanged";
 } {
@@ -495,6 +503,7 @@ function updateSourceWorkspaceIntegration(
       workspaceId: sourceState.workspaceId,
     });
     return {
+      agentHookActions: ensureAgentContextHooks(sourceRepo.root),
       gitIgnoreAction: gitIgnore.action,
       sourceStateAction,
     };
@@ -503,6 +512,7 @@ function updateSourceWorkspaceIntegration(
     treeRepoUrl,
   });
   return {
+    agentHookActions: ensureAgentContextHooks(sourceRepo.root),
     gitIgnoreAction: gitIgnore.action,
     sourceStateAction: "unchanged",
   };
@@ -520,6 +530,9 @@ function commitSourceIntegration(
       FIRST_TREE_INDEX_FILE,
       AGENT_INSTRUCTIONS_FILE,
       CLAUDE_INSTRUCTIONS_FILE,
+      CLAUDE_SETTINGS_PATH,
+      CODEX_CONFIG_PATH,
+      CODEX_HOOKS_PATH,
       ".gitignore",
     ].filter((path) => existsSync(join(sourceRepo.root, path))),
   ].filter((path, index, items) => items.indexOf(path) === index);
@@ -813,6 +826,10 @@ export function runPublish(repo?: Repo, options?: PublishOptions): number {
       sourceRepo.root,
     );
     const treeSlug = `${sourceGitHub.owner}/${treeRepo.repoName()}`;
+    const treeAgentHooks = ensureAgentContextHooks(treeRepo.root);
+    for (const message of formatAgentContextHookMessages(treeAgentHooks)) {
+      console.log(`  ${message}`);
+    }
 
     const committedTreeChanges = commitTreeState(runner, treeRepo);
     if (committedTreeChanges) {
@@ -873,6 +890,9 @@ export function runPublish(repo?: Repo, options?: PublishOptions): number {
           ? `    Updated \`${SOURCE_STATE}\` for \`${relativeRepoPath(boundSourceRepo.root, localTreeRoot)}\`.`
           : `    Reused the existing \`${SOURCE_STATE}\` entry for \`${relativeRepoPath(boundSourceRepo.root, localTreeRoot)}\`.`,
       );
+      for (const message of formatAgentContextHookMessages(sourceIntegrationState.agentHookActions)) {
+        console.log(`    ${message}`);
+      }
     }
 
     if (sourceRepoRoots.length === 1) {

--- a/src/engine/repo.ts
+++ b/src/engine/repo.ts
@@ -190,7 +190,11 @@ export class Repo {
   }
 
   anyAgentConfig(): boolean {
-    const knownConfigs = [".claude/settings.json", ".codex/config.json"];
+    const knownConfigs = [
+      ".claude/settings.json",
+      ".codex/config.toml",
+      ".codex/hooks.json",
+    ];
     return knownConfigs.some((c) => this.pathExists(c));
   }
 

--- a/src/engine/rules/agent-integration.ts
+++ b/src/engine/rules/agent-integration.ts
@@ -1,25 +1,28 @@
 import type { Repo } from "#engine/repo.js";
 import type { RuleResult } from "#engine/rules/index.js";
-import { claudeCodeExampleCandidates } from "#engine/runtime/adapters.js";
+import {
+  claudeCodeExampleCandidates,
+  codexExampleCandidates,
+  inspectAgentContextHooks,
+} from "#engine/runtime/adapters.js";
 import { FRAMEWORK_EXAMPLES_DIR } from "#engine/runtime/asset-loader.js";
 
 export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
   const [claudeExamplePath] = claudeCodeExampleCandidates();
-  if (repo.pathExists(".claude/settings.json")) {
-    const hasNewHook = repo.fileContains(
-      ".claude/settings.json",
-      "first-tree inject-context",
+  const [codexExamplePath] = codexExampleCandidates();
+  const health = inspectAgentContextHooks(repo.root);
+
+  if (health.claudeSettings === "stale") {
+    tasks.push(
+      `Refresh the SessionStart hook in \`.claude/settings.json\` (see \`${claudeExamplePath}/\`).`,
     );
-    const hasLegacyHook = repo.fileContains(
-      ".claude/settings.json",
-      "inject-tree-context",
+  }
+
+  if (health.codexConfig === "stale" || health.codexHooks === "stale") {
+    tasks.push(
+      `Refresh the Codex SessionStart hook setup in \`.codex/config.toml\` and \`.codex/hooks.json\` (see \`${codexExamplePath}/\`).`,
     );
-    if (!hasNewHook && !hasLegacyHook) {
-      tasks.push(
-        `Add SessionStart hook to \`.claude/settings.json\` (see \`${claudeExamplePath}/\`)`,
-      );
-    }
   } else if (!repo.anyAgentConfig()) {
     tasks.push(
       `No agent configuration detected. Configure your agent to load tree context at session start. See \`${FRAMEWORK_EXAMPLES_DIR}/\` for supported agents. You can skip this and set it up later.`,

--- a/src/engine/runtime/adapters.ts
+++ b/src/engine/runtime/adapters.ts
@@ -46,6 +46,23 @@ export interface AgentContextHookHealth {
   codexHooks: AgentConfigHealth;
 }
 
+export interface AgentContextHookFileReport {
+  id: keyof AgentContextHookHealth;
+  path: string;
+  status: AgentConfigHealth;
+  summary: string;
+}
+
+export interface AgentContextHookReport {
+  overall: "current" | "drifted";
+  files: AgentContextHookFileReport[];
+  health: AgentContextHookHealth;
+  repairHint: string;
+}
+
+const AGENT_CONTEXT_REPAIR_HINT =
+  "Repair with a mutating first-tree command such as `first-tree upgrade`, `first-tree bind`, `first-tree init`, `first-tree workspace sync`, or `first-tree publish`.";
+
 export function formatAgentContextHookMessages(
   result: AgentContextHookSyncResult,
 ): string[] {
@@ -101,11 +118,38 @@ export function injectTreeContextHint(): string {
 }
 
 export function inspectAgentContextHooks(targetRoot: string): AgentContextHookHealth {
-  return {
+  return inspectAgentContextHookReport(targetRoot).health;
+}
+
+export function inspectAgentContextHookReport(
+  targetRoot: string,
+): AgentContextHookReport {
+  const health: AgentContextHookHealth = {
     claudeSettings: inspectClaudeSettingsHealth(targetRoot),
     codexConfig: inspectCodexConfigHealth(targetRoot),
     codexHooks: inspectCodexHooksHealth(targetRoot),
   };
+
+  const files: AgentContextHookFileReport[] = [
+    buildAgentContextHookFileReport("claudeSettings", CLAUDE_SETTINGS_PATH, health.claudeSettings),
+    buildAgentContextHookFileReport("codexConfig", CODEX_CONFIG_PATH, health.codexConfig),
+    buildAgentContextHookFileReport("codexHooks", CODEX_HOOKS_PATH, health.codexHooks),
+  ];
+
+  return {
+    overall: files.every((file) => file.status === "current") ? "current" : "drifted",
+    files,
+    health,
+    repairHint: AGENT_CONTEXT_REPAIR_HINT,
+  };
+}
+
+export function formatAgentContextHookDriftMessages(
+  report: AgentContextHookReport,
+): string[] {
+  return report.files
+    .filter((file) => file.status !== "current")
+    .map((file) => `\`${file.path}\`: ${file.status} — ${file.summary}`);
 }
 
 export function ensureAgentContextHooks(
@@ -238,6 +282,48 @@ function inspectCodexHooksHealth(targetRoot: string): AgentConfigHealth {
     return "stale";
   } catch {
     return "stale";
+  }
+}
+
+function buildAgentContextHookFileReport(
+  id: keyof AgentContextHookHealth,
+  path: string,
+  status: AgentConfigHealth,
+): AgentContextHookFileReport {
+  switch (id) {
+    case "claudeSettings":
+      return {
+        id,
+        path,
+        status,
+        summary: status === "current"
+          ? "Claude Code SessionStart hook is current."
+          : status === "missing"
+          ? "Missing the managed Claude Code SessionStart hook file."
+          : "Does not point at the managed first-tree SessionStart hook.",
+      };
+    case "codexConfig":
+      return {
+        id,
+        path,
+        status,
+        summary: status === "current"
+          ? "Codex project config enables `codex_hooks`."
+          : status === "missing"
+          ? "Missing the managed Codex project config file."
+          : "Does not enable `codex_hooks = true` for project-scoped hooks.",
+      };
+    case "codexHooks":
+      return {
+        id,
+        path,
+        status,
+        summary: status === "current"
+          ? "Codex hooks file contains the managed SessionStart hook."
+          : status === "missing"
+          ? "Missing the managed Codex hooks file."
+          : "Does not contain the managed first-tree SessionStart hook.",
+      };
   }
 }
 

--- a/src/engine/runtime/adapters.ts
+++ b/src/engine/runtime/adapters.ts
@@ -1,5 +1,11 @@
-import { copyFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
 import {
   CLAUDE_FRAMEWORK_EXAMPLES_DIR,
   FRAMEWORK_EXAMPLES_DIR,
@@ -8,9 +14,13 @@ import {
 } from "#engine/runtime/asset-loader.js";
 
 export const CLAUDE_SETTINGS_PATH = ".claude/settings.json";
-export const CODEX_CONFIG_PATH = ".codex/config.json";
+export const CODEX_CONFIG_PATH = ".codex/config.toml";
+export const CODEX_HOOKS_PATH = ".codex/hooks.json";
 export const INJECT_CONTEXT_COMMAND =
   "npx -p first-tree first-tree inject-context --skip-version-check";
+
+const CODEX_SESSION_START_MATCHER = "startup|resume";
+const CODEX_SESSION_START_STATUS = "Loading First Tree context";
 
 const STALE_INJECT_CONTEXT_PATTERNS = [
   /\.agents\/skills\/first-tree\/assets\/framework\/helpers\/inject-tree-context\.sh/g,
@@ -21,6 +31,54 @@ const STALE_INJECT_CONTEXT_PATTERNS = [
   /\.scripts\/inject-tree-context\.sh/g,
 ];
 
+export type AgentConfigAction = "created" | "updated" | "unchanged";
+export type AgentConfigHealth = "current" | "missing" | "stale";
+
+export interface AgentContextHookSyncResult {
+  claudeSettings: AgentConfigAction;
+  codexConfig: AgentConfigAction;
+  codexHooks: AgentConfigAction;
+}
+
+export interface AgentContextHookHealth {
+  claudeSettings: AgentConfigHealth;
+  codexConfig: AgentConfigHealth;
+  codexHooks: AgentConfigHealth;
+}
+
+export function formatAgentContextHookMessages(
+  result: AgentContextHookSyncResult,
+): string[] {
+  const messages: string[] = [];
+  if (result.claudeSettings === "created") {
+    messages.push(
+      "Created `.claude/settings.json` with the first-tree SessionStart hook.",
+    );
+  } else if (result.claudeSettings === "updated") {
+    messages.push(
+      "Updated `.claude/settings.json` to use the first-tree SessionStart hook.",
+    );
+  }
+
+  if (result.codexConfig === "created") {
+    messages.push("Created `.codex/config.toml` with `codex_hooks = true`.");
+  } else if (result.codexConfig === "updated") {
+    messages.push("Updated `.codex/config.toml` to enable `codex_hooks`.");
+  }
+
+  if (result.codexHooks === "created") {
+    messages.push(
+      "Created `.codex/hooks.json` with the first-tree `SessionStart` hook.",
+    );
+  } else if (result.codexHooks === "updated") {
+    messages.push(
+      "Updated `.codex/hooks.json` to use the first-tree `SessionStart` hook.",
+    );
+  }
+
+  return messages;
+}
+
 export function claudeCodeExampleCandidates(): string[] {
   return [
     join(CLAUDE_FRAMEWORK_EXAMPLES_DIR, "claude-code"),
@@ -30,17 +88,48 @@ export function claudeCodeExampleCandidates(): string[] {
   ];
 }
 
+export function codexExampleCandidates(): string[] {
+  return [
+    join(FRAMEWORK_EXAMPLES_DIR, "codex"),
+    join(LEGACY_REPO_SKILL_EXAMPLES_DIR, "codex"),
+    join(LEGACY_EXAMPLES_DIR, "codex"),
+  ];
+}
+
 export function injectTreeContextHint(): string {
   return INJECT_CONTEXT_COMMAND;
 }
 
+export function inspectAgentContextHooks(targetRoot: string): AgentContextHookHealth {
+  return {
+    claudeSettings: inspectClaudeSettingsHealth(targetRoot),
+    codexConfig: inspectCodexConfigHealth(targetRoot),
+    codexHooks: inspectCodexHooksHealth(targetRoot),
+  };
+}
+
+export function ensureAgentContextHooks(
+  targetRoot: string,
+): AgentContextHookSyncResult {
+  return {
+    claudeSettings: writeManagedTextFile(
+      join(targetRoot, CLAUDE_SETTINGS_PATH),
+      buildClaudeSettingsDocument,
+    ),
+    codexConfig: writeManagedTextFile(
+      join(targetRoot, CODEX_CONFIG_PATH),
+      buildCodexConfigDocument,
+    ),
+    codexHooks: writeManagedTextFile(
+      join(targetRoot, CODEX_HOOKS_PATH),
+      buildCodexHooksDocument,
+    ),
+  };
+}
+
 /**
- * Update a user repo's `.claude/settings.json` SessionStart hook command if
- * it still references one of the legacy `inject-tree-context.sh` paths. The
- * file's JSON structure is preserved — we only do a textual substitution.
- *
- * Returns "updated" if any substitution was made, "unchanged" if the file
- * is missing, has no stale reference, or already uses the CLI command.
+ * Backward-compatible wrapper kept for older call sites and tests that only
+ * reason about the Claude Code settings file.
  */
 export function refreshInjectContextHook(
   targetRoot: string,
@@ -49,6 +138,7 @@ export function refreshInjectContextHook(
   if (!existsSync(fullPath)) {
     return "unchanged";
   }
+
   const original = readFileSync(fullPath, "utf-8");
   let updated = original;
   for (const pattern of STALE_INJECT_CONTEXT_PATTERNS) {
@@ -58,17 +148,276 @@ export function refreshInjectContextHook(
     /("command"\s*:\s*")(?:\.\/)?scripts\/inject-tree-context\.sh(")/g,
     `$1${INJECT_CONTEXT_COMMAND}$2`,
   );
-  // Strip any leading "./" the legacy bash script started with so the
-  // command runs cleanly.
   updated = updated.replace(
     /\.\/(npx -p first-tree first-tree inject-context --skip-version-check)/g,
     "$1",
   );
+
   if (updated === original) {
     return "unchanged";
   }
+
   writeFileSync(fullPath, updated);
   return "updated";
+}
+
+function inspectClaudeSettingsHealth(targetRoot: string): AgentConfigHealth {
+  const fullPath = join(targetRoot, CLAUDE_SETTINGS_PATH);
+  if (!existsSync(fullPath)) {
+    return "missing";
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(fullPath, "utf-8")) as unknown;
+    const root = isObject(parsed) ? parsed : {};
+    const hooks = cloneObject(root.hooks);
+    const sessionStart = Array.isArray(hooks.SessionStart) ? hooks.SessionStart : [];
+    let hasCurrent = false;
+    for (const group of sessionStart) {
+      if (!isObject(group) || !Array.isArray(group.hooks)) {
+        continue;
+      }
+      for (const hook of group.hooks) {
+        if (!isObject(hook) || hook.type !== "command" || typeof hook.command !== "string") {
+          continue;
+        }
+        if (hook.command === INJECT_CONTEXT_COMMAND) {
+          hasCurrent = true;
+          continue;
+        }
+        if (matchesLegacyHookPattern(hook.command)) {
+          return "stale";
+        }
+      }
+    }
+    return hasCurrent ? "current" : "stale";
+  } catch {
+    return "stale";
+  }
+}
+
+function inspectCodexConfigHealth(targetRoot: string): AgentConfigHealth {
+  const fullPath = join(targetRoot, CODEX_CONFIG_PATH);
+  if (!existsSync(fullPath)) {
+    return "missing";
+  }
+  const current = normalizeText(readFileSync(fullPath, "utf-8"));
+  const expected = normalizeText(buildCodexConfigDocument(current));
+  return current === expected ? "current" : "stale";
+}
+
+function inspectCodexHooksHealth(targetRoot: string): AgentConfigHealth {
+  const fullPath = join(targetRoot, CODEX_HOOKS_PATH);
+  if (!existsSync(fullPath)) {
+    return "missing";
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(fullPath, "utf-8")) as unknown;
+    const root = isObject(parsed) ? parsed : {};
+    const hooks = cloneObject(root.hooks);
+    const sessionStart = Array.isArray(hooks.SessionStart) ? hooks.SessionStart : [];
+    for (const group of sessionStart) {
+      if (
+        !isObject(group)
+        || group.matcher !== CODEX_SESSION_START_MATCHER
+        || !Array.isArray(group.hooks)
+      ) {
+        continue;
+      }
+      for (const hook of group.hooks) {
+        if (
+          isObject(hook)
+          && hook.type === "command"
+          && hook.command === INJECT_CONTEXT_COMMAND
+        ) {
+          return "current";
+        }
+      }
+    }
+    return "stale";
+  } catch {
+    return "stale";
+  }
+}
+
+function writeManagedTextFile(
+  fullPath: string,
+  builder: (current: string | null) => string,
+): AgentConfigAction {
+  const current = existsSync(fullPath)
+    ? normalizeText(readFileSync(fullPath, "utf-8"))
+    : null;
+  const next = normalizeText(builder(current));
+  if (current === next) {
+    return "unchanged";
+  }
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, next);
+  return current === null ? "created" : "updated";
+}
+
+function buildClaudeSettingsDocument(current: string | null): string {
+  const root = readJsonObject(current);
+  const hooks = cloneObject(root.hooks);
+  const sessionStart = Array.isArray(hooks.SessionStart)
+    ? hooks.SessionStart
+    : [];
+
+  hooks.SessionStart = [
+    ...stripManagedHooks(sessionStart, isClaudeManagedHook),
+    {
+      hooks: [
+        {
+          type: "command",
+          command: INJECT_CONTEXT_COMMAND,
+        },
+      ],
+    },
+  ];
+
+  root.hooks = hooks;
+  return `${JSON.stringify(root, null, 2)}\n`;
+}
+
+function buildCodexConfigDocument(current: string | null): string {
+  const normalized = normalizeText(current ?? "");
+  if (normalized.trim() === "") {
+    return "[features]\ncodex_hooks = true\n";
+  }
+
+  const featuresMatch = normalized.match(/^\[features\]\s*$/m);
+  if (featuresMatch === null || featuresMatch.index === undefined) {
+    return `${normalized.trimEnd()}\n\n[features]\ncodex_hooks = true\n`;
+  }
+
+  const sectionStart = featuresMatch.index + featuresMatch[0].length;
+  const rest = normalized.slice(sectionStart);
+  const nextSectionOffset = rest.search(/^\[[^\]]+\]\s*$/m);
+  const sectionEnd = nextSectionOffset >= 0
+    ? sectionStart + nextSectionOffset
+    : normalized.length;
+  const before = normalized.slice(0, sectionStart);
+  const body = normalized.slice(sectionStart, sectionEnd);
+  const after = normalized.slice(sectionEnd);
+
+  if (/^\s*codex_hooks\s*=\s*true\s*$/m.test(body)) {
+    return normalized;
+  }
+
+  if (/^\s*codex_hooks\s*=\s*false\s*$/m.test(body)) {
+    return `${before}${body.replace(/^\s*codex_hooks\s*=\s*false\s*$/m, "codex_hooks = true")}${after}`;
+  }
+
+  const trimmedBody = body.trimEnd();
+  const nextBody = trimmedBody === ""
+    ? "\ncodex_hooks = true\n"
+    : `${trimmedBody}\ncodex_hooks = true\n`;
+  return `${before}${nextBody}${after.replace(/^\n*/, "\n")}`;
+}
+
+function buildCodexHooksDocument(current: string | null): string {
+  const root = readJsonObject(current);
+  const hooks = cloneObject(root.hooks);
+  const sessionStart = Array.isArray(hooks.SessionStart)
+    ? hooks.SessionStart
+    : [];
+
+  hooks.SessionStart = [
+    ...stripManagedHooks(sessionStart, isCodexManagedHook),
+    {
+      matcher: CODEX_SESSION_START_MATCHER,
+      hooks: [
+        {
+          type: "command",
+          command: INJECT_CONTEXT_COMMAND,
+          statusMessage: CODEX_SESSION_START_STATUS,
+        },
+      ],
+    },
+  ];
+
+  root.hooks = hooks;
+  return `${JSON.stringify(root, null, 2)}\n`;
+}
+
+function stripManagedHooks(
+  groups: unknown[],
+  isManagedHook: (hook: Record<string, unknown>) => boolean,
+): Record<string, unknown>[] {
+  const cleanedGroups: Record<string, unknown>[] = [];
+
+  for (const candidate of groups) {
+    if (!isObject(candidate)) {
+      continue;
+    }
+
+    const hooks = Array.isArray(candidate.hooks) ? candidate.hooks : [];
+    const cleanedHooks = hooks.filter((hook) =>
+      !(isObject(hook) && isManagedHook(hook))
+    );
+
+    if (cleanedHooks.length === 0) {
+      continue;
+    }
+
+    cleanedGroups.push({
+      ...candidate,
+      hooks: cleanedHooks,
+    });
+  }
+
+  return cleanedGroups;
+}
+
+function isClaudeManagedHook(hook: Record<string, unknown>): boolean {
+  if (hook.type !== "command" || typeof hook.command !== "string") {
+    return false;
+  }
+  return hook.command === INJECT_CONTEXT_COMMAND || matchesLegacyHookPattern(hook.command);
+}
+
+function isCodexManagedHook(hook: Record<string, unknown>): boolean {
+  return hook.type === "command" && hook.command === INJECT_CONTEXT_COMMAND;
+}
+
+function matchesLegacyHookPattern(command: string): boolean {
+  if (command === INJECT_CONTEXT_COMMAND || command === `./${INJECT_CONTEXT_COMMAND}`) {
+    return true;
+  }
+  return STALE_INJECT_CONTEXT_PATTERNS.some((pattern) => {
+    pattern.lastIndex = 0;
+    return pattern.test(command);
+  })
+    || /(?:\.\/)?scripts\/inject-tree-context\.sh/.test(command);
+}
+
+function readJsonObject(text: string | null): Record<string, unknown> {
+  if (text === null) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    return isObject(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function cloneObject(value: unknown): Record<string, unknown> {
+  return isObject(value) ? { ...value } : {};
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function normalizeText(text: string): string {
+  return ensureTrailingNewline(text.replaceAll("\r\n", "\n"));
+}
+
+function ensureTrailingNewline(text: string): string {
+  return text.endsWith("\n") ? text : `${text}\n`;
 }
 
 /**

--- a/src/engine/runtime/source-repo-index.ts
+++ b/src/engine/runtime/source-repo-index.ts
@@ -55,10 +55,20 @@ export function buildSourceRepoIndex(bindings: TreeBindingState[]): string {
     return `${lines.join("\n")}\n`;
   }
 
-  lines.push(
+  lines.push(...buildSourceRepoIndexTable(bindings));
+  lines.push("");
+  return `${lines.join("\n")}\n`;
+}
+
+export function buildSourceRepoIndexTable(bindings: TreeBindingState[]): string[] {
+  if (bindings.length === 0) {
+    return ["No bound source/workspace repos have been recorded yet."];
+  }
+
+  const lines = [
     "| Source | GitHub | Binding | Tree Entrypoint |",
     "| --- | --- | --- | --- |",
-  );
+  ];
 
   for (const binding of [...bindings].sort(compareBindings)) {
     lines.push(
@@ -71,18 +81,20 @@ export function buildSourceRepoIndex(bindings: TreeBindingState[]): string {
     );
   }
 
-  lines.push("");
-  return `${lines.join("\n")}\n`;
+  return lines;
 }
 
-function compareBindings(left: TreeBindingState, right: TreeBindingState): number {
+export function compareBindings(
+  left: TreeBindingState,
+  right: TreeBindingState,
+): number {
   const nameOrder = left.sourceName.localeCompare(right.sourceName);
   return nameOrder === 0
     ? left.sourceId.localeCompare(right.sourceId)
     : nameOrder;
 }
 
-function formatRemoteCell(binding: TreeBindingState): string {
+export function formatRemoteCell(binding: TreeBindingState): string {
   if (!binding.remoteUrl) {
     return "Missing in binding metadata";
   }

--- a/src/engine/runtime/tree-first-context.ts
+++ b/src/engine/runtime/tree-first-context.ts
@@ -1,0 +1,116 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { TREE_SOURCE_REPOS_FILE } from "#engine/runtime/asset-loader.js";
+import {
+  listTreeBindings,
+  readTreeState,
+} from "#engine/runtime/binding-state.js";
+import { readLocalTreeConfig } from "#engine/runtime/local-tree-config.js";
+import { buildSourceRepoIndexTable } from "#engine/runtime/source-repo-index.js";
+
+const ROOT_NODE_FILE = "NODE.md";
+
+interface ResolvedTreeContextRoot {
+  currentEntrypoint?: string;
+  entrypointLabel: string;
+  treeRoot: string;
+}
+
+export interface TreeFirstContextBundle {
+  additionalContext: string;
+  treeRoot: string;
+}
+
+export function buildTreeFirstContextBundle(
+  currentRoot: string,
+): TreeFirstContextBundle | null {
+  const resolved = resolveTreeContextRoot(currentRoot);
+
+  if (resolved === null) {
+    return readFallbackLocalNode(currentRoot);
+  }
+
+  const nodePath = join(resolved.treeRoot, ROOT_NODE_FILE);
+  if (!existsSync(nodePath)) {
+    return null;
+  }
+
+  const rootNode = readFileSync(nodePath, "utf-8").trimEnd();
+  const bindings = listTreeBindings(resolved.treeRoot);
+  const sections = [rootNode];
+  const repoContext = buildRepoContextSection(
+    bindings,
+    resolved.currentEntrypoint,
+    resolved.entrypointLabel,
+  );
+
+  if (repoContext !== null) {
+    sections.push(repoContext);
+  }
+
+  return {
+    additionalContext: `${sections.join("\n\n---\n\n")}\n`,
+    treeRoot: resolved.treeRoot,
+  };
+}
+
+function resolveTreeContextRoot(currentRoot: string): ResolvedTreeContextRoot | null {
+  if (readTreeState(currentRoot) !== null) {
+    return {
+      entrypointLabel: "tree repo root",
+      treeRoot: currentRoot,
+    };
+  }
+
+  const localTreeConfig = readLocalTreeConfig(currentRoot);
+  if (localTreeConfig === null) {
+    return null;
+  }
+
+  const treeRoot = resolve(currentRoot, localTreeConfig.localPath);
+  if (!existsSync(treeRoot)) {
+    return null;
+  }
+
+  return {
+    currentEntrypoint: localTreeConfig.entrypoint,
+    entrypointLabel: "bound source/workspace root",
+    treeRoot,
+  };
+}
+
+function readFallbackLocalNode(currentRoot: string): TreeFirstContextBundle | null {
+  const nodePath = join(currentRoot, ROOT_NODE_FILE);
+  if (!existsSync(nodePath)) {
+    return null;
+  }
+
+  return {
+    additionalContext: readFileSync(nodePath, "utf-8"),
+    treeRoot: currentRoot,
+  };
+}
+
+function buildRepoContextSection(
+  bindings: ReturnType<typeof listTreeBindings>,
+  currentEntrypoint: string | undefined,
+  entrypointLabel: string,
+): string | null {
+  if (bindings.length === 0 && currentEntrypoint === undefined) {
+    return null;
+  }
+
+  const lines = [
+    "## Tree-First Cross-Repo Working Context",
+    "",
+    "- Repo index source: `.first-tree/bindings/*.json`",
+    `- Human-readable index: \`${TREE_SOURCE_REPOS_FILE}\` when present`,
+    `- Current entrypoint: \`${currentEntrypoint ?? entrypointLabel}\``,
+    "",
+    "## Bound Source/Workspace Repos",
+    "",
+    ...buildSourceRepoIndexTable(bindings),
+  ];
+
+  return lines.join("\n");
+}

--- a/src/engine/upgrade.ts
+++ b/src/engine/upgrade.ts
@@ -20,7 +20,8 @@ import {
   type FrameworkLayout,
 } from "#engine/runtime/asset-loader.js";
 import {
-  refreshInjectContextHook,
+  ensureAgentContextHooks,
+  formatAgentContextHookMessages,
   refreshShippedWorkflows,
 } from "#engine/runtime/adapters.js";
 import {
@@ -208,13 +209,11 @@ function logTreeSourceRepoIndexSync(
   }
 }
 
-function logInjectContextHookRefresh(
-  hookRefresh: "updated" | "unchanged",
+function logAgentContextHookRefresh(
+  hookRefresh: ReturnType<typeof ensureAgentContextHooks>,
 ): void {
-  if (hookRefresh === "updated") {
-    console.log(
-      "Updated `.claude/settings.json` SessionStart hook to use `npx -p first-tree first-tree inject-context --skip-version-check`.",
-    );
+  for (const message of formatAgentContextHookMessages(hookRefresh)) {
+    console.log(message);
   }
 }
 
@@ -405,10 +404,11 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
       const changedFiles = updates
         .filter((update) => update.action !== "unchanged")
         .map((update) => update.file);
-      const hookRefresh = refreshInjectContextHook(workingRepo.root);
+      const hookRefresh = ensureAgentContextHooks(workingRepo.root);
       const indexChanged =
         firstTreeIndex.action === "created" || firstTreeIndex.action === "updated";
-      if (changedFiles.length === 0 && !indexChanged && hookRefresh === "unchanged") {
+      const hookChanged = formatAgentContextHookMessages(hookRefresh).length > 0;
+      if (changedFiles.length === 0 && !indexChanged && !hookChanged) {
         if (firstTreeIndex.action === "skipped") {
           console.log(
             `Left \`${FIRST_TREE_INDEX_FILE}\` unchanged because it already contains unmanaged content.`,
@@ -435,7 +435,7 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
           `Left \`${FIRST_TREE_INDEX_FILE}\` unchanged because it already contains unmanaged content.`,
         );
       }
-      logInjectContextHookRefresh(hookRefresh);
+      logAgentContextHookRefresh(hookRefresh);
       if (changedFiles.length > 0) {
         console.log(
           `Updated the ${SOURCE_INTEGRATION_MARKER} marker lines in ${changedFiles.map((file) => `\`${file}\``).join(" and ")}.`,
@@ -454,7 +454,7 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
 
     const wipedPaths = wipeInstalledSkill(workingRepo.root);
     copyCanonicalSkill(sourceRoot, workingRepo.root);
-    const hookRefresh = refreshInjectContextHook(workingRepo.root);
+    const hookRefresh = ensureAgentContextHooks(workingRepo.root);
     const refreshedWorkflows = refreshShippedWorkflows(
       workingRepo.root,
       join(resolveBundledAssetRoot(sourceRoot), "workflows"),
@@ -483,7 +483,7 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
     console.log(
       `Refreshed ${installedSkillRootsDisplay()} in this source/workspace repo.`,
     );
-    logInjectContextHookRefresh(hookRefresh);
+    logAgentContextHookRefresh(hookRefresh);
     if (refreshedWorkflows.length > 0) {
       console.log(
         `Overwrote shipped workflow files: ${refreshedWorkflows.map((f) => `\`.github/workflows/${f}\``).join(", ")}.`,
@@ -533,7 +533,7 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
       installedTreeSkillVersion !== null
       && missingInstalledRoots.length === 0
       && compareSkillVersions(installedTreeSkillVersion, packagedVersion) === 0;
-    const hookRefresh = refreshInjectContextHook(workingRepo.root);
+    const hookRefresh = ensureAgentContextHooks(workingRepo.root);
 
     if (treeMetadataUpToDate && treeSkillUpToDate) {
       const sourceRepoIndex = syncTreeSourceRepoIndex(workingRepo.root);
@@ -542,7 +542,7 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
         `Already up to date with the bundled tree metadata and installed tree skill (${workingRepo.frameworkVersionPath()} = ${localVersion}).`,
       );
       logTreeSourceRepoIndexSync(sourceRepoIndex);
-      logInjectContextHookRefresh(hookRefresh);
+      logAgentContextHookRefresh(hookRefresh);
       return 0;
     }
 
@@ -567,7 +567,7 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
     const sourceRepoIndex = syncTreeSourceRepoIndex(workingRepo.root);
     logTreeSourceRepoIndexSync(sourceRepoIndex);
     ensureSyncRunbook(workingRepo.root, sourceRoot);
-    logInjectContextHookRefresh(hookRefresh);
+    logAgentContextHookRefresh(hookRefresh);
 
     const output = formatUpgradeTaskList(
       workingRepo,
@@ -586,17 +586,17 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
     missingInstalledRoots.length === 0 &&
     compareSkillVersions(localVersion, packagedVersion) === 0
   ) {
-    const hookRefresh = refreshInjectContextHook(workingRepo.root);
+    const hookRefresh = ensureAgentContextHooks(workingRepo.root);
     console.log(
       `Already up to date with the bundled skill (${workingRepo.frameworkVersionPath()} = ${localVersion}).`,
     );
-    logInjectContextHookRefresh(hookRefresh);
+    logAgentContextHookRefresh(hookRefresh);
     return 0;
   }
 
   const wipedPaths = wipeInstalledSkill(workingRepo.root);
   copyCanonicalSkill(sourceRoot, workingRepo.root);
-  const hookRefresh = refreshInjectContextHook(workingRepo.root);
+  const hookRefresh = ensureAgentContextHooks(workingRepo.root);
   const refreshedWorkflows = refreshShippedWorkflows(
     workingRepo.root,
     join(resolveBundledAssetRoot(sourceRoot), "workflows"),
@@ -609,7 +609,7 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
   console.log(
     `Installed lightweight skill payload at ${installedSkillRootsDisplay()}.`,
   );
-  logInjectContextHookRefresh(hookRefresh);
+  logAgentContextHookRefresh(hookRefresh);
   if (refreshedWorkflows.length > 0) {
     console.log(
       `Overwrote shipped workflow files: ${refreshedWorkflows.map((f) => `\`.github/workflows/${f}\``).join(", ")}.`,

--- a/src/engine/verify.ts
+++ b/src/engine/verify.ts
@@ -10,6 +10,10 @@ import {
   CLAUDE_INSTRUCTIONS_FILE,
   LEGACY_AGENT_INSTRUCTIONS_FILE,
 } from "#engine/runtime/asset-loader.js";
+import {
+  formatAgentContextHookDriftMessages,
+  inspectAgentContextHookReport,
+} from "#engine/runtime/adapters.js";
 import { runValidateMembers } from "#engine/validators/members.js";
 import { runValidateNodes } from "#engine/validators/nodes.js";
 
@@ -23,6 +27,7 @@ Checks performed:
   - Installed skill version file exists
   - Root NODE.md has valid frontmatter (title, owners)
   - AGENTS.md and CLAUDE.md exist with framework markers
+  - Claude Code / Codex SessionStart hook drift is reported without rewriting files
   - Node validation: frontmatter, owners syntax, soft_links resolve,
     directory listing consistency, no empty nodes, no title mismatches
   - Member validation: at least one member, required fields present
@@ -166,11 +171,27 @@ export function runVerify(repo?: Repo, nodeValidator?: NodeValidator): number {
       duplicatePlaceholderFiles.length === 0,
   ) && allPassed;
 
-  // 4. Node validation
+  // 4. Agent context hook drift
+  const agentContextHookReport = inspectAgentContextHookReport(r.root);
+  if (agentContextHookReport.overall !== "current") {
+    console.log("  Agent context drift detected:\n");
+    for (const message of formatAgentContextHookDriftMessages(
+      agentContextHookReport,
+    )) {
+      console.log(`    - ${message}`);
+    }
+    console.log(`\n  ${agentContextHookReport.repairHint}\n`);
+  }
+  allPassed = check(
+    "Managed Claude Code / Codex agent context files are current",
+    agentContextHookReport.overall === "current",
+  ) && allPassed;
+
+  // 5. Node validation
   const { exitCode } = validate(r.root);
   allPassed = check("Node validation passes", exitCode === 0) && allPassed;
 
-  // 5. Member validation
+  // 6. Member validation
   const members = runValidateMembers(r.root);
   allPassed = check("Member validation passes", members.exitCode === 0) && allPassed;
 

--- a/src/engine/verify.ts
+++ b/src/engine/verify.ts
@@ -39,6 +39,8 @@ messages so you can fix them and re-run.
 When run inside a source/workspace repo (no tree content, only the source
 integration), verify exits with an error and points you to the dedicated
 tree repo. Pass \`--tree-path\` to verify the dedicated tree from elsewhere.
+When \`--tree-path\` is used from a bound source/workspace root, verify also
+reports caller-root Claude/Codex drift without rewriting those files.
 
 Options:
   --tree-path PATH   Verify a tree repo from another working directory
@@ -71,12 +73,48 @@ export interface ValidateNodesResult {
 
 export type NodeValidator = (root: string) => ValidateNodesResult;
 
+export interface VerifyOptions {
+  callerRepo?: Repo;
+}
+
 function defaultNodeValidator(root: string): ValidateNodesResult {
   const { exitCode } = runValidateNodes(root);
   return { exitCode };
 }
 
-export function runVerify(repo?: Repo, nodeValidator?: NodeValidator): number {
+function shouldCheckCallerRootAgentContext(
+  targetRepo: Repo,
+  callerRepo: Repo | undefined,
+): callerRepo is Repo {
+  return callerRepo !== undefined
+    && callerRepo.root !== targetRepo.root
+    && callerRepo.hasSourceWorkspaceIntegration();
+}
+
+function runAgentContextHookCheck(
+  label: string,
+  repo: Repo,
+): { passed: boolean } {
+  const agentContextHookReport = inspectAgentContextHookReport(repo.root);
+  if (agentContextHookReport.overall !== "current") {
+    console.log(`  ${label} drift detected:\n`);
+    for (const message of formatAgentContextHookDriftMessages(
+      agentContextHookReport,
+    )) {
+      console.log(`    - ${message}`);
+    }
+    console.log(`\n  ${agentContextHookReport.repairHint}\n`);
+  }
+  return {
+    passed: agentContextHookReport.overall === "current",
+  };
+}
+
+export function runVerify(
+  repo?: Repo,
+  nodeValidator?: NodeValidator,
+  options?: VerifyOptions,
+): number {
   const r = repo ?? new Repo();
   const validate = nodeValidator ?? defaultNodeValidator;
 
@@ -171,27 +209,30 @@ export function runVerify(repo?: Repo, nodeValidator?: NodeValidator): number {
       duplicatePlaceholderFiles.length === 0,
   ) && allPassed;
 
-  // 4. Agent context hook drift
-  const agentContextHookReport = inspectAgentContextHookReport(r.root);
-  if (agentContextHookReport.overall !== "current") {
-    console.log("  Agent context drift detected:\n");
-    for (const message of formatAgentContextHookDriftMessages(
-      agentContextHookReport,
-    )) {
-      console.log(`    - ${message}`);
-    }
-    console.log(`\n  ${agentContextHookReport.repairHint}\n`);
-  }
+  // 4. Agent context hook drift for the verified tree target
+  const treeAgentContextCheck = runAgentContextHookCheck("Agent context", r);
   allPassed = check(
     "Managed Claude Code / Codex agent context files are current",
-    agentContextHookReport.overall === "current",
+    treeAgentContextCheck.passed,
   ) && allPassed;
 
-  // 5. Node validation
+  // 5. Optional caller-root drift when verify targets another tree checkout
+  if (shouldCheckCallerRootAgentContext(r, options?.callerRepo)) {
+    const callerAgentContextCheck = runAgentContextHookCheck(
+      `Caller root agent context (${options.callerRepo.root})`,
+      options.callerRepo,
+    );
+    allPassed = check(
+      "Caller root managed Claude Code / Codex agent context files are current",
+      callerAgentContextCheck.passed,
+    ) && allPassed;
+  }
+
+  // 6. Node validation
   const { exitCode } = validate(r.root);
   allPassed = check("Node validation passes", exitCode === 0) && allPassed;
 
-  // 6. Member validation
+  // 7. Member validation
   const members = runValidateMembers(r.root);
   allPassed = check("Member validation passes", members.exitCode === 0) && allPassed;
 
@@ -230,5 +271,10 @@ export function runVerifyCli(args: string[] = []): number {
     return 1;
   }
 
-  return runVerify(treePath ? new Repo(resolve(process.cwd(), treePath)) : undefined);
+  const callerRepo = treePath ? new Repo() : undefined;
+  return runVerify(
+    treePath ? new Repo(resolve(process.cwd(), treePath)) : undefined,
+    undefined,
+    { callerRepo },
+  );
 }

--- a/tests/bind.test.ts
+++ b/tests/bind.test.ts
@@ -46,6 +46,12 @@ describe("runBind", () => {
     expect(existsSync(join(treeRoot, ".claude", "skills", "first-tree", "SKILL.md"))).toBe(
       true,
     );
+    expect(existsSync(join(sourceRoot, ".claude", "settings.json"))).toBe(true);
+    expect(existsSync(join(sourceRoot, ".codex", "config.toml"))).toBe(true);
+    expect(existsSync(join(sourceRoot, ".codex", "hooks.json"))).toBe(true);
+    expect(existsSync(join(treeRoot, ".claude", "settings.json"))).toBe(true);
+    expect(existsSync(join(treeRoot, ".codex", "config.toml"))).toBe(true);
+    expect(existsSync(join(treeRoot, ".codex", "hooks.json"))).toBe(true);
     expect(treeBinding?.sourceName).toBe("product-repo");
     expect(existsSync(join(treeRoot, ".gitmodules"))).toBe(false);
     expect(

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -14,6 +14,7 @@ import {
   SKILL_ROOT,
   TREE_VERSION,
 } from "#engine/runtime/asset-loader.js";
+import { ensureAgentContextHooks } from "#engine/runtime/adapters.js";
 
 interface TmpDir {
   path: string;
@@ -90,6 +91,10 @@ export function makeSourceRepo(root: string): void {
   );
   writeFileSync(join(root, "src", "index.ts"), "export const ready = true;\n");
   commitWorkingTree(root, "Initial source repo");
+}
+
+export function makeManagedAgentContext(root: string): void {
+  ensureAgentContextHooks(root);
 }
 
 export function makeLegacyFramework(root: string, version = "0.1.0"): void {

--- a/tests/inject-context.test.ts
+++ b/tests/inject-context.test.ts
@@ -1,8 +1,13 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runInjectContext } from "../src/engine/commands/inject-context.js";
+import {
+  writeSourceState,
+  writeTreeBinding,
+  writeTreeState,
+} from "../src/engine/runtime/binding-state.js";
 
 describe("runInjectContext", () => {
   let tmpDir: string;
@@ -49,6 +54,75 @@ describe("runInjectContext", () => {
     const payload = JSON.parse(logged[0]);
     expect(payload.hookSpecificOutput.additionalContext).toBe(
       'has "quotes" and\nnewlines\tand\\backslash',
+    );
+  });
+
+  it("resolves tree-first context from a bound source repo", () => {
+    const sourceRoot = join(tmpDir, "product-repo");
+    const treeRoot = join(tmpDir, "org-context");
+    mkdirSync(sourceRoot, { recursive: true });
+    mkdirSync(treeRoot, { recursive: true });
+    writeFileSync(
+      join(treeRoot, "NODE.md"),
+      [
+        "---",
+        "title: Org Context",
+        "owners: [alice]",
+        "---",
+        "",
+        "# Org Context",
+        "",
+        "Shared context for the organization.",
+        "",
+      ].join("\n"),
+    );
+    writeTreeState(treeRoot, {
+      treeId: "org-context",
+      treeMode: "shared",
+      treeRepoName: "org-context",
+    });
+    writeSourceState(sourceRoot, {
+      bindingMode: "shared-source",
+      rootKind: "git-repo",
+      scope: "repo",
+      sourceId: "product-repo-1234abcd",
+      sourceName: "product-repo",
+      tree: {
+        entrypoint: "/workspaces/product-repo",
+        localPath: relative(sourceRoot, treeRoot),
+        remoteUrl: "https://github.com/acme/org-context.git",
+        treeId: "org-context",
+        treeMode: "shared",
+        treeRepoName: "org-context",
+      },
+    });
+    writeTreeBinding(treeRoot, "product-repo-1234abcd", {
+      bindingMode: "shared-source",
+      entrypoint: "/workspaces/product-repo",
+      remoteUrl: "git@github.com:acme/product-repo.git",
+      rootKind: "git-repo",
+      scope: "repo",
+      sourceId: "product-repo-1234abcd",
+      sourceName: "product-repo",
+      sourceRootPath: relative(treeRoot, sourceRoot),
+      treeMode: "shared",
+      treeRepoName: "org-context",
+    });
+    process.chdir(sourceRoot);
+
+    const code = runInjectContext([]);
+
+    expect(code).toBe(0);
+    const payload = JSON.parse(logged[0]);
+    expect(payload.hookSpecificOutput.additionalContext).toContain("# Org Context");
+    expect(payload.hookSpecificOutput.additionalContext).toContain(
+      "## Tree-First Cross-Repo Working Context",
+    );
+    expect(payload.hookSpecificOutput.additionalContext).toContain(
+      "`/workspaces/product-repo`",
+    );
+    expect(payload.hookSpecificOutput.additionalContext).toContain(
+      "[acme/product-repo](https://github.com/acme/product-repo)",
     );
   });
 

--- a/tests/inspect.test.ts
+++ b/tests/inspect.test.ts
@@ -1,0 +1,86 @@
+import { rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { inspectRepo } from "#engine/inspect.js";
+import { Repo } from "#engine/repo.js";
+import {
+  CLAUDE_SETTINGS_PATH,
+  CODEX_HOOKS_PATH,
+} from "#engine/runtime/adapters.js";
+import {
+  makeManagedAgentContext,
+  makeSourceRepo,
+  useTmpDir,
+} from "./helpers.js";
+
+describe("inspectRepo", () => {
+  it("returns a detailed current agent context hook report", () => {
+    const tmp = useTmpDir();
+    makeSourceRepo(tmp.path);
+    makeManagedAgentContext(tmp.path);
+
+    const inspection = inspectRepo(new Repo(tmp.path));
+
+    expect(inspection.agentContextHookReport.overall).toBe("current");
+    expect(inspection.agentContextHookReport.files).toEqual([
+      expect.objectContaining({
+        id: "claudeSettings",
+        path: CLAUDE_SETTINGS_PATH,
+        status: "current",
+      }),
+      expect.objectContaining({
+        id: "codexConfig",
+        path: ".codex/config.toml",
+        status: "current",
+      }),
+      expect.objectContaining({
+        id: "codexHooks",
+        path: CODEX_HOOKS_PATH,
+        status: "current",
+      }),
+    ]);
+  });
+
+  it("reports per-file drift and a repair hint", () => {
+    const tmp = useTmpDir();
+    makeSourceRepo(tmp.path);
+    makeManagedAgentContext(tmp.path);
+    rmSync(join(tmp.path, CODEX_HOOKS_PATH));
+    writeFileSync(
+      join(tmp.path, CLAUDE_SETTINGS_PATH),
+      JSON.stringify({
+        hooks: {
+          SessionStart: [
+            {
+              hooks: [
+                {
+                  type: "command",
+                  command: ".context-tree/scripts/inject-tree-context.sh",
+                },
+              ],
+            },
+          ],
+        },
+      }, null, 2),
+    );
+
+    const inspection = inspectRepo(new Repo(tmp.path));
+
+    expect(inspection.agentContextHookReport.overall).toBe("drifted");
+    expect(inspection.agentContextHookReport.repairHint).toContain(
+      "first-tree upgrade",
+    );
+    expect(inspection.agentContextHookReport.files).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "claudeSettings",
+          status: "stale",
+        }),
+        expect.objectContaining({
+          id: "codexHooks",
+          status: "missing",
+        }),
+      ]),
+    );
+  });
+});

--- a/tests/repo.test.ts
+++ b/tests/repo.test.ts
@@ -179,6 +179,14 @@ describe("anyAgentConfig", () => {
     expect(repo.anyAgentConfig()).toBe(true);
   });
 
+  it("returns true with codex hooks", () => {
+    const tmp = useTmpDir();
+    mkdirSync(join(tmp.path, ".codex"), { recursive: true });
+    writeFileSync(join(tmp.path, ".codex", "hooks.json"), "{}");
+    const repo = new Repo(tmp.path);
+    expect(repo.anyAgentConfig()).toBe(true);
+  });
+
   it("returns false without any config", () => {
     const tmp = useTmpDir();
     const repo = new Repo(tmp.path);

--- a/tests/rules.test.ts
+++ b/tests/rules.test.ts
@@ -284,7 +284,7 @@ describe("agentIntegration rule", () => {
     mkdirSync(join(tmp.path, ".claude"));
     writeFileSync(
       join(tmp.path, ".claude", "settings.json"),
-      '{"hooks": {"inject-tree-context": true}}',
+      '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"npx -p first-tree first-tree inject-context --skip-version-check"}]}]}}',
     );
     const repo = new Repo(tmp.path);
     const result = agentIntegration.evaluate(repo);
@@ -450,7 +450,7 @@ describe("evaluateAll", () => {
     mkdirSync(join(tmp.path, ".claude"), { recursive: true });
     writeFileSync(
       join(tmp.path, ".claude", "settings.json"),
-      '{"hooks": {"inject-tree-context": true}}',
+      '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"npx -p first-tree first-tree inject-context --skip-version-check"}]}]}}',
     );
     const wfDir = join(tmp.path, ".github", "workflows");
     mkdirSync(wfDir, { recursive: true });

--- a/tests/upgrade.test.ts
+++ b/tests/upgrade.test.ts
@@ -248,6 +248,9 @@ describe("runUpgrade", () => {
     expect(readFileSync(join(repoDir.path, "AGENTS.md"), "utf-8")).toContain(
       "## Source Repo Index",
     );
+    expect(existsSync(join(repoDir.path, ".claude", "settings.json"))).toBe(true);
+    expect(existsSync(join(repoDir.path, ".codex", "config.toml"))).toBe(true);
+    expect(existsSync(join(repoDir.path, ".codex", "hooks.json"))).toBe(true);
   });
 
   it("refreshes a stale SessionStart hook even when a dedicated tree repo is already current", () => {
@@ -319,6 +322,9 @@ describe("runUpgrade", () => {
     expect(readFileSync(join(repoDir.path, ".gitignore"), "utf-8")).toContain(
       ".first-tree/tmp/",
     );
+    expect(existsSync(join(repoDir.path, ".claude", "settings.json"))).toBe(true);
+    expect(existsSync(join(repoDir.path, ".codex", "config.toml"))).toBe(true);
+    expect(existsSync(join(repoDir.path, ".codex", "hooks.json"))).toBe(true);
     expectFirstTreeIndexSymlink(repoDir.path);
     expect(existsSync(join(repoDir.path, INSTALLED_PROGRESS))).toBe(false);
   });

--- a/tests/verify.test.ts
+++ b/tests/verify.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { runInit } from "#engine/init.js";
@@ -13,6 +13,10 @@ import {
   TREE_PROGRESS,
 } from "#engine/runtime/asset-loader.js";
 import {
+  CLAUDE_SETTINGS_PATH,
+  CODEX_HOOKS_PATH,
+} from "#engine/runtime/adapters.js";
+import {
   useTmpDir,
   makeAgentsMd,
   makeClaudeMd,
@@ -21,6 +25,7 @@ import {
   makeNode,
   makeSourceRepo,
   makeMembers,
+  makeManagedAgentContext,
   makeSourceSkill,
   makeTreeMetadata,
 } from "./helpers.js";
@@ -104,6 +109,7 @@ describe("checkProgress", () => {
 function buildFullRepo(root: string): void {
   mkdirSync(join(root, ".git"));
   makeTreeMetadata(root);
+  makeManagedAgentContext(root);
   writeFileSync(
     join(root, "NODE.md"),
     "---\ntitle: My Org\nowners: [alice]\n---\n# Content\n",
@@ -214,6 +220,7 @@ describe("runVerify failing", () => {
   it("fails when AGENTS.md is missing", () => {
     const tmp = useTmpDir();
     makeTreeMetadata(tmp.path);
+    makeManagedAgentContext(tmp.path);
     writeFileSync(
       join(tmp.path, "NODE.md"),
       "---\ntitle: My Org\nowners: [alice]\n---\n",
@@ -227,6 +234,7 @@ describe("runVerify failing", () => {
   it("fails when CLAUDE.md is missing", () => {
     const tmp = useTmpDir();
     makeFramework(tmp.path);
+    makeManagedAgentContext(tmp.path);
     writeFileSync(
       join(tmp.path, "NODE.md"),
       "---\ntitle: My Org\nowners: [alice]\n---\n",
@@ -241,6 +249,7 @@ describe("runVerify failing", () => {
     const tmp = useTmpDir();
     mkdirSync(join(tmp.path, ".git"));
     makeTreeMetadata(tmp.path);
+    makeManagedAgentContext(tmp.path);
     makeNode(tmp.path);
     makeAgentsMd(tmp.path, { legacyName: true, markers: true, userContent: true });
     makeClaudeMd(tmp.path, { markers: true, userContent: true });
@@ -290,6 +299,38 @@ describe("runVerify failing", () => {
     const repo = new Repo(tmp.path);
     const ret = runVerify(repo, failValidator);
     expect(ret).toBe(1);
+  });
+
+  it("fails when a managed agent context file is missing", () => {
+    const tmp = useTmpDir();
+    buildFullRepo(tmp.path);
+    rmSync(join(tmp.path, CODEX_HOOKS_PATH));
+    const repo = new Repo(tmp.path);
+    expect(runVerify(repo, passValidator)).toBe(1);
+  });
+
+  it("fails when the Claude SessionStart hook is stale", () => {
+    const tmp = useTmpDir();
+    buildFullRepo(tmp.path);
+    writeFileSync(
+      join(tmp.path, CLAUDE_SETTINGS_PATH),
+      JSON.stringify({
+        hooks: {
+          SessionStart: [
+            {
+              hooks: [
+                {
+                  type: "command",
+                  command: ".context-tree/scripts/inject-tree-context.sh",
+                },
+              ],
+            },
+          ],
+        },
+      }, null, 2),
+    );
+    const repo = new Repo(tmp.path);
+    expect(runVerify(repo, passValidator)).toBe(1);
   });
 
   it("gives a dedicated-tree hint when run from a source repo", () => {

--- a/tests/verify.test.ts
+++ b/tests/verify.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { runInit } from "#engine/init.js";
-import { check, checkProgress, runVerify } from "#engine/verify.js";
+import { check, checkProgress, runVerify, runVerifyCli } from "#engine/verify.js";
 import { Repo } from "#engine/repo.js";
 import {
   AGENT_INSTRUCTIONS_FILE,
@@ -331,6 +331,34 @@ describe("runVerify failing", () => {
     );
     const repo = new Repo(tmp.path);
     expect(runVerify(repo, passValidator)).toBe(1);
+  });
+
+  it("fails via --tree-path when the caller root agent context drifts", () => {
+    const sandbox = useTmpDir();
+    const sourceRoot = join(sandbox.path, "product-repo");
+    const treeRoot = join(sandbox.path, "product-repo-tree");
+    makeSourceRepo(sourceRoot);
+    mkdirSync(treeRoot, { recursive: true });
+    buildFullRepo(treeRoot);
+    makeFramework(sourceRoot);
+    makeManagedAgentContext(sourceRoot);
+    writeFileSync(
+      join(sourceRoot, AGENT_INSTRUCTIONS_FILE),
+      `${SOURCE_INTEGRATION_MARKER} Use the installed \`first-tree\` skill here.\n`,
+    );
+    writeFileSync(
+      join(sourceRoot, CLAUDE_INSTRUCTIONS_FILE),
+      `${SOURCE_INTEGRATION_MARKER} Use the installed \`first-tree\` skill here.\n`,
+    );
+    rmSync(join(sourceRoot, CODEX_HOOKS_PATH));
+
+    const originalCwd = process.cwd();
+    process.chdir(sourceRoot);
+    try {
+      expect(runVerifyCli(["--tree-path", "../product-repo-tree"])).toBe(1);
+    } finally {
+      process.chdir(originalCwd);
+    }
   });
 
   it("gives a dedicated-tree hint when run from a source repo", () => {

--- a/tests/wipe-and-refresh.test.ts
+++ b/tests/wipe-and-refresh.test.ts
@@ -8,6 +8,8 @@ import {
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  ensureAgentContextHooks,
+  inspectAgentContextHooks,
   refreshInjectContextHook,
   refreshShippedWorkflows,
 } from "../src/engine/runtime/adapters.js";
@@ -229,6 +231,77 @@ describe("refreshInjectContextHook", () => {
   it("returns unchanged when settings.json is missing", () => {
     const tmp = useTmpDir();
     expect(refreshInjectContextHook(tmp.path)).toBe("unchanged");
+  });
+});
+
+describe("ensureAgentContextHooks", () => {
+  it("creates Claude Code and Codex hook files when they are missing", () => {
+    const tmp = useTmpDir();
+
+    const result = ensureAgentContextHooks(tmp.path);
+
+    expect(result).toEqual({
+      claudeSettings: "created",
+      codexConfig: "created",
+      codexHooks: "created",
+    });
+    expect(
+      readFileSync(join(tmp.path, ".claude", "settings.json"), "utf-8"),
+    ).toContain("first-tree inject-context");
+    expect(
+      readFileSync(join(tmp.path, ".codex", "config.toml"), "utf-8"),
+    ).toContain("codex_hooks = true");
+    expect(
+      readFileSync(join(tmp.path, ".codex", "hooks.json"), "utf-8"),
+    ).toContain("\"matcher\": \"startup|resume\"");
+    expect(inspectAgentContextHooks(tmp.path)).toEqual({
+      claudeSettings: "current",
+      codexConfig: "current",
+      codexHooks: "current",
+    });
+  });
+
+  it("updates stale Codex files while preserving unrelated configuration", () => {
+    const tmp = useTmpDir();
+    mkdirSync(join(tmp.path, ".codex"), { recursive: true });
+    writeFileSync(
+      join(tmp.path, ".codex", "config.toml"),
+      ['model = "gpt-5.4"', "", "[features]", "codex_hooks = false", ""].join("\n"),
+    );
+    writeFileSync(
+      join(tmp.path, ".codex", "hooks.json"),
+      JSON.stringify(
+        {
+          hooks: {
+            PreToolUse: [
+              {
+                matcher: "Bash",
+                hooks: [
+                  {
+                    type: "command",
+                    command: "echo pre-tool",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const result = ensureAgentContextHooks(tmp.path);
+    const config = readFileSync(join(tmp.path, ".codex", "config.toml"), "utf-8");
+    const hooks = readFileSync(join(tmp.path, ".codex", "hooks.json"), "utf-8");
+
+    expect(result.codexConfig).toBe("updated");
+    expect(result.codexHooks).toBe("updated");
+    expect(config).toContain('model = "gpt-5.4"');
+    expect(config).toContain("codex_hooks = true");
+    expect(hooks).toContain("\"PreToolUse\"");
+    expect(hooks).toContain("\"SessionStart\"");
+    expect(hooks).toContain("Loading First Tree context");
   });
 });
 


### PR DESCRIPTION
## Summary

- expand `first-tree inject-context` from local `NODE.md` passthrough to a tree-first bundle built from the tree root plus bindings-derived repo index
- add adapter-managed SessionStart hook/config support for both Claude Code and Codex, and wire it into bind/init/publish/upgrade flows
- add read-only drift reporting so `inspect` exposes per-file hook health, `verify` fails on missing/stale managed agent context files without rewriting them, and `verify --tree-path ...` also reports caller-root drift when invoked from a bound source/workspace root

## Validation

- [x] `pnpm validate:skill`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm pack` if package contents or install/upgrade behavior changed

## Change Surface

- [x] Thin CLI shell (`src/`, package/build wiring)
- [ ] Canonical skill behavior (`skills/first-tree/engine/`)
- [x] Shipped framework payload (`skills/first-tree/assets/framework/`)
- [ ] Maintainer or user docs (`README.md`, `CONTRIBUTING.md`, `references/`)

## Notes

- package/install behavior changes: source and tree repos now ensure Claude Code plus Codex SessionStart integration; Codex uses `.codex/config.toml` and `.codex/hooks.json`
- docs or tests updated to match: tests cover tree-first context composition, adapter health/writer behavior, inspect JSON drift reporting, verify read-only failure paths, and caller-root drift during `verify --tree-path`; decision PR: https://github.com/agent-team-foundation/first-tree-context/pull/135
- follow-up work: if we want a standalone workspace-wide health sweep beyond explicit `verify --tree-path` use, that should be a separate command/option
- `pnpm build` and `pnpm pack` still emit the existing tsdown `define` warning but complete successfully