### PR TITLE
fix(sync): dedup, parent-node, diff-prompt, soft-links, supplement cleanup (#121-#125)

### DIFF
--- a/src/products/tree/engine/sync.ts
+++ b/src/products/tree/engine/sync.ts
@@ -611,21 +611,75 @@ async function claudeCliAvailable(shellRun: ShellRun): Promise<boolean> {
   return result.code === 0;
 }
 
-async function fetchPrChangedFiles(
+interface PrFileChange {
+  filename: string;
+  patch: string | undefined;
+  status: string | undefined;
+}
+
+const DIFF_NOISE_PATTERNS = [
+  /(^|\/)(?:package-lock\.json|pnpm-lock\.yaml|yarn\.lock|Cargo\.lock|poetry\.lock|Gemfile\.lock)$/,
+  /(^|\/)(?:dist|build|out|coverage|node_modules|__pycache__)\//,
+  /\.(?:lock|min\.js|min\.css|map|snap)$/,
+];
+
+function isDiffNoise(filename: string): boolean {
+  return DIFF_NOISE_PATTERNS.some((re) => re.test(filename));
+}
+
+async function fetchPrFileChanges(
   shellRun: ShellRun,
   ownerRepo: { owner: string; repo: string },
   prNumber: number,
-): Promise<string[]> {
+): Promise<PrFileChange[]> {
   try {
     const result = await shellRun("gh", [
       "api", `/repos/${ownerRepo.owner}/${ownerRepo.repo}/pulls/${prNumber}/files`,
-      "--jq", ".[].filename",
+      "--paginate",
     ]);
     if (result.code !== 0) return [];
-    return result.stdout.trim().split("\n").filter(Boolean);
+    const raw = result.stdout.trim();
+    if (raw === "") return [];
+    // --paginate concatenates JSON arrays; normalize to a flat array.
+    const normalized = raw.replace(/\]\s*\[/g, ",");
+    const parsed = JSON.parse(normalized) as Array<{ filename?: string; patch?: string; status?: string }>;
+    return parsed
+      .filter((f) => typeof f.filename === "string")
+      .map((f) => ({ filename: f.filename!, patch: f.patch, status: f.status }));
   } catch {
     return [];
   }
+}
+
+/**
+ * Build a truncated diff summary for the classification prompt (#123).
+ * Filters generated/lockfile noise and caps per-file hunks so large PRs
+ * don't blow the context window.
+ */
+function formatPrDiffForPrompt(
+  files: PrFileChange[],
+  opts?: { maxFiles?: number; maxLinesPerFile?: number },
+): string {
+  const maxFiles = opts?.maxFiles ?? 15;
+  const maxLinesPerFile = opts?.maxLinesPerFile ?? 40;
+  const signal = files.filter((f) => !isDiffNoise(f.filename));
+  const selected = signal.slice(0, maxFiles);
+  const parts: string[] = [];
+  for (const f of selected) {
+    if (!f.patch) continue;
+    const lines = f.patch.split("\n");
+    const truncated = lines.length > maxLinesPerFile;
+    const shown = truncated ? lines.slice(0, maxLinesPerFile) : lines;
+    parts.push(`--- ${f.filename} (${f.status ?? "modified"})`);
+    parts.push(...shown);
+    if (truncated) {
+      parts.push(`... (${lines.length - maxLinesPerFile} more lines in this file)`);
+    }
+  }
+  if (signal.length > maxFiles) {
+    parts.push(`... (${signal.length - maxFiles} more files omitted)`);
+  }
+  return parts.join("\n");
 }
 
 async function classifyDriftViaClaude(
@@ -633,6 +687,7 @@ async function classifyDriftViaClaude(
   drift: DriftReport,
   treeNodes: TreeNodeSummary[],
   changedFiles?: string[],
+  diffSummary?: string,
 ): Promise<ClassificationItem[]> {
   // Build keywords from the PR for relevance matching
   const driftText = [
@@ -670,6 +725,9 @@ async function classifyDriftViaClaude(
     ...drift.mergedPrTitles.map((title) => `pr ${title}`),
     ...(changedFiles && changedFiles.length > 0
       ? [`\nChanged files in this PR (use these to verify what was actually modified):\n${changedFiles.slice(0, 50).join("\n")}`]
+      : []),
+    ...(diffSummary && diffSummary.length > 0
+      ? [`\nTruncated diff hunks (use these as factual ground truth; generated/lockfile noise is filtered):\n${diffSummary}`]
       : []),
   ].join("\n");
 
@@ -1466,10 +1524,20 @@ export async function runSync(
             mergedPrTitles: [pr.title],
           };
 
-          const prFiles = pr.number > 0
-            ? await fetchPrChangedFiles(shellRun, drift.ownerRepo, pr.number)
+          const prFileChanges = pr.number > 0
+            ? await fetchPrFileChanges(shellRun, drift.ownerRepo, pr.number)
             : [];
-          const proposals = await classifyDriftViaClaude(shellRun, perPrDrift, treeNodes, prFiles);
+          const prFiles = prFileChanges.map((f) => f.filename);
+          const diffSummary = prFileChanges.length > 0
+            ? formatPrDiffForPrompt(prFileChanges)
+            : "";
+          const proposals = await classifyDriftViaClaude(
+            shellRun,
+            perPrDrift,
+            treeNodes,
+            prFiles,
+            diffSummary,
+          );
 
           if (proposals.length === 0) {
             console.log(

--- a/src/products/tree/engine/sync.ts
+++ b/src/products/tree/engine/sync.ts
@@ -337,6 +337,13 @@ interface ClassificationItem {
   suggested_node_title: string;
   suggested_node_body_markdown: string;
   /**
+   * Tree paths (e.g. "engineering/backend", "governance") that the drafted
+   * NODE.md body references and should be declared as frontmatter
+   * `soft_links` (#124). Optional — omit or empty when there are no
+   * cross-domain references.
+   */
+  suggested_soft_links?: string[];
+  /**
    * Source PR numbers (other than the owning group's) that independently
    * proposed this same target path. Populated by the dedup pass so the
    * surviving PR can credit the dropped claimants in its body (#121).
@@ -764,12 +771,15 @@ Return a JSON array. Each element represents one area that needs a NEW tree node
   "target_node_path": null,
   "rationale": "one sentence explaining why the tree needs this node",
   "suggested_node_title": "Human-readable title for the node",
-  "suggested_node_body_markdown": "Draft NODE.md body content ONLY (2-5 paragraphs, no YAML frontmatter)"
+  "suggested_node_body_markdown": "Draft NODE.md body content ONLY (2-5 paragraphs, no YAML frontmatter)",
+  "suggested_soft_links": ["other/tree/path", "another/one"]
 }
 
-For TREE_OK items, only path, type, and rationale are required (other fields can be empty strings).
+For TREE_OK items, only path, type, and rationale are required (other fields can be empty strings or omitted).
 
-IMPORTANT: \`suggested_node_body_markdown\` must contain body content only. Do NOT include YAML frontmatter or code fences.
+IMPORTANT:
+- \`suggested_node_body_markdown\` must contain body content only. Do NOT include YAML frontmatter or code fences.
+- \`suggested_soft_links\` must list every tree path the body cross-references (other domains, governance, backend, etc.) so the new node shows up in the tree graph. Use paths from the "Current tree nodes" list above. Omit or use [] when the body does not reference other domains.
 
 Return a JSON array only, no prose.`;
   const CLAUDE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes per classification
@@ -1059,11 +1069,26 @@ async function prepareProposalGroup(
       const nodePath = join(absDir, "NODE.md");
       // Only write if NODE.md doesn't already exist (don't overwrite human-authored nodes)
       if (!existsSync(nodePath)) {
-        const content = [
+        const frontmatter = [
           "---",
           `title: "${capitalizedTitle.replace(/"/g, '\\"')}"`,
           `owners: [${owners.join(", ")}]`,
-          "---",
+        ];
+        const softLinks = Array.isArray(proposal.suggested_soft_links)
+          ? Array.from(
+              new Set(
+                proposal.suggested_soft_links
+                  .map((s) => (typeof s === "string" ? s.trim() : ""))
+                  .filter((s) => s.length > 0 && s !== dirSegment),
+              ),
+            ).sort()
+          : [];
+        if (softLinks.length > 0) {
+          frontmatter.push(`soft_links: [${softLinks.join(", ")}]`);
+        }
+        frontmatter.push("---");
+        const content = [
+          ...frontmatter,
           "",
           body,
           "",

--- a/src/products/tree/engine/sync.ts
+++ b/src/products/tree/engine/sync.ts
@@ -332,7 +332,6 @@ interface DriftReport {
 interface ClassificationItem {
   path: string;
   type: "TREE_MISS" | "TREE_OK";
-  target_node_path: string | null;
   rationale: string;
   suggested_node_title: string;
   suggested_node_body_markdown: string;
@@ -768,7 +767,6 @@ Return a JSON array. Each element represents one area that needs a NEW tree node
 {
   "path": "suggested/node/path",
   "type": "TREE_MISS" | "TREE_OK",
-  "target_node_path": null,
   "rationale": "one sentence explaining why the tree needs this node",
   "suggested_node_title": "Human-readable title for the node",
   "suggested_node_body_markdown": "Draft NODE.md body content ONLY (2-5 paragraphs, no YAML frontmatter)",
@@ -778,6 +776,7 @@ Return a JSON array. Each element represents one area that needs a NEW tree node
 For TREE_OK items, only path, type, and rationale are required (other fields can be empty strings or omitted).
 
 IMPORTANT:
+- Only return TREE_MISS or TREE_OK. Sync does not support in-place edits to existing NODE.md files, so do not propose supplement-style updates — if an existing node needs more content, classify as TREE_MISS with a new path and leave the existing node alone.
 - \`suggested_node_body_markdown\` must contain body content only. Do NOT include YAML frontmatter or code fences.
 - \`suggested_soft_links\` must list every tree path the body cross-references (other domains, governance, backend, etc.) so the new node shows up in the tree graph. Use paths from the "Current tree nodes" list above. Omit or use [] when the body does not reference other domains.
 
@@ -1197,7 +1196,7 @@ async function prepareProposalGroup(
     "",
     "Proposals:",
     ...group.proposals.map((p) => {
-      const base = `- ${p.type}: ${p.target_node_path ?? p.path} \u2014 ${p.rationale}`;
+      const base = `- ${p.type}: ${p.path} \u2014 ${p.rationale}`;
       if (p.coClaimingSourcePrs && p.coClaimingSourcePrs.length > 0) {
         const credits = p.coClaimingSourcePrs.map((n) => `#${n}`).join(", ");
         return `${base} (also identified by ${credits})`;
@@ -1571,8 +1570,16 @@ export async function runSync(
             return { pr, filtered: [] as ClassificationItem[], written: [] as string[] };
           }
 
-          const filtered = proposals.filter((p) => p.type !== "TREE_OK");
-          const okCount = proposals.length - filtered.length;
+          const dropped = proposals.filter(
+            (p) => p.type !== "TREE_MISS" && p.type !== "TREE_OK",
+          );
+          for (const d of dropped) {
+            console.log(
+              `  \u26A0 ${prLabel}: dropping unsupported classification type "${d.type}" for path "${d.path}" (sync only applies TREE_MISS edits; see #125)`,
+            );
+          }
+          const filtered = proposals.filter((p) => p.type === "TREE_MISS");
+          const okCount = proposals.filter((p) => p.type === "TREE_OK").length;
 
           console.log(
             `  ${prLabel}: ${filtered.length} proposals (${okCount} TREE_OK skipped)`,

--- a/src/products/tree/engine/sync.ts
+++ b/src/products/tree/engine/sync.ts
@@ -336,6 +336,12 @@ interface ClassificationItem {
   rationale: string;
   suggested_node_title: string;
   suggested_node_body_markdown: string;
+  /**
+   * Source PR numbers (other than the owning group's) that independently
+   * proposed this same target path. Populated by the dedup pass so the
+   * surviving PR can credit the dropped claimants in its body (#121).
+   */
+  coClaimingSourcePrs?: number[];
 }
 
 /** A group of proposals tied to one source PR (or unlinked commits). */
@@ -1107,9 +1113,14 @@ async function prepareProposalGroup(
     `- Proposal files: ${group.proposalPaths.length}`,
     "",
     "Proposals:",
-    ...group.proposals.map(
-      (p) => `- ${p.type}: ${p.target_node_path ?? p.path} \u2014 ${p.rationale}`,
-    ),
+    ...group.proposals.map((p) => {
+      const base = `- ${p.type}: ${p.target_node_path ?? p.path} \u2014 ${p.rationale}`;
+      if (p.coClaimingSourcePrs && p.coClaimingSourcePrs.length > 0) {
+        const credits = p.coClaimingSourcePrs.map((n) => `#${n}`).join(", ");
+        return `${base} (also identified by ${credits})`;
+      }
+      return base;
+    }),
     "",
     "Commits:",
     ...drift.commits.map(
@@ -1492,24 +1503,59 @@ export async function runSync(
       classifiedPrs.push(...results);
     }
 
-    // Deduplicate proposals targeting the same node path across PRs
-    const claimedPaths = new Set<string>();
+    // Deduplicate proposals that target the same node path across source PRs.
+    // Strategy (#121): group all proposals by normalized target path, pick the
+    // entry with the longest suggested body as the winner, drop the rest, and
+    // annotate the winner with the losing source-PR numbers so the surviving
+    // tree PR can credit every contributor in its body.
+    interface DedupEntry {
+      classified: ClassifiedPr;
+      proposal: ClassificationItem;
+    }
+    const byPath = new Map<string, DedupEntry[]>();
     for (const classified of classifiedPrs) {
-      const deduped: ClassificationItem[] = [];
       for (const p of classified.filtered) {
-        if (p.type !== "TREE_MISS") {
-          deduped.push(p);
-          continue;
-        }
+        if (p.type !== "TREE_MISS") continue;
         const normPath = (p.path ?? "").replace(/\/NODE\.md$/i, "").replace(/^\//, "").toLowerCase();
-        if (normPath && claimedPaths.has(normPath)) {
-          console.log(`  \u23ED Dedup: ${normPath} already claimed by another PR — skipping from PR #${classified.pr.number}`);
-          continue;
-        }
-        if (normPath) claimedPaths.add(normPath);
-        deduped.push(p);
+        if (!normPath) continue;
+        const list = byPath.get(normPath) ?? [];
+        list.push({ classified, proposal: p });
+        byPath.set(normPath, list);
       }
-      classified.filtered = deduped;
+    }
+    const winningProposals = new Set<ClassificationItem>();
+    for (const [normPath, entries] of byPath) {
+      if (entries.length === 1) {
+        winningProposals.add(entries[0].proposal);
+        continue;
+      }
+      // Rank by body length (stronger content first), then by source PR number
+      // (oldest first) for stable ties.
+      const ranked = [...entries].sort((a, b) => {
+        const aLen = (a.proposal.suggested_node_body_markdown ?? "").length;
+        const bLen = (b.proposal.suggested_node_body_markdown ?? "").length;
+        if (aLen !== bLen) return bLen - aLen;
+        const aNum = a.classified.pr.number ?? Number.MAX_SAFE_INTEGER;
+        const bNum = b.classified.pr.number ?? Number.MAX_SAFE_INTEGER;
+        return aNum - bNum;
+      });
+      const winner = ranked[0];
+      winningProposals.add(winner.proposal);
+      const coClaimants = ranked
+        .slice(1)
+        .map((e) => e.classified.pr.number)
+        .filter((n): n is number => typeof n === "number" && n > 0);
+      if (coClaimants.length > 0) {
+        winner.proposal.coClaimingSourcePrs = Array.from(new Set(coClaimants)).sort((a, b) => a - b);
+      }
+      console.log(
+        `  \u23ED Dedup: ${normPath} claimed by ${ranked.length} PR(s); kept PR #${winner.classified.pr.number} (body=${(winner.proposal.suggested_node_body_markdown ?? "").length} chars), dropped ${coClaimants.map((n) => `#${n}`).join(", ") || "(none)"}`,
+      );
+    }
+    for (const classified of classifiedPrs) {
+      classified.filtered = classified.filtered.filter(
+        (p) => p.type !== "TREE_MISS" || winningProposals.has(p),
+      );
     }
 
     const totalProposals = classifiedPrs.reduce((sum, c) => sum + c.filtered.length, 0);

--- a/src/products/tree/engine/sync.ts
+++ b/src/products/tree/engine/sync.ts
@@ -1007,22 +1007,29 @@ async function prepareProposalGroup(
         writeFileSync(nodePath, content);
         writtenFiles.push(nodePath);
 
-        // Update parent NODE.md sub-domains list if the new dir isn't listed
+        // Update parent NODE.md sub-domains list if the new dir isn't listed.
+        // If the parent has no Sub-domains section at all, append one so the
+        // child is discoverable via top-down tree navigation (#122).
         const parentNodePath = join(dirname(absDir), "NODE.md");
         if (existsSync(parentNodePath)) {
           try {
             const parentContent = readFileSync(parentNodePath, "utf-8");
             const newDirName = basename(absDir);
-            if (!parentContent.includes(`${newDirName}/`) && !parentContent.includes(`${newDirName}\\`)) {
+            const alreadyListed = parentContent.includes(`${newDirName}/`) || parentContent.includes(`${newDirName}\\`);
+            if (!alreadyListed) {
+              const newLine = `- \`${newDirName}/\` — ${capitalizedTitle}\n`;
               const subDomainsMatch = parentContent.match(/(##\s*Sub-?domains?[^\n]*\n)([\s\S]*?)(\n##|\n---|\z)/i);
+              let updated: string | null = null;
               if (subDomainsMatch) {
                 const insertPoint = parentContent.indexOf(subDomainsMatch[0]) + subDomainsMatch[1].length + subDomainsMatch[2].length;
-                const newLine = `- \`${newDirName}/\` — ${capitalizedTitle}\n`;
-                const updated = parentContent.slice(0, insertPoint) + newLine + parentContent.slice(insertPoint);
-                writeFileSync(parentNodePath, updated);
-                writtenFiles.push(parentNodePath);
-                console.log(`  \u2713 Updated parent: ${relative(treeRoot, parentNodePath)} (added ${newDirName}/)`);
+                updated = parentContent.slice(0, insertPoint) + newLine + parentContent.slice(insertPoint);
+              } else {
+                const trimmed = parentContent.replace(/\s+$/, "");
+                updated = `${trimmed}\n\n## Sub-domains\n\n${newLine}`;
               }
+              writeFileSync(parentNodePath, updated);
+              writtenFiles.push(parentNodePath);
+              console.log(`  \u2713 Updated parent: ${relative(treeRoot, parentNodePath)} (added ${newDirName}/)`);
             }
           } catch { /* non-fatal */ }
         }

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -806,6 +806,99 @@ describe("sync -- PR labeling", () => {
     expect(nodeText).not.toContain("@alice");
   });
 
+  it("emits soft_links frontmatter when Claude returns cross-domain references (#124)", async () => {
+    const tmp = useTmpDir();
+    makeTreeShell(tmp.path);
+    const fromSha = "aa".repeat(20);
+    const toSha = "bb".repeat(20);
+    writeTreeBinding(tmp.path, "source-softlinks", {
+      bindingMode: "standalone-source",
+      entrypoint: "/repos/source",
+      lastReconciledSourceCommit: fromSha,
+      remoteUrl: "https://github.com/alice/source.git",
+      rootKind: "git-repo",
+      scope: "repo",
+      sourceId: "source-softlinks",
+      sourceName: "source",
+      sourceRootPath: "../source",
+      treeMode: "dedicated",
+      treeRepoName: "tree",
+    });
+    const shellRun: ShellRun = async (command, args) => {
+      if (command === "gh" && args[0] === "auth") return okAuth();
+      if (command === "claude" && args[0] === "--version") return claudeVersionOk();
+      if (command === "gh" && args[0] === "api") {
+        const path = args[1] ?? "";
+        if (path === "/repos/alice/source/commits/HEAD") {
+          return { stdout: `${toSha}\n`, stderr: "", code: 0 };
+        }
+        if (path.startsWith("/repos/alice/source/compare/")) {
+          return {
+            stdout: JSON.stringify({
+              commits: [{
+                sha: "1".repeat(40),
+                commit: { message: "feat(mcp): add server (#401)", author: { name: "a", date: "2026-04-01T00:00:00Z" } },
+                files: [{ filename: "mcp/server.ts" }],
+              }],
+            }),
+            stderr: "",
+            code: 0,
+          };
+        }
+        if (path.startsWith("search/issues")) {
+          return {
+            stdout: JSON.stringify({
+              items: [{
+                number: 401,
+                title: "feat(mcp): add server",
+                pull_request: { merged_at: "2026-04-01T00:00:00Z", merge_commit_sha: "1".repeat(40) },
+              }],
+            }),
+            stderr: "",
+            code: 0,
+          };
+        }
+      }
+      if (command === "claude" && args[0] === "-p") {
+        return {
+          stdout: JSON.stringify([{
+            path: "mcp",
+            type: "TREE_MISS",
+            target_node_path: null,
+            rationale: "New MCP area",
+            suggested_node_title: "MCP",
+            suggested_node_body_markdown: "# MCP\nUses governance/ rules and backend/ transport.",
+            suggested_soft_links: ["governance", "backend", "governance", "mcp"],
+          }]),
+          stderr: "",
+          code: 0,
+        };
+      }
+      if (command === "gh" && args[0] === "pr" && args[1] === "list") {
+        return { stdout: "[]", stderr: "", code: 0 };
+      }
+      if (command === "git") {
+        if (args[0] === "symbolic-ref") return { stdout: "main\n", stderr: "", code: 0 };
+        if (args.includes("diff") && args.includes("--cached") && args.includes("--quiet")) {
+          return { stdout: "", stderr: "", code: 1 };
+        }
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
+    };
+    const code = await runSync(
+      tmp.path,
+      { source: undefined, propose: false, apply: true, dryRun: true },
+      { shellRun, verifyTree: () => 0 },
+    );
+    expect(code).toBe(0);
+    const nodeText = readFileSync(join(tmp.path, "mcp", "NODE.md"), "utf-8");
+    // soft_links must be present, sorted, deduped, and must not include the
+    // target's own path ("mcp").
+    expect(nodeText).toMatch(/soft_links: \[backend, governance\]/);
+    expect(nodeText).not.toMatch(/soft_links:[^\n]*mcp/);
+  });
+
   it("feeds truncated diff hunks and filters lockfile noise in the classification prompt (#123)", async () => {
     const tmp = useTmpDir();
     makeTreeShell(tmp.path);

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -899,6 +899,119 @@ describe("sync -- PR labeling", () => {
     expect(nodeText).not.toMatch(/soft_links:[^\n]*mcp/);
   });
 
+  it("drops TREE_SUPPLEMENT items instead of advertising unapplied edits (#125)", async () => {
+    const tmp = useTmpDir();
+    makeTreeShell(tmp.path);
+    // Seed an existing node that a supplement item would target.
+    mkdirSync(join(tmp.path, "backend"), { recursive: true });
+    writeFileSync(
+      join(tmp.path, "backend", "NODE.md"),
+      "---\ntitle: \"Backend\"\nowners: [@alice]\n---\n\nHand-authored.\n",
+    );
+    const fromSha = "aa".repeat(20);
+    const toSha = "bb".repeat(20);
+    writeTreeBinding(tmp.path, "source-supplement", {
+      bindingMode: "standalone-source",
+      entrypoint: "/repos/source",
+      lastReconciledSourceCommit: fromSha,
+      remoteUrl: "https://github.com/alice/source.git",
+      rootKind: "git-repo",
+      scope: "repo",
+      sourceId: "source-supplement",
+      sourceName: "source",
+      sourceRootPath: "../source",
+      treeMode: "dedicated",
+      treeRepoName: "tree",
+    });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const shellRun: ShellRun = async (command, args) => {
+      if (command === "gh" && args[0] === "auth") return okAuth();
+      if (command === "claude" && args[0] === "--version") return claudeVersionOk();
+      if (command === "gh" && args[0] === "api") {
+        const path = args[1] ?? "";
+        if (path === "/repos/alice/source/commits/HEAD") {
+          return { stdout: `${toSha}\n`, stderr: "", code: 0 };
+        }
+        if (path.startsWith("/repos/alice/source/compare/")) {
+          return {
+            stdout: JSON.stringify({
+              commits: [{
+                sha: "1".repeat(40),
+                commit: { message: "feat(api): ratelimits (#501)", author: { name: "a", date: "2026-04-01T00:00:00Z" } },
+                files: [{ filename: "api/ratelimit.ts" }],
+              }],
+            }),
+            stderr: "",
+            code: 0,
+          };
+        }
+        if (path.startsWith("search/issues")) {
+          return {
+            stdout: JSON.stringify({
+              items: [{
+                number: 501,
+                title: "feat(api): ratelimits",
+                pull_request: { merged_at: "2026-04-01T00:00:00Z", merge_commit_sha: "1".repeat(40) },
+              }],
+            }),
+            stderr: "",
+            code: 0,
+          };
+        }
+      }
+      if (command === "claude" && args[0] === "-p") {
+        return {
+          stdout: JSON.stringify([
+            {
+              path: "api/ratelimits",
+              type: "TREE_MISS",
+              rationale: "New rate-limit subsystem",
+              suggested_node_title: "API ratelimits",
+              suggested_node_body_markdown: "# Ratelimits\nBody.",
+            },
+            {
+              path: "backend",
+              type: "TREE_SUPPLEMENT",
+              rationale: "Existing backend node should mention rate limits too",
+              suggested_node_title: "Backend",
+              suggested_node_body_markdown: "Supplement content that would rewrite Backend.",
+            },
+          ]),
+          stderr: "",
+          code: 0,
+        };
+      }
+      if (command === "gh" && args[0] === "pr" && args[1] === "list") {
+        return { stdout: "[]", stderr: "", code: 0 };
+      }
+      if (command === "git") {
+        if (args[0] === "symbolic-ref") return { stdout: "main\n", stderr: "", code: 0 };
+        if (args.includes("diff") && args.includes("--cached") && args.includes("--quiet")) {
+          return { stdout: "", stderr: "", code: 1 };
+        }
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
+    };
+    const code = await runSync(
+      tmp.path,
+      { source: undefined, propose: false, apply: true, dryRun: true },
+      { shellRun, verifyTree: () => 0 },
+    );
+    expect(code).toBe(0);
+    // TREE_MISS proposal produced a new NODE.md.
+    expect(existsSync(join(tmp.path, "api", "ratelimits", "NODE.md"))).toBe(true);
+    // Existing backend NODE.md is preserved byte-for-byte (no supplement applied).
+    const backendText = readFileSync(join(tmp.path, "backend", "NODE.md"), "utf-8");
+    expect(backendText).toBe(
+      "---\ntitle: \"Backend\"\nowners: [@alice]\n---\n\nHand-authored.\n",
+    );
+    // Sync logged that it dropped the unsupported TREE_SUPPLEMENT item.
+    const logs = logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(logs).toMatch(/dropping unsupported classification type "TREE_SUPPLEMENT"/);
+    logSpy.mockRestore();
+  });
+
   it("feeds truncated diff hunks and filters lockfile noise in the classification prompt (#123)", async () => {
     const tmp = useTmpDir();
     makeTreeShell(tmp.path);

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -806,6 +806,111 @@ describe("sync -- PR labeling", () => {
     expect(nodeText).not.toContain("@alice");
   });
 
+  it("creates a Sub-domains section on parent NODE.md when missing (#122)", async () => {
+    const tmp = useTmpDir();
+    makeTreeShell(tmp.path);
+    mkdirSync(join(tmp.path, "engineering"), { recursive: true });
+    writeFileSync(
+      join(tmp.path, "engineering", "NODE.md"),
+      "---\ntitle: Engineering\nowners: [alice]\n---\n# Engineering\n\nSome intro text.\n",
+    );
+    const fromSha = "aa".repeat(20);
+    const toSha = "bb".repeat(20);
+    writeTreeBinding(tmp.path, "source-parent", {
+      bindingMode: "standalone-source",
+      entrypoint: "/repos/source",
+      lastReconciledSourceCommit: fromSha,
+      remoteUrl: "https://github.com/alice/source.git",
+      rootKind: "git-repo",
+      scope: "repo",
+      sourceId: "source-parent",
+      sourceName: "source",
+      sourceRootPath: "../source",
+      treeMode: "dedicated",
+      treeRepoName: "tree",
+    });
+    const shellRun: ShellRun = async (command, args) => {
+      if (command === "gh" && args[0] === "auth") return okAuth();
+      if (command === "claude" && args[0] === "--version") return claudeVersionOk();
+      if (command === "gh" && args[0] === "api") {
+        const path = args[1] ?? "";
+        if (path === "/repos/alice/source/commits/HEAD") {
+          return { stdout: `${toSha}\n`, stderr: "", code: 0 };
+        }
+        if (path.startsWith("/repos/alice/source/compare/")) {
+          return {
+            stdout: JSON.stringify({
+              commits: [{
+                sha: "1".repeat(40),
+                commit: {
+                  message: "feat(mcp): bootstrap server (#201)",
+                  author: { name: "alice", date: "2026-04-01T00:00:00Z" },
+                },
+                files: [{ filename: "engineering/mcp/server.ts" }],
+              }],
+            }),
+            stderr: "",
+            code: 0,
+          };
+        }
+        if (path.startsWith("search/issues")) {
+          return {
+            stdout: JSON.stringify({
+              items: [{
+                number: 201,
+                title: "feat(mcp): bootstrap server",
+                pull_request: {
+                  merged_at: "2026-04-01T00:00:00Z",
+                  merge_commit_sha: "1".repeat(40),
+                },
+              }],
+            }),
+            stderr: "",
+            code: 0,
+          };
+        }
+      }
+      if (command === "claude" && args[0] === "-p") {
+        return {
+          stdout: JSON.stringify([{
+            path: "engineering/mcp",
+            type: "TREE_MISS",
+            target_node_path: null,
+            rationale: "New MCP area not in tree",
+            suggested_node_title: "MCP",
+            suggested_node_body_markdown: "# MCP\nBootstrap details.",
+          }]),
+          stderr: "",
+          code: 0,
+        };
+      }
+      if (command === "gh" && args[0] === "pr" && args[1] === "list") {
+        return { stdout: "[]", stderr: "", code: 0 };
+      }
+      if (command === "git") {
+        if (args[0] === "symbolic-ref") {
+          return { stdout: "main\n", stderr: "", code: 0 };
+        }
+        if (args.includes("diff") && args.includes("--cached") && args.includes("--quiet")) {
+          return { stdout: "", stderr: "", code: 1 };
+        }
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
+    };
+    const code = await runSync(
+      tmp.path,
+      { source: undefined, propose: false, apply: true, dryRun: true },
+      { shellRun, verifyTree: () => 0 },
+    );
+    expect(code).toBe(0);
+
+    const parentText = readFileSync(join(tmp.path, "engineering", "NODE.md"), "utf-8");
+    expect(parentText).toMatch(/## Sub-domains/);
+    expect(parentText).toContain("`mcp/`");
+    expect(parentText).toContain("MCP");
+  });
+
   it("regenerates and stages CODEOWNERS inside each content PR (#119)", async () => {
     const tmp = useTmpDir();
     makeTreeShell(tmp.path);

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -806,6 +806,104 @@ describe("sync -- PR labeling", () => {
     expect(nodeText).not.toContain("@alice");
   });
 
+  it("feeds truncated diff hunks and filters lockfile noise in the classification prompt (#123)", async () => {
+    const tmp = useTmpDir();
+    makeTreeShell(tmp.path);
+    const fromSha = "aa".repeat(20);
+    const toSha = "bb".repeat(20);
+    writeTreeBinding(tmp.path, "source-diff", {
+      bindingMode: "standalone-source",
+      entrypoint: "/repos/source",
+      lastReconciledSourceCommit: fromSha,
+      remoteUrl: "https://github.com/alice/source.git",
+      rootKind: "git-repo",
+      scope: "repo",
+      sourceId: "source-diff",
+      sourceName: "source",
+      sourceRootPath: "../source",
+      treeMode: "dedicated",
+      treeRepoName: "tree",
+    });
+    let capturedPrompt = "";
+    const shellRun: ShellRun = async (command, args) => {
+      if (command === "gh" && args[0] === "auth") return okAuth();
+      if (command === "claude" && args[0] === "--version") return claudeVersionOk();
+      if (command === "gh" && args[0] === "api") {
+        const path = args[1] ?? "";
+        if (path === "/repos/alice/source/commits/HEAD") {
+          return { stdout: `${toSha}\n`, stderr: "", code: 0 };
+        }
+        if (path.startsWith("/repos/alice/source/compare/")) {
+          return {
+            stdout: JSON.stringify({
+              commits: [{
+                sha: "1".repeat(40),
+                commit: { message: "feat: add oauth (#301)", author: { name: "a", date: "2026-04-01T00:00:00Z" } },
+                files: [{ filename: "auth/oauth.ts" }],
+              }],
+            }),
+            stderr: "",
+            code: 0,
+          };
+        }
+        if (path.startsWith("search/issues")) {
+          return {
+            stdout: JSON.stringify({
+              items: [{
+                number: 301,
+                title: "feat: add oauth",
+                pull_request: { merged_at: "2026-04-01T00:00:00Z", merge_commit_sha: "1".repeat(40) },
+              }],
+            }),
+            stderr: "",
+            code: 0,
+          };
+        }
+        if (path.includes("/pulls/301/files")) {
+          return {
+            stdout: JSON.stringify([
+              {
+                filename: "auth/oauth.ts",
+                status: "added",
+                patch: "@@ -0,0 +1,3 @@\n+export function oauthLogin(code: string) {\n+  return fetch('/oauth/callback?code=' + code);\n+}",
+              },
+              {
+                filename: "pnpm-lock.yaml",
+                status: "modified",
+                patch: "@@ -1,5000 +1,5050 @@\n(massive lockfile churn)",
+              },
+            ]),
+            stderr: "",
+            code: 0,
+          };
+        }
+      }
+      if (command === "claude" && args[0] === "-p") {
+        capturedPrompt = args.at(-1) ?? "";
+        return {
+          stdout: JSON.stringify([]),
+          stderr: "",
+          code: 0,
+        };
+      }
+      return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
+    };
+    const code = await runSync(
+      tmp.path,
+      { source: undefined, propose: true, apply: false, dryRun: false },
+      { shellRun },
+    );
+    expect(code).toBe(0);
+    expect(capturedPrompt).toContain("Truncated diff hunks");
+    expect(capturedPrompt).toContain("oauthLogin");
+    expect(capturedPrompt).toContain("auth/oauth.ts");
+    // Lockfile hunks must be filtered out of the diff section (filename is
+    // still allowed in the Changed-files list — that's a cheap signal).
+    const diffSection = capturedPrompt.split("Truncated diff hunks")[1] ?? "";
+    expect(diffSection).not.toContain("pnpm-lock.yaml");
+    expect(diffSection).not.toContain("massive lockfile churn");
+  });
+
   it("dedups duplicate-path proposals, keeps strongest, credits others (#121)", async () => {
     const tmp = useTmpDir();
     makeTreeShell(tmp.path);

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -806,6 +806,141 @@ describe("sync -- PR labeling", () => {
     expect(nodeText).not.toContain("@alice");
   });
 
+  it("dedups duplicate-path proposals, keeps strongest, credits others (#121)", async () => {
+    const tmp = useTmpDir();
+    makeTreeShell(tmp.path);
+    const fromSha = "aa".repeat(20);
+    const toSha = "bb".repeat(20);
+    writeTreeBinding(tmp.path, "source-dedup", {
+      bindingMode: "standalone-source",
+      entrypoint: "/repos/source",
+      lastReconciledSourceCommit: fromSha,
+      remoteUrl: "https://github.com/alice/source.git",
+      rootKind: "git-repo",
+      scope: "repo",
+      sourceId: "source-dedup",
+      sourceName: "source",
+      sourceRootPath: "../source",
+      treeMode: "dedicated",
+      treeRepoName: "tree",
+    });
+    const shortBody = "# MCP\nshort.";
+    const longBody = "# MCP\n" + "Detailed bootstrap, auth, and routing notes. ".repeat(20);
+    const prCreateCalls: string[][] = [];
+    const checkoutBranches: string[] = [];
+    let classifyCall = 0;
+    const shellRun: ShellRun = async (command, args) => {
+      if (command === "gh" && args[0] === "auth") return okAuth();
+      if (command === "claude" && args[0] === "--version") return claudeVersionOk();
+      if (command === "gh" && args[0] === "api") {
+        const path = args[1] ?? "";
+        if (path === "/repos/alice/source/commits/HEAD") {
+          return { stdout: `${toSha}\n`, stderr: "", code: 0 };
+        }
+        if (path.startsWith("/repos/alice/source/compare/")) {
+          return {
+            stdout: JSON.stringify({
+              commits: [
+                {
+                  sha: "1".repeat(40),
+                  commit: { message: "feat(mcp): start (#201)", author: { name: "a", date: "2026-04-01T00:00:00Z" } },
+                  files: [{ filename: "engineering/mcp/a.ts" }],
+                },
+                {
+                  sha: "2".repeat(40),
+                  commit: { message: "feat(mcp): more (#202)", author: { name: "b", date: "2026-04-02T00:00:00Z" } },
+                  files: [{ filename: "engineering/mcp/b.ts" }],
+                },
+              ],
+            }),
+            stderr: "",
+            code: 0,
+          };
+        }
+        if (path.startsWith("search/issues")) {
+          return {
+            stdout: JSON.stringify({
+              items: [
+                {
+                  number: 201,
+                  title: "feat(mcp): start",
+                  pull_request: { merged_at: "2026-04-01T00:00:00Z", merge_commit_sha: "1".repeat(40) },
+                },
+                {
+                  number: 202,
+                  title: "feat(mcp): more",
+                  pull_request: { merged_at: "2026-04-02T00:00:00Z", merge_commit_sha: "2".repeat(40) },
+                },
+              ],
+            }),
+            stderr: "",
+            code: 0,
+          };
+        }
+      }
+      if (command === "claude" && args[0] === "-p") {
+        classifyCall += 1;
+        // First PR (#201) gets the SHORT body, second PR (#202) gets LONG.
+        const body = classifyCall === 1 ? shortBody : longBody;
+        return {
+          stdout: JSON.stringify([{
+            path: "engineering/mcp",
+            type: "TREE_MISS",
+            target_node_path: null,
+            rationale: "Claude picked mcp",
+            suggested_node_title: "MCP",
+            suggested_node_body_markdown: body,
+          }]),
+          stderr: "",
+          code: 0,
+        };
+      }
+      if (command === "gh" && args[0] === "pr" && args[1] === "list") {
+        return { stdout: "[]", stderr: "", code: 0 };
+      }
+      if (command === "gh" && args[0] === "pr" && args[1] === "create") {
+        prCreateCalls.push([...args]);
+        return { stdout: "https://github.com/x/y/pull/1\n", stderr: "", code: 0 };
+      }
+      if (command === "gh" && args[0] === "pr" && args[1] === "edit") {
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      if (command === "gh" && args[0] === "label") {
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      if (command === "git") {
+        if (args[0] === "symbolic-ref") return { stdout: "main\n", stderr: "", code: 0 };
+        if (args[0] === "checkout" && args[1] === "-B") {
+          checkoutBranches.push(args[2]);
+          return { stdout: "", stderr: "", code: 0 };
+        }
+        if (args.includes("diff") && args.includes("--cached") && args.includes("--quiet")) {
+          return { stdout: "", stderr: "", code: 1 };
+        }
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
+    };
+    const code = await runSync(
+      tmp.path,
+      { source: undefined, propose: false, apply: true, dryRun: false },
+      { shellRun, verifyTree: () => 0 },
+    );
+    expect(code).toBe(0);
+
+    // Exactly ONE content branch should be created for engineering/mcp, not two.
+    const contentBranches = checkoutBranches.filter((b) => b.includes("sync-source-dedup-pr"));
+    expect(contentBranches).toEqual(["first-tree/sync-source-dedup-pr202"]);
+
+    // The surviving PR body must credit the dropped PR (#201).
+    const contentPrCreate = prCreateCalls.find((args) =>
+      args.some((a) => typeof a === "string" && a.includes("from alice/source#202")),
+    );
+    expect(contentPrCreate).toBeDefined();
+    const bodyArg = contentPrCreate?.[contentPrCreate.indexOf("--body") + 1] ?? "";
+    expect(bodyArg).toContain("also identified by #201");
+  });
+
   it("creates a Sub-domains section on parent NODE.md when missing (#122)", async () => {
     const tmp = useTmpDir();
     makeTreeShell(tmp.path);


### PR DESCRIPTION
Follow-up to #127 — the remaining five items from the #108 execution plan, now that the CODEOWNERS work has landed.

## Commits (one issue per commit)

| Commit | Issue | What changed |
|---|---|---|
| `fix(sync): auto-insert Sub-domains section on parent NODE.md` | #122 | `prepareProposalGroup` now creates a `## Sub-domains` section on the parent NODE.md when none exists, instead of skipping the parent update. |
| `fix(sync): pick strongest variant and credit co-claimants on dedup` | #121 | Proposal dedup no longer first-come-wins: proposals targeting the same normalized path are ranked by body length (tie-break by PR number), the strongest wins, losers are dropped, and the surviving PR body credits the dropped claimants as `(also identified by #NNN, #MMM)`. |
| `feat(sync): include truncated diff hunks in classification prompt` | #123 | Classification now fetches per-PR file changes (with `--paginate`), filters lockfile / snapshot / vendored noise, truncates to ≤15 files × ≤40 lines per file, and threads the hunks into Claude's prompt alongside the existing cheap signals. |
| `feat(sync): emit soft_links frontmatter from classification` | #124 | The classification prompt asks Claude for cross-domain references and the NODE.md writer emits a sorted, deduped, self-excluded `soft_links: [...]` line when non-empty. |
| `fix(sync): drop unsupported classification types so PR body matches diff` | #125 | Classification filter is now strict — only `TREE_MISS` and `TREE_OK` survive; any other type (e.g. legacy `TREE_SUPPLEMENT`) is dropped with a warning instead of being advertised in a PR body that never actually edits the target NODE.md. The dead `target_node_path` scaffolding is removed from the interface, prompt, and PR renderer. |

## Test

- `pnpm test tests/sync.test.ts` — 25/25 passing, including five new regression tests (one per commit):
  - "creates a Sub-domains section on parent NODE.md when missing (#122)"
  - "dedups duplicate-path proposals, keeps strongest, credits others (#121)"
  - "feeds truncated diff hunks and filters lockfile noise in the classification prompt (#123)"
  - "emits soft_links frontmatter when Claude returns cross-domain references (#124)"
  - "drops TREE_SUPPLEMENT items instead of advertising unapplied edits (#125)"
- `pnpm typecheck` clean.
- The 29 pre-existing failures on the full `pnpm test` run are the same `execFileSync` git-commit errors flagged on #127 (reproducible with this branch's changes stashed).

## Closes

- Closes #121
- Closes #122
- Closes #123
- Closes #124
- Closes #125

Tracker: #108.