### PR TITLE
docs: add agent citation and PR cross-reference rules

### DIFF
--- a/assets/framework/templates/agents.md.template
+++ b/assets/framework/templates/agents.md.template
@@ -33,6 +33,7 @@ Do not skip this. The tree is already a compression of expensive knowledge — c
 - **The tree is not for execution details.** Function signatures, DB schemas, API endpoints, ad copy — those live in source systems. The tree captures the *why* and *how things connect*.
 - **Bring source repos in as additional working directories.** When you need to inspect or edit code, open the relevant source repositories alongside this tree instead of copying execution detail into the tree.
 - **Respect ownership.** Each node declares owners in its frontmatter. If your changes touch a domain you don't own, flag it — the owner needs to review.
+- **Cite the tree when it matters.** When a tree node influenced your decision — changed your approach, ruled out an option, or surfaced a constraint — mention it naturally: "Based on kael/chat-ux.md, streaming is required here" or "This conflicts with the constraint in platform/auth.md." Don't cite every read; cite the ones that shaped the outcome.
 
 ## After Every Task
 
@@ -43,6 +44,7 @@ Ask yourself: **Does the tree need updating?**
 - Not every task changes the tree, but the question must always be asked.
 - If the task changed decisions, constraints, rationale, or ownership, open the tree PR first. Then open the source/workspace code PR.
 - If the task changed only implementation details, skip the tree PR and open only the source/workspace code PR.
+- **Link tree PRs and code PRs.** When a task produces both a tree PR and a code PR, cross-reference them in the PR body: tree PR links to `Code PR: owner/repo#N`, code PR links to `Tree PR: owner/tree-repo#N`.
 
 ## Reference
 


### PR DESCRIPTION
## Summary
- Add "Cite the tree when it matters" rule to During the Task section — agents mention tree nodes that influenced their decisions
- Add "Link tree PRs and code PRs" rule to After Every Task section — tree PR and code PR cross-reference each other in PR body

## Motivation
Tree's value is invisible to users — agents read it and make better decisions, but users don't see the connection. These two rules make tree value passively visible:
1. Daily work: agents cite tree sources when decisions are influenced
2. PR review: reviewers see the decision-execution link between tree and code PRs

## Scope of this PR
This PR **only updates the bundled template** (`assets/framework/templates/agents.md.template`). It affects:
- **New tree repos** initialized with `first-tree init` after this version — the new rules are written into AGENTS.md automatically
- **Existing tree repos** — NOT auto-refreshed. Per the current CLI design (`upgrade.ts:282-289`), framework block updates are surfaced as a manual task in `progress.md` after running `first-tree upgrade`, instructing maintainers to "compare the framework section in AGENTS.md with the bundled template and update the text between the markers."

Whether to switch to automatic framework block refresh is a separate design decision (see "Follow-up" below) and intentionally out of scope here.

## Test plan
- [ ] Run `first-tree init` in a fresh repo, verify the generated AGENTS.md contains both new rules
- [ ] Run `first-tree upgrade` in an existing tree repo, verify `progress.md` includes the "Compare the framework section..." manual task pointing maintainers to sync the new rules

## Follow-up (separate PR/issue)
Discuss whether `first-tree upgrade` should automatically refresh the AGENTS.md framework block (analogous to how `SOURCE_INTEGRATION` block is auto-replaced in `source-integration.ts:214-228`). Open questions:
- Replace the manual task in `upgrade.ts:282-289`?
- How to handle AGENTS.md vs CLAUDE.md when they're separate files (not symlinked)?
- How to handle user customizations inside the framework block, even though the marker forbids them?

🤖 Generated with [Claude Code](https://claude.com/claude-code)