### PR TITLE
fix(sync): regenerate CODEOWNERS inside each content PR (#119)

### DIFF
--- a/src/products/tree/engine/sync.ts
+++ b/src/products/tree/engine/sync.ts
@@ -1041,9 +1041,19 @@ async function prepareProposalGroup(
     };
   }
 
-  // NOTE: Only stage the specific NODE.md files this PR created.
-  // Do NOT use git add -A — that would pick up proposals, binding, CODEOWNERS
-  // from other operations and create a mega-PR.
+  // Regenerate CODEOWNERS alongside the new NODE.md files so each content PR
+  // is self-consistent under `generate-codeowners --check`. Without this the
+  // check fails per-PR until the housekeeping PR catches up (#119).
+  await runGenerateCodeownersForTree(treeRoot);
+  const codeownersPath = join(treeRoot, ".github", "CODEOWNERS");
+  if (existsSync(codeownersPath)) {
+    writtenFiles.push(codeownersPath);
+  }
+
+  // NOTE: Only stage the specific files this PR produced (new NODE.md files,
+  // any parent NODE.md updates, and the regenerated CODEOWNERS). Do NOT use
+  // `git add -A` — that would pick up proposal files and the binding from
+  // other in-flight work and create a mega-PR.
   for (const file of writtenFiles) {
     await shellRun("git", ["add", file], { cwd: treeRoot });
   }
@@ -1582,11 +1592,12 @@ export async function runSync(
           }
         }
 
-        // Open a housekeeping PR: pin the binding + regenerate CODEOWNERS
-        // This is the ONLY PR that touches the binding file and CODEOWNERS,
-        // avoiding cascade merge conflicts between individual sync PRs.
+        // Open a housekeeping PR that only pins the binding.
+        // CODEOWNERS used to live here too, but each content PR now regenerates
+        // it (#119) so per-PR `generate-codeowners --check` passes without
+        // waiting on housekeeping to merge.
         if (!flags.dryRun && preparedGroups.length > 0) {
-          console.log("\nOpening housekeeping PR (binding pin + CODEOWNERS)...");
+          console.log("\nOpening housekeeping PR (binding pin)...");
           const hkBranch = `first-tree/sync-${drift.binding.sourceId}-housekeeping`;
           const hkCheckout = await shellRun("git", ["checkout", "-B", hkBranch, originalRef], { cwd: repo.root });
           if (hkCheckout.code !== 0) {
@@ -1601,23 +1612,22 @@ export async function runSync(
             lastReconciledAt: now().toISOString(),
           });
 
-          // Regenerate CODEOWNERS
-          await runGenerateCodeownersForTree(repo.root);
-
           await shellRun("git", ["add", "-A"], { cwd: repo.root });
           const hkDiff = await shellRun("git", ["diff", "--cached", "--quiet"], { cwd: repo.root });
           if (hkDiff.code !== 0) {
-            await shellRun("git", ["commit", "-m", `chore(sync): pin ${drift.binding.sourceId} to ${drift.toSha.slice(0, 7)} + regenerate CODEOWNERS`], { cwd: repo.root });
+            await shellRun("git", ["commit", "-m", `chore(sync): pin ${drift.binding.sourceId} to ${drift.toSha.slice(0, 7)}`], { cwd: repo.root });
             await shellRun("git", ["push", "origin", "HEAD"], { cwd: repo.root });
             const hkPr = await shellRun("gh", [
               "pr", "create",
               "--title", `chore(sync): housekeeping for ${drift.binding.sourceId}`,
               "--body", [
-                "Housekeeping PR — pins the sync bookmark and regenerates CODEOWNERS.",
+                "Housekeeping PR — pins the sync bookmark.",
                 "",
                 "**Merge this AFTER all sync PRs are merged.**",
                 "",
                 `Pins \`lastReconciledSourceCommit\` to \`${drift.toSha.slice(0, 7)}\`.`,
+                "",
+                "CODEOWNERS is regenerated inside each content PR, so no CODEOWNERS diff is expected here.",
               ].join("\n"),
             ], { cwd: repo.root });
             if (hkPr.code === 0) {
@@ -1633,7 +1643,7 @@ export async function runSync(
             return 1;
           }
         } else if (flags.dryRun && preparedGroups.length > 0) {
-          console.log(`\n(dry-run) would open housekeeping PR to pin binding to ${drift.toSha.slice(0, 7)} + regenerate CODEOWNERS`);
+          console.log(`\n(dry-run) would open housekeeping PR to pin binding to ${drift.toSha.slice(0, 7)}`);
         }
       }
     }

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -806,6 +806,154 @@ describe("sync -- PR labeling", () => {
     expect(nodeText).not.toContain("@alice");
   });
 
+  it("regenerates and stages CODEOWNERS inside each content PR (#119)", async () => {
+    const tmp = useTmpDir();
+    makeTreeShell(tmp.path);
+    mkdirSync(join(tmp.path, ".github"), { recursive: true });
+    writeFileSync(
+      join(tmp.path, ".github", "CODEOWNERS"),
+      "# stale\n/old/ @nobody\n",
+    );
+    const fromSha = "aa".repeat(20);
+    const toSha = "bb".repeat(20);
+    writeTreeBinding(tmp.path, "source-codeowners", {
+      bindingMode: "standalone-source",
+      entrypoint: "/repos/source",
+      lastReconciledSourceCommit: fromSha,
+      remoteUrl: "https://github.com/alice/source.git",
+      rootKind: "git-repo",
+      scope: "repo",
+      sourceId: "source-codeowners",
+      sourceName: "source",
+      sourceRootPath: "../source",
+      treeMode: "dedicated",
+      treeRepoName: "tree",
+    });
+    const gitAddCalls: string[][] = [];
+    const commitCalls: string[][] = [];
+    const prCreateCalls: string[][] = [];
+    const shellRun: ShellRun = async (command, args) => {
+      if (command === "gh" && args[0] === "auth") return okAuth();
+      if (command === "claude" && args[0] === "--version") return claudeVersionOk();
+      if (command === "gh" && args[0] === "api") {
+        const path = args[1] ?? "";
+        if (path === "/repos/alice/source/commits/HEAD") {
+          return { stdout: `${toSha}\n`, stderr: "", code: 0 };
+        }
+        if (path.startsWith("/repos/alice/source/compare/")) {
+          return {
+            stdout: JSON.stringify({
+              commits: [{
+                sha: "1".repeat(40),
+                commit: {
+                  message: "feat(pkg-a): add thing (#101)",
+                  author: { name: "alice", date: "2026-04-01T00:00:00Z" },
+                },
+                files: [{ filename: "pkg-a/x.ts" }],
+              }],
+            }),
+            stderr: "",
+            code: 0,
+          };
+        }
+        if (path.startsWith("search/issues")) {
+          return {
+            stdout: JSON.stringify({
+              items: [{
+                number: 101,
+                title: "feat(pkg-a): add thing",
+                pull_request: {
+                  merged_at: "2026-04-01T00:00:00Z",
+                  merge_commit_sha: "1".repeat(40),
+                },
+              }],
+            }),
+            stderr: "",
+            code: 0,
+          };
+        }
+      }
+      if (command === "claude" && args[0] === "-p") {
+        return {
+          stdout: JSON.stringify([{
+            path: "pkg-a",
+            type: "TREE_MISS",
+            target_node_path: null,
+            rationale: "No node for pkg-a",
+            suggested_node_title: "pkg-a",
+            suggested_node_body_markdown: "# pkg-a",
+          }]),
+          stderr: "",
+          code: 0,
+        };
+      }
+      if (command === "gh" && args[0] === "pr" && args[1] === "list") {
+        return { stdout: "[]", stderr: "", code: 0 };
+      }
+      if (command === "gh" && args[0] === "pr" && args[1] === "create") {
+        prCreateCalls.push([...args]);
+        return { stdout: "https://github.com/x/y/pull/1\n", stderr: "", code: 0 };
+      }
+      if (command === "gh" && args[0] === "pr" && args[1] === "edit") {
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      if (command === "gh" && args[0] === "label") {
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      if (command === "git") {
+        if (args[0] === "symbolic-ref") {
+          return { stdout: "main\n", stderr: "", code: 0 };
+        }
+        if (args[0] === "add") {
+          gitAddCalls.push([...args]);
+          return { stdout: "", stderr: "", code: 0 };
+        }
+        if (args[0] === "commit") {
+          commitCalls.push([...args]);
+          return { stdout: "", stderr: "", code: 0 };
+        }
+        if (args.includes("diff") && args.includes("--cached") && args.includes("--quiet")) {
+          return { stdout: "", stderr: "", code: 1 };
+        }
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
+    };
+    const code = await runSync(
+      tmp.path,
+      { source: undefined, propose: false, apply: true, dryRun: false },
+      { shellRun, verifyTree: () => 0 },
+    );
+    expect(code).toBe(0);
+
+    // Content PR must stage both the new NODE.md and the regenerated CODEOWNERS.
+    const contentAddTargets = gitAddCalls
+      .filter((args) => args[0] === "add" && args[1] !== "-A")
+      .map((args) => args[1] ?? "");
+    expect(contentAddTargets.some((p) => p.endsWith("/pkg-a/NODE.md"))).toBe(true);
+    expect(contentAddTargets.some((p) => p.endsWith("/.github/CODEOWNERS"))).toBe(true);
+
+    // CODEOWNERS on disk must reflect the new owners, not the stale seed.
+    const codeowners = readFileSync(join(tmp.path, ".github", "CODEOWNERS"), "utf-8");
+    expect(codeowners).toContain("Auto-generated from Context Tree");
+    expect(codeowners).toContain("/pkg-a/");
+    expect(codeowners).toContain("@alice");
+    expect(codeowners).not.toContain("@nobody");
+
+    // Housekeeping PR must no longer advertise CODEOWNERS work.
+    const housekeepingCommit = commitCalls.find((args) =>
+      args.some((a) => typeof a === "string" && a.startsWith("chore(sync): pin source-codeowners")),
+    );
+    expect(housekeepingCommit).toBeDefined();
+    expect(housekeepingCommit?.join(" ")).not.toContain("regenerate CODEOWNERS");
+    const housekeepingPr = prCreateCalls.find((args) =>
+      args.some((a) => typeof a === "string" && a.includes("housekeeping for source-codeowners")),
+    );
+    expect(housekeepingPr).toBeDefined();
+    const hkBody = housekeepingPr?.[housekeepingPr.indexOf("--body") + 1] ?? "";
+    expect(hkBody).not.toContain("regenerates CODEOWNERS");
+  });
+
   it("asks Claude for body-only markdown without YAML frontmatter", async () => {
     const tmp = useTmpDir();
     makeTreeShell(tmp.path);


### PR DESCRIPTION
Closes #119. First execution slot of the #108 tracker.

## Problem

Sync content PRs used to defer CODEOWNERS to the housekeeping PR. The maintainer's `generate-codeowners --check` runs per PR and fails on every content PR until housekeeping merges — 4 of 30 paperclip-tree sync PRs were rejected for this alone.

## Change

- `src/products/tree/engine/sync.ts` — `prepareProposalGroup` now calls the CODEOWNERS generator after writing new NODE.md files (and any parent NODE.md updates), and stages `.github/CODEOWNERS` alongside them. Each content PR is now self-consistent under `generate-codeowners --check`.
- The housekeeping PR no longer regenerates CODEOWNERS. Its scope narrows to pinning `lastReconciledSourceCommit`. Commit message, PR title, PR body and dry-run log updated to match.

## Test

- New regression test `tests/sync.test.ts › regenerates and stages CODEOWNERS inside each content PR (#119)` asserts:
  - `git add` stages both the new NODE.md and `.github/CODEOWNERS` in the content PR
  - The on-disk CODEOWNERS reflects the new owners (not the stale seed)
  - The housekeeping commit message and PR body no longer mention CODEOWNERS
- Full `tests/sync.test.ts` suite: 20/20 passing.
- `pnpm typecheck` clean. `pnpm build` clean. `pnpm validate:skill` clean.
- The 29 failing tests on the full `pnpm test` run are pre-existing `execFileSync` git-commit failures in `tests/helpers.ts`, unrelated to this change (reproduced with this branch's changes stashed).

## Follow-ups (tracked on #108)

Remaining patterns are spun out: #121 (proposal dedup), #122 (parent NODE.md), #123 (diff in classification prompt), #124 (soft_links), #125 (TREE_SUPPLEMENT).