### PR TITLE
docs(migration): pre-work specs for breeze TS rewrite

### DIFF
--- a/docs/migration/01-http-api-contract.md
+++ b/docs/migration/01-http-api-contract.md
@@ -1,0 +1,276 @@
+# 01 — HTTP / SSE API Contract
+
+Source of truth: `first-tree-breeze/breeze-runner/src/http.rs` (384 lines) and
+the embedded `first-tree-breeze/breeze-runner/src/dashboard.html` (193 lines).
+Server is spawned from `service.rs:413-429` (`spawn_http_server`) as part of
+`run_forever`. This doc pins the observed behaviour of that server so the TS
+port can reproduce it byte-for-byte.
+
+## 1. Listener
+
+- Default bind: `127.0.0.1:7878`. Port is `Config::http_port`
+  (`config.rs:136`, default literal `7878` at `config.rs:200, 335`). Overridable
+  via `--http-port` / `BREEZE_HTTP_PORT`.
+- Loopback only. `http.rs:28-32` explicitly rejects any non-`127.0.0.1` bind
+  address with `"refusing to bind http server on non-loopback address ..."`.
+  The TS port must preserve this invariant — never bind to `0.0.0.0`.
+- Disabled by `--no-http` / `BREEZE_HTTP_DISABLED` (`config.rs:201, 246`). When
+  disabled the server thread is not spawned (`service.rs:360-362`).
+- Listener is set to non-blocking with a 100 ms poll loop, so shutdown via the
+  shared `stop: Arc<AtomicBool>` can exit within ~100 ms (`http.rs:33-62`).
+- Each accepted connection is handled on its own thread
+  (`http.rs:47-51`). There is no connection pool limit; under load the TS port
+  should match this "one task per connection" shape or use Node's `http` server
+  with equivalent semantics.
+- Per-connection read timeout is 5 s (`http.rs:75`). Stream is switched back to
+  blocking mode before reading the request line.
+- HTTP parsing is hand-rolled and extremely minimal (`http.rs:116-136`):
+  it reads the first line, then drains headers until an empty line. Headers
+  themselves are discarded; no `Host`, `Accept`, or `Authorization` parsing.
+
+## 2. Routes
+
+Routing is a simple exact-match after stripping the query string (`http.rs:148-168`).
+Only `GET` is accepted; everything else falls through to 404.
+
+| Route                                | Method | Response                    | Notes |
+|--------------------------------------|--------|-----------------------------|-------|
+| `/`, `/dashboard`, `/index.html`     | GET    | 200 text/html (dashboard)   | Same handler |
+| `/healthz`                           | GET    | 200 text/plain `ok\n`       | Liveness probe |
+| `/inbox`                             | GET    | 200 application/json passthrough of `~/.breeze/inbox.json` | 404 if file missing |
+| `/activity`                          | GET    | 200 application/json array (last 200 lines) | Always 200, empty array if file missing |
+| `/events`                            | GET    | 200 text/event-stream (SSE) | Long-lived |
+| anything else                        | GET    | 404 text/plain `not found\n`| |
+| any non-GET                          | any    | 404 text/plain `not found\n`| Including `POST /inbox` etc. |
+
+Query strings are stripped but otherwise ignored. The unit test
+`http.rs:360` asserts `GET /inbox?all=1 HTTP/1.1 → Route::Inbox` — so `?all=1`
+on `/inbox` is legal but has no effect.
+
+### 2.1 `GET /` / `/dashboard` / `/index.html`
+
+`write_dashboard` (`http.rs:92-109`):
+
+```
+HTTP/1.1 200 OK\r\n
+Content-Type: text/html; charset=utf-8\r\n
+Content-Length: <len>\r\n
+Cache-Control: no-store\r\n
+Connection: close\r\n
+\r\n
+<DASHBOARD_HTML>
+```
+
+- `DASHBOARD_HTML` is compiled in via `include_str!("dashboard.html")`
+  (`http.rs:90`). The TS port must ship the same HTML file verbatim (or an
+  equivalent) and serve it with identical headers.
+- Response closes the connection immediately (`Connection: close`).
+
+### 2.2 `GET /healthz`
+
+`write_plain(stream, 200, "ok\n")` (`http.rs:82`, helper at `http.rs:170-185`).
+Emits:
+
+```
+HTTP/1.1 200 OK\r\n
+Content-Type: text/plain; charset=utf-8\r\n
+Content-Length: 3\r\n
+Cache-Control: no-store\r\n
+Connection: close\r\n
+\r\n
+ok
+```
+
+(The trailing newline is part of the body; `Content-Length: 3`.)
+
+### 2.3 `GET /inbox`
+
+Handler: `write_json_file(stream, &inbox_dir.join("inbox.json"))`
+(`http.rs:83`, `187-207`).
+
+- If `~/.breeze/inbox.json` exists: reads the file as UTF-8 and streams it back
+  unchanged with `Content-Type: application/json; charset=utf-8`.
+- If missing: returns 404 with body `inbox.json not found\n` (not JSON).
+- The inbox file itself is produced atomically by the fetcher
+  (`fetcher.rs:583-598` — write tmp, rename). See doc #2 for the JSON shape.
+- No content compression. No streaming — the whole file is buffered into the
+  response string.
+
+### 2.4 `GET /activity`
+
+Handler: `write_activity_tail(stream, &inbox_dir.join("activity.log"), 200)`
+(`http.rs:84`, `209-249`).
+
+- Reads `~/.breeze/activity.log`, which is JSONL (one JSON object per line).
+  See doc #2 for entry schemas.
+- Keeps only the **last 200 non-empty lines** (`tail_as_json_array`,
+  `http.rs:230-249`).
+- Concatenates them into a JSON array by string-joining the lines with commas
+  and wrapping in `[...]` — the code does NOT re-parse the JSON. If a line in
+  `activity.log` is malformed JSON, the array will be malformed too.
+- If the file is missing or unreadable: body is literal `[]` (still 200 OK).
+- Response:
+
+```
+HTTP/1.1 200 OK\r\n
+Content-Type: application/json; charset=utf-8\r\n
+Content-Length: <len>\r\n
+Cache-Control: no-store\r\n
+Connection: close\r\n
+\r\n
+[{...},{...},...]
+```
+
+The 200-line limit is hardcoded. No `?limit=` support today.
+
+### 2.5 `GET /events` (Server-Sent Events)
+
+Handler: `stream_events(stream, bus, stop)` (`http.rs:85`, `252-332`).
+
+Response headers:
+
+```
+HTTP/1.1 200 OK\r\n
+Content-Type: text/event-stream\r\n
+Cache-Control: no-store\r\n
+Connection: keep-alive\r\n
+X-Accel-Buffering: no\r\n
+\r\n
+```
+
+(Note: no `Content-Length`; the stream is indefinite.)
+
+Immediately after headers, the server sends a hello frame:
+
+```
+event: ready
+data: "subscribed"
+
+```
+
+(`http.rs:265`) so the dashboard's `addEventListener("ready", ...)` fires.
+
+After that the server blocks on a bounded `recv_timeout(15 s)` on the in-process
+bus (`http.rs:267-287`). There are two event kinds defined in `bus.rs:11-19`:
+
+#### `event: inbox`
+
+Fired whenever the fetcher has finished a poll
+(`fetcher.rs:124-129`). Payload (encoded via `Json::Object`, single-line,
+deterministic key order):
+
+```
+event: inbox
+data: {"last_poll":"2026-04-16T20:15:30Z","total":422,"new_count":3}
+
+```
+
+- `last_poll`: ISO-8601 UTC, seconds precision (see `format_utc_iso` in
+  `fetcher.rs:690`).
+- `total`: `i64` — total notifications in the inbox after this poll.
+- `new_count`: `i64` — notifications whose `breeze_status == "new"`.
+
+#### `event: activity`
+
+Fired once per activity log event produced by the fetcher diff
+(`fetcher.rs:130-132`). The `data:` payload is the exact JSON line the fetcher
+appends to `activity.log`. See doc #2 for those shapes (`new` and `transition`).
+
+```
+event: activity
+data: {"ts":"2026-04-16T20:15:30Z","event":"new","id":"...","type":"PullRequest","repo":"...","title":"...","url":"..."}
+
+```
+
+Note: `bin/breeze-status-manager` (the shell script) appends additional event
+kinds (`claimed`, `transition` with `by`/`reason`) directly to `activity.log`
+but it does NOT publish through the bus, so those never flow over SSE. The TS
+port should decide whether to unify that (the statusline-manager is a shell
+script; see doc #3).
+
+#### Keep-alive
+
+Every 15 s of idle, the server writes a comment line `: ping\n\n`
+(`http.rs:282`) to keep intermediate proxies from closing the stream.
+
+#### Disconnect handling
+
+If `write_all` errors with `"Broken pipe"` or `"closed"`, the handler returns
+`Ok(())` silently (`http.rs:273-276`). Any other write error propagates.
+
+Each subscriber gets its own `BusReceiver` via `bus.subscribe()`; subscribers
+that drop are pruned on the next publish (`bus.rs:41-46`).
+
+## 3. SSE framing
+
+`send_sse` (`http.rs:310-332`):
+
+- Writes `event: <name>\n`.
+- For each line of `data`, writes `data: <line>\n`. Multi-line data is emitted
+  as multiple `data:` lines.
+- If the data ends with `\n`, an empty `data: \n` is also appended (preserving
+  the trailing newline per SSE spec).
+- Ends with a blank line.
+- Flushes after every frame.
+
+## 4. Static assets
+
+Only `dashboard.html` is served. There are **no separate CSS or JS files** —
+the dashboard embeds all CSS in `<style>` and all JS in `<script>`
+(`dashboard.html:7-67` CSS, `93-190` JS). The TS port does not need a static
+file handler; a single HTML blob is sufficient.
+
+The dashboard client makes two outbound requests:
+- `fetch("/inbox", { cache: "no-store" })` on load and whenever SSE fires
+  (`dashboard.html:149-159, 168-169`).
+- `new EventSource("/events")` (`dashboard.html:161-174`).
+
+It never calls `/activity` directly in the shipped dashboard.
+
+## 5. Auth / CORS
+
+**No auth, no CORS headers.** The loopback bind is the only access control.
+The TS port must preserve this: no `Access-Control-Allow-Origin`, no cookies,
+no tokens. If we bind to `127.0.0.1` we cannot easily expose this dashboard to
+other machines without also adding an auth layer. Out of scope for the port.
+
+## 6. Error response format
+
+Every error path uses `write_plain(stream, <code>, <body>)` which returns
+`text/plain` with `Cache-Control: no-store` and `Connection: close`. Bodies
+observed:
+
+- `404 not found\n` — unknown route or non-GET method
+- `404 inbox.json not found\n` — `/inbox` when the file is absent
+
+`reason_phrase` (`http.rs:334-340`) only knows `200 → "OK"` and `404 → "Not
+Found"`. Any other code would emit an empty reason — but no other code is used
+today.
+
+There is no JSON error envelope and no structured error type. If TS chooses to
+add JSON errors, it should do so only on new endpoints.
+
+## 7. Things the Rust server does not do
+
+Recorded here so the TS port doesn't over-engineer:
+
+- No WebSocket — only SSE.
+- No HTTP/2, no TLS, no chunked transfer (responses rely on `Content-Length`).
+- No request body parsing; all routes are `GET` with no body.
+- No partial reads of `inbox.json` — the full file is sent every time.
+- No log of HTTP accesses (only errors are printed to stderr).
+- No rate limiting, no compression.
+- The server shares the process with the poll loop, broker, and runners; there
+  is no separate process boundary.
+
+## 8. Unverified / needs TS verification
+
+- **Line 322-324 of `http.rs`** (`data.ends_with('\n')` branch) emits a spurious
+  trailing empty `data: \n` followed by the frame-terminating blank line. This
+  is subtle and it is unclear whether existing JS consumers rely on it. Phase 3
+  should capture a sample raw SSE stream with `curl -N http://127.0.0.1:7878/events`
+  and diff against the TS output byte-for-byte.
+- The dashboard's `new EventSource` auto-reconnects on error
+  (`dashboard.html:170-173`). The Rust server does not hint `retry:`. The TS
+  server should match (omit `retry:`) unless we deliberately add reconnect
+  tuning.

--- a/docs/migration/02-inbox-store-schema.md
+++ b/docs/migration/02-inbox-store-schema.md
@@ -1,0 +1,434 @@
+# 02 — `~/.breeze/` Store Schema
+
+Source of truth:
+- `first-tree-breeze/breeze-runner/src/fetcher.rs` (981 lines, esp. `write_inbox`,
+  `append_activity_events`, `InboxEntry`, `ActivityEvent`, `resolve_inbox_dir`)
+- `first-tree-breeze/breeze-runner/src/store.rs` (180 lines — runner store)
+- `first-tree-breeze/breeze-runner/src/json.rs` (140 lines — encoder)
+- `first-tree-breeze/breeze-runner/src/lock.rs`
+- `first-tree-breeze/breeze-runner/src/task.rs` (`ThreadRecord`)
+- `first-tree-breeze/bin/breeze-status-manager` (claims directory)
+- Live `~/.breeze/inbox.json` and `~/.breeze/activity.log` observed on this
+  machine on 2026-04-16 (redacted examples below).
+
+The store is split into two trees with different ownership:
+
+```
+~/.breeze/                       (shared — statusline + skill + poller read)
+├── inbox.json                   (sole writer: Rust fetcher OR bin/breeze-poll)
+├── activity.log                 (writers: Rust fetcher AND bin/breeze-status-manager)
+└── claims/                      (writers: bin/breeze-status-manager; reader: Rust fetcher cleanup)
+    └── <notification-id>/
+        ├── claimed_at           (ISO-8601 UTC)
+        ├── claimed_by           (session id)
+        └── action               (free-text label)
+```
+
+```
+~/.breeze/runner/                (Rust daemon's private state)
+├── threads/<fileid>.env         (per-thread bookkeeping)
+├── tasks/<task-id>/
+│   ├── task.env                 (per-task metadata)
+│   ├── prompt.txt               (prompt fed to the agent)
+│   ├── runner-output.txt        (agent's output_last_message content)
+│   ├── runner-stdout.log
+│   ├── runner-stderr.log
+│   └── snapshot/                (frozen gh API pulls for the agent)
+│       ├── task-summary.env
+│       ├── README.txt
+│       ├── subject.json + subject.json.meta
+│       ├── latest-comment.json + .meta
+│       ├── pr-view.json + .meta
+│       ├── pr.diff + .meta
+│       ├── pr-reviews.json + .meta
+│       ├── issue-view.json + .meta        (issue path only)
+│       └── issue-comments.json + .meta
+├── repos/<owner>__<name>.git/   (bare mirrors)
+├── workspaces/<repo-slug>/<kind>-<stable-id>/  (git worktrees)
+├── locks/<host>__<login>__<profile>/
+│   └── lock.env
+├── broker/
+│   ├── bin/gh                   (POSIX shim script)
+│   ├── requests/req-<epoch>-<pid>-<rand>/
+│   │   ├── argv.txt
+│   │   ├── cwd.txt
+│   │   ├── gh_host.txt          (optional)
+│   │   ├── gh_repo.txt          (optional)
+│   │   ├── stdout.txt           (written by broker)
+│   │   ├── stderr.txt           (written by broker)
+│   │   └── response.env         (sentinel for shim; rm -rf'd by shim after read)
+│   └── history/<fingerprint-id>/
+│       ├── stdout.txt
+│       ├── stderr.txt
+│       └── response.env
+├── logs/breeze-runner-<epoch>.log   (stdout+stderr from nohup/launchd)
+├── runtime/status.env
+└── launchd/com.breeze.runner.<login>.<profile>.plist   (macOS only)
+```
+
+`resolve_inbox_dir` (`fetcher.rs:652-657`) honors `$BREEZE_DIR` and otherwise
+uses `$HOME/.breeze`. The runner home defaults to `$HOME/.breeze/runner`
+(`config.rs:166-167`, honors `$BREEZE_HOME`). So the shared shell-visible tree
+and the Rust daemon's private tree are separate by convention.
+
+## 1. `~/.breeze/inbox.json`
+
+Produced by `write_inbox` (`fetcher.rs:583-599`) — **atomic** rename from
+`inbox.json.tmp` to `inbox.json`. Entry encoding is in
+`entry_to_json` (`fetcher.rs:601-631`).
+
+Top-level shape:
+
+```jsonc
+{
+  "last_poll": "2026-04-16T20:15:30Z",   // string; ISO-8601 UTC, seconds-precision
+  "notifications": [ /* InboxEntry objects, sorted (see below) */ ]
+}
+```
+
+### 1.1 `InboxEntry` fields (`fetcher.rs:22-38` and `entry_to_json`)
+
+All fields are always present (the encoder never omits keys); nullable fields
+use JSON `null`.
+
+| Key             | JSON type            | Source/meaning | Notes |
+|-----------------|----------------------|----------------|-------|
+| `id`            | string               | GitHub notification thread id | Opaque; stable across polls |
+| `type`          | string               | `subject.type` from `/notifications` | E.g. `PullRequest`, `Issue`, `Discussion`, `Release`, `CheckSuite`, `Commit` (last two filtered upstream, see `fetcher.rs:15`) |
+| `reason`        | string               | Raw GitHub `reason` | E.g. `review_requested`, `mention`, `team_mention`, `comment`, `assign`, `author`, `manual`, `subscribed`, `participating` |
+| `repo`          | string               | `repository.full_name` (`owner/name`) | |
+| `title`         | string               | `subject.title` | Free-text |
+| `url`           | string               | `subject.url` (API URL) | May point at a PR or issue API path |
+| `last_actor`    | string               | `subject.latest_comment_url // subject.url` | Despite the name, this is a URL, not a login. (Verified in live sample: it holds `https://api.github.com/.../issues/comments/<id>` values.) |
+| `updated_at`    | string               | `updated_at` from GitHub | ISO-8601 UTC |
+| `unread`        | bool                 | `unread` | |
+| `priority`      | number (int64)       | `priority_for_reason(reason)` (`fetcher.rs:370-378`) | Lower = more urgent. See table below |
+| `number`        | number or null       | Trailing digits parsed from `url` (`fetcher.rs:380-390`) | null for Discussions / non-numeric subjects |
+| `html_url`      | string               | Rebuilt `https://<host>/<repo>/pull/<n>` or `/issues/<n>` (`fetcher.rs:392-399`) | Falls back to `https://<host>/<repo>` when no number |
+| `gh_state`      | string or null       | From GraphQL label enrichment | `"OPEN"`, `"CLOSED"`, `"MERGED"`, or null |
+| `labels`        | array of strings     | From GraphQL label enrichment (`first: 10`) | Empty array if none or if enrichment skipped |
+| `breeze_status` | string               | Derived (`compute_breeze_status`, `fetcher.rs:353-368`) | One of `"new" | "wip" | "human" | "done"` |
+
+`priority` table (`fetcher.rs:370-378` — note these are **inbox display
+priorities**, lower = more urgent, distinct from the dispatcher `priority_for`
+in `classify.rs` which is higher = more urgent):
+
+| `reason`            | `priority` |
+|---------------------|------------|
+| `review_requested`  | 1          |
+| `mention`           | 2          |
+| `assign`            | 3          |
+| `participating`     | 4          |
+| anything else       | 5          |
+
+Sort order (`sort_entries`, `fetcher.rs:401-408`): `priority` asc, then
+`updated_at` desc, then `id` asc.
+
+### 1.2 Real example (redacted, from live `~/.breeze/inbox.json`)
+
+```json
+{
+  "last_poll": "2026-04-16T20:15:30Z",
+  "notifications": [
+    {
+      "id": "23576674030",
+      "type": "PullRequest",
+      "reason": "author",
+      "repo": "serenakeyitan/paperclip-tree",
+      "title": "fix(tree): salvage nya1 member node from closed sync PR 282",
+      "url": "https://api.github.com/repos/serenakeyitan/paperclip-tree/pulls/290",
+      "last_actor": "https://api.github.com/repos/serenakeyitan/paperclip-tree/issues/comments/4258143984",
+      "updated_at": "2026-04-16T07:24:28Z",
+      "unread": false,
+      "priority": 5,
+      "number": 290,
+      "html_url": "https://github.com/serenakeyitan/paperclip-tree/pull/290",
+      "gh_state": "OPEN",
+      "labels": [],
+      "breeze_status": "new"
+    }
+  ]
+}
+```
+
+### 1.3 Writer invariants
+
+- Written via `write_text(tmp) + fs::rename(tmp, inbox.json)` in
+  `fetcher.rs:594-597`. On POSIX this is atomic w.r.t. concurrent readers.
+- Encoder guarantees no internal whitespace (`json.rs` builds a compact string).
+  The live file observed has whitespace — that is from the legacy
+  `bin/breeze-poll` bash script (`jq ... > file`), NOT the Rust writer. Readers
+  must cope with both pretty-printed and compact inbox JSON.
+- The Rust fetcher is the **sole writer** under the `run`/`run-once` daemon.
+  `bin/breeze-status-manager set` however *also* does a best-effort inline
+  `jq` rewrite of `inbox.json` (`breeze-status-manager:143-149`) to update the
+  local `breeze_status` optimistically before the next poll confirms it. This
+  violates single-writer cleanly, and Phase 3 should decide whether to keep
+  that behaviour. The races are short (the user-set label gets overwritten on
+  the next poll anyway).
+
+### 1.4 Reader contract
+
+Documented callers:
+- `/inbox` HTTP route (see doc #1) — passthrough.
+- `bin/breeze-status-manager` — uses `jq` to read/write selected fields.
+- `bin/breeze-statusline-wrapper` and the `/breeze` skill (not in this repo).
+
+Unverified: the `bin/breeze-statusline-wrapper` script is 7 lines and likely
+execs `bin/breeze-status`. Check before removal.
+
+## 2. `~/.breeze/activity.log`
+
+Append-only JSONL (one JSON object per line, terminated by `\n`).
+Produced by two writers:
+
+### 2.1 Rust fetcher writer (`fetcher.rs:633-650`)
+
+`append_activity_events` reads the existing file, ensures a trailing newline,
+then appends one JSON line per `ActivityEvent`. Not atomic across processes:
+the Rust code uses `write_text` (full file rewrite), so a concurrent reader
+that opens mid-write might see a truncated tail. In practice all writes happen
+from one process.
+
+Event kinds produced by the fetcher (`fetcher.rs:472-537`):
+
+**`event: "new"`** — a notification id was not in the previous poll state.
+
+```json
+{"ts":"2026-04-16T20:15:30Z","event":"new","id":"23576674030","type":"PullRequest","repo":"owner/repo","title":"...","url":"https://github.com/owner/repo/pull/290"}
+```
+
+Fields: `ts, event, id, type, repo, title, url`. Note: `url` here is the
+`html_url`, not the API url.
+
+**`event: "transition"`** — a notification's `breeze_status` changed since
+the previous poll. The fetcher intentionally suppresses `new → done`
+transitions that are purely from GitHub auto-close/merge (`fetcher.rs:564-568`).
+
+```json
+{"ts":"...","event":"transition","id":"...","type":"...","repo":"...","title":"...","url":"...","from":"new","to":"wip"}
+```
+
+### 2.2 `bin/breeze-status-manager` writer
+
+This shell script appends its own events directly via `>> "$LOG_FILE"`
+(`breeze-status-manager:39-41`). Events it writes:
+
+**`event: "transition"`** (with extra `by` + `reason` fields):
+
+```json
+{"ts":"2026-04-16T20:15:30Z","event":"transition","id":"...","type":"...","repo":"...","title":"...","url":"...","by":"session-id","reason":"why","from":"new","to":"wip"}
+```
+
+**`event: "claimed"`** (claim acquired):
+
+```json
+{"ts":"...","event":"claimed","id":"...","type":"...","repo":"...","title":"...","url":"...","by":"session-id","action":"working"}
+```
+
+### 2.3 Legacy bash `bin/breeze-poll` writer
+
+Also appends events when used as the legacy poller. Observed on this machine
+(the Rust daemon is not currently running):
+
+**`event: "poll"`** — only emitted when the bash poller detected new
+notifications on this cycle (`bin/breeze-poll:262-265`):
+
+```json
+{"ts":"2026-04-16T20:15:30Z","event":"poll","count":422}
+```
+
+The Rust poller does NOT emit `poll` events — Phase 3 should decide whether to
+preserve this for dashboards/log-viewers that look for it (`breeze-watch`).
+
+### 2.4 Reader contract
+
+- `/activity` HTTP endpoint tails the last 200 lines (see doc #1).
+- `bin/breeze-watch` tails the log for a live dashboard.
+- SSE `activity` events carry one-line payloads matching 2.1 exactly.
+
+No rotation today. The file grows unboundedly. Phase 3 should add rotation —
+the TS port is a natural place to introduce it.
+
+## 3. `~/.breeze/claims/`
+
+Owned by `bin/breeze-status-manager` (`breeze-status-manager:172-220`).
+Cleaned up by the Rust fetcher's `cleanup_expired_claims`
+(`fetcher.rs:659-688`, called from `service.rs:221, 399`).
+
+Layout: `~/.breeze/claims/<notification-id>/` with three files:
+
+- `claimed_at` — ISO-8601 UTC string produced by `date -u +%Y-%m-%dT%H:%M:%SZ`
+- `claimed_by` — free-text session id (the caller passes `<session-id>`)
+- `action` — free-text label (default `working`)
+
+Claim semantics:
+- Atomic acquisition via `mkdir` (`breeze-status-manager:177`) — the one
+  process that wins the mkdir writes the three files; losers read the existing
+  claim.
+- Timeout: 300 s (`CLAIM_TIMEOUT=300` in `breeze-status-manager:29` and
+  `claim_is_stale` check `service.rs:221` via `cleanup_expired_claims(..., 300)`).
+- Stale claims (older than 300 s) can be overwritten by a new claimant
+  (`breeze-status-manager:192-213`).
+- Cleanup path: `fetcher.rs:659-688` walks `~/.breeze/claims/`, parses each
+  `claimed_at` via `parse_github_timestamp_epoch`, and `rm -rf`'s directories
+  older than 300 s.
+
+## 4. `~/.breeze/runner/runtime/status.env`
+
+Key=value file (see `util.rs` `parse_kv_lines` / `write_lines`). Written by
+`Service::refresh_runtime` every loop tick (`service.rs:944-994`) and read at
+startup (`service.rs:92-99`).
+
+Keys observed:
+- `last_poll_epoch` — unix seconds
+- `last_identity` — `<login>@<host>`
+- `allowed_repos` — comma-separated or `"all"`
+- `active_tasks` — integer count
+- `queued_tasks` — integer count
+- `last_note` — free-text, multiline-encoded (`util::encode_multiline`)
+- `active_titles` — `;`-separated `<task_id>:<encoded-title>`
+- `next_search_reconcile_epoch` — unix seconds
+- `last_poll_warning` — free-text, multiline-encoded
+
+Atomicity: `write_lines` → `write_text` → plain `fs::write` — not atomic. A
+concurrent reader could theoretically see a partial file. In practice only one
+process writes; readers that fail to parse a line simply drop it.
+
+## 5. `~/.breeze/runner/threads/<stable-file-id>.env`
+
+Per-thread bookkeeping for dispatcher de-duplication / retry. Keys defined
+in `task.rs:156-209` (`ThreadRecord`):
+
+- `thread_key` (multiline-encoded) — canonical API path, e.g. `/repos/o/r/pulls/12`
+- `repo` (multiline-encoded) — `owner/name`
+- `last_seen_updated_at` (multiline-encoded) — GitHub timestamp most recently observed
+- `last_handled_updated_at` (multiline-encoded) — timestamp at which we last marked handled/skipped
+- `last_result` (multiline-encoded) — `"handled" | "skipped" | "failed" | ...`
+- `failure_count` — u32
+- `next_retry_epoch` — u64 seconds; 0 if immediate
+- `last_task_id` (multiline-encoded) — most recent task id for this thread
+
+Filename is `stable_file_id(thread_key).env` — a hash so `/` in paths doesn't
+break the filesystem (`store.rs:49-51`). Reader: `load_thread_record`
+(`store.rs:53-70`). Writer: `save_thread_record` (`store.rs:72-74`).
+
+## 6. `~/.breeze/runner/tasks/<task-id>/task.env`
+
+Per-task metadata, also key=value (`store.rs:80-98`). Task id format is
+`task-<epoch>-<stable-id>` (`service.rs:684`). Keys written by the dispatcher
+(`service.rs:717-752`, completion at `884-930`, setup-failure at `813-856`):
+
+- `task_id`
+- `status` — `"running" | "handled" | "skipped" | "failed" | "simulated" | "orphaned"`
+- `repo`, `workspace_repo`, `thread_key`, `title`, `kind`, `reason`
+- `workspace_path`, `mirror_dir`, `repo_url`, `snapshot_dir`, `gh_shim_dir`
+- `started_at` (epoch seconds)
+- `finished_at` (epoch seconds, absent while running)
+- `updated_at` (original GitHub timestamp)
+- `source` — `"notifications" | "review-search" | "assigned-search" | "recovered-running"`
+- `runner` — `"codex" | "claude"` (the runner that actually won)
+- `summary` — multiline-encoded free-text
+- `runner_output_path`
+
+On startup the dispatcher scans these dirs (`service.rs:570-641`) to recover
+any task left in `status=running` from a prior crashed run: it rewrites such
+tasks to `status=orphaned` and re-enqueues them.
+
+Workspaces referenced by `workspace_path` get GC'd after
+`workspace_ttl_secs` (default 3 days) by `Store::cleanup_old_workspaces`
+(`store.rs:127-179`).
+
+## 7. `~/.breeze/runner/locks/<host>__<login>__<profile>/lock.env`
+
+`LockInfo` (`lock.rs:10-56`). Keys:
+
+- `pid` — u32
+- `host`, `login`, `profile` — strings
+- `heartbeat_epoch`, `started_epoch` — u64
+- `active_tasks` — usize
+- `note` (multiline-encoded)
+
+Acquisition uses `mkdir` for atomic exclusion (`lock.rs:75-103`). Heartbeat is
+refreshed every loop iteration via `refresh()`. A lock is considered stale if
+`now - heartbeat_epoch > 20*60` **or** `kill -0 pid` fails (`lock.rs:174-185`).
+Lock dir is removed on `Drop` (`lock.rs:133-137`) — i.e. only on clean exit.
+
+## 8. `~/.breeze/runner/broker/`
+
+The broker is the process-local `gh` serializer (see doc #4). Filesystem
+contract:
+
+- `broker/bin/gh` — POSIX shim script, written at startup (`broker.rs:35`) with
+  mode `0o755`. The script source is `SHIM_SCRIPT` (`broker.rs:390-446`). It
+  serializes `gh` calls from runner subprocesses by dropping a request dir and
+  polling for a response.
+- `broker/requests/req-<epoch>-<pid>-<suffix>/`
+  - `cwd.txt`, `argv.txt` (one arg per line), `gh_host.txt` (optional),
+    `gh_repo.txt` (optional) — written by the shim.
+  - `stdout.txt`, `stderr.txt`, `response.env` — written by the broker.
+    `response.env` is the sentinel the shim polls for (keys: `status_code`,
+    `stdout_path`, `stderr_path`, `completed_at_ms`).
+  - The shim `rm -rf`'s its own request dir after reading the response
+    (`broker.rs:444`). On start, the broker also purges any leftover request
+    dirs (`broker.rs:61-66`).
+- `broker/history/<stable-id>/` — mutation response cache, TTL 15 min
+  (`broker.rs:220`). Files: `stdout.txt`, `stderr.txt`, `response.env` (keys
+  `status_code`, `completed_at_ms`). Used for idempotent replay of mutating
+  `gh` commands (see `mutation_fingerprint`, `broker.rs:222-272`).
+
+## 9. `~/.breeze/runner/logs/`
+
+`breeze-runner-<epoch>.log` per start (`service.rs:260-261`). Receives the
+merged stdout+stderr of the background process.
+
+## 10. `~/.breeze/runner/launchd/`
+
+macOS only. Single file `com.breeze.runner.<sanitized-login>.<sanitized-profile>.plist`
+(`service.rs:1073-1086, 1176-1206`). Not atomic; overwritten on each
+`start_with_launchctl`.
+
+## 11. Who-writes-what matrix
+
+| Path                                          | Writer(s)                                           | Readers |
+|-----------------------------------------------|-----------------------------------------------------|---------|
+| `~/.breeze/inbox.json`                        | Rust `Fetcher::poll_once` (atomic); **also** `bin/breeze-status-manager` optimistic `jq` rewrite; **also** legacy `bin/breeze-poll` | HTTP `/inbox`, dashboard, `bin/breeze-status-manager`, statusline, `/breeze` skill |
+| `~/.breeze/activity.log`                      | Rust fetcher (append); `bin/breeze-status-manager` (append); legacy `bin/breeze-poll` (append) | HTTP `/activity`, SSE, `bin/breeze-watch` |
+| `~/.breeze/claims/`                           | `bin/breeze-status-manager`                         | Rust `cleanup_expired_claims`, `get` in status-manager |
+| `~/.breeze/runner/runtime/status.env`         | Rust `Service::refresh_runtime`                     | Rust bootstrap, `breeze-runner status` |
+| `~/.breeze/runner/threads/*.env`              | Rust `Store::save_thread_record`                    | Rust `Store::load_thread_record` |
+| `~/.breeze/runner/tasks/*/task.env`           | Rust dispatcher / completion handler                | Rust `list_task_metadata`, `cleanup_old_workspaces` |
+| `~/.breeze/runner/locks/*/lock.env`           | Rust `ServiceLock::refresh`                         | `find_lock` readers, `breeze-runner status|stop` |
+| `~/.breeze/runner/broker/bin/gh`              | Rust at broker start                                | Runner subprocesses (execve) |
+| `~/.breeze/runner/broker/requests/*/`         | Shim (inputs) + Rust broker (outputs)               | Each other — cross-process IPC |
+| `~/.breeze/runner/broker/history/*/`          | Rust broker                                         | Rust broker (cache hit lookup) |
+| `~/.breeze/runner/logs/*.log`                 | OS redirected stdout/stderr                         | Human / `tail -f` |
+
+## 12. Atomicity summary
+
+- **Atomic (tmp + rename):** only `inbox.json` (`fetcher.rs:594-597`). Good.
+- **Best-effort (plain `fs::write`):** everything else, including all `.env`
+  files and `activity.log`. Safe because there's one writer per file in the
+  daemon, but the shared `inbox.json` has three potential writers (see 11).
+- **Atomic (mkdir):** lock directories (`lock.rs:75`) and claim directories
+  (`breeze-status-manager:177`).
+
+The TS port should:
+1. Keep the atomic rename for `inbox.json`.
+2. Document the mkdir-based locking / claiming contract (cross-process).
+3. Decide whether to treat `bin/breeze-status-manager` and `bin/breeze-poll`
+   as still-shipped or deprecated. Their writer access to `inbox.json` and
+   `activity.log` is a compatibility constraint if they stay.
+
+## 13. Unverified / needs human input
+
+- Exact JSON key ordering in `inbox.json` is load-bearing for the legacy
+  status-manager's `jq` queries (it does `.id` and `.breeze_status` lookups
+  which are key-agnostic, so this is probably fine). Phase 3 should grep
+  external consumers (the `/breeze` skill) for any ordered iteration.
+- Whether any downstream consumer relies on `priority` being `int64`
+  specifically (Rust encodes as `Number(i64)`). JS will round-trip fine under
+  2^53, which is far beyond any realistic value.
+- The encoder escapes all control characters `< 0x20` via `\uXXXX`
+  (`json.rs:87-89`). Titles containing control chars will look escaped. No
+  test confirms this survives the HTTP passthrough.

--- a/docs/migration/03-status-state-machine.md
+++ b/docs/migration/03-status-state-machine.md
@@ -1,0 +1,293 @@
+# 03 — Status State Machine
+
+Source of truth:
+- `first-tree-breeze/breeze-runner/src/classify.rs` (200 lines — **this is the
+  `TaskKind` classifier for the dispatcher**; do not confuse with
+  `breeze_status`)
+- `first-tree-breeze/breeze-runner/src/fetcher.rs:353-368` —
+  `compute_breeze_status` (the real derivation rule)
+- `first-tree-breeze/bin/breeze-status-manager` (266 lines — label write path)
+- `first-tree-breeze/breeze-runner/src/runner.rs:206-219` — the prompt
+  instructing agents to set labels themselves
+- GitHub labels `breeze:new`, `breeze:wip`, `breeze:human`, `breeze:done`
+
+There are two separate state concepts in breeze. Don't conflate them:
+
+1. **`breeze_status`** — the label-derived per-notification status that drives
+   the dashboard, statusline, and `/breeze` skill. Values: `new | wip | human | done`.
+2. **`TaskKind` + dispatcher priority** — how the runner scheduler classifies
+   and prioritizes a candidate before dispatching an agent (see doc #4). Not a
+   state machine.
+
+This doc covers (1). (2) is referenced only where it interacts with labels.
+
+## 1. State diagram
+
+```mermaid
+stateDiagram-v2
+    [*] --> new: notification seen<br/>(no breeze:* label, gh_state=OPEN)
+
+    new --> wip: agent/user adds breeze:wip label
+    new --> human: agent/user adds breeze:human label
+    new --> done: gh_state flips to MERGED or CLOSED
+    new --> done: agent/user adds breeze:done label
+
+    wip --> human: label swap (remove wip, add human)
+    wip --> done: label swap (remove wip, add done)
+    wip --> done: gh_state -> MERGED/CLOSED
+    wip --> new: all breeze:* labels removed (and gh_state still OPEN)
+
+    human --> wip: label swap (remove human, add wip)
+    human --> done: label swap (remove human, add done)
+    human --> done: gh_state -> MERGED/CLOSED
+    human --> new: all breeze:* labels removed (and gh_state still OPEN)
+
+    done --> new: breeze:done removed AND gh_state becomes OPEN again (e.g. PR reopened)
+    done --> wip: same, plus breeze:wip added
+    done --> human: same, plus breeze:human added
+
+    note right of done
+      breeze:done wins over gh_state OPEN
+      gh_state MERGED/CLOSED wins over breeze:human/wip
+      but NOT over absence of breeze:done
+    end note
+```
+
+The transitions observable in `activity.log` are a subset of these: see §5.
+
+## 2. Derivation rule (`compute_breeze_status`, `fetcher.rs:353-368`)
+
+The canonical rule. Inputs per notification: `gh_state: Option<&str>` from the
+GraphQL enrichment (`OPEN | CLOSED | MERGED | null`) and `labels: &[String]`
+from the same enrichment.
+
+Precedence (top wins):
+
+1. **`labels` contains `breeze:done`** → `"done"`
+2. **`gh_state ∈ {"MERGED", "CLOSED"}`** → `"done"`
+3. **`labels` contains `breeze:human`** → `"human"`
+4. **`labels` contains `breeze:wip`** → `"wip"`
+5. otherwise → `"new"`
+
+Implementation:
+
+```rust
+// fetcher.rs:353-368
+pub fn compute_breeze_status(gh_state: Option<&str>, labels: &[String]) -> &'static str {
+    let has = |needle: &str| labels.iter().any(|label| label == needle);
+    if has("breeze:done") { return "done"; }
+    if matches!(gh_state, Some("MERGED") | Some("CLOSED")) { return "done"; }
+    if has("breeze:human") { return "human"; }
+    if has("breeze:wip") { return "wip"; }
+    "new"
+}
+```
+
+Covered by tests at `fetcher.rs:796-822` including the "done beats
+human+wip" case and the "OPEN + no label = new" default.
+
+Important subtleties:
+
+- **`breeze:new` is not part of the derivation.** The bash status-manager sets
+  `breeze:new` as an optional explicit marker (`breeze-status-manager:115-118`
+  and `breeze-status-manager:247`), but the Rust derivation ignores it. The
+  labels created via `ensure-labels` include `breeze:new` purely for human
+  readability; absence of `breeze:*` labels is the real "new" signal.
+- **Labels are fetched via one `first: 10` GraphQL call per PR/issue** batched
+  by repo (`fetcher.rs:209-254`). If a PR has more than 10 labels and
+  `breeze:*` is off the end, derivation may be wrong. Unverified whether any
+  real repo exceeds this.
+- **`gh_state` is only populated for `Issue` or `PullRequest` subjects**
+  (`fetcher.rs:167-175`). Discussions, Releases, etc. always get `gh_state =
+  null` and therefore get the label-only path. An un-closable Discussion with
+  no labels will remain `new` forever.
+
+## 3. Label write path (`bin/breeze-status-manager set`)
+
+When a user or agent asks the status-manager to change state:
+
+```
+breeze-status-manager set <notification-id> <new-status> [--by <session>] [--reason <text>]
+```
+
+Steps (`breeze-status-manager:76-170`):
+
+1. Look up `repo` and `number` for the notification id from `inbox.json` via
+   `jq` (`breeze-status-manager:90`). Fail if missing.
+2. **Always** first remove every `breeze:*` label via per-label calls
+   (`breeze-status-manager:98-103`). The per-label loop exists because
+   `gh ... --remove-label 'a,b,c'` errors if any one label doesn't exist on
+   the item:
+   ```
+   for lbl in breeze:new breeze:wip breeze:human breeze:done; do
+     gh issue edit "$num" --repo "$repo" --remove-label "$lbl" 2>/dev/null || true
+   done
+   ```
+   (All `2>/dev/null || true` — failures are swallowed silently.)
+3. Based on `new-status` (`breeze-status-manager:115-135`):
+   - `new` → only the removal; no add.
+   - `wip` → add `breeze:wip` (color `e4e669`, desc "Breeze: work in progress")
+   - `human` → add `breeze:human` (color `d93f0b`, desc "Breeze: needs human attention")
+   - `done` → add `breeze:done` (color `0e8a16`, desc "Breeze: handled")
+4. Adding a label falls back to creating it first if the repo doesn't have it
+   (`breeze-status-manager:106-112`):
+   ```
+   gh issue edit ... --add-label "$label" 2>/dev/null || {
+     gh label create "$label" --repo "$repo" --color "$color" --description "$desc" --force
+     gh issue edit ... --add-label "$label"
+   }
+   ```
+5. If the new status is not `wip`, remove the local claim directory
+   (`breeze-status-manager:137-140`).
+6. Optimistically patch `~/.breeze/inbox.json` in place via `jq` to set
+   `breeze_status` to the new value (`breeze-status-manager:143-149`). This
+   will be overwritten next poll but gives the statusline a fast-path update.
+7. Append a `transition` event to `~/.breeze/activity.log` with the old
+   status, new status, session id (`by`), and reason (`breeze-status-manager:151-168`).
+
+Notes:
+
+- All calls go through `gh issue edit` even for pull requests. This works
+  because GitHub treats PRs as a kind of issue and the issue-labels API works
+  on either. (Running it on a closed PR still succeeds for label ops.)
+- There is no check that the local label change actually went through — all
+  `gh` errors are swallowed with `|| true`. If the user lacks push rights the
+  local `inbox.json` will be patched but the GitHub label will not move, and
+  the NEXT poll will revert `breeze_status` to whatever GitHub actually shows.
+  This is the silent "non-labeler fallback".
+- `set` happens synchronously from the shell. It does NOT flow through the
+  `GhExecutor` rate-limit machinery — so it can collide with the daemon's
+  `gh` calls. In practice mutations to labels are cheap and rare enough that
+  GitHub's secondary rate limit rarely triggers.
+
+## 4. Agent-side self-labeling (runner prompt)
+
+Every agent task is handed a prompt that includes explicit labeling
+instructions (`runner.rs:206-214`):
+
+```
+Status labeling rule (REQUIRED): label the issue / pull request with your current status using exactly one of:
+- `breeze:wip` — you are actively working on it
+- `breeze:human` — you need human input or judgment to proceed
+- `breeze:done` — you have finished handling it
+
+Apply the label via `gh`, for example:
+  gh issue edit <number> --repo <owner>/<repo> --add-label "breeze:<status>"
+  gh pr edit   <number> --repo <owner>/<repo> --add-label "breeze:<status>"
+Remove any previous `breeze:*` label when the status changes so only one
+`breeze:*` label remains on the item. Set `breeze:wip` as soon as you start
+real work, and set `breeze:done` or `breeze:human` before you stop.
+```
+
+So the **agent itself** makes the `gh` calls — not the Rust daemon. The
+daemon's role is only to (a) poll the labels back in, (b) re-derive
+`breeze_status`, and (c) emit `transition` events.
+
+Consequence for the TS port: transitions in this system are driven by the
+agent's behavior through `gh` (which funnels through the broker shim in
+`broker/bin/gh` — see doc #4), not by a direct label-edit method on the
+daemon. The daemon has no `set_status(thread, status)` function; the closest
+is the shell `bin/breeze-status-manager set` that the user runs from a
+terminal.
+
+## 5. Transitions observable from the daemon (`activity.log`)
+
+The Rust fetcher only emits a `transition` event when:
+- The id was in the previous poll state (`seen_before == true`), AND
+- The new `breeze_status` differs from the old one, AND
+- NOT the special case "`new → done` driven purely by GitHub auto-close/merge"
+  (`fetcher.rs:564-568`).
+
+The suppression of `new → done` is because it's noisy — a merged PR that was
+never touched by breeze doesn't need a log entry. The same event will still
+update the counts in the dashboard via the next `inbox` SSE event.
+
+Transition records generated from the shell script
+(`bin/breeze-status-manager:151-168`) carry extra `by` and `reason` fields
+and are appended directly; they are NOT filtered the same way.
+
+## 6. Reason / metadata hooks
+
+`--reason <text>` is accepted by `breeze-status-manager set`
+(`breeze-status-manager:84-87`) and is stored in the `activity.log`
+transition entry as `reason: "<text>"` (`breeze-status-manager:164-168`).
+
+There is no other reason storage. The Rust code does not propagate or read
+`reason`. It is effectively a free-form audit note visible only in
+`activity.log` and via `/activity` / `bin/breeze-watch`.
+
+`--by <session-id>` is similarly stored as `by: "<session-id>"` in the
+transition entry. Empty string is valid. No uniqueness or session validation.
+
+The agent's self-labeling via `gh issue edit --add-label` (see §4) does
+NOT route through `breeze-status-manager`, so it does NOT write a transition
+entry with `by`/`reason`. The transition will instead be detected the next
+time the fetcher polls, and will be logged as an anonymous `transition` event
+(no `by`, no `reason`) by `fetcher.rs:633-650`.
+
+## 7. Label color / description contract
+
+The exact label metadata the ecosystem expects. Defined in
+`breeze-status-manager:121-130, 247-250`:
+
+| Label            | Color hex | Description                            |
+|------------------|-----------|----------------------------------------|
+| `breeze:new`     | `0075ca`  | Breeze: new notification               |
+| `breeze:wip`     | `e4e669`  | Breeze: work in progress               |
+| `breeze:human`   | `d93f0b`  | Breeze: needs human attention          |
+| `breeze:done`    | `0e8a16`  | Breeze: handled                        |
+
+`ensure-labels <repo>` (`breeze-status-manager:244-252`) creates all four
+with `gh label create --force`. The TS port's install/setup path should keep
+the same colors so dashboards and mixed deployments agree.
+
+## 8. Non-labeler fallback
+
+When the active gh identity lacks push permission on the target repo:
+
+1. **Agent self-label path** (from the prompt): the agent's `gh issue edit
+   --add-label` will fail. The agent has no retry/fallback in the shipped
+   prompt (see `runner.rs:206-219`). The task completes and the daemon's next
+   poll still sees no `breeze:*` label, so `breeze_status` remains `new`.
+2. **`breeze-status-manager set` path**: the script swallows all errors
+   (`2>/dev/null || true`) and still applies the local `inbox.json` patch.
+   The next poll overwrites the local patch with the real (label-less) state,
+   reverting to `new`.
+3. **`gh_state` auto-transition**: still works — no write permission needed to
+   read `state` from GraphQL. Merged/closed PRs will still derive to `done`
+   regardless of labeler status.
+
+Net effect: users without push rights see their statusline count move only
+when the PR/issue is merged or closed. `wip` / `human` are effectively no-ops
+for them. No warning or error is surfaced to the user today.
+
+Unverified: whether any repo uses a bot / action to mirror labels from a
+different source. Phase 3 should check if `agent-team-foundation/*` repos
+carry any label automation.
+
+## 9. Edge cases worth testing in the TS port
+
+- Item with **both** `breeze:done` and `breeze:wip` → should still resolve to
+  `done` (test at `fetcher.rs:816-822`).
+- Item with `gh_state = OPEN` and `breeze:human` + `breeze:wip` → human wins
+  (precedence in §2).
+- PR transitions from open → merged while `breeze:human` label is on it →
+  `human` → `done` transition is emitted (not suppressed — suppression only
+  applies to `new → done` auto-transitions; verified `fetcher.rs:564-568`).
+- PR reopened after being marked done → `gh_state` flips OPEN and `breeze:done`
+  label may still be present → still reports `done` (labels win). Ensure the
+  TS port preserves this, because the alternative interpretation ("if
+  reopened, revert to new") would be a behavior change.
+- A `Discussion` notification: `gh_state` is null; only labels drive status.
+
+## 10. Unverified / needs human input
+
+- The source treats `gh_state` values as case-sensitive uppercase strings
+  (`"OPEN"`, `"CLOSED"`, `"MERGED"`). These come from the GraphQL `state` enum
+  which is uppercase by spec. The TS port should match exactly; no
+  canonicalization.
+- The ordering of `breeze:done` > `gh_state` closed/merged vs the ordering of
+  `gh_state` > `breeze:human` — verified by the test at
+  `fetcher.rs:796-822`. But the decision rationale ("done is a human
+  assertion, closed/merged is a GitHub fact") is not documented anywhere in
+  the source. Phase 3 may want to surface this as a comment or design note.

--- a/docs/migration/04-broker-agent-lifecycle.md
+++ b/docs/migration/04-broker-agent-lifecycle.md
@@ -1,0 +1,465 @@
+# 04 — Broker and Agent Lifecycle
+
+Source of truth:
+- `first-tree-breeze/breeze-runner/src/service.rs` (1408 lines — main loop,
+  dispatch, lock, completion, launchd integration)
+- `first-tree-breeze/breeze-runner/src/runner.rs` (305 lines — per-agent
+  subprocess, prompt template, result parsing)
+- `first-tree-breeze/breeze-runner/src/broker.rs` (539 lines — cross-process
+  `gh` serializer and mutation cache)
+- `first-tree-breeze/breeze-runner/src/gh_executor.rs` (303 lines — rate
+  limiter and `command_is_mutating` classifier)
+- `first-tree-breeze/breeze-runner/src/lock.rs` (209 lines — service lock)
+- `first-tree-breeze/breeze-runner/src/config.rs` — governing config keys
+- `first-tree-breeze/breeze-runner/src/classify.rs` — `TaskKind`, priority
+- `first-tree-breeze/breeze-runner/src/workspace.rs` — git worktree setup
+
+The term "broker" here refers to two distinct things in the Rust code:
+
+1. **`GhBroker`** (`broker.rs`) — a cross-process serializer for `gh` CLI
+   calls. It is NOT the thing that decides which notifications to act on. It
+   exists so the agent subprocess can still shell out to `gh` under a single
+   rate-limited writer.
+2. **The dispatcher in `Service::run_loop`** (`service.rs:443-501`) — the loop
+   that polls GitHub, picks candidates, and launches agent subprocesses. This
+   is what most people mean when they say "the broker fires".
+
+Both are covered below.
+
+## 1. Process model at steady state
+
+A single `breeze-runner` process owns:
+
+- A main thread running `Service::run_loop` (`service.rs:443-501`) — the
+  dispatcher.
+- A background `Inbox poll loop` thread started by `spawn_inbox_poll_loop`
+  (`service.rs:372-411`) — refreshes `~/.breeze/inbox.json` every
+  `inbox_poll_interval_secs` (default 60 s).
+- A background `HTTP/SSE server` thread started by `spawn_http_server`
+  (`service.rs:413-429`) — serves `:7878`.
+- A background `Gh broker` thread started by `GhBroker::start`
+  (`broker.rs:57-76`) — drains `~/.breeze/runner/broker/requests/` and invokes
+  real `gh`.
+- Short-lived runner threads (`service.rs:767-799`) — one per active task.
+  Each blocks on `Command::new("codex" | "claude").status()` until the agent
+  exits.
+
+Single lock `~/.breeze/runner/locks/<host>__<login>__<profile>/lock.env`
+excludes a second `breeze-runner` process for the same identity (see doc #2
+§7 and `lock.rs`).
+
+## 2. When does the dispatcher fire?
+
+`run_loop` (`service.rs:443-501`) runs a tight loop:
+
+1. Verify the gh identity hasn't changed (`verify_identity`, `service.rs:503-513`).
+2. Refresh `runtime/status.env` for the statusline.
+3. If `did_poll` is false:
+   - Re-enqueue any orphaned `status=running` tasks from previous runs
+     (`enqueue_recoverable_tasks`, `service.rs:570-641`).
+   - Call `poll_candidates` (`service.rs:515-542`) → `GhClient::collect_candidates`
+     (`gh.rs:247-300`). This fetches notifications and (on the reconcile
+     schedule) search results.
+   - Filter via `should_schedule` (`service.rs:643-672`) and enqueue.
+   - Set `did_poll = true`.
+4. Dispatch as many pending candidates as `max_parallel` allows
+   (`dispatch_pending`, `service.rs:674-811`).
+5. Wait on the completion channel with a timeout:
+   - If `once == true` and nothing is pending/active: break out of the loop.
+   - If `active.is_empty()`: wait `poll_interval_secs` (default **600 s**).
+   - Else: wait 2 s.
+6. If the timeout fires and `once == false`, set `did_poll = false` so the
+   next iteration polls again.
+7. Drain completions via `handle_completion` (`service.rs:879-942`).
+
+Key intervals (`config.rs` defaults):
+
+- `poll_interval_secs` = 600 (10 min) — dispatcher idle tick when no active
+  tasks.
+- `inbox_poll_interval_secs` = 60 — inbox refresh tick (separate thread).
+- `search_reconcile_interval_secs` = 6 h — how often `include_search=true` is
+  set on `collect_candidates`. When rate-limited this grows to 15 min
+  (`service.rs:526-530`).
+- `notification_lookback_secs` = 24 h — notifications older than this are
+  dropped (`gh.rs:287-289`).
+- `task_limit` = 100 — search API `--limit` per source.
+
+So: **the dispatcher polls every 10 minutes when idle, and every 2 s when at
+least one agent is running (to drain completions promptly). The inbox refresh
+is independent at 60 s.**
+
+There is no state-change trigger: a status transition written by the
+status-manager does NOT kick the dispatcher; it only updates `inbox.json` for
+the statusline. The dispatcher's notion of work comes from the GitHub
+`/notifications` API, not from local labels.
+
+## 3. What exactly does the dispatcher dispatch?
+
+For each poll the Rust client returns zero or more `TaskCandidate` objects
+from three sources (`gh.rs:247-300`):
+
+| Source              | gh call                                                  | Task kind candidates |
+|---------------------|----------------------------------------------------------|----------------------|
+| `notifications`     | `gh api /notifications?all=true&participating=false&per_page=100 --paginate` | Review, Mention, Comment, Assigned{Issue,PR}, Discussion (via `classify_notification`, `classify.rs:70-90`) |
+| `review-search`     | `gh search prs --review-requested=@me --state open ...`  | `ReviewRequest` only |
+| `assigned-search`   | `gh search issues --assignee=@me --state open --include-prs` | `AssignedIssue` or `AssignedPullRequest` |
+
+The last two are rate-limited and only run every
+`search_reconcile_interval_secs`.
+
+`should_process_reason` (`classify.rs:39-50`) filters notification reasons:
+only `review_requested`, `comment`, `mention`, `team_mention`, `assign`,
+`author`, `manual` are actionable. Reasons like `subscribed`, `ci_activity`
+are ignored, even though they appear in the inbox display.
+
+### Candidate priority (`classify.rs:52-68`)
+
+This is the **dispatcher** priority (higher = dispatched first), distinct
+from the inbox-display `priority` in doc #2.
+
+| Kind                           | Priority |
+|--------------------------------|----------|
+| `ReviewRequest`                | 100      |
+| `Mention`                      | 95       |
+| `Discussion`                   | 90       |
+| `Comment`                      | 85       |
+| `AssignedPullRequest`          | 80       |
+| `AssignedIssue`                | 70       |
+| `Other`                        | 50 (100 if reason == review_requested) |
+
+Candidates are sorted by priority desc, then `updated_at` desc, then
+`thread_key` asc (`gh.rs:291-297`).
+
+### Filtering before dispatch (`should_schedule`, `service.rs:643-672`)
+
+For each candidate the dispatcher:
+
+1. Loads the `ThreadRecord` for the `thread_key` (see doc #2 §5). Updates
+   `last_seen_updated_at`, saves it back.
+2. Skips if `next_retry_epoch > now` (back-off window still active).
+3. Skips if `candidate.updated_at <= last_handled_updated_at` (already
+   handled at this timestamp).
+4. Fetches `latest_visible_activity` (`gh.rs:235-245`) — inspects latest
+   comment + latest review timestamp. If the latest activity on the thread
+   was by the current login and it post-dates the candidate's `updated_at`,
+   skip and mark the thread as `last_result=skipped`
+   (`should_ignore_latest_self_activity` in `gh.rs`).
+
+## 4. What gets dispatched to the agent subprocess?
+
+For each selected candidate (`dispatch_pending`, `service.rs:674-811`):
+
+1. Generate task id: `task-<epoch>-<stable-id>` (`service.rs:684`).
+2. Create `~/.breeze/runner/tasks/<task-id>/`.
+3. Hydrate the snapshot via `gh.rs:302-479`. This writes 1–5 JSON files into
+   `<task-dir>/snapshot/` depending on the subject type:
+   - Always: `task-summary.env`, `README.txt`, `subject.json`, optionally
+     `latest-comment.json`
+   - PR: `pr-view.json`, `pr.diff`, `issue-comments.json`, `pr-reviews.json`
+   - Issue: `issue-view.json`, `issue-comments.json`
+4. Possibly reroute the candidate's `workspace_repo` to the operator's
+   self-repo if the discussion is about configuring breeze-runner itself
+   (`route_workspace_candidate` + `should_route_to_operator_repo`,
+   `service.rs:859-877, 1313-1340`). Heuristic: text contains both a
+   "change-requesting" verb and a user-targeting phrase, AND mentions
+   `breeze-runner`.
+5. `WorkspaceManager::prepare` (`workspace.rs:35-81`):
+   - Ensures a bare mirror at `~/.breeze/runner/repos/<slug>.git`.
+   - Fetches `refs/pull/<n>/head` into `refs/remotes/origin/breeze-runner-pr-<n>`
+     when the candidate is a PR; otherwise uses the mirror's `HEAD`.
+   - Creates a detached-HEAD worktree at
+     `~/.breeze/runner/workspaces/<slug>/<kind>-<stable-id>`.
+   - Seeds local `user.name = "<login> via breeze-runner"` and
+     `user.email = "<login>@users.noreply.github.com"`.
+6. Pick runner: `runners.execution_order()` (`runner.rs:78-86`) returns the
+   configured runner list rotated by a counter, so Codex and Claude alternate
+   across tasks when both are available. The first runner is "selected", the
+   rest are fallbacks tried in order on failure.
+7. Write `tasks/<task-id>/task.env` with `status=running`, the chosen runner
+   name, and all the metadata in doc #2 §6.
+8. Spawn a thread running `execute_task(runners, request)`
+   (`service.rs:767-799`, `service.rs:1254-1280`). Each runner in the list is
+   attempted until one returns `Ok`; otherwise a combined failure is reported.
+
+### The agent subprocess
+
+`RunnerSpec::execute` (`runner.rs:88-170`) builds the prompt, writes it to
+`<task-dir>/prompt.txt`, and execs:
+
+**Codex path** (`runner.rs:105-127`):
+```
+codex exec \
+  --cd <workspace_dir> \
+  --dangerously-bypass-approvals-and-sandbox \
+  --output-last-message <task-dir>/runner-output.txt \
+  [--model <codex_model>] \
+  <task-dir>/prompt.txt
+```
+stdin = null, stdout → `runner-stdout.log`, stderr → `runner-stderr.log`.
+Env:
+- `PATH` = `<gh_shim_dir>:<existing PATH>` (the broker shim comes first)
+- `BREEZE_BROKER_DIR = ~/.breeze/runner/broker`
+- `BREEZE_SNAPSHOT_DIR = <task-dir>/snapshot`
+- `BREEZE_TASK_DIR = <task-dir>`
+
+**Claude path** (`runner.rs:128-150`):
+```
+cd <workspace_dir>
+claude -p --permission-mode bypassPermissions [--model <claude_model>] "<prompt>"
+```
+Same env vars. stdout is captured to `runner-stdout.log` and then **copied
+to** `runner-output.txt` (`runner.rs:146-148`) because Claude doesn't have a
+`--output-last-message` flag.
+
+In both cases the Rust thread blocks on `status()`. There is no per-task
+timeout: if Codex or Claude hangs forever, the dispatcher thread for that
+task hangs forever. See §8 for implications.
+
+### Prompt contents (`runner.rs:172-231`)
+
+The agent receives a templated prompt with:
+- The agent's identity (`{git_id}` = active gh login).
+- Breeze's own repo URL: `https://github.com/agent-team-foundation/breeze`.
+- The task URL (comment-anchored when a comment is known, else PR/issue URL).
+- Local context: `task_id`, `repo`, optional `working repository` (when the
+  workspace was routed to the operator's self-repo), `kind`, `workspace
+  path`, `snapshot_dir`, `task_dir`.
+- A "don't stop until" list (read context, complete task, reply on GitHub).
+- The label-setting rule covered in doc #3.
+- A disclosure sentence the agent is required to include once in any public
+  reply (the `BREEZE_DISCLOSURE` env var / `--disclosure` flag,
+  `config.rs:195-198`).
+- Instruction to end with `BREEZE_RESULT: status=<handled|skipped|failed>
+  summary=<one-line>`.
+
+The daemon parses the last `BREEZE_RESULT:` line via `parse_result`
+(`runner.rs:233-260`). If none is found, the status defaults to `handled` and
+the summary is the last line of output.
+
+### Completion
+
+`handle_completion` (`service.rs:879-942`):
+
+- Removes the task from `active`.
+- Updates `tasks/<task-id>/task.env` with final status, summary,
+  runner_output_path, runner name.
+- Updates the `ThreadRecord`:
+  - On `handled` / `skipped`: sets `last_handled_updated_at`, resets
+    `failure_count` and `next_retry_epoch`.
+  - On `failed`: increments `failure_count`, sets `next_retry_epoch = now +
+    retry_delay(failure_count)` where `retry_delay(n) = 60 * 2^min(n, 6)`
+    seconds (`service.rs:1282-1285`), capped at `poll_interval_secs`
+    (`service.rs:1209-1211`).
+- If the completion channel reports an `Err(string)`: same as `failed` but
+  writes the error string into `summary`.
+
+## 5. Concurrency model
+
+- Max concurrent tasks: `config.max_parallel` (default **20**; `config.rs:180,
+  321`).
+- The dispatcher's inner loop fills the active set up to the cap
+  (`service.rs:681`), then waits for completions.
+- Per-thread dedup: `queued_threads: HashSet<String>` keyed on
+  `thread_key` prevents a single thread from being enqueued twice in the
+  same pass (`service.rs:558-566`). The active set is also consulted
+  (`service.rs:552-557`).
+- Recovery on startup: tasks that are `status=running` from a previous
+  process are renamed to `status=orphaned` and re-queued
+  (`service.rs:570-641`). This is why there is a Phase 3 contract around
+  single-ownership of `tasks/`.
+
+There is **no claim-based exclusion across machines** (unlike the
+user-facing `~/.breeze/claims/` dir, which is for the skill/statusline).
+Running `breeze-runner` on two machines for the same gh login is prevented
+only by the local `locks/` directory, which is per-machine. See §9.
+
+## 6. The gh broker (cross-process `gh` serializer)
+
+`GhBroker` (`broker.rs`) is the second meaning of "broker". It exists because
+the agent subprocess needs to call `gh` (for comments, reviews, labels, PR
+creation) but must share the same rate-limit budget as the daemon. The design:
+
+1. The daemon writes a shim script at `~/.breeze/runner/broker/bin/gh` mode
+   `0o755` (`broker.rs:35-44`). Source is `SHIM_SCRIPT` (`broker.rs:390-446`).
+2. The agent subprocess has `PATH` prefixed with `broker/bin/` and
+   `BREEZE_BROKER_DIR=~/.breeze/runner/broker` set (`runner.rs:99-103`).
+3. When the agent runs `gh`, the shim is invoked instead.
+4. The shim creates `$BREEZE_BROKER_DIR/requests/req-<epoch>-<pid>-<rand>/`,
+   writes `cwd.txt`, `argv.txt` (one arg per line), and optionally
+   `gh_host.txt`, `gh_repo.txt`. Then it polls for `response.env` every
+   100 ms, with a default timeout of 1800 s (`BREEZE_BROKER_TIMEOUT_SECS`,
+   exit 124 on timeout).
+5. The broker thread (`serve_loop`, `broker.rs:96-126`) polls `requests/`
+   every 100 ms, handles pending requests in sorted order.
+6. For each request: `handle_request` (`broker.rs:145-211`) reconstructs a
+   `GhCommandSpec`, checks the mutation-response cache, then runs real `gh`
+   via `GhExecutor::run`.
+7. The executor enforces rate limits (`gh_executor.rs:119-167`):
+   - Per-bucket next-allowed timestamps (`Core`, `Search`, `Write`).
+   - Write cooldown `gh_write_cooldown_ms` between mutating commands
+     (default 1250 ms, `config.rs:189-190`).
+   - On rate-limit detection (`is_rate_limited`, `gh_executor.rs:247-254`,
+     scans for "secondary rate limit", "rate limit exceeded", etc.), sets
+     `next_core_epoch_ms += 60_000 * 2^min(streak, 4)`.
+   - Up to 3 attempts per call before giving up.
+8. The broker writes the result to `stdout.txt`, `stderr.txt`, and
+   `response.env` (`broker.rs:353-372`). The shim reads these, `rm -rf`s the
+   request dir, and exits with the status code.
+9. Successful mutations get cached in `history/<fingerprint-id>/` with a
+   15-minute TTL (`broker.rs:220, 296-331`). The fingerprint normalizes
+   `--body` / `--body-file` contents via `stable_file_id` so that retries
+   with the same payload hit the cache even if the tmp file path is
+   different (`broker.rs:222-272`). This is the idempotency layer — it
+   prevents duplicate GitHub comments when an agent retries after a
+   transient failure.
+
+Mutation classification (`gh_executor.rs:181-245`): `command_is_mutating`
+returns true for `issue comment/close/create/delete/edit/lock/pin/reopen/transfer/unlock/unpin`,
+`pr close/comment/create/edit/merge/ready/reopen/review/update-branch`,
+`label clone/create/delete/edit`, and for `gh api` calls with an explicit
+non-GET `-X/--method` or with any `-f/-F/--field/--raw-field/--input` flag.
+
+The broker is started inside `acquire_lock` (`service.rs:431-441`) and
+stopped on `Drop`. It purges any leftover `requests/` on start
+(`broker.rs:61-66`).
+
+## 7. How does the dispatcher know when an agent job is done?
+
+Per-task thread blocks on `Command::status()` → reads the status + the
+`runner-output.txt` file → parses `BREEZE_RESULT` → sends a `TaskCompletion`
+over an mpsc channel back to the main loop
+(`service.rs:767-799`, `runner.rs:88-170`, `service.rs:483-496`).
+
+There is **no polling of GitHub** to detect completion. The contract is
+strictly: the agent exits, and the last `BREEZE_RESULT:` line dictates the
+status. If the agent crashes without writing a `BREEZE_RESULT:` line, the
+output file will not have one, and `parse_result` defaults to `("handled",
+last_line)` — so a silent crash is indistinguishable from a success.
+
+## 8. Failure handling
+
+| Failure                                 | Handling                                                                 |
+|-----------------------------------------|--------------------------------------------------------------------------|
+| Setup error before agent launches (snapshot, workspace prep)     | `record_setup_failure` writes `status=failed` + summary, increments `failure_count`, schedules `next_retry_epoch` (`service.rs:813-857`) |
+| `gh` identity changed mid-run           | `verify_identity` returns `Err`; loop exits (`service.rs:503-513`)       |
+| Agent subprocess non-zero exit          | Current runner returns `Err`; next runner in `execution_order` is tried (`service.rs:1254-1280`); if all fail, task marked `failed` |
+| Agent hangs forever                     | **Not handled.** The per-task thread blocks indefinitely on `.status()`. No per-task timeout in the code. This is a known gap for the TS port. |
+| Agent crashes with no `BREEZE_RESULT:`  | Silently treated as `handled` with the last line of stdout as the summary (`runner.rs:233-260`). |
+| Broker shim timeout (no response in 1800 s) | Shim exits 124 and stderr message (`SHIM_SCRIPT` at `broker.rs:424-430`). The agent sees this as a `gh` failure. |
+| Rate-limit (secondary / abuse)          | Executor retries up to 3× with exponential back-off per bucket (`gh_executor.rs:69-85, 154-167`). After retries it returns the failing output; caller surfaces it. |
+| Dispatcher process crash mid-task       | Next startup's `enqueue_recoverable_tasks` rewrites `status=running` tasks to `orphaned` and re-queues them (`service.rs:570-641`). |
+
+## 9. Configuration surface
+
+Breeze does not read a YAML file. All config is CLI flags and env vars,
+resolved in `Config::parse` (`config.rs:140-311`). The spec question "which
+`~/.breeze/config.yaml` keys govern broker behavior" has no answer in this
+codebase: **there is no `~/.breeze/config.yaml`**. Phase 3 may introduce one,
+but the Rust daemon today is configured only by:
+
+Key knobs for broker/dispatcher behavior (default → env var → CLI flag):
+
+| Config field                          | Default     | Env var                              | CLI flag                           |
+|---------------------------------------|-------------|--------------------------------------|------------------------------------|
+| `home`                                | `~/.breeze/runner` | `BREEZE_HOME`                 | `--home`                           |
+| `host`                                | `github.com`| `BREEZE_HOST`                        | `--host`                           |
+| `profile`                             | `default`   | `BREEZE_PROFILE`                     | `--profile`                        |
+| `repo_filter`                         | empty (all) | `BREEZE_ALLOWED_REPOS` (CSV of `owner/repo` or `owner/*`) | `--allow-repo` |
+| `runners`                             | `codex,claude` | `BREEZE_RUNNERS`                  | `--runner`                         |
+| `max_parallel`                        | 20          | `BREEZE_MAX_PARALLEL`                | `--max-parallel`                   |
+| `poll_interval_secs`                  | 600         | `BREEZE_POLL_INTERVAL_SECS`          | `--poll-interval-secs`             |
+| `inbox_poll_interval_secs`            | 60          | `BREEZE_INBOX_POLL_INTERVAL_SECS`    | `--inbox-poll-interval-secs`       |
+| `task_limit`                          | 100         | `BREEZE_TASK_LIMIT`                  | `--task-limit`                     |
+| `notification_lookback_secs`          | 86_400      | `BREEZE_NOTIFICATION_LOOKBACK_SECS`  | `--notification-lookback-secs`     |
+| `search_reconcile_interval_secs`      | 21_600      | `BREEZE_SEARCH_RECONCILE_INTERVAL_SECS` | `--search-reconcile-interval-secs` |
+| `gh_write_cooldown_ms`                | 1250        | `BREEZE_GH_WRITE_COOLDOWN_MS`        | `--gh-write-cooldown-ms`           |
+| `workspace_ttl_secs`                  | 259_200 (3d)| `BREEZE_WORKSPACE_TTL_SECS`          | `--workspace-ttl-secs`             |
+| `codex_model`                         | none        | `BREEZE_CODEX_MODEL`                 | `--codex-model`                    |
+| `claude_model`                        | none        | `BREEZE_CLAUDE_MODEL`                | `--claude-model`                   |
+| `disclosure_text`                     | see below   | `BREEZE_DISCLOSURE`                  | `--disclosure`                     |
+| `dry_run`                             | false       | `BREEZE_DRY_RUN`                     | `--dry-run` / `--no-dry-run`       |
+| `http_port`                           | 7878        | `BREEZE_HTTP_PORT`                   | `--http-port`                      |
+| `http_disabled`                       | false       | `BREEZE_HTTP_DISABLED`               | `--no-http`                        |
+
+Default disclosure: `"Agent note: this reply was prepared and posted by breeze
+running locally for the active account."` (`config.rs:195-198`).
+
+Env vars additionally passed through to the launchd plist (`service.rs:1214-1228`):
+`AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT_BACKUP`,
+`AZURE_OPENAI_API_KEY_BACKUP`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
+`GH_TOKEN`, `GITHUB_TOKEN`, `CODEX_HOME`, `CLAUDE_CODE_USE_BEDROCK`,
+`CLAUDE_CODE_USE_VERTEX`.
+
+### How notifications are selected for auto-action
+
+There is no config that maps "notifications of kind X → dispatch". The
+selection is hard-coded:
+
+- `should_process_reason` whitelist (`classify.rs:39-50`): only seven reasons
+  are ever actionable. Everything else is ignored by the dispatcher (though
+  still displayed in the inbox).
+- `repo_filter` (per-account allow-list of `owner/repo` or `owner/*`
+  patterns) is the only coarse knob. Anything outside the allowlist is
+  dropped both in notifications and search phases.
+- `dry_run` short-circuits the runner spawn (`service.rs:768-775`) and
+  writes `status=simulated` — useful for verifying the dispatcher end-to-end
+  without agent costs.
+- There is no per-`TaskKind` disable; the only filter is the reason
+  whitelist.
+
+### `dry_run` behavior
+
+When `dry_run=true`, the dispatcher still goes through snapshot + workspace +
+`task.env=running` setup; only the `execute_task` call is replaced with a
+synthetic `TaskExecutionResult { status: "simulated", summary: "dry-run
+scheduled task" }` (`service.rs:768-775`). `runner-output.txt` is NOT
+written in this case — the path is recorded but the file doesn't exist.
+
+## 10. `start` / `run` / `run-once` commands
+
+- `run` (and default with no args) → `run_forever` (`service.rs:355-366`).
+  Acquires lock, spawns inbox/HTTP threads, runs `run_loop(once=false)`.
+- `run-once` → `run_once` (`service.rs:350-353`). Single poll, drain
+  queue, exit.
+- `start` → `start_background` (`service.rs:255-348`). On macOS writes a
+  launchd plist and bootstraps via `launchctl bootstrap gui/<uid>`; elsewhere
+  spawns `nohup breeze-runner run ...`. Returns after confirming a live lock
+  file (750 ms settle time).
+- `stop` → `stop` (`service.rs:231-245`). On macOS first runs
+  `launchctl bootout`; then `kill <pid>` from the lock file.
+- `status` (`service.rs:145-195`) / `doctor` (`service.rs:107-143`) — read-only
+  introspection on lock + runtime.
+- `cleanup` (`service.rs:197-207`) — GCs stale workspaces via
+  `Store::cleanup_old_workspaces`.
+- `poll` (`service.rs:209-229`) — one-shot inbox refresh; no dispatch.
+
+## 11. Unverified / needs human input
+
+- **No per-task timeout.** Phase 3 should add one (likely
+  `Command::spawn` + `wait_timeout`-style or explicit `SIGTERM` after N
+  minutes). The Rust code does not do it today. The TS port should not
+  ship without it; pick a default (e.g. 30 min) and make it configurable.
+- **Silent crash → `handled`.** `runner.rs:253-259`: if the agent exits
+  successfully but emitted no `BREEZE_RESULT:`, the status defaults to
+  `handled` and the summary is the last stdout line. The TS port should
+  consider logging a warning and/or defaulting to `failed` instead when
+  exit status is 0 but `BREEZE_RESULT` is absent. This is a policy
+  decision, not a straightforward migration.
+- **`broker.rs:181-190` short-circuits a cached mutation response without
+  invoking `gh` at all.** If the GitHub side has been rolled back or
+  manually reverted in the 15-minute cache window, the cached success will
+  hide that from the agent. This is a correctness-vs-idempotency trade-off
+  and worth flagging during port review.
+- **`runner.rs:144-148`** writes Claude's stdout verbatim to
+  `runner-output.txt`, so it includes every intermediate line, not just the
+  last assistant message. `parse_result` handles this by scanning bottom-up
+  for `BREEZE_RESULT:`. Keep this behavior or unify across runners — the TS
+  port may want Claude's structured output (`--output-format json`) once
+  that's stable.
+- **The launchd integration assumes macOS + `launchctl` + a gui domain.**
+  For Linux we fall back to `nohup`. The TS port will likely want a unified
+  process manager abstraction; systemd/launchd/`forever` are all candidates
+  but none exist in the Rust code today.
+- **`BREEZE_BROKER_TIMEOUT_SECS=1800`** is embedded in the shim script
+  (`broker.rs:422`). A full 30-minute ceiling for any single `gh` call is
+  generous; Phase 3 might expose it as a config knob.


### PR DESCRIPTION
## Summary
Four authoritative specs for the upcoming TS port of breeze-runner, to be used by Phase 2/3 implementation work.

- `01-http-api-contract.md` — every HTTP route on :7878 (dashboard, healthz, inbox, activity, SSE /events), including exact header order, SSE framing, and error shapes
- `02-inbox-store-schema.md` — `~/.breeze/` filesystem layout, `inbox.json` + `activity.log` JSON schemas, `runner/` private state (threads, tasks, locks, broker, runtime), writer/reader matrix, atomicity
- `03-status-state-machine.md` — label-driven `breeze_status` derivation, transitions (Mermaid diagram), agent self-labeling prompt, non-labeler fallback
- `04-broker-agent-lifecycle.md` — dispatcher polling cadence, candidate classification, agent subprocess invocation (Codex + Claude), the `gh` broker serializer with mutation-response cache, failure handling

Every non-obvious claim carries a `file.rs:Lxxx` reference to the Rust source. "Unverified" flags are called out explicitly for each spec's tail section.

## Test plan
- [ ] Human review: every claim has a Rust line reference or an explicit "unverified" note
- [ ] State diagram renders in GitHub Mermaid preview
- [ ] No secrets/PII in example payloads (live inbox.json sample is redacted to public GitHub URLs only)

Not for merge — these specs are reference material for the TS port, not a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)