### PR TITLE
fix: reinstall incomplete skill payloads during upgrade

### DIFF
--- a/src/engine/repo.ts
+++ b/src/engine/repo.ts
@@ -8,6 +8,7 @@ import {
   FRAMEWORK_VERSION,
   FIRST_TREE_INDEX_FILE,
   INSTALLED_PROGRESS,
+  INSTALLED_SKILL_REQUIRED_FILES,
   INSTALLED_SKILL_VERSION,
   LEGACY_AGENT_INSTRUCTIONS_FILE,
   LEGACY_PROGRESS,
@@ -201,8 +202,7 @@ export class Repo {
   missingInstalledSkillRoots(): string[] {
     return this.installedSkillRoots().filter(
       (root) =>
-        !this.pathExists(join(root, "SKILL.md")) ||
-        !this.pathExists(join(root, "VERSION")),
+        INSTALLED_SKILL_REQUIRED_FILES.some((relPath) => !this.pathExists(join(root, relPath))),
     );
   }
 

--- a/src/engine/runtime/asset-loader.ts
+++ b/src/engine/runtime/asset-loader.ts
@@ -6,6 +6,16 @@ export const BUNDLED_SKILL_ROOT = join("skills", SKILL_NAME);
 export const SKILL_ROOT = join(".agents", "skills", SKILL_NAME);
 export const CLAUDE_SKILL_ROOT = join(".claude", "skills", SKILL_NAME);
 export const INSTALLED_SKILL_ROOTS = [SKILL_ROOT, CLAUDE_SKILL_ROOT] as const;
+export const INSTALLED_SKILL_REQUIRED_FILES = [
+  "SKILL.md",
+  "VERSION",
+  join("references", "whitepaper.md"),
+  join("references", "onboarding.md"),
+  join("references", "source-workspace-installation.md"),
+  join("references", "principles.md"),
+  join("references", "ownership-and-naming.md"),
+  join("references", "upgrade-contract.md"),
+] as const;
 export const FIRST_TREE_INDEX_FILE = "WHITEPAPER.md";
 export const TREE_RUNTIME_ROOT = ".first-tree";
 export const TREE_VERSION = join(TREE_RUNTIME_ROOT, "VERSION");

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -27,6 +27,33 @@ export function useTmpDir(): TmpDir {
   return { path: dir };
 }
 
+function writeCurrentSkillReferences(skillRoot: string): void {
+  writeFileSync(
+    join(skillRoot, "references", "whitepaper.md"),
+    "# First Tree — White Paper\n",
+  );
+  writeFileSync(
+    join(skillRoot, "references", "onboarding.md"),
+    "# Context Tree Onboarding\n",
+  );
+  writeFileSync(
+    join(skillRoot, "references", "source-workspace-installation.md"),
+    "# Source/Workspace Installation Contract\n",
+  );
+  writeFileSync(
+    join(skillRoot, "references", "principles.md"),
+    "# Tree Principles\n",
+  );
+  writeFileSync(
+    join(skillRoot, "references", "ownership-and-naming.md"),
+    "# Node Naming and Ownership Model\n",
+  );
+  writeFileSync(
+    join(skillRoot, "references", "upgrade-contract.md"),
+    "# Upgrade Contract\n",
+  );
+}
+
 export function makeFramework(root: string, version = "0.1.0"): void {
   for (const skillRoot of [SKILL_ROOT, CLAUDE_SKILL_ROOT]) {
     mkdirSync(join(root, skillRoot, "references"), { recursive: true });
@@ -34,10 +61,7 @@ export function makeFramework(root: string, version = "0.1.0"): void {
       join(root, skillRoot, "SKILL.md"),
       "---\nname: first-tree\ndescription: installed\n---\n",
     );
-    writeFileSync(
-      join(root, skillRoot, "references", "whitepaper.md"),
-      "# First Tree — White Paper\n",
-    );
+    writeCurrentSkillReferences(join(root, skillRoot));
     writeFileSync(
       join(root, skillRoot, "VERSION"),
       `${version}\n`,
@@ -134,10 +158,7 @@ export function makeSourceSkill(root: string, version = "0.2.0"): void {
     join(frameworkRoot, "manifest.json"),
     "{}\n",
   );
-  writeFileSync(
-    join(skillRoot, "references", "whitepaper.md"),
-    "# About Context Tree\n",
-  );
+  writeCurrentSkillReferences(skillRoot);
   writeFileSync(
     join(frameworkRoot, "VERSION"),
     `${version}\n`,

--- a/tests/upgrade.test.ts
+++ b/tests/upgrade.test.ts
@@ -16,11 +16,13 @@ import { writeTreeBinding } from "#engine/runtime/binding-state.js";
 import {
   AGENT_INSTRUCTIONS_FILE,
   CLAUDE_INSTRUCTIONS_FILE,
+  CLAUDE_SKILL_ROOT,
   FIRST_TREE_INDEX_FILE,
   FRAMEWORK_VERSION,
   INSTALLED_PROGRESS,
   INSTALLED_SKILL_VERSION,
   LEGACY_AGENT_INSTRUCTIONS_FILE,
+  SKILL_ROOT,
   SOURCE_INTEGRATION_MARKER,
   TREE_PROGRESS,
   TREE_VERSION,
@@ -44,6 +46,21 @@ function expectFirstTreeIndexSymlink(root: string): void {
   expect(readlinkSync(path)).toBe(
     join(".agents", "skills", "first-tree", "references", "whitepaper.md"),
   );
+}
+
+function makeLegacyAboutInstalledSkill(root: string, version = "0.2.0"): void {
+  for (const skillRoot of [SKILL_ROOT, CLAUDE_SKILL_ROOT]) {
+    mkdirSync(join(root, skillRoot, "references"), { recursive: true });
+    writeFileSync(
+      join(root, skillRoot, "SKILL.md"),
+      "---\nname: first-tree\ndescription: installed\n---\n",
+    );
+    writeFileSync(
+      join(root, skillRoot, "references", "about.md"),
+      "# Legacy About\n",
+    );
+    writeFileSync(join(root, skillRoot, "VERSION"), `${version}\n`);
+  }
 }
 
 function writeStaleInjectContextSettings(
@@ -364,11 +381,11 @@ describe("runUpgrade", () => {
     );
   });
 
-  it("removes a managed legacy FIRST_TREE.md while installing WHITEPAPER.md", () => {
+  it("reinstalls an older 0.2.x skill before replacing FIRST_TREE.md with WHITEPAPER.md", () => {
     const repoDir = useTmpDir();
     const sourceDir = useTmpDir();
     makeSourceRepo(repoDir.path);
-    makeFramework(repoDir.path, "0.2.0");
+    makeLegacyAboutInstalledSkill(repoDir.path, "0.2.0");
     writeFileSync(
       join(repoDir.path, AGENT_INSTRUCTIONS_FILE),
       `${SOURCE_INTEGRATION_MARKER} old text\n`,
@@ -376,17 +393,6 @@ describe("runUpgrade", () => {
     writeFileSync(
       join(repoDir.path, CLAUDE_INSTRUCTIONS_FILE),
       `${SOURCE_INTEGRATION_MARKER} old text\n`,
-    );
-    writeFileSync(
-      join(
-        repoDir.path,
-        ".agents",
-        "skills",
-        "first-tree",
-        "references",
-        "about.md",
-      ),
-      "# Legacy About\n",
     );
     symlinkSync(
       join(".agents", "skills", "first-tree", "references", "about.md"),
@@ -400,6 +406,12 @@ describe("runUpgrade", () => {
 
     expect(result).toBe(0);
     expect(() => lstatSync(join(repoDir.path, "FIRST_TREE.md"))).toThrow();
+    expect(readFileSync(join(repoDir.path, INSTALLED_SKILL_VERSION), "utf-8").trim()).toBe("0.2.0");
+    expect(readFileSync(join(repoDir.path, SKILL_ROOT, "SKILL.md"), "utf-8")).toContain(
+      "description: test",
+    );
+    expect(existsSync(join(repoDir.path, SKILL_ROOT, "references", "about.md"))).toBe(false);
+    expect(existsSync(join(repoDir.path, SKILL_ROOT, "references", "whitepaper.md"))).toBe(true);
     expectFirstTreeIndexSymlink(repoDir.path);
     expect(existsSync(join(repoDir.path, INSTALLED_PROGRESS))).toBe(false);
   });


### PR DESCRIPTION
## Summary
Follow-up to #99.

Same-minor `first-tree upgrade` runs could treat an older `0.2.x` install as current even when the installed skill payload still only had `about.md`. That left `WHITEPAPER.md` pointing at a missing `references/whitepaper.md`.

- treat missing required skill payload references as an incomplete installed skill
- force reinstall when a same-minor install is missing `whitepaper.md` and the other required references
- add a regression test that seeds a real pre-rename `0.2.x` install and updates shared test fixtures to match the shipped payload layout

## Validation
- `pnpm test -- tests/upgrade.test.ts tests/init.test.ts tests/repo.test.ts tests/bind.test.ts tests/publish.test.ts` (Vitest executed the full suite in this workspace: 27 files / 383 tests passed)
- `pnpm typecheck`
