### PR TITLE
Phase 3a: port breeze daemon read path to TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,13 +53,13 @@
     "ink-testing-library": "^4.0.0",
     "tsdown": "^0.12.0",
     "typescript": "^5.8.0",
-    "vitest": "^3.2.0",
-    "yaml": "^2.8.3"
+    "vitest": "^3.2.0"
   },
   "dependencies": {
     "ink": "^7.0.0",
     "proper-lockfile": "^4.1.2",
     "react": "^19.2.5",
+    "yaml": "^2.8.3",
     "zod": "^4.3.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       react:
         specifier: ^19.2.5
         version: 19.2.5
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -42,9 +45,6 @@ importers:
       vitest:
         specifier: ^3.2.0
         version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3)
-      yaml:
-        specifier: ^2.8.3
-        version: 2.8.3
 
 packages:
 

--- a/src/products/breeze/cli.ts
+++ b/src/products/breeze/cli.ts
@@ -1,14 +1,20 @@
 /**
  * Breeze product dispatcher.
  *
- * Phase 2b: `poll`, `watch`, and `statusline` are TS ports. The daemon
- * commands (`run`, `run-once`, `start`, `stop`, `status`, `cleanup`,
- * `doctor`) and the setup/installer still bridge to the Rust binary +
- * `first-tree-breeze/setup` — those are Phase 3.
+ * Phase 3a adds the `daemon` subcommand with a `--backend=ts|rust` flag.
+ * The `rust` backend (default) continues to route through `bridge.ts`
+ * into the `breeze-runner` binary — identical to the Phase 2b behaviour,
+ * just under a new command name. The `ts` backend lazy-imports the
+ * Phase 3a runner skeleton (`./daemon/runner-skeleton.ts`).
  *
- * Heavy deps (child_process, ink, react) live in the dynamically-imported
- * command modules so `first-tree breeze --help` and
- * `first-tree tree ...` stay lightweight.
+ * Phase 2b ports: `poll`, `watch`, `statusline` are TS commands. The
+ * daemon-mode commands (`run`, `run-once`, `start`, `stop`, `status`,
+ * `cleanup`, `doctor`) still bridge to the Rust binary while Phase 3b/3c
+ * (http, broker, bus) are implemented.
+ *
+ * Heavy deps (child_process, ink, react, daemon modules) live in the
+ * dynamically-imported command modules so `first-tree breeze --help`
+ * and `first-tree tree ...` stay lightweight.
  */
 
 import { join } from "node:path";
@@ -25,6 +31,12 @@ Commands that run the Rust daemon (\`breeze-runner\`):
   status                Print broker / inbox status
   doctor                Diagnose the local install
   cleanup               Clean up stale state
+
+Daemon (phase 3, experimental):
+  daemon [--backend=ts|rust]
+                        Run the breeze daemon in the foreground.
+                        \`--backend=rust\` (default) is equivalent to \`run\`.
+                        \`--backend=ts\` launches the in-progress TS port.
 
 TypeScript commands (no daemon required):
   poll                  Poll GitHub notifications once and update the inbox
@@ -68,7 +80,16 @@ type StatuslineTarget = {
   kind: "statusline";
 };
 
-type Target = RunnerTarget | SetupTarget | TsTarget | StatuslineTarget;
+type DaemonTarget = {
+  kind: "daemon";
+};
+
+type Target =
+  | RunnerTarget
+  | SetupTarget
+  | TsTarget
+  | StatuslineTarget
+  | DaemonTarget;
 
 const DISPATCH: Record<string, Target> = {
   install: { kind: "setup" },
@@ -89,7 +110,52 @@ const DISPATCH: Record<string, Target> = {
 
   // Statusline gets its own tiny dist bundle for sub-30ms cold start.
   statusline: { kind: "statusline" },
+
+  // Phase 3a daemon (backend-switched).
+  daemon: { kind: "daemon" },
 };
+
+/**
+ * Split `--backend=...` out of the argv. Supports both
+ * `--backend=ts` and `--backend ts` forms. Unknown values fall through
+ * to the default (`rust`) and leave the flag in the residual argv so
+ * the chosen backend can reject/surface it.
+ *
+ * Exported for tests.
+ */
+export function extractBackendFlag(args: readonly string[]): {
+  backend: "ts" | "rust";
+  rest: string[];
+} {
+  const rest: string[] = [];
+  let backend: "ts" | "rust" = "rust";
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--backend") {
+      const value = args[i + 1];
+      if (value === "ts" || value === "rust") {
+        backend = value;
+        i += 1;
+        continue;
+      }
+      // Unknown/missing value: keep the flag in `rest` so the backend
+      // complains with a full error message.
+      rest.push(arg);
+      continue;
+    }
+    if (arg?.startsWith("--backend=")) {
+      const value = arg.slice("--backend=".length);
+      if (value === "ts" || value === "rust") {
+        backend = value;
+        continue;
+      }
+      rest.push(arg);
+      continue;
+    }
+    rest.push(arg);
+  }
+  return { backend, rest };
+}
 
 export async function runBreeze(
   args: string[],
@@ -151,6 +217,21 @@ export async function runBreeze(
         const packageRoot = bridge.resolveFirstTreePackageRoot();
         const bundlePath = join(packageRoot, "dist", "breeze-statusline.js");
         return bridge.spawnInherit(process.execPath, [bundlePath, ...rest]);
+      }
+      case "daemon": {
+        const { backend, rest: residual } = extractBackendFlag(rest);
+        if (backend === "ts") {
+          // Phase 3a: TS daemon (read path only). Lazy-imported so the
+          // daemon modules (poller, identity, yaml config) never touch
+          // cold-start latency for non-daemon commands.
+          const mod = await import("./daemon/runner-skeleton.js");
+          return await mod.runDaemon(residual);
+        }
+        // Default: route through the Rust runner's `run` subcommand for
+        // parity with Phase 2b. Forwards flag order verbatim.
+        const bridge = await import("./bridge.js");
+        const runner = bridge.resolveBreezeRunner();
+        return bridge.spawnInherit(runner.path, ["run", ...residual]);
       }
     }
   } catch (err) {

--- a/src/products/breeze/core/config.ts
+++ b/src/products/breeze/core/config.ts
@@ -1,12 +1,30 @@
 /**
- * Runtime config for breeze TS-port commands.
+ * Runtime config for breeze TS-port commands and the TS daemon backend.
  *
- * Phase 2a has no `config.yaml` file yet (spec doc 4 §9 — the Rust
- * runner takes no config file today; broker/dispatcher options are CLI
- * flags + env vars only). This module simply collects the env and
- * CLI-flag knobs shared by `status-manager` and (later) the daemon
- * port so callers don't hard-code env-var names.
+ * There are two config surfaces in this module:
+ *
+ * 1. `loadBreezeConfig` — the lightweight per-command knob bag used by
+ *    `status-manager` / `poll` / etc. (Phase 2a). Env-only today.
+ *
+ * 2. `loadBreezeDaemonConfig` — the daemon-level config introduced in
+ *    Phase 3a. Reads `~/.first-tree/breeze/config.yaml` (or the older
+ *    `~/.breeze/config.yaml`, for back-compat with any hand-written
+ *    files), merges with env vars and CLI overrides, and returns a
+ *    validated `DaemonConfig`.
+ *
+ * Priority (highest wins): CLI overrides > env vars > yaml > defaults.
+ *
+ * NOTE: the runtime data directory (`inbox.json`, `activity.log`, claim
+ * locks) remains `~/.breeze/` for Phase 3 — only the *config* moves to
+ * `~/.first-tree/breeze/`. This matches the scope constraint that
+ * Phase 3a must not break format parity with the Rust daemon.
  */
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { parse as parseYaml } from "yaml";
 
 export const CLAIM_TIMEOUT_SECS = 300; // 5 minutes; matches bin/breeze-status-manager:29
 
@@ -31,4 +49,208 @@ export function loadBreezeConfig(deps: LoadConfigDeps = {}): BreezeConfig {
     identityTtlMs: 24 * 60 * 60 * 1000,
     claimTimeoutSecs: CLAIM_TIMEOUT_SECS,
   };
+}
+
+/* ------------------------------------------------------------------ */
+/* Phase 3a: daemon-level config                                      */
+/* ------------------------------------------------------------------ */
+
+export interface DaemonConfig {
+  /** Poll cadence in seconds. Rust default: 60s. */
+  pollIntervalSec: number;
+  /** Per-task runtime budget. Rust equivalent lives in dispatcher (Phase 3c). */
+  taskTimeoutSec: number;
+  /** Log verbosity: `debug` | `info` | `warn` | `error`. */
+  logLevel: "debug" | "info" | "warn" | "error";
+  /** Localhost HTTP port for the dashboard + SSE stream. */
+  httpPort: number;
+  /** GitHub API host. */
+  host: string;
+}
+
+export const DAEMON_CONFIG_DEFAULTS: DaemonConfig = {
+  pollIntervalSec: 60,
+  taskTimeoutSec: 15 * 60,
+  logLevel: "info",
+  httpPort: 7878,
+  host: "github.com",
+};
+
+export interface DaemonCliOverrides {
+  pollIntervalSec?: number;
+  taskTimeoutSec?: number;
+  logLevel?: string;
+  httpPort?: number;
+  host?: string;
+}
+
+export interface LoadDaemonConfigDeps {
+  env?: (name: string) => string | undefined;
+  readFile?: (path: string) => string;
+  fileExists?: (path: string) => boolean;
+  homeDir?: () => string;
+  /** Explicit path override; primarily for tests. Beats the search path. */
+  configPath?: string;
+  /** CLI overrides that beat env and yaml. */
+  cliOverrides?: DaemonCliOverrides;
+}
+
+/**
+ * Locations searched for `config.yaml`, in order. The new canonical
+ * location is under `~/.first-tree/breeze/` — the older `~/.breeze/`
+ * location is checked second for back-compat. First hit wins.
+ */
+export function breezeDaemonConfigSearchPaths(
+  homeDir: string = homedir(),
+): string[] {
+  return [
+    join(homeDir, ".first-tree", "breeze", "config.yaml"),
+    join(homeDir, ".breeze", "config.yaml"),
+  ];
+}
+
+interface RawYamlConfig {
+  poll_interval_sec?: unknown;
+  pollIntervalSec?: unknown;
+  task_timeout_sec?: unknown;
+  taskTimeoutSec?: unknown;
+  log_level?: unknown;
+  logLevel?: unknown;
+  http_port?: unknown;
+  httpPort?: unknown;
+  host?: unknown;
+}
+
+function pickNumber(...values: unknown[]): number | undefined {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+      return value;
+    }
+    if (typeof value === "string") {
+      const n = Number.parseInt(value, 10);
+      if (Number.isFinite(n) && n > 0) return n;
+    }
+  }
+  return undefined;
+}
+
+function pickString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+function pickLogLevel(value: unknown): DaemonConfig["logLevel"] | undefined {
+  if (
+    value === "debug" ||
+    value === "info" ||
+    value === "warn" ||
+    value === "error"
+  ) {
+    return value;
+  }
+  return undefined;
+}
+
+/**
+ * Load daemon config with priority: CLI overrides > env > yaml > defaults.
+ *
+ * Env vars honored (kept compatible with breeze-runner names):
+ *   BREEZE_POLL_INTERVAL_SECS  / BREEZE_INBOX_POLL_INTERVAL_SECS
+ *   BREEZE_HTTP_PORT
+ *   BREEZE_LOG_LEVEL
+ *   BREEZE_HOST / GH_HOST
+ *   BREEZE_TASK_TIMEOUT_SECS
+ *
+ * The yaml schema accepts snake_case (preferred) or camelCase keys.
+ * Unknown yaml keys are ignored (forward-compat).
+ */
+export function loadBreezeDaemonConfig(
+  deps: LoadDaemonConfigDeps = {},
+): DaemonConfig {
+  const env = deps.env ?? ((name) => process.env[name]);
+  const readFile = deps.readFile ?? ((p) => readFileSync(p, "utf-8"));
+  const fileExists = deps.fileExists ?? existsSync;
+  const homeDir = deps.homeDir ?? homedir;
+  const cli = deps.cliOverrides ?? {};
+
+  // 1. Defaults.
+  const config: DaemonConfig = { ...DAEMON_CONFIG_DEFAULTS };
+
+  // 2. YAML overlay.
+  const candidates = deps.configPath
+    ? [deps.configPath]
+    : breezeDaemonConfigSearchPaths(homeDir());
+  for (const path of candidates) {
+    if (!fileExists(path)) continue;
+    let raw: string;
+    try {
+      raw = readFile(path);
+    } catch {
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = parseYaml(raw);
+    } catch (err) {
+      throw new Error(
+        `failed to parse breeze daemon config at ${path}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    if (parsed !== null && typeof parsed === "object") {
+      const y = parsed as RawYamlConfig;
+      const pollInterval = pickNumber(y.poll_interval_sec, y.pollIntervalSec);
+      if (pollInterval !== undefined) config.pollIntervalSec = pollInterval;
+      const taskTimeout = pickNumber(y.task_timeout_sec, y.taskTimeoutSec);
+      if (taskTimeout !== undefined) config.taskTimeoutSec = taskTimeout;
+      const logLevel = pickLogLevel(y.log_level ?? y.logLevel);
+      if (logLevel !== undefined) config.logLevel = logLevel;
+      const httpPort = pickNumber(y.http_port, y.httpPort);
+      if (httpPort !== undefined && httpPort < 65_536) {
+        config.httpPort = httpPort;
+      }
+      const host = pickString(y.host);
+      if (host !== undefined) config.host = host;
+    }
+    // First existing file wins — stop searching.
+    break;
+  }
+
+  // 3. Env overlay.
+  const envPoll = pickNumber(
+    env("BREEZE_POLL_INTERVAL_SECS"),
+    env("BREEZE_INBOX_POLL_INTERVAL_SECS"),
+  );
+  if (envPoll !== undefined) config.pollIntervalSec = envPoll;
+  const envTaskTimeout = pickNumber(env("BREEZE_TASK_TIMEOUT_SECS"));
+  if (envTaskTimeout !== undefined) config.taskTimeoutSec = envTaskTimeout;
+  const envLogLevel = pickLogLevel(env("BREEZE_LOG_LEVEL"));
+  if (envLogLevel !== undefined) config.logLevel = envLogLevel;
+  const envPort = pickNumber(env("BREEZE_HTTP_PORT"));
+  if (envPort !== undefined && envPort < 65_536) config.httpPort = envPort;
+  const envHost = pickString(env("BREEZE_HOST"), env("GH_HOST"));
+  if (envHost !== undefined) config.host = envHost;
+
+  // 4. CLI overrides.
+  if (cli.pollIntervalSec !== undefined && cli.pollIntervalSec > 0) {
+    config.pollIntervalSec = cli.pollIntervalSec;
+  }
+  if (cli.taskTimeoutSec !== undefined && cli.taskTimeoutSec > 0) {
+    config.taskTimeoutSec = cli.taskTimeoutSec;
+  }
+  const cliLogLevel = pickLogLevel(cli.logLevel);
+  if (cliLogLevel !== undefined) config.logLevel = cliLogLevel;
+  if (
+    cli.httpPort !== undefined &&
+    cli.httpPort > 0 &&
+    cli.httpPort < 65_536
+  ) {
+    config.httpPort = cli.httpPort;
+  }
+  if (cli.host !== undefined && cli.host.length > 0) {
+    config.host = cli.host;
+  }
+
+  return config;
 }

--- a/src/products/breeze/core/store.ts
+++ b/src/products/breeze/core/store.ts
@@ -4,11 +4,14 @@
  *
  * SINGLE-WRITER RULE (spec doc 2 §1.3):
  * -------------------------------------
- * Only the Rust daemon's poller loop (Phase 3: TS daemon's poller) may
- * call `writeInbox` directly with a full payload. All other callers —
- * `status-manager`, ad-hoc commands, this module's consumers — must go
- * through `updateInbox(mutator)` which acquires the advisory lock,
- * reads the current inbox, applies `mutator`, and writes atomically.
+ * Only a poller loop — the Rust `breeze-runner` fetcher, the TS daemon
+ * poller at `daemon/poller.ts`, or the one-shot TS `commands/poll.ts` —
+ * may call `writeInbox` directly with a full payload. All other callers
+ * (`status-manager`, ad-hoc commands, this module's consumers, the
+ * Phase 3b/3c http/broker/bus) must go through `updateInbox(mutator)`
+ * which acquires the advisory lock, reads the current inbox, applies
+ * `mutator`, and writes atomically. This rule keeps the notification
+ * set authoritative in exactly one place.
  *
  * The lock is implemented with `proper-lockfile` (mkdir-style under the
  * hood, cross-process safe). Stale locks are reclaimed after 10s by

--- a/src/products/breeze/daemon/identity.ts
+++ b/src/products/breeze/daemon/identity.ts
@@ -1,0 +1,157 @@
+/**
+ * Daemon-level identity resolver.
+ *
+ * TS port of `first-tree-breeze/breeze-runner/src/identity.rs`.
+ *
+ * The daemon needs a richer identity than the one-shot commands:
+ *   - `host`  — GitHub host (default `github.com`)
+ *   - `login` — the authenticated user's GH login
+ *   - `gitProtocol` — `https` | `ssh` (from `gh auth status --json hosts`)
+ *   - `scopes` — OAuth scope list; used by `hasRequiredScope` to warn if
+ *     the token lacks `repo`/`notifications`
+ *   - `lockKey(profile)` — `host__login__profile`, used by the broker
+ *     lock directory (`~/.breeze/runner/locks/<lockKey>/`). Phase 3c
+ *     consumes this; we produce it now so identity is stable.
+ *
+ * Caching: delegates to `core/identity-cache.ts`'s 24h-TTL JSON file at
+ * `~/.breeze/identity.json`. The core cache only stores `{login, host,
+ * fetched_at_ms}` because one-shot callers don't need scopes. The
+ * daemon fetches the richer payload via `gh auth status --json hosts`
+ * and keeps it in memory for the lifetime of the daemon process.
+ */
+
+import { GhClient, GhExecError } from "../core/gh.js";
+
+export interface DaemonIdentity {
+  host: string;
+  login: string;
+  gitProtocol: string;
+  scopes: string[];
+}
+
+export function identityLockKey(
+  identity: DaemonIdentity,
+  profile: string,
+): string {
+  return `${identity.host}__${identity.login}__${profile}`;
+}
+
+export function identityHasRequiredScope(identity: DaemonIdentity): boolean {
+  return identity.scopes.some(
+    (scope) => scope === "repo" || scope === "notifications",
+  );
+}
+
+export interface ResolveDaemonIdentityDeps {
+  gh?: GhClient;
+  host?: string;
+}
+
+interface AuthStatusHostEntry {
+  active?: boolean;
+  user?: string;
+  login?: string;
+  gitProtocol?: string;
+  git_protocol?: string;
+  scopes?: string | string[];
+}
+
+interface AuthStatusPayload {
+  hosts?: Record<string, AuthStatusHostEntry | AuthStatusHostEntry[]>;
+}
+
+/**
+ * Parse the scope field as `gh` returns it. Shape varies:
+ *   - Comma-separated string (`"repo,workflow"`) — older output
+ *   - Array of strings (`["repo", "workflow"]`) — newer output
+ */
+function parseScopes(raw: unknown): string[] {
+  if (Array.isArray(raw)) {
+    return raw
+      .filter((s): s is string => typeof s === "string")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+  }
+  if (typeof raw === "string") {
+    return raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+  }
+  return [];
+}
+
+/**
+ * Pick the active account from a `gh auth status --json hosts` payload.
+ * Handles both shapes seen in the wild (single object vs array per host).
+ */
+export function pickActiveIdentityFromAuthStatus(
+  payload: AuthStatusPayload,
+  targetHost: string,
+): DaemonIdentity | null {
+  const hosts = payload.hosts ?? {};
+  for (const [host, bucket] of Object.entries(hosts)) {
+    if (host !== targetHost) continue;
+    const candidates: AuthStatusHostEntry[] = Array.isArray(bucket)
+      ? bucket
+      : [bucket];
+    const active = candidates.find((c) => c?.active === true) ?? candidates[0];
+    if (!active) continue;
+    const login = active.user ?? active.login;
+    if (typeof login !== "string" || login.length === 0) continue;
+    const gitProtocol = active.gitProtocol ?? active.git_protocol ?? "https";
+    return {
+      host,
+      login,
+      gitProtocol,
+      scopes: parseScopes(active.scopes),
+    };
+  }
+  return null;
+}
+
+/**
+ * Resolve the active gh identity for the daemon. Uses
+ * `gh auth status --json hosts` with a jq-free JSON parse in Node.
+ */
+export function resolveDaemonIdentity(
+  deps: ResolveDaemonIdentityDeps = {},
+): DaemonIdentity {
+  const gh = deps.gh ?? new GhClient();
+  const host = deps.host ?? "github.com";
+
+  let stdout: string;
+  try {
+    stdout = gh.runChecked("resolve gh identity", [
+      "auth",
+      "status",
+      "--active",
+      "--hostname",
+      host,
+      "--json",
+      "hosts",
+    ]);
+  } catch (err) {
+    if (err instanceof GhExecError) {
+      throw new Error(
+        `gh auth status failed; run \`gh auth login --hostname ${host}\` first (${err.message.split("\n")[0]})`,
+      );
+    }
+    throw err;
+  }
+
+  let parsed: AuthStatusPayload;
+  try {
+    parsed = JSON.parse(stdout) as AuthStatusPayload;
+  } catch (err) {
+    throw new Error(
+      `gh auth status returned non-JSON output: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const identity = pickActiveIdentityFromAuthStatus(parsed, host);
+  if (!identity) {
+    throw new Error(`no active gh identity found for host \`${host}\``);
+  }
+  return identity;
+}

--- a/src/products/breeze/daemon/poller.ts
+++ b/src/products/breeze/daemon/poller.ts
@@ -1,0 +1,309 @@
+/**
+ * TypeScript port of the Rust breeze daemon's notification poller
+ * (`first-tree-breeze/breeze-runner/src/fetcher.rs`, ~981 lines).
+ *
+ * SINGLE-WRITER RULE (spec doc 2 §1.3, matches core/store.ts):
+ * -------------------------------------------------------------
+ * This module — specifically `pollOnce` — is the ONLY writer of
+ * `~/.breeze/inbox.json` under the TS daemon backend. Broker, HTTP, and
+ * bus (Phase 3b/3c) are read-only with respect to the inbox.
+ *
+ * The on-disk format is bit-compatible with the Rust fetcher:
+ * `core/store.ts` emits the same key order as `entry_to_json`, uses JSON
+ * `null` for nullable fields, and writes via atomic tmp+rename.
+ *
+ * Throttling (ported 1:1 from `gh_executor.rs`):
+ * ---------------------------------------------
+ * The Rust fetcher rate-limits `gh` calls across three buckets (core,
+ * search, write). The daemon poller only uses `core` (notifications +
+ * GraphQL are both read-only core-bucket calls), so we keep a single
+ * scalar `nextAllowedEpochMs` plus a `rateLimitStreak` counter that
+ * escalates backoff exponentially from 60s up to 60*16=960s (16min) on
+ * consecutive 429/abuse responses. See `registerRateLimit`.
+ *
+ * Spec refs:
+ *   - `docs/migration/02-inbox-store-schema.md` (inbox shape)
+ *   - `docs/migration/04-broker-agent-lifecycle.md` §1 (poll cadence)
+ *   - Rust parity: `fetcher.rs::Fetcher::poll_once` and
+ *     `gh_executor.rs::{GhExecutor,is_rate_limited,command_is_mutating}`
+ *
+ * Thin relationship to `commands/poll.ts`:
+ *   - `poll.ts` is the one-shot CLI (`first-tree breeze poll`) that
+ *     executes exactly one fetch + write + exit. It is tested standalone.
+ *   - This daemon poller wraps the same core functions (`parseNotifications`,
+ *     `sortEntries`, `enrichWithLabels`, `classifyEntries`, `diffEvents`)
+ *     in a long-running loop with rate-limit backoff and AbortController
+ *     cancellation.
+ */
+
+import { existsSync, mkdirSync } from "node:fs";
+
+import { appendActivityEvent } from "../core/activity-log.js";
+import { GhClient, GhExecError } from "../core/gh.js";
+import type { BreezePaths } from "../core/paths.js";
+import { updateInbox } from "../core/store.js";
+import {
+  classifyEntries,
+  diffEvents,
+  enrichWithLabels,
+  parseNotifications,
+  sortEntries,
+  splitConcatenatedJsonArrays,
+} from "../commands/poll.js";
+import type { Inbox } from "../core/types.js";
+
+export interface PollerLogger {
+  info: (line: string) => void;
+  warn: (line: string) => void;
+  error: (line: string) => void;
+}
+
+const DEFAULT_LOGGER: PollerLogger = {
+  info: (line) => process.stdout.write(`${line}\n`),
+  warn: (line) => process.stderr.write(`WARN: ${line}\n`),
+  error: (line) => process.stderr.write(`ERROR: ${line}\n`),
+};
+
+export interface PollerOptions {
+  /** Cadence between polls, in seconds. */
+  pollIntervalSec: number;
+  /** GitHub host (usually `github.com`). */
+  host: string;
+  /** Injected `gh` wrapper. Tests supply a stub. */
+  gh?: GhClient;
+  /** Filesystem layout. Production code passes `resolveBreezePaths()`. */
+  paths: BreezePaths;
+  /** Abort signal for cooperative shutdown (wired from SIGTERM handler). */
+  signal?: AbortSignal;
+  /** `Date.now`-style clock override for tests. */
+  now?: () => number;
+  /** Logger sink. Defaults to stdout/stderr. */
+  logger?: PollerLogger;
+  /**
+   * Injected sleep used between polls and while backing off on rate
+   * limits. Tests can replace this with an instant resolver.
+   */
+  sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
+}
+
+export interface PollOutcome {
+  /** Total entries in the inbox this cycle. */
+  total: number;
+  /** Number classified as `new`. */
+  newCount: number;
+  /** One-line warnings (degraded fetch, enrichment partial, etc). */
+  warnings: string[];
+  /** True if GitHub returned a rate-limit signature. */
+  rateLimited: boolean;
+}
+
+interface PollOnceDeps {
+  gh: GhClient;
+  paths: BreezePaths;
+  host: string;
+  now: () => number;
+}
+
+/** Seconds-precision ISO-8601 UTC, matching `date -u +%Y-%m-%dT%H:%M:%SZ`. */
+function formatUtcIso(epochMs: number): string {
+  return `${new Date(epochMs).toISOString().slice(0, 19)}Z`;
+}
+
+/**
+ * Best-effort `gh`-output classifier. Copy of `is_rate_limited` in
+ * `gh_executor.rs:247-254` — kept in sync with the Rust heuristic.
+ */
+export function isRateLimited(stdout: string, stderr: string): boolean {
+  const combined = `${stdout}\n${stderr}`.toLowerCase();
+  return (
+    combined.includes("secondary rate limit") ||
+    combined.includes("rate limit exceeded") ||
+    combined.includes("api rate limit") ||
+    combined.includes("abuse detection") ||
+    combined.includes("retry after")
+  );
+}
+
+/**
+ * Exponential backoff schedule. Mirrors `register_rate_limit`
+ * (`gh_executor.rs:154-167`): base 60s, doubled per consecutive
+ * 429/abuse response, capped at `60s * 2^4 = 960s` (16min).
+ */
+export function rateLimitBackoffMs(streak: number): number {
+  const exponent = Math.min(Math.max(streak, 1), 4);
+  return 60_000 * Math.pow(2, exponent);
+}
+
+async function defaultSleep(
+  ms: number,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (ms <= 0) return;
+  if (signal?.aborted) return;
+  return new Promise<void>((resolve) => {
+    const handle = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+    const onAbort = (): void => {
+      clearTimeout(handle);
+      cleanup();
+      resolve();
+    };
+    const cleanup = (): void => {
+      if (signal) signal.removeEventListener("abort", onAbort);
+    };
+    if (signal) signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
+ * Run a single poll cycle: fetch notifications, enrich labels, classify,
+ * write inbox.json, append activity events. Returns a structured
+ * outcome; never throws on GitHub-side failure (warnings only), to
+ * mirror the Rust fetcher's degraded behaviour (fetcher.rs:89-99).
+ */
+export async function pollOnce(deps: PollOnceDeps): Promise<PollOutcome> {
+  const { gh, paths, host, now } = deps;
+  if (!existsSync(paths.root)) mkdirSync(paths.root, { recursive: true });
+
+  const warnings: string[] = [];
+
+  // Fetch notifications. `--paginate` concatenates pages; we split.
+  let rawPages: string[];
+  try {
+    const stdout = gh.runChecked("fetch notifications", [
+      "api",
+      "/notifications?all=true",
+      "--paginate",
+      "-H",
+      "X-GitHub-Api-Version: 2022-11-28",
+    ]);
+    rawPages = splitConcatenatedJsonArrays(stdout);
+  } catch (err) {
+    if (err instanceof GhExecError) {
+      const combined = `${err.stdout}\n${err.stderr}`;
+      const rateLimited = isRateLimited(err.stdout, err.stderr);
+      warnings.push(
+        `GitHub notifications fetch failed: ${err.message.split("\n")[0]}`,
+      );
+      return {
+        total: 0,
+        newCount: 0,
+        warnings,
+        rateLimited,
+      };
+    }
+    throw err;
+  }
+
+  const entries = parseNotifications(rawPages, host);
+  sortEntries(entries);
+
+  const enrichmentWarning = enrichWithLabels(entries, gh, host);
+  if (enrichmentWarning) {
+    warnings.push(`label enrichment degraded: ${enrichmentWarning}`);
+  }
+  classifyEntries(entries);
+
+  const pollTs = formatUtcIso(now());
+  const nextInbox: Inbox = { last_poll: pollTs, notifications: entries };
+
+  let diff: ReturnType<typeof diffEvents> = [];
+  await updateInbox(
+    (current) => {
+      diff = diffEvents(current, entries);
+      return nextInbox;
+    },
+    { inboxPath: paths.inbox },
+  );
+
+  for (const ev of diff) {
+    if (ev.kind === "new") {
+      appendActivityEvent(paths.activityLog, {
+        ts: pollTs,
+        event: "new",
+        id: ev.entry.id,
+        type: ev.entry.type,
+        repo: ev.entry.repo,
+        title: ev.entry.title,
+        url: ev.entry.html_url,
+      });
+    } else if (ev.kind === "transition" && ev.from && ev.to) {
+      appendActivityEvent(paths.activityLog, {
+        ts: pollTs,
+        event: "transition",
+        id: ev.entry.id,
+        type: ev.entry.type,
+        repo: ev.entry.repo,
+        title: ev.entry.title,
+        url: ev.entry.html_url,
+        from: ev.from,
+        to: ev.to,
+      });
+    }
+  }
+
+  const total = entries.length;
+  const newCount = entries.filter((e) => e.breeze_status === "new").length;
+  return { total, newCount, warnings, rateLimited: false };
+}
+
+/**
+ * The long-running poll loop. Resolves when `signal` aborts. Callers
+ * fire-and-await this inside `runner-skeleton.ts`.
+ *
+ * Behaviour:
+ *   - Runs `pollOnce` immediately on start.
+ *   - Sleeps `pollIntervalSec` between successful cycles.
+ *   - On rate-limit detection, escalates the sleep per
+ *     `rateLimitBackoffMs(streak)` until a clean cycle resets the streak.
+ *   - `signal.aborted` triggers a clean return; in-flight `pollOnce` is
+ *     not force-cancelled (the advisory lock on inbox.json must drain).
+ */
+export async function runPoller(options: PollerOptions): Promise<void> {
+  const gh = options.gh ?? new GhClient();
+  const logger = options.logger ?? DEFAULT_LOGGER;
+  const now = options.now ?? Date.now;
+  const sleep = options.sleep ?? defaultSleep;
+  const signal = options.signal;
+
+  let rateLimitStreak = 0;
+
+  while (!signal?.aborted) {
+    let outcome: PollOutcome;
+    try {
+      outcome = await pollOnce({
+        gh,
+        paths: options.paths,
+        host: options.host,
+        now,
+      });
+    } catch (err) {
+      // Local/setup error (not a gh-side failure). Log and retry after
+      // a regular interval — the operator needs to fix the environment.
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error(`poll cycle crashed: ${message}`);
+      await sleep(options.pollIntervalSec * 1000, signal);
+      continue;
+    }
+
+    for (const warning of outcome.warnings) logger.warn(warning);
+
+    if (outcome.rateLimited) {
+      rateLimitStreak += 1;
+      const backoff = rateLimitBackoffMs(rateLimitStreak);
+      logger.warn(
+        `rate-limited by GitHub; sleeping ${Math.round(backoff / 1000)}s (streak=${rateLimitStreak})`,
+      );
+      await sleep(backoff, signal);
+      continue;
+    }
+
+    rateLimitStreak = 0;
+    logger.info(
+      `breeze: polled ${outcome.total} notifications (${outcome.newCount} new)`,
+    );
+    await sleep(options.pollIntervalSec * 1000, signal);
+  }
+}

--- a/src/products/breeze/daemon/runner-skeleton.ts
+++ b/src/products/breeze/daemon/runner-skeleton.ts
@@ -1,0 +1,252 @@
+/**
+ * Minimal TS daemon entrypoint.
+ *
+ * This is Phase 3a: read-path only. The daemon spins up the notification
+ * poller and waits for a shutdown signal. HTTP, broker, bus, dispatcher
+ * are deferred to Phase 3b/3c — this skeleton explicitly leaves those
+ * wiring points as TODOs so reviewers can see the future surface.
+ *
+ * Launch path:
+ *   `first-tree breeze daemon --backend=ts`
+ * delegates here via `src/products/breeze/cli.ts`. The `rust` backend
+ * (default in Phase 3a) continues to route through
+ * `bridge.ts::resolveBreezeRunner` and the Rust `breeze-runner` binary;
+ * nothing in this file touches that path.
+ *
+ * Shutdown contract:
+ *   - SIGTERM / SIGINT cascade through a single AbortController.
+ *   - The poller observes `signal.aborted`, finishes any in-flight
+ *     `pollOnce` (including draining the inbox.json advisory lock),
+ *     then resolves.
+ *   - The daemon exits with code 0 on clean shutdown, 1 if the poller
+ *     threw.
+ */
+
+import { resolveBreezePaths } from "../core/paths.js";
+import { loadBreezeDaemonConfig, type DaemonConfig } from "../core/config.js";
+
+import { resolveDaemonIdentity, identityHasRequiredScope } from "./identity.js";
+import { runPoller, type PollerLogger } from "./poller.js";
+
+export interface DaemonCliOverrides {
+  pollIntervalSec?: number;
+  host?: string;
+  logLevel?: string;
+  httpPort?: number;
+  // taskTimeoutSec is read today but not yet consumed; kept for Phase 3b.
+  taskTimeoutSec?: number;
+}
+
+export interface DaemonRunOptions {
+  /** Parsed CLI overrides (from `--poll-interval-secs` etc). */
+  cliOverrides?: DaemonCliOverrides;
+  /** Whether to install SIGTERM/SIGINT handlers. Tests pass `false`. */
+  installSignalHandlers?: boolean;
+  /** Injected signal for tests (takes precedence over signal handlers). */
+  signal?: AbortSignal;
+  /** Logger override for tests. */
+  logger?: PollerLogger;
+}
+
+const DEFAULT_LOGGER: PollerLogger = {
+  info: (line) => process.stdout.write(`${line}\n`),
+  warn: (line) => process.stderr.write(`WARN: ${line}\n`),
+  error: (line) => process.stderr.write(`ERROR: ${line}\n`),
+};
+
+/**
+ * Parse the `--backend=...` / `--poll-interval-secs` style argv the
+ * daemon accepts. Very small on purpose; breeze-runner has ~20 flags
+ * but Phase 3a only needs a handful for the read path.
+ *
+ * Recognised flags (all optional):
+ *   --poll-interval-secs <n>
+ *   --host <host>
+ *   --log-level <level>
+ *   --http-port <n>
+ *   --task-timeout-secs <n>
+ *
+ * Unknown flags are dropped silently in Phase 3a — they'll be parsed by
+ * the future full-featured daemon in 3b/3c. This keeps the skeleton
+ * forward-compatible with existing Rust-backend invocations.
+ */
+export function parseDaemonArgs(argv: readonly string[]): DaemonCliOverrides {
+  const overrides: DaemonCliOverrides = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = (): string | undefined => argv[i + 1];
+    const advance = (): void => {
+      i += 1;
+    };
+    switch (arg) {
+      case "--poll-interval-secs":
+      case "--poll-interval-sec": {
+        const value = next();
+        if (value !== undefined) {
+          const n = Number.parseInt(value, 10);
+          if (Number.isFinite(n) && n > 0) overrides.pollIntervalSec = n;
+          advance();
+        }
+        break;
+      }
+      case "--host": {
+        const value = next();
+        if (value !== undefined) {
+          overrides.host = value;
+          advance();
+        }
+        break;
+      }
+      case "--log-level": {
+        const value = next();
+        if (value !== undefined) {
+          overrides.logLevel = value;
+          advance();
+        }
+        break;
+      }
+      case "--http-port": {
+        const value = next();
+        if (value !== undefined) {
+          const n = Number.parseInt(value, 10);
+          if (Number.isFinite(n) && n > 0 && n < 65_536) {
+            overrides.httpPort = n;
+          }
+          advance();
+        }
+        break;
+      }
+      case "--task-timeout-secs":
+      case "--task-timeout-sec": {
+        const value = next();
+        if (value !== undefined) {
+          const n = Number.parseInt(value, 10);
+          if (Number.isFinite(n) && n > 0) overrides.taskTimeoutSec = n;
+          advance();
+        }
+        break;
+      }
+      default:
+        // Forward-compat: ignore unknown flags in 3a.
+        break;
+    }
+  }
+  return overrides;
+}
+
+/**
+ * Install SIGTERM/SIGINT handlers that trigger the AbortController.
+ * Returns a cleanup function that removes the handlers — tests should
+ * call it to avoid polluting the signal table across test cases.
+ */
+function installShutdownHandlers(
+  controller: AbortController,
+  logger: PollerLogger,
+): () => void {
+  const signals: NodeJS.Signals[] = ["SIGTERM", "SIGINT"];
+  const onSignal = (signal: NodeJS.Signals): void => {
+    if (controller.signal.aborted) return;
+    logger.info(`received ${signal}; shutting down`);
+    controller.abort();
+  };
+  const bound: Array<[NodeJS.Signals, (s: NodeJS.Signals) => void]> = [];
+  for (const sig of signals) {
+    const handler = (): void => onSignal(sig);
+    process.on(sig, handler);
+    bound.push([sig, handler]);
+  }
+  return () => {
+    for (const [sig, handler] of bound) {
+      process.off(sig, handler);
+    }
+  };
+}
+
+/**
+ * Main daemon entry. Exits only on signal or fatal error.
+ * Returns an exit code suitable for `process.exit`.
+ */
+export async function runDaemon(
+  argv: readonly string[] = [],
+  options: DaemonRunOptions = {},
+): Promise<number> {
+  const logger = options.logger ?? DEFAULT_LOGGER;
+  const cliOverrides = options.cliOverrides ?? parseDaemonArgs(argv);
+
+  let config: DaemonConfig;
+  try {
+    config = loadBreezeDaemonConfig({ cliOverrides });
+  } catch (err) {
+    logger.error(
+      `failed to load daemon config: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return 1;
+  }
+
+  const paths = resolveBreezePaths();
+
+  // Identity resolution is best-effort at startup. The daemon will still
+  // try to poll if identity fails — the poller uses the host-only env,
+  // not the login. But we log loudly so operators notice.
+  try {
+    const identity = resolveDaemonIdentity({ host: config.host });
+    if (!identityHasRequiredScope(identity)) {
+      logger.warn(
+        `gh token for ${identity.login}@${identity.host} lacks \`repo\`/\`notifications\` scope; poll may return empty results`,
+      );
+    } else {
+      logger.info(
+        `breeze daemon: identity=${identity.login}@${identity.host}`,
+      );
+    }
+  } catch (err) {
+    logger.warn(
+      `identity resolution failed (continuing): ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  // Wire abort cascade. Tests may pass a pre-built signal directly.
+  const controller = new AbortController();
+  let uninstallHandlers: (() => void) | null = null;
+  const installHandlers = options.installSignalHandlers ?? true;
+  if (installHandlers) {
+    uninstallHandlers = installShutdownHandlers(controller, logger);
+  }
+  if (options.signal) {
+    if (options.signal.aborted) controller.abort();
+    else options.signal.addEventListener("abort", () => controller.abort(), {
+      once: true,
+    });
+  }
+
+  logger.info(
+    `breeze daemon: poll-interval=${config.pollIntervalSec}s host=${config.host} http-port=${config.httpPort}`,
+  );
+  // TODO(Phase 3b): start http server bound to 127.0.0.1:${config.httpPort}.
+  // TODO(Phase 3c): start broker gh-serializer + bus + dispatcher.
+  // For now only the poller runs — it is the read path and is
+  // already feature-complete per the Phase 3a scope.
+
+  let exitCode = 0;
+  try {
+    await runPoller({
+      pollIntervalSec: config.pollIntervalSec,
+      host: config.host,
+      paths,
+      signal: controller.signal,
+      logger,
+    });
+  } catch (err) {
+    logger.error(
+      `poller exited with error: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
+    );
+    exitCode = 1;
+  } finally {
+    if (uninstallHandlers) uninstallHandlers();
+  }
+
+  logger.info("breeze daemon: shutdown complete");
+  return exitCode;
+}
+
+export default runDaemon;

--- a/tests/breeze-daemon-config.test.ts
+++ b/tests/breeze-daemon-config.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for the Phase 3a daemon config loader.
+ *
+ * Verifies the priority pipeline documented in `core/config.ts`:
+ *   CLI overrides > env vars > yaml > defaults.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  DAEMON_CONFIG_DEFAULTS,
+  breezeDaemonConfigSearchPaths,
+  loadBreezeDaemonConfig,
+} from "../src/products/breeze/core/config.js";
+
+describe("loadBreezeDaemonConfig", () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "breeze-daemon-cfg-"));
+  });
+  afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+  it("falls back to defaults when nothing is configured", () => {
+    const cfg = loadBreezeDaemonConfig({
+      env: () => undefined,
+      fileExists: () => false,
+      readFile: () => "",
+      homeDir: () => tmp,
+    });
+    expect(cfg).toEqual(DAEMON_CONFIG_DEFAULTS);
+    expect(cfg.pollIntervalSec).toBe(60);
+    expect(cfg.httpPort).toBe(7878);
+    expect(cfg.logLevel).toBe("info");
+    expect(cfg.host).toBe("github.com");
+  });
+
+  it("reads yaml over defaults (snake_case keys)", () => {
+    const yaml = `poll_interval_sec: 30
+task_timeout_sec: 300
+log_level: debug
+http_port: 9191
+host: ghe.example.com
+`;
+    const configPath = join(tmp, "config.yaml");
+    writeFileSync(configPath, yaml, "utf-8");
+    const cfg = loadBreezeDaemonConfig({
+      env: () => undefined,
+      configPath,
+    });
+    expect(cfg.pollIntervalSec).toBe(30);
+    expect(cfg.taskTimeoutSec).toBe(300);
+    expect(cfg.logLevel).toBe("debug");
+    expect(cfg.httpPort).toBe(9191);
+    expect(cfg.host).toBe("ghe.example.com");
+  });
+
+  it("accepts camelCase yaml keys too (forward-compat)", () => {
+    const yaml = `pollIntervalSec: 45
+httpPort: 8080
+`;
+    const configPath = join(tmp, "config.yaml");
+    writeFileSync(configPath, yaml, "utf-8");
+    const cfg = loadBreezeDaemonConfig({
+      env: () => undefined,
+      configPath,
+    });
+    expect(cfg.pollIntervalSec).toBe(45);
+    expect(cfg.httpPort).toBe(8080);
+  });
+
+  it("env vars beat yaml", () => {
+    const yaml = `poll_interval_sec: 30\nhttp_port: 9191\n`;
+    const configPath = join(tmp, "config.yaml");
+    writeFileSync(configPath, yaml, "utf-8");
+    const envBag: Record<string, string> = {
+      BREEZE_POLL_INTERVAL_SECS: "120",
+      BREEZE_HTTP_PORT: "4242",
+    };
+    const cfg = loadBreezeDaemonConfig({
+      env: (name) => envBag[name],
+      configPath,
+    });
+    expect(cfg.pollIntervalSec).toBe(120);
+    expect(cfg.httpPort).toBe(4242);
+  });
+
+  it("CLI overrides beat env and yaml", () => {
+    const yaml = `poll_interval_sec: 30\nhttp_port: 9191\n`;
+    const configPath = join(tmp, "config.yaml");
+    writeFileSync(configPath, yaml, "utf-8");
+    const envBag: Record<string, string> = {
+      BREEZE_POLL_INTERVAL_SECS: "120",
+      BREEZE_HTTP_PORT: "4242",
+    };
+    const cfg = loadBreezeDaemonConfig({
+      env: (name) => envBag[name],
+      configPath,
+      cliOverrides: { pollIntervalSec: 5, httpPort: 1234 },
+    });
+    expect(cfg.pollIntervalSec).toBe(5);
+    expect(cfg.httpPort).toBe(1234);
+  });
+
+  it("searches ~/.first-tree/breeze/ before ~/.breeze/", () => {
+    const paths = breezeDaemonConfigSearchPaths(tmp);
+    expect(paths[0]).toBe(join(tmp, ".first-tree", "breeze", "config.yaml"));
+    expect(paths[1]).toBe(join(tmp, ".breeze", "config.yaml"));
+  });
+
+  it("honors BREEZE_INBOX_POLL_INTERVAL_SECS as a fallback env key", () => {
+    const envBag: Record<string, string> = {
+      BREEZE_INBOX_POLL_INTERVAL_SECS: "15",
+    };
+    const cfg = loadBreezeDaemonConfig({
+      env: (name) => envBag[name],
+      configPath: join(tmp, "no-such-file.yaml"),
+    });
+    expect(cfg.pollIntervalSec).toBe(15);
+  });
+
+  it("GH_HOST is an accepted host fallback", () => {
+    const envBag: Record<string, string> = { GH_HOST: "ghe.internal" };
+    const cfg = loadBreezeDaemonConfig({
+      env: (name) => envBag[name],
+      configPath: join(tmp, "no-such-file.yaml"),
+    });
+    expect(cfg.host).toBe("ghe.internal");
+  });
+
+  it("rejects malformed yaml with a descriptive error", () => {
+    const configPath = join(tmp, "config.yaml");
+    writeFileSync(configPath, "poll_interval_sec: : :\n", "utf-8");
+    expect(() =>
+      loadBreezeDaemonConfig({
+        env: () => undefined,
+        configPath,
+      }),
+    ).toThrow(/failed to parse breeze daemon config/u);
+  });
+
+  it("ignores invalid log levels in yaml", () => {
+    const configPath = join(tmp, "config.yaml");
+    writeFileSync(configPath, `log_level: silly\n`, "utf-8");
+    const cfg = loadBreezeDaemonConfig({
+      env: () => undefined,
+      configPath,
+    });
+    expect(cfg.logLevel).toBe("info"); // fell back to default
+  });
+
+  it("skips yaml overlay when the file does not exist", () => {
+    const cfg = loadBreezeDaemonConfig({
+      env: () => undefined,
+      configPath: join(tmp, "missing.yaml"),
+    });
+    expect(cfg).toEqual(DAEMON_CONFIG_DEFAULTS);
+  });
+
+  it("accepts first existing yaml in the search order (first-tree wins)", () => {
+    const primaryDir = join(tmp, ".first-tree", "breeze");
+    const legacyDir = join(tmp, ".breeze");
+    writeFileSync(
+      `${tmp}/first.tmp`, // dummy to ensure tmp exists
+      "",
+      "utf-8",
+    );
+    // mkdir -p primary + legacy via real fs
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { mkdirSync, writeFileSync: wfs } = require("node:fs") as typeof import("node:fs");
+    mkdirSync(primaryDir, { recursive: true });
+    mkdirSync(legacyDir, { recursive: true });
+    wfs(join(primaryDir, "config.yaml"), "poll_interval_sec: 7\n", "utf-8");
+    wfs(join(legacyDir, "config.yaml"), "poll_interval_sec: 99\n", "utf-8");
+    const cfg = loadBreezeDaemonConfig({
+      env: () => undefined,
+      homeDir: () => tmp,
+    });
+    expect(cfg.pollIntervalSec).toBe(7);
+  });
+});

--- a/tests/breeze-daemon-identity.test.ts
+++ b/tests/breeze-daemon-identity.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for the Phase 3a daemon identity resolver.
+ *
+ * Parity points vs the Rust `identity.rs`:
+ *   - `lockKey(profile)` formats as `host__login__profile`
+ *   - `hasRequiredScope()` is true iff `repo` or `notifications` is present
+ *   - `resolveDaemonIdentity` surfaces a clean error when `gh auth status`
+ *     fails rather than leaking the raw stderr
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { GhClient } from "../src/products/breeze/core/gh.js";
+import {
+  identityHasRequiredScope,
+  identityLockKey,
+  pickActiveIdentityFromAuthStatus,
+  resolveDaemonIdentity,
+} from "../src/products/breeze/daemon/identity.js";
+
+function makeGhReturning(stdout: string, status = 0): GhClient {
+  const spawn = vi.fn().mockReturnValue({
+    pid: 1,
+    status,
+    signal: null,
+    stdout: Buffer.from(stdout),
+    stderr: Buffer.alloc(0),
+    output: [],
+  });
+  return new GhClient({ spawn });
+}
+
+describe("identityLockKey", () => {
+  it("matches the Rust Identity::lock_key format", () => {
+    const key = identityLockKey(
+      {
+        host: "github.com",
+        login: "bingran-you",
+        gitProtocol: "https",
+        scopes: ["repo"],
+      },
+      "default",
+    );
+    expect(key).toBe("github.com__bingran-you__default");
+  });
+});
+
+describe("identityHasRequiredScope", () => {
+  it("is true when `repo` or `notifications` is in scopes", () => {
+    expect(
+      identityHasRequiredScope({
+        host: "github.com",
+        login: "x",
+        gitProtocol: "https",
+        scopes: ["repo", "workflow"],
+      }),
+    ).toBe(true);
+    expect(
+      identityHasRequiredScope({
+        host: "github.com",
+        login: "x",
+        gitProtocol: "https",
+        scopes: ["notifications"],
+      }),
+    ).toBe(true);
+  });
+  it("is false otherwise", () => {
+    expect(
+      identityHasRequiredScope({
+        host: "github.com",
+        login: "x",
+        gitProtocol: "https",
+        scopes: ["workflow"],
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("pickActiveIdentityFromAuthStatus", () => {
+  it("picks active=true when multiple entries per host", () => {
+    const payload = {
+      hosts: {
+        "github.com": [
+          {
+            user: "old-login",
+            active: false,
+            gitProtocol: "ssh",
+            scopes: "repo",
+          },
+          {
+            user: "active-login",
+            active: true,
+            gitProtocol: "https",
+            scopes: "repo,workflow",
+          },
+        ],
+      },
+    };
+    const id = pickActiveIdentityFromAuthStatus(payload, "github.com");
+    expect(id?.login).toBe("active-login");
+    expect(id?.scopes).toEqual(["repo", "workflow"]);
+    expect(id?.gitProtocol).toBe("https");
+  });
+
+  it("accepts scope arrays as well as comma strings", () => {
+    const payload = {
+      hosts: {
+        "github.com": {
+          user: "x",
+          active: true,
+          gitProtocol: "https",
+          scopes: ["repo", "notifications"],
+        },
+      },
+    };
+    const id = pickActiveIdentityFromAuthStatus(payload, "github.com");
+    expect(id?.scopes).toEqual(["repo", "notifications"]);
+  });
+
+  it("returns null when target host is missing", () => {
+    const payload = {
+      hosts: { "ghe.other": { user: "x", active: true, scopes: "repo" } },
+    };
+    expect(pickActiveIdentityFromAuthStatus(payload, "github.com")).toBeNull();
+  });
+});
+
+describe("resolveDaemonIdentity", () => {
+  it("surfaces gh auth failure with an actionable error", () => {
+    const gh = makeGhReturning("", 1);
+    expect(() => resolveDaemonIdentity({ gh })).toThrow(/gh auth login/u);
+  });
+
+  it("round-trips a realistic payload", () => {
+    const payload = JSON.stringify({
+      hosts: {
+        "github.com": {
+          user: "bingran-you",
+          active: true,
+          gitProtocol: "https",
+          scopes: "repo,workflow,notifications",
+        },
+      },
+    });
+    const gh = makeGhReturning(payload, 0);
+    const id = resolveDaemonIdentity({ gh });
+    expect(id.host).toBe("github.com");
+    expect(id.login).toBe("bingran-you");
+    expect(id.gitProtocol).toBe("https");
+    expect(id.scopes).toContain("repo");
+    expect(identityHasRequiredScope(id)).toBe(true);
+  });
+});

--- a/tests/breeze-daemon-poller.test.ts
+++ b/tests/breeze-daemon-poller.test.ts
@@ -1,0 +1,398 @@
+/**
+ * Parity tests for the Phase 3a TS daemon poller.
+ *
+ * Covers:
+ *   - `pollOnce` transforms a single notification into an inbox entry
+ *     that matches the canonical shape from
+ *     `docs/migration/02-inbox-store-schema.md` §1.2.
+ *   - `isRateLimited` classifier recognises the same signatures as
+ *     `gh_executor.rs::is_rate_limited`.
+ *   - `rateLimitBackoffMs` follows the Rust exponential schedule.
+ *   - `runPoller` loop exits cleanly on AbortSignal.
+ */
+
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GhClient } from "../src/products/breeze/core/gh.js";
+import { resolveBreezePaths } from "../src/products/breeze/core/paths.js";
+import {
+  isRateLimited,
+  pollOnce,
+  rateLimitBackoffMs,
+  runPoller,
+} from "../src/products/breeze/daemon/poller.js";
+
+interface ResponseMatcher {
+  match: (argv: readonly string[]) => boolean;
+  status?: number;
+  stdout?: string;
+  stderr?: string;
+}
+
+function makeStubGh(matchers: ResponseMatcher[]): GhClient {
+  const calls: string[][] = [];
+  const spawn = vi
+    .fn()
+    .mockImplementation((_cmd: string, argv: string[]) => {
+      calls.push([...argv]);
+      for (const m of matchers) {
+        if (m.match(argv)) {
+          return {
+            pid: 1,
+            status: m.status ?? 0,
+            signal: null,
+            stdout: Buffer.from(m.stdout ?? ""),
+            stderr: Buffer.from(m.stderr ?? ""),
+            output: [],
+          };
+        }
+      }
+      return {
+        pid: 1,
+        status: 0,
+        signal: null,
+        stdout: Buffer.alloc(0),
+        stderr: Buffer.alloc(0),
+        output: [],
+      };
+    });
+  return new GhClient({ spawn });
+}
+
+function mkBreezeDir(): { dir: string; inbox: string; activity: string } {
+  const dir = mkdtempSync(join(tmpdir(), "breeze-daemon-poller-"));
+  return {
+    dir,
+    inbox: join(dir, "inbox.json"),
+    activity: join(dir, "activity.log"),
+  };
+}
+
+describe("isRateLimited", () => {
+  it("recognises the same signatures as the Rust helper", () => {
+    expect(isRateLimited("", "API rate limit exceeded (HTTP 403)")).toBe(true);
+    expect(isRateLimited("", "secondary rate limit for user")).toBe(true);
+    expect(isRateLimited("", "abuse detection triggered")).toBe(true);
+    expect(isRateLimited("", "please retry after 60s")).toBe(true);
+    expect(isRateLimited("", "gh: permission denied")).toBe(false);
+    expect(isRateLimited("", "")).toBe(false);
+  });
+});
+
+describe("rateLimitBackoffMs", () => {
+  it("starts at 120s (2^1 * 60s) on first strike", () => {
+    expect(rateLimitBackoffMs(1)).toBe(120_000);
+  });
+  it("doubles per consecutive strike, capped at 2^4 * 60s = 960s", () => {
+    expect(rateLimitBackoffMs(2)).toBe(240_000);
+    expect(rateLimitBackoffMs(3)).toBe(480_000);
+    expect(rateLimitBackoffMs(4)).toBe(960_000);
+    expect(rateLimitBackoffMs(5)).toBe(960_000);
+    expect(rateLimitBackoffMs(100)).toBe(960_000);
+  });
+  it("clamps streak values below 1 to the initial backoff", () => {
+    expect(rateLimitBackoffMs(0)).toBe(120_000);
+    expect(rateLimitBackoffMs(-5)).toBe(120_000);
+  });
+});
+
+describe("pollOnce parity with Rust fetcher", () => {
+  let ctx: ReturnType<typeof mkBreezeDir>;
+  beforeEach(() => {
+    ctx = mkBreezeDir();
+  });
+  afterEach(() => rmSync(ctx.dir, { recursive: true, force: true }));
+
+  it("writes an inbox.json whose single entry matches the canonical schema", async () => {
+    // Canonical shape (redacted) copied from docs/migration §1.2:
+    //   {
+    //     "id": "23576674030",
+    //     "type": "PullRequest",
+    //     "reason": "author",
+    //     "repo": "serenakeyitan/paperclip-tree",
+    //     "title": "fix(tree): salvage nya1 member node from closed sync PR 282",
+    //     "url": "https://api.github.com/.../pulls/290",
+    //     "last_actor": "https://api.github.com/.../issues/comments/4258143984",
+    //     "updated_at": "2026-04-16T07:24:28Z",
+    //     "unread": false,
+    //     "priority": 5,
+    //     "number": 290,
+    //     "html_url": "https://github.com/.../pull/290",
+    //     "gh_state": "OPEN",
+    //     "labels": [],
+    //     "breeze_status": "new"
+    //   }
+    const rawNotification = JSON.stringify([
+      {
+        id: "23576674030",
+        subject: {
+          type: "PullRequest",
+          title: "fix(tree): salvage nya1 member node from closed sync PR 282",
+          url: "https://api.github.com/repos/serenakeyitan/paperclip-tree/pulls/290",
+          latest_comment_url:
+            "https://api.github.com/repos/serenakeyitan/paperclip-tree/issues/comments/4258143984",
+        },
+        repository: { full_name: "serenakeyitan/paperclip-tree" },
+        reason: "author",
+        updated_at: "2026-04-16T07:24:28Z",
+        unread: false,
+      },
+    ]);
+    const graphqlResponse = JSON.stringify({
+      data: {
+        repository: {
+          n290: {
+            number: 290,
+            state: "OPEN",
+            labels: { nodes: [] },
+          },
+        },
+      },
+    });
+    const gh = makeStubGh([
+      {
+        match: (argv) => argv[0] === "api" && argv[1]?.startsWith("/notifications"),
+        stdout: rawNotification,
+      },
+      {
+        match: (argv) => argv[0] === "api" && argv[1] === "graphql",
+        stdout: graphqlResponse,
+      },
+    ]);
+    const paths = resolveBreezePaths({ env: () => ctx.dir });
+
+    const outcome = await pollOnce({
+      gh,
+      paths,
+      host: "github.com",
+      now: () => Date.parse("2026-04-16T20:15:30Z"),
+    });
+
+    expect(outcome.total).toBe(1);
+    expect(outcome.newCount).toBe(1);
+    expect(outcome.warnings).toEqual([]);
+    expect(outcome.rateLimited).toBe(false);
+
+    const parsed = JSON.parse(readFileSync(ctx.inbox, "utf-8")) as {
+      last_poll: string;
+      notifications: Array<Record<string, unknown>>;
+    };
+    expect(parsed.last_poll).toBe("2026-04-16T20:15:30Z");
+    expect(parsed.notifications).toHaveLength(1);
+
+    // Verify every field from the spec matrix, including null fields.
+    const entry = parsed.notifications[0];
+    expect(entry).toMatchObject({
+      id: "23576674030",
+      type: "PullRequest",
+      reason: "author",
+      repo: "serenakeyitan/paperclip-tree",
+      title: "fix(tree): salvage nya1 member node from closed sync PR 282",
+      url: "https://api.github.com/repos/serenakeyitan/paperclip-tree/pulls/290",
+      last_actor:
+        "https://api.github.com/repos/serenakeyitan/paperclip-tree/issues/comments/4258143984",
+      updated_at: "2026-04-16T07:24:28Z",
+      unread: false,
+      priority: 5,
+      number: 290,
+      html_url: "https://github.com/serenakeyitan/paperclip-tree/pull/290",
+      gh_state: "OPEN",
+      labels: [],
+      breeze_status: "new",
+    });
+
+    // Key order must match the Rust entry_to_json output (spec §1.1).
+    expect(Object.keys(entry)).toEqual([
+      "id",
+      "type",
+      "reason",
+      "repo",
+      "title",
+      "url",
+      "last_actor",
+      "updated_at",
+      "unread",
+      "priority",
+      "number",
+      "html_url",
+      "gh_state",
+      "labels",
+      "breeze_status",
+    ]);
+  });
+
+  it("marks rateLimited=true when notifications fetch is rate-limited", async () => {
+    const gh = makeStubGh([
+      {
+        match: (argv) =>
+          argv[0] === "api" && argv[1]?.startsWith("/notifications"),
+        status: 1,
+        stderr: "API rate limit exceeded (HTTP 403)",
+      },
+    ]);
+    const paths = resolveBreezePaths({ env: () => ctx.dir });
+    const outcome = await pollOnce({
+      gh,
+      paths,
+      host: "github.com",
+      now: () => Date.parse("2026-04-16T20:15:30Z"),
+    });
+    expect(outcome.rateLimited).toBe(true);
+    expect(outcome.warnings.length).toBeGreaterThan(0);
+  });
+
+  it("emits null for nullable fields (number, gh_state)", async () => {
+    const rawNotification = JSON.stringify([
+      {
+        id: "disc-1",
+        subject: { type: "Discussion", title: "chat", url: null },
+        repository: { full_name: "o/r" },
+        reason: "subscribed",
+        updated_at: "2026-04-16T10:00:00Z",
+        unread: false,
+      },
+    ]);
+    const gh = makeStubGh([
+      {
+        match: (argv) =>
+          argv[0] === "api" && argv[1]?.startsWith("/notifications"),
+        stdout: rawNotification,
+      },
+    ]);
+    const paths = resolveBreezePaths({ env: () => ctx.dir });
+    await pollOnce({
+      gh,
+      paths,
+      host: "github.com",
+      now: () => Date.parse("2026-04-16T20:00:00Z"),
+    });
+    const parsed = JSON.parse(readFileSync(ctx.inbox, "utf-8")) as {
+      notifications: Array<{ number: unknown; gh_state: unknown }>;
+    };
+    expect(parsed.notifications[0].number).toBeNull();
+    expect(parsed.notifications[0].gh_state).toBeNull();
+  });
+});
+
+describe("runPoller loop", () => {
+  let ctx: ReturnType<typeof mkBreezeDir>;
+  beforeEach(() => {
+    ctx = mkBreezeDir();
+  });
+  afterEach(() => rmSync(ctx.dir, { recursive: true, force: true }));
+
+  it("exits cleanly when the AbortSignal fires", async () => {
+    const gh = makeStubGh([
+      {
+        match: (argv) =>
+          argv[0] === "api" && argv[1]?.startsWith("/notifications"),
+        stdout: "[]",
+      },
+    ]);
+    const paths = resolveBreezePaths({ env: () => ctx.dir });
+    const controller = new AbortController();
+
+    // Zero-delay sleep so the loop iterates many times quickly; the signal
+    // is the only thing that stops it.
+    const sleep = vi.fn().mockImplementation(async (_ms: number, signal?: AbortSignal) => {
+      if (signal?.aborted) return;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    });
+
+    const logs: string[] = [];
+    const logger = {
+      info: (line: string) => logs.push(`INFO ${line}`),
+      warn: (line: string) => logs.push(`WARN ${line}`),
+      error: (line: string) => logs.push(`ERROR ${line}`),
+    };
+
+    const runPromise = runPoller({
+      pollIntervalSec: 1,
+      host: "github.com",
+      gh,
+      paths,
+      signal: controller.signal,
+      logger,
+      sleep,
+    });
+
+    // Let a few iterations go through, then abort.
+    await new Promise<void>((resolve) => setTimeout(resolve, 20));
+    controller.abort();
+
+    await expect(runPromise).resolves.toBeUndefined();
+    expect(sleep).toHaveBeenCalled();
+    // At least one successful poll should have been logged.
+    expect(logs.some((l) => l.includes("polled 0 notifications"))).toBe(true);
+  });
+
+  it("backs off on rate-limit cycles", async () => {
+    // First call is rate-limited; second is ok. Verify the sleep between
+    // them matches rateLimitBackoffMs(1) = 120_000.
+    let callIdx = 0;
+    const spawn = vi.fn().mockImplementation((_cmd: string, argv: string[]) => {
+      const isNotifications =
+        argv[0] === "api" && argv[1]?.startsWith("/notifications");
+      if (!isNotifications) {
+        return {
+          pid: 1,
+          status: 0,
+          signal: null,
+          stdout: Buffer.alloc(0),
+          stderr: Buffer.alloc(0),
+          output: [],
+        };
+      }
+      callIdx += 1;
+      if (callIdx === 1) {
+        return {
+          pid: 1,
+          status: 1,
+          signal: null,
+          stdout: Buffer.alloc(0),
+          stderr: Buffer.from("API rate limit exceeded"),
+          output: [],
+        };
+      }
+      return {
+        pid: 1,
+        status: 0,
+        signal: null,
+        stdout: Buffer.from("[]"),
+        stderr: Buffer.alloc(0),
+        output: [],
+      };
+    });
+    const gh = new GhClient({ spawn });
+    const paths = resolveBreezePaths({ env: () => ctx.dir });
+    const controller = new AbortController();
+
+    const sleepCalls: number[] = [];
+    const sleep = vi.fn().mockImplementation(async (ms: number) => {
+      sleepCalls.push(ms);
+      // After the first rate-limit backoff and one success, abort.
+      if (sleepCalls.length >= 2) controller.abort();
+    });
+
+    await runPoller({
+      pollIntervalSec: 1,
+      host: "github.com",
+      gh,
+      paths,
+      signal: controller.signal,
+      sleep,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    });
+
+    expect(sleepCalls[0]).toBe(120_000); // rate-limit backoff
+    expect(sleepCalls[1]).toBe(1000); // normal interval after recovery
+  });
+});

--- a/tests/breeze-daemon-runner.test.ts
+++ b/tests/breeze-daemon-runner.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests for the Phase 3a daemon runner-skeleton entrypoint and CLI wiring.
+ *
+ * Covers:
+ *   - `parseDaemonArgs` parses the recognised flag set and ignores unknowns
+ *   - `extractBackendFlag` (from cli.ts) separates --backend from the residual argv
+ *   - `daemon --backend=ts` invokes the TS runner; `--backend=rust` bridges
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  parseDaemonArgs,
+  runDaemon,
+} from "../src/products/breeze/daemon/runner-skeleton.js";
+import { extractBackendFlag } from "../src/products/breeze/cli.js";
+
+describe("parseDaemonArgs", () => {
+  it("parses all recognised flags", () => {
+    const out = parseDaemonArgs([
+      "--poll-interval-secs",
+      "30",
+      "--host",
+      "ghe.example.com",
+      "--log-level",
+      "debug",
+      "--http-port",
+      "9191",
+      "--task-timeout-secs",
+      "600",
+    ]);
+    expect(out).toEqual({
+      pollIntervalSec: 30,
+      host: "ghe.example.com",
+      logLevel: "debug",
+      httpPort: 9191,
+      taskTimeoutSec: 600,
+    });
+  });
+
+  it("accepts --poll-interval-sec as a singular alias", () => {
+    const out = parseDaemonArgs(["--poll-interval-sec", "10"]);
+    expect(out.pollIntervalSec).toBe(10);
+  });
+
+  it("ignores unknown flags for forward-compat", () => {
+    const out = parseDaemonArgs(["--frobnicate", "1", "--host", "gh.io"]);
+    expect(out).toEqual({ host: "gh.io" });
+  });
+
+  it("drops invalid numeric values", () => {
+    const out = parseDaemonArgs([
+      "--poll-interval-secs",
+      "nope",
+      "--http-port",
+      "-1",
+    ]);
+    expect(out.pollIntervalSec).toBeUndefined();
+    expect(out.httpPort).toBeUndefined();
+  });
+});
+
+describe("extractBackendFlag", () => {
+  it("defaults to rust when no flag is present", () => {
+    const { backend, rest } = extractBackendFlag(["run", "--foo"]);
+    expect(backend).toBe("rust");
+    expect(rest).toEqual(["run", "--foo"]);
+  });
+
+  it("supports --backend=ts / --backend=rust", () => {
+    expect(extractBackendFlag(["--backend=ts"])).toEqual({
+      backend: "ts",
+      rest: [],
+    });
+    expect(extractBackendFlag(["--backend=rust", "--verbose"])).toEqual({
+      backend: "rust",
+      rest: ["--verbose"],
+    });
+  });
+
+  it("supports space-separated --backend ts", () => {
+    expect(extractBackendFlag(["--backend", "ts", "--x"])).toEqual({
+      backend: "ts",
+      rest: ["--x"],
+    });
+  });
+
+  it("keeps unknown --backend values in rest and defaults to rust", () => {
+    const { backend, rest } = extractBackendFlag(["--backend=julia"]);
+    expect(backend).toBe("rust");
+    expect(rest).toEqual(["--backend=julia"]);
+  });
+});
+
+describe("runDaemon end-to-end skeleton", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("exits cleanly when the injected AbortSignal is pre-aborted", async () => {
+    // Signal is already aborted → the poller loop runs zero iterations
+    // and runDaemon returns 0. We stub out identity resolution failure
+    // so the test doesn't touch the real `gh` binary.
+    const controller = new AbortController();
+    controller.abort();
+
+    const logs: string[] = [];
+    const logger = {
+      info: (line: string) => logs.push(`INFO ${line}`),
+      warn: (line: string) => logs.push(`WARN ${line}`),
+      error: (line: string) => logs.push(`ERROR ${line}`),
+    };
+
+    // Even though identity will fail (no `gh` in test env), runDaemon
+    // should continue and the poller should exit immediately because
+    // the signal is pre-aborted.
+    const code = await runDaemon([], {
+      cliOverrides: { pollIntervalSec: 1 },
+      installSignalHandlers: false,
+      signal: controller.signal,
+      logger,
+    });
+    expect(code).toBe(0);
+    expect(logs.some((l) => l.includes("shutdown complete"))).toBe(true);
+  });
+});
+
+describe("cli dispatcher routes daemon --backend flag", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("routes `daemon --backend=ts` to the TS runner", async () => {
+    const runDaemonSpy = vi.fn(async () => 0);
+
+    vi.doMock("../src/products/breeze/daemon/runner-skeleton.js", () => ({
+      runDaemon: runDaemonSpy,
+    }));
+    vi.doMock("../src/products/breeze/bridge.js", () => ({
+      resolveBreezeRunner: vi.fn(() => {
+        throw new Error("TS backend must not call the Rust bridge");
+      }),
+      resolveBundledBreezeScript: vi.fn(),
+      resolveBreezeSetupScript: vi.fn(),
+      resolveFirstTreePackageRoot: vi.fn(() => "/pkg"),
+      spawnInherit: vi.fn(() => {
+        throw new Error("TS backend must not spawn");
+      }),
+    }));
+
+    const { runBreeze } = await import("../src/products/breeze/cli.js");
+    const code = await runBreeze(
+      ["daemon", "--backend=ts", "--poll-interval-secs", "30"],
+      () => {},
+    );
+    expect(code).toBe(0);
+    expect(runDaemonSpy).toHaveBeenCalledWith([
+      "--poll-interval-secs",
+      "30",
+    ]);
+  });
+
+  it("routes `daemon` (default backend) through the Rust bridge's `run` subcommand", async () => {
+    const spawnSpy = vi.fn().mockReturnValue(0);
+    const resolveRunnerSpy = vi
+      .fn()
+      .mockReturnValue({ path: "/runner", source: "path" });
+
+    vi.doMock("../src/products/breeze/daemon/runner-skeleton.js", () => ({
+      runDaemon: vi.fn(() => {
+        throw new Error("Rust backend must not call the TS daemon");
+      }),
+    }));
+    vi.doMock("../src/products/breeze/bridge.js", () => ({
+      resolveBreezeRunner: resolveRunnerSpy,
+      resolveBundledBreezeScript: vi.fn(),
+      resolveBreezeSetupScript: vi.fn(),
+      resolveFirstTreePackageRoot: vi.fn(() => "/pkg"),
+      spawnInherit: spawnSpy,
+    }));
+
+    const { runBreeze } = await import("../src/products/breeze/cli.js");
+    const code = await runBreeze(["daemon", "--verbose"], () => {});
+    expect(code).toBe(0);
+    expect(resolveRunnerSpy).toHaveBeenCalledOnce();
+    expect(spawnSpy).toHaveBeenCalledWith("/runner", ["run", "--verbose"]);
+  });
+});


### PR DESCRIPTION
## Summary

Ports the breeze daemon's **read path** (notification poller, identity resolver, runner skeleton) from Rust to TypeScript, introduces a YAML config layer, and wires `first-tree breeze daemon --backend=ts|rust` without breaking the existing Rust-backed `run`/`status`/`stop` flow.

- New `src/products/breeze/daemon/` tree:
  - `poller.ts` — single-writer poll loop; 1:1 port of `gh_executor.rs`'s rate-limit backoff (60s base → 2^streak, capped at 16min)
  - `identity.ts` — `gh auth status --json hosts` resolver with `lockKey(profile)` matching `identity.rs`
  - `runner-skeleton.ts` — AbortController-driven event loop with SIGTERM/SIGINT cascade; stubs `http`/`broker`/`bus` as TODOs for 3b/3c
- `core/config.ts` extended with `loadBreezeDaemonConfig`: searches `~/.first-tree/breeze/config.yaml` first, then `~/.breeze/config.yaml`; priority is `CLI > env > yaml > defaults`. Runtime data dir stays `~/.breeze/` per spec (format parity).
- `cli.ts` gets a new `daemon` subcommand with `--backend=ts|rust` (defaults to `rust`; 3d will flip).
- `store.ts` docstring updated to document the single-writer invariant now that the TS poller participates.

## Scope & non-scope

**In scope (Phase 3a):**
- Read path only: fetch notifications → enrich labels → classify → write inbox.json → append activity events.
- Bit-compatible `inbox.json` with the Rust fetcher (key order, null handling, atomic rename) — already provided by the Phase 2a `core/store.ts`. This PR adds parity tests to lock it in.
- Single-writer rule documented in both `poller.ts` and `core/store.ts` comments.
- Lazy imports: `src/cli.ts` has no static reference to anything under `daemon/`; `products/breeze/cli.ts` only dynamic-imports `./daemon/runner-skeleton.js` inside the `daemon --backend=ts` branch.
- No breaking changes to bridge path. Every existing runner subcommand (`run`, `run-once`, `start`, `stop`, `status`, `cleanup`, `doctor`, `install`) is untouched and still bridges to Rust.

**Out of scope (deferred):**
- **Phase 3b**: localhost HTTP server + SSE stream (`http.rs` → `daemon/http.ts`). `httpPort` is parsed and logged but nothing binds a socket.
- **Phase 3c**: gh-serializer broker + bus + dispatcher (`broker.rs`, `bus.rs`, `service.rs`). These are what turn the skeleton into a full daemon; the skeleton has TODO markers where they attach.
- **Phase 3d**: flipping `--backend` default to `ts`, deprecating the Rust runner.

## Validation

- `pnpm typecheck` — clean.
- `pnpm build` — produces 44 dist files (no new top-level bundles; `daemon/*` is chunked under existing product code).
- `pnpm validate:skill` — clean.
- `pnpm test` — **573 passing** (up from 533). 40 new tests across 4 files:
  - `breeze-daemon-poller.test.ts` (9): canonical inbox entry shape parity, rate-limit detection, backoff schedule, AbortSignal shutdown, rate-limit recovery timing
  - `breeze-daemon-config.test.ts` (12): full priority pipeline (defaults → yaml → env → CLI), search-path order, malformed yaml, legacy env fallback
  - `breeze-daemon-identity.test.ts` (8): lock-key format, scope detection, multi-account auth payload parsing
  - `breeze-daemon-runner.test.ts` (11): flag parser, CLI `--backend` routing, pre-aborted signal clean-exit
- The 29 pre-existing test failures in `upgrade.test.ts`, `verify.test.ts`, `sync.test.ts`, `wipe-and-refresh.test.ts` etc. are environmental (sandbox forces GPG-signed commits, which the signing server rejects in this harness). Verified these also fail on a clean `main` checkout before any of this PR's changes.

## Deviations from spec / notes

- **Reuse of `commands/poll.ts`**: the Phase 2b `poll.ts` one-shot command already contains a working TS port of `parseNotifications`, `enrichWithLabels`, `diffEvents`, etc. Rather than duplicate that logic in `daemon/poller.ts`, the daemon imports those functions and wraps them in the interval loop + rate-limit bookkeeping. This keeps one source of truth for the transformation and lets the existing `breeze-poll.test.ts` (18 tests) continue to validate it. The daemon poller adds the `pollOnce` wrapper, loop cadence, rate-limit detection, and rate-limit streak logic on top.
- **Rate-limit throttling scope**: the Rust `GhExecutor` tracks three buckets (core/search/write). The daemon poller only issues read-only `gh api` calls (`/notifications` REST + GraphQL labels), so Phase 3a keeps a single scalar for next-allowed time + a streak counter. When Phase 3c adds the dispatcher (which does mutating `gh` calls), the full three-bucket state machine becomes necessary — flagged with a comment in `poller.ts`.
- **Identity caching**: the existing `core/identity.ts` uses the simpler `gh api /user` path with a 24h disk cache. The Rust daemon uses `gh auth status --json hosts` for a richer identity (with scopes + gitProtocol) and doesn't persist to disk. Phase 3a's `daemon/identity.ts` uses the `gh auth status` path (to expose `scopes`/`gitProtocol`/`lockKey` needed by Phase 3c) and does **not** write a disk cache — the daemon resolves once at startup and keeps the value in memory. The one-shot commands continue to use the existing `core/identity.ts` unchanged.
- **`taskTimeoutSec` is parsed but unused**: it's in `DaemonConfig` so the yaml schema is stable across 3a→3c, but the dispatcher that consumes it doesn't exist yet. Noted inline.
- **`yaml` moved from devDependencies to dependencies**: it was already a devDep (used by `skill-artifacts.test.ts`), but daemon config now requires it at runtime.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` — 573 green (pre-existing env failures ignored)
- [x] `pnpm build`
- [x] `pnpm validate:skill`
- [ ] Smoke test `first-tree breeze daemon --backend=ts` against a live `gh`-authenticated machine (requires host env — defer to maintainer review)
- [ ] Verify `first-tree tree sync` cold start unchanged (the Phase 0 test guards this; not modified here)

## Follow-ups

- Phase 3b: `daemon/http.ts` — bind localhost, serve `/inbox`, `/activity` SSE.
- Phase 3c: `daemon/broker.ts` + `daemon/bus.ts` + `daemon/dispatcher.ts`. Will convert the poller's scalar rate-limit state into the three-bucket Rust-parity state machine.
- Phase 3d: flip `--backend` default to `ts`, document Rust deprecation path.

https://claude.ai/code/session_01MmTfkkXJcj6YkEAkKNx2Js