### PR TITLE
Phase 3c: port breeze daemon broker + dispatcher to TypeScript

### DIFF
--- a/src/products/breeze/core/config.ts
+++ b/src/products/breeze/core/config.ts
@@ -70,7 +70,11 @@ export interface DaemonConfig {
 
 export const DAEMON_CONFIG_DEFAULTS: DaemonConfig = {
   pollIntervalSec: 60,
-  taskTimeoutSec: 15 * 60,
+  // Phase 3c bug fix 1: per-task timeout default 30 min. Rust dispatcher
+  // had no timeout (documented silent-hang failure mode in
+  // `docs/migration/04-broker-agent-lifecycle.md` §8). We set a generous
+  // ceiling so the broker will always eventually reclaim a stuck task.
+  taskTimeoutSec: 30 * 60,
   logLevel: "info",
   httpPort: 7878,
   host: "github.com",

--- a/src/products/breeze/daemon/broker.ts
+++ b/src/products/breeze/daemon/broker.ts
@@ -1,0 +1,539 @@
+/**
+ * Phase 3c: cross-process `gh` broker for the TypeScript breeze daemon.
+ *
+ * Port of `first-tree-breeze/breeze-runner/src/broker.rs`.
+ *
+ * Purpose
+ * -------
+ * Agent subprocesses (codex/claude) shell out to `gh` for issue /
+ * pr / review mutations. Those calls must share the same rate-limit
+ * budget as the daemon and must be serialized across processes so
+ * two agent runs cannot double-post a comment. The broker achieves
+ * that by installing a shim `gh` binary (`SHIM_SCRIPT`) on the
+ * agent's `PATH` — the shim enqueues a request directory under
+ * `<broker_dir>/requests/` and polls for `response.env`. The daemon
+ * drains the queue in a single thread and invokes real `gh` via
+ * `GhExecutor`.
+ *
+ * Files on disk (identical to Rust):
+ *   <broker_dir>/
+ *     bin/gh                 — POSIX shim script (mode 0755)
+ *     requests/
+ *       req-<epoch>-<pid>-<rand>/
+ *         argv.txt            — one arg per line (written by shim)
+ *         cwd.txt             — pwd of the shim invocation
+ *         gh_host.txt (opt)   — GH_HOST forwarded from agent env
+ *         gh_repo.txt (opt)   — GH_REPO forwarded from agent env
+ *         stdout.txt          — written by broker
+ *         stderr.txt          — written by broker
+ *         response.env        — status_code + paths + epoch
+ *     history/
+ *       <fingerprint-id>/
+ *         stdout.txt, stderr.txt, response.env
+ *         (15-minute TTL; see MUTATION_CACHE_TTL_MS)
+ *
+ * Correctness gaps vs Rust (flagged in spec doc 4 §11)
+ * ----------------------------------------------------
+ *   - Mutation-response cache can mask a human rollback. We match the
+ *     15-minute TTL, but Phase 3c adds a `forceRefresh` hook that
+ *     `runner-skeleton.ts` can wire to a future CLI flag. Currently
+ *     unused.
+ *   - Claude's stdout-to-output-file copy is handled in `runner.ts`,
+ *     not here.
+ */
+
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { createHash } from "node:crypto";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+
+import {
+  GhExecutor,
+  bucketForArgs,
+  commandIsMutating,
+  type ExecOutput,
+  type GhCommandSpec,
+} from "./gh-executor.js";
+
+export const MUTATION_CACHE_TTL_MS = 15 * 60 * 1_000;
+
+/**
+ * Shim script the agent subprocess invokes in place of real `gh`.
+ * Keep byte-for-byte stable with Rust `SHIM_SCRIPT` — any divergence
+ * breaks idempotency/caching.
+ */
+export const SHIM_SCRIPT = `#!/bin/sh
+set -eu
+
+broker_dir="\${BREEZE_BROKER_DIR:?missing BREEZE_BROKER_DIR}"
+requests_dir="$broker_dir/requests"
+mkdir -p "$requests_dir"
+
+suffix="$(od -An -N2 -tu2 /dev/urandom 2>/dev/null | tr -d ' ' || echo 0)"
+request_dir="$requests_dir/req-$(date +%s)-$$-$suffix"
+mkdir -p "$request_dir"
+
+pwd > "$request_dir/cwd.txt"
+: > "$request_dir/argv.txt"
+for arg in "$@"; do
+  case "$arg" in
+    *'
+'*)
+      echo "breeze-runner gh shim does not support newline arguments" >&2
+      exit 2
+      ;;
+  esac
+  printf '%s\\n' "$arg" >> "$request_dir/argv.txt"
+done
+
+if [ -n "\${GH_HOST:-}" ]; then
+  printf '%s' "$GH_HOST" > "$request_dir/gh_host.txt"
+fi
+
+if [ -n "\${GH_REPO:-}" ]; then
+  printf '%s' "$GH_REPO" > "$request_dir/gh_repo.txt"
+fi
+
+timeout_secs="\${BREEZE_BROKER_TIMEOUT_SECS:-1800}"
+deadline=$(( $(date +%s) + timeout_secs ))
+while [ ! -f "$request_dir/response.env" ]; do
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    echo "breeze-runner gh shim timed out waiting for broker" >&2
+    exit 124
+  fi
+  sleep 0.1
+done
+
+status_code="$(sed -n 's/^status_code=//p' "$request_dir/response.env" | tail -n 1)"
+stdout_path="$(sed -n 's/^stdout_path=//p' "$request_dir/response.env" | tail -n 1)"
+stderr_path="$(sed -n 's/^stderr_path=//p' "$request_dir/response.env" | tail -n 1)"
+
+if [ -n "\${stdout_path:-}" ] && [ -f "$stdout_path" ]; then
+  cat "$stdout_path"
+fi
+
+if [ -n "\${stderr_path:-}" ] && [ -f "$stderr_path" ]; then
+  cat "$stderr_path" >&2
+fi
+
+rm -rf "$request_dir"
+exit "\${status_code:-1}"
+`;
+
+export interface GhBrokerOptions {
+  brokerDir: string;
+  executor: GhExecutor;
+  /** Poll interval in ms between serve-loop passes. Default 100. */
+  pollIntervalMs?: number;
+  /** Injected clock (ms). Tests override. */
+  now?: () => number;
+  /** Injected logger. */
+  logger?: {
+    warn: (line: string) => void;
+    error: (line: string) => void;
+  };
+}
+
+export interface RunningBroker {
+  /** Directory containing `bin/gh` shim. Set on agent `PATH`. */
+  shimDir: string;
+  /** `BREEZE_BROKER_DIR` passed to the agent. */
+  brokerDir: string;
+  /** Stop the serve loop and wait for in-flight requests to finish. */
+  stop(): Promise<void>;
+  /** Resolves when the serve loop exits (either via stop or error). */
+  done: Promise<void>;
+}
+
+/** Start the broker and its serve loop. */
+export async function startGhBroker(
+  options: GhBrokerOptions,
+): Promise<RunningBroker> {
+  const brokerDir = options.brokerDir;
+  const requestsDir = join(brokerDir, "requests");
+  const historyDir = join(brokerDir, "history");
+  const binDir = join(brokerDir, "bin");
+  ensureDir(requestsDir);
+  ensureDir(historyDir);
+  ensureDir(binDir);
+
+  const shimPath = join(binDir, "gh");
+  writeFileSync(shimPath, SHIM_SCRIPT);
+  if (process.platform !== "win32") {
+    chmodSync(shimPath, 0o755);
+  }
+
+  // Purge stale requests from a previous process.
+  purgeStaleRequests(requestsDir);
+
+  const pollIntervalMs = options.pollIntervalMs ?? 100;
+  const now = options.now ?? (() => Date.now());
+  const logger = options.logger ?? {
+    warn: (line: string) => process.stderr.write(`WARN: ${line}\n`),
+    error: (line: string) => process.stderr.write(`ERROR: ${line}\n`),
+  };
+  const stop = { flag: false };
+
+  const done = (async () => {
+    while (!stop.flag) {
+      let pending: string[];
+      try {
+        pending = listPendingRequests(requestsDir);
+      } catch (err) {
+        logger.error(
+          `broker: failed to scan request queue: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        await sleep(250);
+        continue;
+      }
+
+      if (pending.length === 0) {
+        await sleep(pollIntervalMs);
+        continue;
+      }
+
+      for (const requestDir of pending) {
+        if (stop.flag) return;
+        try {
+          await handleRequest({
+            requestDir,
+            historyDir,
+            executor: options.executor,
+            now,
+          });
+        } catch (err) {
+          writeFailureResponse(
+            requestDir,
+            err instanceof Error ? err.message : String(err),
+            now,
+          );
+        }
+      }
+    }
+  })();
+
+  return {
+    shimDir: binDir,
+    brokerDir,
+    async stop(): Promise<void> {
+      stop.flag = true;
+      await done;
+    },
+    done,
+  };
+}
+
+function listPendingRequests(requestsDir: string): string[] {
+  const entries = readdirSync(requestsDir, { withFileTypes: true });
+  const pending: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const dir = join(requestsDir, entry.name);
+    if (existsSync(join(dir, "response.env"))) continue;
+    // The shim writes argv.txt after mkdir; skip dirs without it to
+    // avoid racing against partial writes.
+    if (!existsSync(join(dir, "argv.txt"))) continue;
+    pending.push(dir);
+  }
+  pending.sort();
+  return pending;
+}
+
+function purgeStaleRequests(requestsDir: string): void {
+  if (!existsSync(requestsDir)) return;
+  for (const entry of readdirSync(requestsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const dir = join(requestsDir, entry.name);
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+interface HandleRequestOptions {
+  requestDir: string;
+  historyDir: string;
+  executor: GhExecutor;
+  now: () => number;
+}
+
+async function handleRequest(opts: HandleRequestOptions): Promise<void> {
+  const { requestDir, historyDir, executor, now } = opts;
+  const args = readLines(join(requestDir, "argv.txt"));
+  const cwd = readTextIfExists(join(requestDir, "cwd.txt")).trim();
+  const ghHost = readTextIfExists(join(requestDir, "gh_host.txt")).trim();
+  const ghRepo = readTextIfExists(join(requestDir, "gh_repo.txt")).trim();
+
+  const envs: Record<string, string> = {};
+  if (ghHost) envs.GH_HOST = ghHost;
+  if (ghRepo) envs.GH_REPO = ghRepo;
+
+  const spec: GhCommandSpec = {
+    context: `brokered gh ${args.join(" ")}`,
+    cwd: cwd || undefined,
+    envs,
+    bucket: bucketForArgs(args),
+    mutating: commandIsMutating(args),
+    args,
+  };
+
+  const fingerprint = mutationFingerprint(spec);
+  if (fingerprint !== undefined) {
+    const cached = readCachedMutationResponse({
+      historyDir,
+      fingerprint,
+      now,
+    });
+    if (cached) {
+      writeSuccessResponse({
+        requestDir,
+        stdout: cached.stdout,
+        stderr: cached.stderr,
+        statusCode: cached.statusCode,
+        now,
+      });
+      return;
+    }
+  }
+
+  const output = await executor.run(spec);
+  if (output.statusCode === 0 && fingerprint !== undefined) {
+    writeCachedMutationResponse({
+      historyDir,
+      fingerprint,
+      stdout: output.stdout,
+      stderr: output.stderr,
+      statusCode: output.statusCode,
+      now,
+    });
+  }
+  writeSuccessResponse({
+    requestDir,
+    stdout: output.stdout,
+    stderr: output.stderr,
+    statusCode: output.statusCode,
+    now,
+  });
+}
+
+interface CachedMutationResponse {
+  stdout: string;
+  stderr: string;
+  statusCode: number;
+}
+
+/**
+ * Normalize a spec into a cache-stable key. Bodies and body-files are
+ * hashed so retries with the same payload hit the cache even when the
+ * tmp file path differs. Matches Rust `mutation_fingerprint`.
+ */
+export function mutationFingerprint(
+  spec: GhCommandSpec,
+): string | undefined {
+  if (!spec.mutating) return undefined;
+  const normalized: string[] = [];
+  const args = spec.args;
+  let i = 0;
+  while (i < args.length) {
+    const current = args[i];
+    if (current === "--body" || current === "-b") {
+      normalized.push(current);
+      const body = args[i + 1];
+      if (body !== undefined) {
+        normalized.push(`body-hash:${stableFileId(body)}`);
+        i += 2;
+        continue;
+      }
+    } else if (current === "--body-file" || current === "-F") {
+      normalized.push(current);
+      const path = args[i + 1];
+      if (path !== undefined) {
+        const contents = readBodyFile(path, spec);
+        normalized.push(`body-file-hash:${stableFileId(contents)}`);
+        i += 2;
+        continue;
+      }
+    }
+    normalized.push(current);
+    i += 1;
+  }
+
+  const envs = Object.entries(spec.envs ?? {})
+    .filter(([key]) => key === "GH_HOST" || key === "GH_REPO")
+    .sort(([a1, a2], [b1, b2]) => (a1 === b1 ? a2.localeCompare(b2) : a1.localeCompare(b1)));
+  for (const [key, value] of envs) {
+    normalized.push(`env:${key}=${value}`);
+  }
+  if (spec.cwd) {
+    normalized.push(`cwd:${spec.cwd}`);
+  }
+  return normalized.join("\n");
+}
+
+function readBodyFile(path: string, spec: GhCommandSpec): string {
+  const abs = isAbsolute(path)
+    ? path
+    : spec.cwd
+      ? resolve(spec.cwd, path)
+      : path;
+  if (!existsSync(abs)) {
+    throw new Error(
+      `missing body file for brokered gh command: ${abs}`,
+    );
+  }
+  return readFileSync(abs, "utf8");
+}
+
+function cacheDirFor(historyDir: string, fingerprint: string): string {
+  return join(historyDir, stableFileId(fingerprint));
+}
+
+interface ReadCachedOptions {
+  historyDir: string;
+  fingerprint: string;
+  now: () => number;
+}
+
+export function readCachedMutationResponse(
+  opts: ReadCachedOptions,
+): CachedMutationResponse | undefined {
+  const dir = cacheDirFor(opts.historyDir, opts.fingerprint);
+  const responseFile = join(dir, "response.env");
+  if (!existsSync(responseFile)) return undefined;
+  const values = parseKvLines(readFileSync(responseFile, "utf8"));
+  const completedAt = Number.parseInt(values.completed_at_ms ?? "0", 10) || 0;
+  if (opts.now() - completedAt > MUTATION_CACHE_TTL_MS) {
+    rmSync(dir, { recursive: true, force: true });
+    return undefined;
+  }
+  const statusCode = Number.parseInt(values.status_code ?? "1", 10);
+  if (!Number.isFinite(statusCode) || statusCode !== 0) {
+    rmSync(dir, { recursive: true, force: true });
+    return undefined;
+  }
+  const stdout = readTextIfExists(join(dir, "stdout.txt"));
+  const stderr = readTextIfExists(join(dir, "stderr.txt"));
+  return { stdout, stderr, statusCode };
+}
+
+interface WriteCachedOptions {
+  historyDir: string;
+  fingerprint: string;
+  stdout: string;
+  stderr: string;
+  statusCode: number;
+  now: () => number;
+}
+
+export function writeCachedMutationResponse(
+  opts: WriteCachedOptions,
+): void {
+  const dir = cacheDirFor(opts.historyDir, opts.fingerprint);
+  ensureDir(dir);
+  writeFileSync(join(dir, "stdout.txt"), opts.stdout);
+  writeFileSync(join(dir, "stderr.txt"), opts.stderr);
+  writeFileSync(
+    join(dir, "response.env"),
+    [
+      `status_code=${opts.statusCode}`,
+      `completed_at_ms=${opts.now()}`,
+      "",
+    ].join("\n"),
+  );
+}
+
+interface WriteSuccessOptions {
+  requestDir: string;
+  stdout: string;
+  stderr: string;
+  statusCode: number;
+  now: () => number;
+}
+
+function writeSuccessResponse(opts: WriteSuccessOptions): void {
+  const stdoutPath = join(opts.requestDir, "stdout.txt");
+  const stderrPath = join(opts.requestDir, "stderr.txt");
+  writeFileSync(stdoutPath, opts.stdout);
+  writeFileSync(stderrPath, opts.stderr);
+  writeFileSync(
+    join(opts.requestDir, "response.env"),
+    [
+      `status_code=${opts.statusCode}`,
+      `stdout_path=${stdoutPath}`,
+      `stderr_path=${stderrPath}`,
+      `completed_at_ms=${opts.now()}`,
+      "",
+    ].join("\n"),
+  );
+}
+
+function writeFailureResponse(
+  requestDir: string,
+  error: string,
+  now: () => number,
+): void {
+  const stdoutPath = join(requestDir, "stdout.txt");
+  const stderrPath = join(requestDir, "stderr.txt");
+  writeFileSync(stdoutPath, "");
+  writeFileSync(stderrPath, error);
+  writeFileSync(
+    join(requestDir, "response.env"),
+    [
+      "status_code=1",
+      `stdout_path=${stdoutPath}`,
+      `stderr_path=${stderrPath}`,
+      `completed_at_ms=${now()}`,
+      "",
+    ].join("\n"),
+  );
+}
+
+/* ------------------------ low-level helpers ------------------------ */
+
+function ensureDir(path: string): void {
+  mkdirSync(path, { recursive: true });
+}
+
+function readTextIfExists(path: string): string {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function readLines(path: string): string[] {
+  const raw = readFileSync(path, "utf8");
+  return raw.split("\n").filter((line) => line.length > 0);
+}
+
+function parseKvLines(text: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const line of text.split("\n")) {
+    const eq = line.indexOf("=");
+    if (eq === -1) continue;
+    const key = line.slice(0, eq);
+    if (!key) continue;
+    result[key] = line.slice(eq + 1);
+  }
+  return result;
+}
+
+/** Rust `util::stable_file_id` is a sha256 hex. Match it. */
+export function stableFileId(contents: string): string {
+  return createHash("sha256").update(contents).digest("hex").slice(0, 32);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/products/breeze/daemon/bus.ts
+++ b/src/products/breeze/daemon/bus.ts
@@ -1,0 +1,205 @@
+/**
+ * Phase 3c: in-process event bus for the TypeScript breeze daemon.
+ *
+ * Port of `first-tree-breeze/breeze-runner/src/bus.rs`.
+ *
+ * SINGLE-WRITER RULE (spec doc 2 §1.3):
+ * -------------------------------------
+ * This module is **read-only** with respect to `~/.breeze/inbox.json`.
+ * Only the poller (`daemon/poller.ts`) writes the inbox. The bus
+ * multicasts events produced by the poller/broker; subscribers (http SSE
+ * stream, the broker's own completion handler, future observers) only
+ * consume events. Never call a store writer from a subscriber.
+ *
+ * Design (matches Rust `Bus`):
+ * ----------------------------
+ *   - Publishers call `bus.publish(event)`. Delivery is synchronous:
+ *     `publish` iterates the subscriber list and invokes each listener
+ *     on the calling stack (ordering guaranteed per-subscriber).
+ *   - Subscribers call `bus.subscribe(listener)` and get back an
+ *     unsubscribe function. The listener receives every event published
+ *     after subscription; there is no replay of historical events.
+ *   - Listeners that throw do NOT abort publishing — the thrown error is
+ *     swallowed and the next listener is still called, matching Rust's
+ *     `sender.send(event.clone()).is_ok()` retain-on-success semantics.
+ *     (In Rust the analogue is that a dropped receiver short-circuits
+ *     its own delivery; a thrown exception on our side is the nearest
+ *     equivalent.)
+ *
+ * Backpressure:
+ *   - Rust uses an unbounded `mpsc::channel`, so a slow subscriber can
+ *     accumulate arbitrarily many queued events. We match that: delivery
+ *     is synchronous and unbounded per listener, because our listeners
+ *     (SSE stream writer, broker completion handler) are non-blocking
+ *     against the bus. If a future subscriber needs to buffer, it can
+ *     keep its own queue.
+ *   - There is no drop policy. A listener that returns without throwing
+ *     is assumed to have consumed the event; a listener that throws is
+ *     logged (via the optional `onError` hook) but stays subscribed.
+ *
+ * Shutdown:
+ *   - `close()` detaches every subscriber and marks the bus as stopped.
+ *   - After `close()`, further `publish` calls are no-ops (events are
+ *     dropped silently). Late `subscribe` calls return an already-detached
+ *     unsubscribe function. This matches Rust's "drop the bus; senders
+ *     time out" behaviour.
+ */
+
+/**
+ * Event payloads broadcast by the Phase 3c bus. Discriminated on `kind`.
+ *
+ * The `inbox` event mirrors Rust `Event::InboxUpdated` (bus.rs:12-19),
+ * fired by the poller after each successful `pollOnce`. The `activity`
+ * event mirrors `Event::Activity` and is fired both by the poller (for
+ * `new`/`transition`) and by the broker (for `dispatched`/`completed`).
+ *
+ * Broker-specific events are additive compared to the Rust bus, which
+ * only carried `InboxUpdated` and `Activity`. We keep the wire names
+ * stable so the SSE layer doesn't need to discriminate new kinds: the
+ * broker events are delivered as `activity` lines (see `encodeSseEvent`
+ * in `sse.ts`).
+ */
+export type BusEvent =
+  | {
+      kind: "inbox";
+      last_poll: string;
+      total: number;
+      new_count: number;
+    }
+  | { kind: "activity"; line: string }
+  | {
+      kind: "task";
+      /** `dispatched` | `completed` | `failed` | `timed_out`. */
+      phase: "dispatched" | "completed" | "failed" | "timed_out";
+      task_id: string;
+      thread_key: string;
+      /** Final status (for `completed`/`failed`/`timed_out`). */
+      status?: string;
+      /** Error or result summary. */
+      summary?: string;
+    };
+
+export type BusListener = (event: BusEvent) => void;
+
+export interface BusOptions {
+  /**
+   * Called when a subscriber throws during delivery. Defaults to a
+   * silent swallow to preserve fan-out semantics. The daemon wires a
+   * logger in production so operators see broker misbehaviour.
+   */
+  onListenerError?: (err: unknown) => void;
+}
+
+export interface Bus {
+  /** Publish an event to every live subscriber. */
+  publish(event: BusEvent): void;
+  /** Register a listener. Returns an unsubscribe function (idempotent). */
+  subscribe(listener: BusListener): () => void;
+  /** Detach every subscriber and stop accepting further publishes. */
+  close(): void;
+  /** Live subscriber count. Useful for tests and shutdown drains. */
+  subscriberCount(): number;
+  /** True after `close()` has been called. */
+  isClosed(): boolean;
+}
+
+/**
+ * Build a fresh in-process bus. Each daemon run creates exactly one
+ * instance; tests build an isolated one per case.
+ */
+export function createBus(options: BusOptions = {}): Bus {
+  const listeners = new Set<BusListener>();
+  let closed = false;
+  const onError = options.onListenerError ?? ((): void => {});
+
+  return {
+    publish(event) {
+      if (closed) return;
+      // Snapshot before iteration so an unsubscribe mid-publish does
+      // not skip a pending listener (matches Rust's `retain`).
+      const snapshot = Array.from(listeners);
+      for (const listener of snapshot) {
+        try {
+          listener(event);
+        } catch (err) {
+          try {
+            onError(err);
+          } catch {
+            /* swallow — onError must not break fan-out. */
+          }
+        }
+      }
+    },
+    subscribe(listener) {
+      if (closed) return () => {};
+      listeners.add(listener);
+      let active = true;
+      return () => {
+        if (!active) return;
+        active = false;
+        listeners.delete(listener);
+      };
+    },
+    close() {
+      if (closed) return;
+      closed = true;
+      listeners.clear();
+    },
+    subscriberCount() {
+      return listeners.size;
+    },
+    isClosed() {
+      return closed;
+    },
+  };
+}
+
+/**
+ * Adapter that exposes a `Bus` through the narrower `SseBus` interface
+ * expected by `daemon/sse.ts::runSseStream`. It forwards only the events
+ * that the SSE layer renders (`inbox`, `activity`, and `task` mapped to
+ * `activity` lines) and drops the rest.
+ *
+ * Keeping the adapter here (rather than inside `sse.ts`) preserves the
+ * Phase 3b SSE module's read-only posture and means we don't need to
+ * widen `SseEvent` to know about broker internals.
+ */
+export function toSseBus(bus: Bus): {
+  subscribe(listener: (ev: import("./sse.js").SseEvent) => void): () => void;
+} {
+  return {
+    subscribe(listener) {
+      return bus.subscribe((event) => {
+        if (event.kind === "inbox") {
+          listener({
+            kind: "inbox",
+            last_poll: event.last_poll,
+            total: event.total,
+            new_count: event.new_count,
+          });
+          return;
+        }
+        if (event.kind === "activity") {
+          listener({ kind: "activity", line: event.line });
+          return;
+        }
+        if (event.kind === "task") {
+          // Render broker-internal task events as activity lines so
+          // the dashboard shows them without schema churn. Compact JSON
+          // keeps parity with `activity.log` jsonl entries.
+          const payload: Record<string, unknown> = {
+            event: `task_${event.phase}`,
+            task_id: event.task_id,
+            thread_key: event.thread_key,
+          };
+          if (event.status !== undefined) payload.status = event.status;
+          if (event.summary !== undefined) payload.summary = event.summary;
+          listener({
+            kind: "activity",
+            line: JSON.stringify(payload),
+          });
+        }
+      });
+    },
+  };
+}

--- a/src/products/breeze/daemon/claim.ts
+++ b/src/products/breeze/daemon/claim.ts
@@ -1,0 +1,537 @@
+/**
+ * Phase 3c: service-wide lock + per-notification claim helpers for the
+ * TypeScript breeze daemon.
+ *
+ * Port of `first-tree-breeze/breeze-runner/src/lock.rs`.
+ *
+ * SINGLE-WRITER RULE (spec doc 2 §1.3):
+ * -------------------------------------
+ * This module is **read-only** with respect to `~/.breeze/inbox.json`.
+ * Everything it writes lives under the daemon-private lock/claim dirs:
+ *   - `<lockDir>/` — one subdirectory per (host, login, profile) tuple,
+ *     holding `lock.env` with pid/heartbeat/note. Mirrors Rust
+ *     `ServiceLock` (`lock.rs:59-137`).
+ *   - `<claimsDir>/<notification-id>/` — per-thread claim directory used
+ *     by the broker to exclude duplicate dispatches for the same
+ *     thread_key in rapid succession. Mirrors the Rust-side
+ *     `queued_threads` HashSet but persists across restarts.
+ *
+ * We use `proper-lockfile` as the low-level primitive for the service
+ * lock. Rust's `lock.rs` relied on atomic `create_dir` + a heartbeat
+ * file; `proper-lockfile` gives us the same "directory-exists = owned"
+ * semantics with automatic stale-lock detection. Differences with Rust
+ * captured inline.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { hostname } from "node:os";
+import { join } from "node:path";
+
+import { lock as pflock, unlock as pfunlock } from "proper-lockfile";
+
+import type { DaemonIdentity } from "./identity.js";
+import { identityLockKey } from "./identity.js";
+
+/**
+ * Heartbeat-staleness window (in seconds). Matches Rust `is_lock_stale`
+ * in `lock.rs:174-176` (20 minutes). If the current epoch is more than
+ * this many seconds beyond the recorded heartbeat, we consider the
+ * previous holder gone and reclaim the dir.
+ */
+export const LOCK_STALE_AFTER_SEC = 20 * 60;
+
+/**
+ * Per-notification claim staleness. Mirrors `CLAIM_TIMEOUT_SECS` in
+ * `core/config.ts` (5 minutes) so the daemon and the skill agree on
+ * when a claim can be reassigned.
+ */
+export const CLAIM_STALE_AFTER_SEC = 5 * 60;
+
+export interface LockInfo {
+  pid: number;
+  host: string;
+  login: string;
+  profile: string;
+  heartbeat_epoch: number;
+  started_epoch: number;
+  active_tasks: number;
+  note: string;
+}
+
+export interface ServiceLockHandle {
+  /** Absolute path to the lock directory (contains `lock.env`). */
+  dir: string;
+  /** Read the current lock metadata. */
+  info(): LockInfo;
+  /** Update heartbeat + active-task count + note. Rewrites `lock.env`. */
+  refresh(activeTasks: number, note: string): void;
+  /** Release the lock (removes the directory). Idempotent. */
+  release(): Promise<void>;
+}
+
+function currentEpochSec(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+function sanitizeFilename(value: string): string {
+  // Matches Rust `util::sanitize_filename` closely: replace anything
+  // that isn't alphanumeric / `-` / `_` / `.` with `_`.
+  return value.replace(/[^A-Za-z0-9_.-]/g, "_");
+}
+
+function encodeMultiline(text: string): string {
+  // Rust's encode_multiline replaces `\\` with `\\\\` and `\n` with `\\n`
+  // so the kv file can round-trip arbitrary text.
+  return text.replace(/\\/g, "\\\\").replace(/\n/g, "\\n");
+}
+
+function decodeMultiline(text: string): string {
+  let out = "";
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (ch === "\\" && i + 1 < text.length) {
+      const next = text[i + 1];
+      if (next === "n") {
+        out += "\n";
+        i += 1;
+        continue;
+      }
+      if (next === "\\") {
+        out += "\\";
+        i += 1;
+        continue;
+      }
+    }
+    out += ch;
+  }
+  return out;
+}
+
+function serialiseLockInfo(info: LockInfo): string {
+  return [
+    `pid=${info.pid}`,
+    `host=${info.host}`,
+    `login=${info.login}`,
+    `profile=${info.profile}`,
+    `heartbeat_epoch=${info.heartbeat_epoch}`,
+    `started_epoch=${info.started_epoch}`,
+    `active_tasks=${info.active_tasks}`,
+    `note=${encodeMultiline(info.note)}`,
+  ].join("\n");
+}
+
+function parseLockInfo(contents: string): LockInfo | null {
+  const entries: Record<string, string> = {};
+  for (const line of contents.split("\n")) {
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    entries[line.slice(0, eq)] = line.slice(eq + 1);
+  }
+  const pid = Number.parseInt(entries.pid ?? "", 10);
+  if (!Number.isFinite(pid)) return null;
+  const heartbeat = Number.parseInt(entries.heartbeat_epoch ?? "", 10);
+  if (!Number.isFinite(heartbeat)) return null;
+  const started = Number.parseInt(entries.started_epoch ?? "", 10);
+  const activeTasks = Number.parseInt(entries.active_tasks ?? "0", 10);
+  return {
+    pid,
+    host: entries.host ?? "",
+    login: entries.login ?? "",
+    profile: entries.profile ?? "",
+    heartbeat_epoch: heartbeat,
+    started_epoch: Number.isFinite(started) ? started : heartbeat,
+    active_tasks: Number.isFinite(activeTasks) ? activeTasks : 0,
+    note: decodeMultiline(entries.note ?? ""),
+  };
+}
+
+/** True if the recorded pid is still alive on this host. */
+function processAlive(pid: number): boolean {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  try {
+    // `process.kill(pid, 0)` throws if the process is gone or we lack
+    // permission. We treat both as "not us" — the heartbeat staleness
+    // check picks up the permission case.
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Stale-detection predicate. Rust uses `heartbeat older than 20 min OR
+ * process not alive`. We match that exactly.
+ *
+ * Exported for tests.
+ */
+export function isLockStale(info: LockInfo, now: number = currentEpochSec()): boolean {
+  const expired = Math.max(0, now - info.heartbeat_epoch) > LOCK_STALE_AFTER_SEC;
+  if (expired) return true;
+  if (info.host === hostname()) {
+    // Only trust the liveness probe when the recorded host matches
+    // ours — otherwise `kill -0` would always report "not alive".
+    return !processAlive(info.pid);
+  }
+  // Different host: we can't probe the pid, so trust the heartbeat.
+  return false;
+}
+
+/**
+ * Resolve the directory that owns the `(host, login, profile)` tuple's
+ * lock. Exported for `findServiceLock` / `stopServiceLock` callers.
+ */
+export function serviceLockDir(
+  baseDir: string,
+  identity: DaemonIdentity,
+  profile: string,
+): string {
+  return join(baseDir, sanitizeFilename(identityLockKey(identity, profile)));
+}
+
+function readLockInfoFromPath(path: string): LockInfo | null {
+  if (!existsSync(path)) return null;
+  try {
+    return parseLockInfo(readFileSync(path, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Locate the current lock for this identity/profile, if any. Mirrors
+ * Rust `find_lock` (`lock.rs:146-153`). Returns `null` when no lock.env
+ * exists.
+ */
+export function findServiceLock(
+  baseDir: string,
+  identity: DaemonIdentity,
+  profile: string,
+): LockInfo | null {
+  const dir = serviceLockDir(baseDir, identity, profile);
+  return readLockInfoFromPath(join(dir, "lock.env"));
+}
+
+export interface AcquireServiceLockOptions {
+  baseDir: string;
+  identity: DaemonIdentity;
+  profile: string;
+  /** Note written alongside the initial heartbeat. Defaults to `started`. */
+  note?: string;
+}
+
+/**
+ * Acquire the per-identity service lock. Throws if another live daemon
+ * owns it. Stale locks (heartbeat > 20min OR process gone) are reclaimed
+ * automatically, mirroring Rust's retry loop (`lock.rs:72-103`).
+ *
+ * We use `proper-lockfile` to *additionally* guard the lock.env write
+ * itself — that gives us cross-process protection against two TS daemons
+ * racing `acquireServiceLock` on the same machine at the exact same
+ * moment. The outer directory is the durable marker.
+ */
+export async function acquireServiceLock(
+  options: AcquireServiceLockOptions,
+): Promise<ServiceLockHandle> {
+  const { baseDir, identity, profile } = options;
+  if (!existsSync(baseDir)) mkdirSync(baseDir, { recursive: true });
+  const dir = serviceLockDir(baseDir, identity, profile);
+  const infoPath = join(dir, "lock.env");
+
+  const maxTries = 3;
+  for (let attempt = 1; attempt <= maxTries; attempt += 1) {
+    try {
+      mkdirSync(dir);
+      // Fresh creation — proceed to write lock.env below.
+      break;
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      if (e.code !== "EEXIST") {
+        throw new Error(
+          `failed to create lock directory "${dir}": ${e.message}`,
+        );
+      }
+      const existing = readLockInfoFromPath(infoPath);
+      if (existing && !isLockStale(existing)) {
+        throw new Error(
+          `breeze daemon is already running for ${existing.login} on ${existing.host} (pid ${existing.pid}, profile "${existing.profile}")`,
+        );
+      }
+      // Stale (or malformed): scrub and retry.
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        /* ignore — next loop iteration will surface any remaining error */
+      }
+      if (attempt === maxTries) {
+        throw new Error(
+          `failed to reclaim stale lock directory "${dir}" after ${maxTries} attempts`,
+        );
+      }
+    }
+  }
+
+  const info: LockInfo = {
+    pid: process.pid,
+    host: identity.host,
+    login: identity.login,
+    profile,
+    heartbeat_epoch: currentEpochSec(),
+    started_epoch: currentEpochSec(),
+    active_tasks: 0,
+    note: options.note ?? "started",
+  };
+  writeFileSync(infoPath, `${serialiseLockInfo(info)}\n`, "utf-8");
+
+  // Take a proper-lockfile lock on infoPath. This is not the durable
+  // ownership record — that's the directory — but it gives us a well-
+  // tested primitive for the refresh path (rename-on-update) and a
+  // cross-process barrier for the acquire race described above.
+  let pfReleased = false;
+  const pfRelease = await pflock(infoPath, {
+    stale: LOCK_STALE_AFTER_SEC * 1000,
+    retries: { retries: 2, minTimeout: 50, maxTimeout: 200 },
+  }).catch(() => {
+    // If proper-lockfile can't take the .lock sentinel, fall back to
+    // directory-only ownership. This matches Rust's behaviour (Rust
+    // has no proper-lockfile equivalent) and keeps the TS port working
+    // in tmpfs / network mount edge cases.
+    return null;
+  });
+
+  let current = info;
+  const handle: ServiceLockHandle = {
+    dir,
+    info: () => ({ ...current }),
+    refresh: (activeTasks, note) => {
+      current = {
+        ...current,
+        active_tasks: activeTasks,
+        heartbeat_epoch: currentEpochSec(),
+        note,
+      };
+      writeFileSync(infoPath, `${serialiseLockInfo(current)}\n`, "utf-8");
+    },
+    release: async () => {
+      if (pfRelease && !pfReleased) {
+        pfReleased = true;
+        try {
+          await pfRelease();
+        } catch {
+          /* ignore — best-effort release */
+        }
+        try {
+          await pfunlock(infoPath).catch(() => undefined);
+        } catch {
+          /* ignore */
+        }
+      }
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    },
+  };
+  return handle;
+}
+
+/* ------------------------------------------------------------------ */
+/* Per-notification claims — used by the broker to exclude duplicate  */
+/* dispatches of the same thread.                                     */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Per-thread claim semantics (matches `commands/status-manager.ts`
+ * `cmdClaim` and the Rust-side `queued_threads` set):
+ *
+ *   - `claimsDir/<id>/` exists → the thread is claimed.
+ *   - `claimsDir/<id>/claimed_at` holds an ISO-8601 timestamp.
+ *   - A claim older than `CLAIM_STALE_AFTER_SEC` (5 min) can be
+ *     reassigned by any caller. Matches the skill's UX.
+ *
+ * The broker uses this to avoid double-dispatching the same
+ * `thread_key` in two passes of the poll loop. It is cheaper than the
+ * Rust in-memory `HashSet<thread_key>` but survives restarts — which is
+ * the main value-add for the TS port, since Node can be killed at any
+ * time.
+ */
+
+export interface ClaimResult {
+  claimed: boolean;
+  /** Session id of the current owner if `claimed=false`. */
+  owner?: string;
+  /** Age of the existing claim in seconds (if any). */
+  ageSec?: number;
+}
+
+export interface ClaimOptions {
+  claimsDir: string;
+  /** Notification id (== thread_key in broker parlance). */
+  id: string;
+  /** Session id — who is claiming. */
+  sessionId: string;
+  /** Freeform action label (e.g. `dispatch`, `working`). */
+  action?: string;
+  /** Override for tests. */
+  now?: () => Date;
+  /** Override staleness window (seconds). Defaults to 5 min. */
+  claimStaleSec?: number;
+}
+
+function formatUtcIso(date: Date): string {
+  // Seconds precision, matching `formatUtcIso` in `commands/poll.ts`.
+  return `${date.toISOString().slice(0, 19)}Z`;
+}
+
+function parseIsoUtc(value: string | undefined | null): number | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+  const ms = Date.parse(trimmed);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function writeClaimBody(claimDir: string, sessionId: string, action: string, nowTs: string): void {
+  writeFileSync(join(claimDir, "claimed_by"), `${sessionId}\n`, "utf-8");
+  writeFileSync(join(claimDir, "claimed_at"), `${nowTs}\n`, "utf-8");
+  writeFileSync(join(claimDir, "action"), `${action}\n`, "utf-8");
+}
+
+/**
+ * Attempt to claim `notification-id` for the given `sessionId`. Returns
+ * `{claimed: true}` on success, otherwise `{claimed: false, owner, ageSec}`.
+ *
+ * Atomicity: uses `mkdir` (EEXIST) as the cross-process lock, matching
+ * `status-manager.ts::cmdClaim`. We do NOT reach for `proper-lockfile`
+ * here because the claim dir is durable state, not a transient barrier.
+ */
+export function tryClaim(options: ClaimOptions): ClaimResult {
+  const { claimsDir, id, sessionId } = options;
+  const staleSec = options.claimStaleSec ?? CLAIM_STALE_AFTER_SEC;
+  const now = options.now ?? (() => new Date());
+  const action = options.action ?? "dispatch";
+  if (!existsSync(claimsDir)) mkdirSync(claimsDir, { recursive: true });
+  const claimDir = join(claimsDir, id);
+
+  let firstClaim = false;
+  try {
+    mkdirSync(claimDir);
+    firstClaim = true;
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    if (e.code !== "EEXIST") {
+      throw new Error(`failed to create claim dir "${claimDir}": ${e.message}`);
+    }
+  }
+
+  const nowTs = formatUtcIso(now());
+  if (firstClaim) {
+    writeClaimBody(claimDir, sessionId, action, nowTs);
+    return { claimed: true };
+  }
+
+  // Someone already owns the dir. Inspect `claimed_at`.
+  const atPath = join(claimDir, "claimed_at");
+  const ts = existsSync(atPath) ? parseIsoUtc(readFileSync(atPath, "utf-8")) : null;
+  const ageSec = ts === null ? Number.POSITIVE_INFINITY : (now().getTime() - ts) / 1000;
+
+  if (ageSec >= staleSec) {
+    writeClaimBody(claimDir, sessionId, action, nowTs);
+    return { claimed: true, ageSec };
+  }
+
+  let owner: string | undefined;
+  const byPath = join(claimDir, "claimed_by");
+  if (existsSync(byPath)) {
+    owner = readFileSync(byPath, "utf-8").split("\n")[0]?.trim() || undefined;
+  }
+  return { claimed: false, owner, ageSec };
+}
+
+/**
+ * Release a previously-held claim. Idempotent.
+ */
+export function releaseClaim(claimsDir: string, id: string): void {
+  const claimDir = join(claimsDir, id);
+  if (!existsSync(claimDir)) return;
+  try {
+    rmSync(claimDir, { recursive: true, force: true });
+  } catch {
+    /* ignore — the next claim attempt will clean it up */
+  }
+}
+
+/**
+ * Read-only: describe the current state of a claim without taking it.
+ * Returns `null` when no claim exists.
+ */
+export function peekClaim(
+  claimsDir: string,
+  id: string,
+): { owner: string; claimedAtMs: number; ageSec: number } | null {
+  const claimDir = join(claimsDir, id);
+  if (!existsSync(claimDir)) return null;
+  const atPath = join(claimDir, "claimed_at");
+  if (!existsSync(atPath)) return null;
+  const ts = parseIsoUtc(readFileSync(atPath, "utf-8"));
+  if (ts === null) return null;
+  const byPath = join(claimDir, "claimed_by");
+  const owner = existsSync(byPath)
+    ? readFileSync(byPath, "utf-8").split("\n")[0]?.trim() ?? ""
+    : "";
+  const ageSec = (Date.now() - ts) / 1000;
+  return { owner, claimedAtMs: ts, ageSec };
+}
+
+/**
+ * Sweep the claims directory for entries older than the staleness
+ * window. Matches `commands/poll.ts::cleanupExpiredClaims` but lives
+ * here so the broker can invoke it on startup + after each dispatch
+ * without reaching into commands/*.
+ */
+export function cleanupExpiredClaims(
+  claimsDir: string,
+  staleSec: number = CLAIM_STALE_AFTER_SEC,
+  now: number = Date.now(),
+): number {
+  if (!existsSync(claimsDir)) return 0;
+  let removed = 0;
+  let entries: string[];
+  try {
+    entries = readdirSync(claimsDir);
+  } catch {
+    return 0;
+  }
+  for (const name of entries) {
+    const claimDir = join(claimsDir, name);
+    try {
+      const st = statSync(claimDir);
+      if (!st.isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    const atPath = join(claimDir, "claimed_at");
+    if (!existsSync(atPath)) continue;
+    const ts = parseIsoUtc(readFileSync(atPath, "utf-8"));
+    if (ts === null) continue;
+    if ((now - ts) / 1000 >= staleSec) {
+      try {
+        rmSync(claimDir, { recursive: true, force: true });
+        removed += 1;
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+  return removed;
+}
+

--- a/src/products/breeze/daemon/dispatcher.ts
+++ b/src/products/breeze/daemon/dispatcher.ts
@@ -1,0 +1,464 @@
+/**
+ * Phase 3c: task dispatcher.
+ *
+ * Port of the dispatch loop in
+ * `first-tree-breeze/breeze-runner/src/service.rs::run_loop` +
+ * `dispatch_pending` + `handle_completion`.
+ *
+ * Role:
+ *   - Accept `TaskCandidate`s from an injected source (`submit`).
+ *   - Gate on the per-notification claim (see `claim.ts`) to dedupe
+ *     across restarts and across this host + laptop.
+ *   - Respect `maxParallel` concurrency ceiling.
+ *   - Prepare a workspace (`workspace.ts`) and run the agent
+ *     (`runner.ts::executeRunner`) with the pool's execution order as
+ *     fallback chain.
+ *   - Publish task-phase events to the bus (`bus.ts`) so SSE
+ *     subscribers see `dispatched` / `completed` / `failed` / `timed_out`.
+ *   - Enforce a per-task timeout (spec doc 4 §8, §11 — Rust had no
+ *     timeout and agent hangs blocked dispatcher threads indefinitely).
+ *
+ * Out of scope (Phase 4):
+ *   - Polling GitHub to produce candidates (`collect_candidates`).
+ *   - Snapshot hydration into `<task-dir>/snapshot/` (`write_task_snapshot`).
+ *   - ThreadRecord retry/backoff bookkeeping. We surface the hook via
+ *     `onCompletion` so a future layer can persist it without this
+ *     module needing to know about the store.
+ */
+
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+import type { Bus } from "./bus.js";
+import {
+  CLAIM_STALE_AFTER_SEC,
+  peekClaim,
+  releaseClaim,
+  tryClaim,
+} from "./claim.js";
+import {
+  RunnerPool,
+  executeRunner,
+  runWithTimeout,
+  type AgentIdentity,
+  type RunnerOutcome,
+  type RunnerRequest,
+  type RunnerSpec,
+  type RunnerSpawner,
+  type RunnerTask,
+} from "./runner.js";
+import {
+  WorkspaceManager,
+  type WorkspaceCandidate,
+} from "./workspace.js";
+
+export interface TaskCandidate {
+  /** Stable key to dedupe across this thread_key. */
+  threadKey: string;
+  /** The underlying GitHub thread id used for claim naming. */
+  notificationId: string;
+  /** Source repository (`owner/repo`). */
+  repo: string;
+  /** Optional operator-routing override; defaults to `repo`. */
+  workspaceRepo?: string;
+  /** Issue/PR kind (issue | pr | review | mention | ...). */
+  kind: string;
+  /** Derived id used for workspace directory naming + task id. */
+  stableId: string;
+  /** Optional PR number (for `refs/pull/<n>/head` fetch). */
+  prNumber?: number;
+  title: string;
+  taskUrl: string;
+  /** Dispatcher priority (higher first). */
+  priority: number;
+  /** ISO timestamp used for tie-breaking older-first. */
+  updatedAt: string;
+}
+
+export interface DispatcherOptions {
+  runnerHome: string;
+  identity: AgentIdentity;
+  runners: readonly RunnerSpec[];
+  workspaceManager: WorkspaceManager;
+  bus: Bus;
+  ghShimDir: string;
+  ghBrokerDir: string;
+  claimsDir: string;
+  disclosureText: string;
+  maxParallel: number;
+  taskTimeoutMs: number;
+  /** Inject a runner spawner; tests pass a stub. Production uses default. */
+  spawner?: RunnerSpawner;
+  /** Inject a clock (seconds). */
+  nowSec?: () => number;
+  /** Hook called once per completion (ok or error). */
+  onCompletion?: (result: CompletionRecord) => void;
+  /** Logger for diagnostic lines. */
+  logger?: DispatcherLogger;
+  /** Dry-run: skip agent execution, publish simulated success. */
+  dryRun?: boolean;
+  /**
+   * Claim TTL in seconds. Defaults to `CLAIM_STALE_AFTER_SEC` (5min)
+   * from `claim.ts` for parity with the skill; the dispatcher may
+   * tune it for long-running tasks.
+   */
+  claimTtlSec?: number;
+}
+
+export interface DispatcherLogger {
+  info: (line: string) => void;
+  warn: (line: string) => void;
+  error: (line: string) => void;
+}
+
+export interface CompletionRecord {
+  taskId: string;
+  threadKey: string;
+  candidate: TaskCandidate;
+  phase: "completed" | "failed" | "timed_out" | "skipped-claim";
+  status?: string;
+  summary?: string;
+  error?: string;
+  runnerName?: string;
+  runnerOutputPath?: string;
+}
+
+interface ActiveTask {
+  taskId: string;
+  threadKey: string;
+  title: string;
+  claimed: boolean;
+  /** Settles when the task's run-and-handle loop finishes. */
+  done: Promise<void>;
+}
+
+const DEFAULT_LOGGER: DispatcherLogger = {
+  info: (line) => process.stdout.write(`${line}\n`),
+  warn: (line) => process.stderr.write(`WARN: ${line}\n`),
+  error: (line) => process.stderr.write(`ERROR: ${line}\n`),
+};
+
+/**
+ * Priority-sorted queue + concurrency gate. Candidates enter via
+ * `submit`; completions are surfaced via the bus and the optional
+ * `onCompletion` hook. The dispatcher never blocks `submit` — it
+ * queues and lets the internal pump drain as slots free up.
+ */
+export class Dispatcher {
+  private readonly options: DispatcherOptions;
+  private readonly runnerPool: RunnerPool;
+  private readonly logger: DispatcherLogger;
+  private readonly pending: TaskCandidate[] = [];
+  private readonly queuedThreads = new Set<string>();
+  private readonly active = new Map<string, ActiveTask>();
+  private readonly nowSec: () => number;
+  private readonly claimTtlSec: number;
+  private stopped = false;
+  /**
+   * AbortController cascaded to every running task. Tripped on `stop()`.
+   */
+  private readonly shutdown = new AbortController();
+
+  constructor(options: DispatcherOptions) {
+    this.options = options;
+    this.runnerPool = new RunnerPool(options.runners);
+    this.logger = options.logger ?? DEFAULT_LOGGER;
+    this.nowSec = options.nowSec ?? (() => Math.floor(Date.now() / 1_000));
+    this.claimTtlSec = options.claimTtlSec ?? CLAIM_STALE_AFTER_SEC;
+  }
+
+  /** Enqueue a candidate. No-op if already pending/active. */
+  submit(candidate: TaskCandidate): void {
+    if (this.stopped) return;
+    if (this.queuedThreads.has(candidate.threadKey)) return;
+    if ([...this.active.values()].some((t) => t.threadKey === candidate.threadKey)) {
+      return;
+    }
+    this.pending.push(candidate);
+    this.queuedThreads.add(candidate.threadKey);
+    this.pending.sort(orderByPriority);
+    this.pump();
+  }
+
+  /** Number of candidates waiting for a slot. */
+  pendingCount(): number {
+    return this.pending.length;
+  }
+
+  /** Number of tasks currently running. */
+  activeCount(): number {
+    return this.active.size;
+  }
+
+  /**
+   * Stop accepting new candidates, abort running tasks, and wait for
+   * them to release. Idempotent.
+   */
+  async stop(): Promise<void> {
+    if (this.stopped) return;
+    this.stopped = true;
+    this.shutdown.abort();
+    // Drain pending queue without running.
+    this.pending.length = 0;
+    this.queuedThreads.clear();
+    await Promise.all(
+      [...this.active.values()].map((t) => t.done.catch(() => undefined)),
+    );
+  }
+
+  /** Pump the queue up to `maxParallel`. */
+  private pump(): void {
+    if (this.stopped) return;
+    while (
+      this.active.size < this.options.maxParallel &&
+      this.pending.length > 0
+    ) {
+      const candidate = this.pending.shift();
+      if (!candidate) break;
+      this.queuedThreads.delete(candidate.threadKey);
+      this.launch(candidate);
+    }
+  }
+
+  private launch(candidate: TaskCandidate): void {
+    const taskId = `task-${this.nowSec()}-${candidate.stableId}`;
+    const taskDir = join(this.options.runnerHome, "tasks", taskId);
+    mkdirSync(taskDir, { recursive: true });
+    const snapshotDir = join(taskDir, "snapshot");
+    mkdirSync(snapshotDir, { recursive: true });
+
+    const claim = tryClaim({
+      claimsDir: this.options.claimsDir,
+      id: candidate.notificationId,
+      sessionId: `dispatcher:${taskId}`,
+      action: "dispatch",
+      claimStaleSec: this.claimTtlSec,
+    });
+
+    if (!claim.claimed) {
+      this.logger.info(
+        `dispatcher: skipping ${candidate.threadKey} — active claim held by ${claim.owner ?? "unknown"}`,
+      );
+      const record: CompletionRecord = {
+        taskId,
+        threadKey: candidate.threadKey,
+        candidate,
+        phase: "skipped-claim",
+        summary: "claim already held",
+      };
+      this.options.onCompletion?.(record);
+      this.publishTask(record);
+      // No state to clean up — we never added to active.
+      return;
+    }
+
+    const active: ActiveTask = {
+      taskId,
+      threadKey: candidate.threadKey,
+      title: candidate.title,
+      claimed: true,
+      done: this.runTask(taskId, taskDir, snapshotDir, candidate).finally(
+        () => {
+          try {
+            releaseClaim(this.options.claimsDir, candidate.notificationId);
+          } catch (err) {
+            this.logger.warn(
+              `dispatcher: failed to release claim: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+          this.active.delete(taskId);
+          this.pump();
+        },
+      ),
+    };
+    this.active.set(taskId, active);
+
+    this.options.bus.publish({
+      kind: "task",
+      phase: "dispatched",
+      task_id: taskId,
+      thread_key: candidate.threadKey,
+      summary: candidate.title,
+    });
+  }
+
+  private async runTask(
+    taskId: string,
+    taskDir: string,
+    snapshotDir: string,
+    candidate: TaskCandidate,
+  ): Promise<void> {
+    if (this.options.dryRun) {
+      const record: CompletionRecord = {
+        taskId,
+        threadKey: candidate.threadKey,
+        candidate,
+        phase: "completed",
+        status: "simulated",
+        summary: "dry-run scheduled task",
+        runnerOutputPath: join(taskDir, "runner-output.txt"),
+      };
+      this.options.onCompletion?.(record);
+      this.publishTask(record);
+      return;
+    }
+
+    let workspaceDir: string;
+    try {
+      const lease = await this.options.workspaceManager.prepare(
+        toWorkspaceCandidate(candidate),
+      );
+      workspaceDir = lease.workspaceDir;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const record: CompletionRecord = {
+        taskId,
+        threadKey: candidate.threadKey,
+        candidate,
+        phase: "failed",
+        error: `workspace prepare failed: ${message}`,
+      };
+      this.options.onCompletion?.(record);
+      this.publishTask(record);
+      return;
+    }
+
+    const request = makeRunnerRequest({
+      candidate,
+      taskId,
+      taskDir,
+      snapshotDir,
+      workspaceDir,
+      identity: this.options.identity,
+      ghShimDir: this.options.ghShimDir,
+      ghBrokerDir: this.options.ghBrokerDir,
+      disclosureText: this.options.disclosureText,
+    });
+
+    const runners = this.runnerPool.executionOrder();
+    const errors: string[] = [];
+    let outcome: RunnerOutcome | undefined;
+    let selectedRunner: RunnerSpec | undefined;
+    let timedOut = false;
+
+    for (const spec of runners) {
+      try {
+        outcome = await runWithTimeout({
+          run: () => executeRunner(spec, request, {
+            timeoutMs: this.options.taskTimeoutMs,
+            spawner: this.options.spawner,
+          }),
+          // `executeRunner`'s spawner handles its own kill hook; we use
+          // runWithTimeout as an additional safety net and propagate
+          // the shutdown signal.
+          kill: () => undefined,
+          timeoutMs: this.options.taskTimeoutMs,
+          signal: this.shutdown.signal,
+        });
+        selectedRunner = spec;
+        break;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        errors.push(`${spec.kind}: ${message}`);
+        if (/^timed out/.test(message) || /^aborted/.test(message)) {
+          timedOut = true;
+          break;
+        }
+      }
+    }
+
+    if (!outcome) {
+      const phase: CompletionRecord["phase"] = timedOut ? "timed_out" : "failed";
+      const record: CompletionRecord = {
+        taskId,
+        threadKey: candidate.threadKey,
+        candidate,
+        phase,
+        error: errors.join("; "),
+      };
+      this.options.onCompletion?.(record);
+      this.publishTask(record);
+      return;
+    }
+
+    const record: CompletionRecord = {
+      taskId,
+      threadKey: candidate.threadKey,
+      candidate,
+      phase: "completed",
+      status: outcome.status,
+      summary: outcome.summary,
+      runnerName: selectedRunner?.kind,
+      runnerOutputPath: outcome.outputPath,
+    };
+    this.options.onCompletion?.(record);
+    this.publishTask(record);
+  }
+
+  private publishTask(record: CompletionRecord): void {
+    if (record.phase === "skipped-claim") return;
+    this.options.bus.publish({
+      kind: "task",
+      phase:
+        record.phase === "timed_out"
+          ? "timed_out"
+          : record.phase === "failed"
+            ? "failed"
+            : "completed",
+      task_id: record.taskId,
+      thread_key: record.threadKey,
+      status: record.status,
+      summary: record.summary ?? record.error,
+    });
+  }
+}
+
+function toWorkspaceCandidate(candidate: TaskCandidate): WorkspaceCandidate {
+  return {
+    repo: candidate.repo,
+    workspaceRepo: candidate.workspaceRepo ?? candidate.repo,
+    kind: candidate.kind,
+    stableId: candidate.stableId,
+    prNumber: candidate.prNumber,
+  };
+}
+
+function makeRunnerRequest(args: {
+  candidate: TaskCandidate;
+  taskId: string;
+  taskDir: string;
+  snapshotDir: string;
+  workspaceDir: string;
+  identity: AgentIdentity;
+  ghShimDir: string;
+  ghBrokerDir: string;
+  disclosureText: string;
+}): RunnerRequest {
+  const task: RunnerTask = {
+    repo: args.candidate.repo,
+    workspaceRepo: args.candidate.workspaceRepo ?? args.candidate.repo,
+    kind: args.candidate.kind,
+    title: args.candidate.title,
+    taskUrl: args.candidate.taskUrl,
+  };
+  return {
+    task,
+    taskId: args.taskId,
+    taskDir: args.taskDir,
+    workspaceDir: args.workspaceDir,
+    snapshotDir: args.snapshotDir,
+    ghShimDir: args.ghShimDir,
+    ghBrokerDir: args.ghBrokerDir,
+    identity: args.identity,
+    disclosureText: args.disclosureText,
+  };
+}
+
+function orderByPriority(a: TaskCandidate, b: TaskCandidate): number {
+  if (a.priority !== b.priority) return b.priority - a.priority;
+  if (a.updatedAt !== b.updatedAt) return a.updatedAt < b.updatedAt ? 1 : -1;
+  return a.threadKey.localeCompare(b.threadKey);
+}
+
+/** Re-export peekClaim for callers that want to inspect without acquiring. */
+export { peekClaim };

--- a/src/products/breeze/daemon/gh-executor.ts
+++ b/src/products/breeze/daemon/gh-executor.ts
@@ -1,0 +1,330 @@
+/**
+ * Phase 3c: `gh` command executor with rate-limit throttling.
+ *
+ * Port of `first-tree-breeze/breeze-runner/src/gh_executor.rs`.
+ *
+ * This is the low-level `gh` runner used by the broker. It does two
+ * things:
+ *
+ *   1. Classifies a command into a bucket (`core` / `search` / `write`)
+ *      and decides whether it is mutating — so callers can consult
+ *      `commandIsMutating` outside the executor.
+ *   2. Runs the command with per-bucket throttling: search commands
+ *      wait on `nextSearchEpochMs`, mutations additionally wait on
+ *      `nextWriteEpochMs` plus `writeCooldownMs` after the previous
+ *      write. On rate-limit detection (secondary / abuse / 429) we back
+ *      off exponentially up to 60s·2^4 = 16 min per bucket and retry up
+ *      to 3 times.
+ *
+ * The executor has no network code of its own — it shells out to a real
+ * `gh` binary via `spawnGh`. Tests inject a fake spawn to drive the
+ * state machine without invoking the network.
+ *
+ * Parity with Rust:
+ *   - `bucketForArgs` mirrors `GhExecutor::bucket_for_args`.
+ *   - `commandIsMutating` mirrors `command_is_mutating` including the
+ *     `api -X METHOD` / `-f|-F|--field|--raw-field|--input` classifier.
+ *   - `isRateLimited` scans stdout+stderr for the same five substrings.
+ *   - Backoff is `60_000 * 2^min(streak, 4)` ms, same as Rust.
+ *   - `wait_for_slot`'s 2s cap per sleep is preserved so the signal
+ *     path can interrupt the loop promptly.
+ */
+
+import { spawn } from "node:child_process";
+
+export type GhBucket = "core" | "search" | "write";
+
+export interface GhCommandSpec {
+  /** Diagnostic label used in error messages. */
+  context: string;
+  /** Working directory for the spawned process. */
+  cwd?: string;
+  /** Extra env vars layered on top of the current process env. */
+  envs?: Record<string, string>;
+  /** `gh`-specific argv (no leading binary). */
+  args: string[];
+  /** Pre-computed bucket; defaults to `bucketForArgs(args)`. */
+  bucket?: GhBucket;
+  /** Pre-computed mutation flag; defaults to `commandIsMutating(args)`. */
+  mutating?: boolean;
+}
+
+export interface ExecOutput {
+  stdout: string;
+  stderr: string;
+  statusCode: number;
+}
+
+export interface GhExecutorOptions {
+  /** Absolute path to the real `gh` binary. */
+  realGh: string;
+  /** Milliseconds required between consecutive write-bucket calls. */
+  writeCooldownMs: number;
+  /** Injected spawn function; tests pass a stub. */
+  spawnGh?: (spec: GhCommandSpec) => Promise<ExecOutput>;
+  /** Injected clock; tests pass a stub. */
+  now?: () => number;
+  /** Injected sleep; tests can short-circuit. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Abort signal; aborts the wait loop and skips further attempts. */
+  signal?: AbortSignal;
+}
+
+export class GhExecutor {
+  private readonly realGh: string;
+  private readonly writeCooldownMs: number;
+  private readonly spawnGh: (spec: GhCommandSpec) => Promise<ExecOutput>;
+  private readonly now: () => number;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private readonly signal?: AbortSignal;
+
+  private nextCoreEpochMs = 0;
+  private nextSearchEpochMs = 0;
+  private nextWriteEpochMs = 0;
+  private lastWriteEpochMs = 0;
+  private rateLimitStreak = 0;
+
+  constructor(options: GhExecutorOptions) {
+    this.realGh = options.realGh;
+    this.writeCooldownMs = options.writeCooldownMs;
+    this.spawnGh = options.spawnGh ?? defaultSpawnGh(options.realGh);
+    this.now = options.now ?? (() => Date.now());
+    this.sleep = options.sleep ?? defaultSleep;
+    this.signal = options.signal;
+  }
+
+  /** Normalize a spec so `bucket` and `mutating` are always set. */
+  static normalize(spec: GhCommandSpec): Required<
+    Pick<GhCommandSpec, "bucket" | "mutating">
+  > &
+    GhCommandSpec {
+    return {
+      ...spec,
+      bucket: spec.bucket ?? bucketForArgs(spec.args),
+      mutating: spec.mutating ?? commandIsMutating(spec.args),
+    };
+  }
+
+  /**
+   * Run with up to 3 retries on rate-limit detection. Returns the last
+   * `ExecOutput` in all cases — callers inspect `statusCode` to decide
+   * whether to surface an error.
+   */
+  async run(raw: GhCommandSpec): Promise<ExecOutput> {
+    const spec = GhExecutor.normalize(raw);
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await this.waitForSlot(spec);
+      if (this.signal?.aborted) {
+        return {
+          stdout: "",
+          stderr: "aborted before executing gh",
+          statusCode: 124,
+        };
+      }
+      const output = await this.spawnGh(spec);
+      if (isRateLimited(output)) {
+        this.registerRateLimit(spec);
+        if (attempt + 1 < 3) continue;
+        return output;
+      }
+      this.registerCompletion(spec);
+      return output;
+    }
+    // Unreachable; the loop always returns.
+    throw new Error("gh executor exhausted retries without returning");
+  }
+
+  /** Run and throw on non-zero exit, returning stdout on success. */
+  async runChecked(raw: GhCommandSpec): Promise<string> {
+    const spec = GhExecutor.normalize(raw);
+    const output = await this.run(spec);
+    if (output.statusCode !== 0) {
+      throw new Error(
+        `${spec.context} failed with exit code ${output.statusCode}\nstdout:\n${output.stdout}\nstderr:\n${output.stderr}`,
+      );
+    }
+    return output.stdout;
+  }
+
+  private async waitForSlot(spec: GhCommandSpec): Promise<void> {
+    while (!this.signal?.aborted) {
+      const now = this.now();
+      let nextAllowed = this.nextCoreEpochMs;
+      if (spec.bucket === "search") {
+        nextAllowed = Math.max(nextAllowed, this.nextSearchEpochMs);
+      }
+      if (spec.mutating) {
+        nextAllowed = Math.max(nextAllowed, this.nextWriteEpochMs);
+        nextAllowed = Math.max(
+          nextAllowed,
+          this.lastWriteEpochMs + this.writeCooldownMs,
+        );
+      }
+      const waitMs = Math.max(0, nextAllowed - now);
+      if (waitMs === 0) return;
+      await this.sleep(Math.min(waitMs, 2_000));
+    }
+  }
+
+  private registerCompletion(spec: GhCommandSpec): void {
+    this.rateLimitStreak = 0;
+    if (spec.mutating) {
+      this.lastWriteEpochMs = this.now();
+    }
+  }
+
+  private registerRateLimit(spec: GhCommandSpec): void {
+    this.rateLimitStreak = Math.min(this.rateLimitStreak + 1, 1_000);
+    const exponent = Math.min(this.rateLimitStreak, 4);
+    const backoffMs = 60_000 * 2 ** exponent;
+    const nextAllowed = this.now() + backoffMs;
+    this.nextCoreEpochMs = Math.max(this.nextCoreEpochMs, nextAllowed);
+    if (spec.bucket === "search") {
+      this.nextSearchEpochMs = Math.max(this.nextSearchEpochMs, nextAllowed);
+    }
+    if (spec.mutating) {
+      this.nextWriteEpochMs = Math.max(this.nextWriteEpochMs, nextAllowed);
+    }
+  }
+
+  /** Diagnostic snapshot; tests use this to assert state transitions. */
+  getState(): {
+    nextCoreEpochMs: number;
+    nextSearchEpochMs: number;
+    nextWriteEpochMs: number;
+    lastWriteEpochMs: number;
+    rateLimitStreak: number;
+  } {
+    return {
+      nextCoreEpochMs: this.nextCoreEpochMs,
+      nextSearchEpochMs: this.nextSearchEpochMs,
+      nextWriteEpochMs: this.nextWriteEpochMs,
+      lastWriteEpochMs: this.lastWriteEpochMs,
+      rateLimitStreak: this.rateLimitStreak,
+    };
+  }
+}
+
+/** Mirrors `GhExecutor::bucket_for_args`. */
+export function bucketForArgs(args: readonly string[]): GhBucket {
+  const first = args[0];
+  if (first === "search") return "search";
+  if (first === "api") {
+    const path = args[1] ?? "";
+    if (
+      path.startsWith("search/") ||
+      path.includes("/search/") ||
+      path.includes("search/")
+    ) {
+      return "search";
+    }
+  }
+  if (commandIsMutating(args)) return "write";
+  return "core";
+}
+
+/** Mirrors `command_is_mutating`. */
+export function commandIsMutating(args: readonly string[]): boolean {
+  const first = args[0];
+  if (first === undefined) return false;
+  switch (first) {
+    case "api":
+      return apiCommandIsMutating(args);
+    case "issue":
+      return new Set([
+        "comment",
+        "close",
+        "create",
+        "delete",
+        "edit",
+        "lock",
+        "pin",
+        "reopen",
+        "transfer",
+        "unlock",
+        "unpin",
+      ]).has(args[1] ?? "");
+    case "pr":
+      return new Set([
+        "close",
+        "comment",
+        "create",
+        "edit",
+        "merge",
+        "ready",
+        "reopen",
+        "review",
+        "update-branch",
+      ]).has(args[1] ?? "");
+    case "label":
+      return new Set(["clone", "create", "delete", "edit"]).has(args[1] ?? "");
+    default:
+      return false;
+  }
+}
+
+function apiCommandIsMutating(args: readonly string[]): boolean {
+  let explicitMethod: string | undefined;
+  let hasFields = false;
+  for (let i = 1; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "-X" || arg === "--method") {
+      const next = args[i + 1];
+      if (next !== undefined) {
+        explicitMethod = next.toUpperCase();
+      }
+      i += 1;
+    } else if (
+      arg === "-f" ||
+      arg === "-F" ||
+      arg === "--field" ||
+      arg === "--raw-field" ||
+      arg === "--input"
+    ) {
+      hasFields = true;
+    }
+  }
+  if (explicitMethod === "GET" || explicitMethod === "HEAD") return false;
+  if (explicitMethod !== undefined) return true;
+  return hasFields;
+}
+
+/** Mirrors `is_rate_limited` in gh_executor.rs. */
+export function isRateLimited(output: ExecOutput): boolean {
+  const combined = `${output.stdout}\n${output.stderr}`.toLowerCase();
+  return (
+    combined.includes("secondary rate limit") ||
+    combined.includes("rate limit exceeded") ||
+    combined.includes("api rate limit") ||
+    combined.includes("abuse detection") ||
+    combined.includes("retry after")
+  );
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function defaultSpawnGh(realGh: string) {
+  return async (spec: GhCommandSpec): Promise<ExecOutput> =>
+    new Promise((resolve, reject) => {
+      const env = { ...process.env, ...(spec.envs ?? {}) };
+      const child = spawn(realGh, spec.args, {
+        cwd: spec.cwd,
+        env,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      let stdout = "";
+      let stderr = "";
+      child.stdout?.on("data", (chunk: Buffer) => {
+        stdout += chunk.toString("utf8");
+      });
+      child.stderr?.on("data", (chunk: Buffer) => {
+        stderr += chunk.toString("utf8");
+      });
+      child.on("error", reject);
+      child.on("close", (code) => {
+        resolve({ stdout, stderr, statusCode: code ?? 1 });
+      });
+    });
+}

--- a/src/products/breeze/daemon/runner-skeleton.ts
+++ b/src/products/breeze/daemon/runner-skeleton.ts
@@ -1,26 +1,36 @@
 /**
  * Minimal TS daemon entrypoint.
  *
- * This is Phase 3a: read-path only. The daemon spins up the notification
- * poller and waits for a shutdown signal. HTTP, broker, bus, dispatcher
- * are deferred to Phase 3b/3c — this skeleton explicitly leaves those
- * wiring points as TODOs so reviewers can see the future surface.
+ * This is the Phase 3a/3b read-path entrypoint plus the Phase 3c
+ * broker/dispatcher startup. The daemon spins up the notification
+ * poller, HTTP/SSE server, gh broker, bus, and dispatcher; SIGTERM
+ * cascades through a single AbortController.
  *
  * Launch path:
  *   `first-tree breeze daemon --backend=ts`
  * delegates here via `src/products/breeze/cli.ts`. The `rust` backend
- * (default in Phase 3a) continues to route through
- * `bridge.ts::resolveBreezeRunner` and the Rust `breeze-runner` binary;
- * nothing in this file touches that path.
+ * continues to route through `bridge.ts::resolveBreezeRunner` and the
+ * Rust `breeze-runner` binary; nothing in this file touches that path.
  *
  * Shutdown contract:
  *   - SIGTERM / SIGINT cascade through a single AbortController.
  *   - The poller observes `signal.aborted`, finishes any in-flight
  *     `pollOnce` (including draining the inbox.json advisory lock),
  *     then resolves.
- *   - The daemon exits with code 0 on clean shutdown, 1 if the poller
- *     threw.
+ *   - Dispatcher.stop() aborts in-flight runner tasks and drains
+ *     pending. Broker.stop() waits for the serve-loop to unwind.
+ *   - The daemon exits with code 0 on clean shutdown, 1 on fatal error.
+ *
+ * Phase 4 note:
+ *   Dispatcher submissions (turning notifications into candidates) are
+ *   deferred. This entrypoint wires the lifecycle but does not yet
+ *   feed the dispatcher — a future poller callback will `submit()` as
+ *   notifications arrive.
  */
+
+import { execSync } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 import { resolveBreezePaths } from "../core/paths.js";
 import { loadBreezeDaemonConfig, type DaemonConfig } from "../core/config.js";
@@ -28,6 +38,12 @@ import { loadBreezeDaemonConfig, type DaemonConfig } from "../core/config.js";
 import { resolveDaemonIdentity, identityHasRequiredScope } from "./identity.js";
 import { startHttpServer, type RunningHttpServer } from "./http.js";
 import { runPoller, type PollerLogger } from "./poller.js";
+import { createBus, toSseBus, type Bus } from "./bus.js";
+import { startGhBroker, type RunningBroker } from "./broker.js";
+import { GhExecutor } from "./gh-executor.js";
+import { Dispatcher } from "./dispatcher.js";
+import { WorkspaceManager } from "./workspace.js";
+import type { RunnerSpec } from "./runner.js";
 
 export interface DaemonCliOverrides {
   pollIntervalSec?: number;
@@ -224,11 +240,78 @@ export async function runDaemon(
     `breeze daemon: poll-interval=${config.pollIntervalSec}s host=${config.host} http-port=${config.httpPort}`,
   );
 
+  // Phase 3c: shared in-process bus drives SSE + broker task events.
+  const bus = createBus({
+    onListenerError: (err) =>
+      logger.warn(
+        `bus listener threw: ${err instanceof Error ? err.message : String(err)}`,
+      ),
+  });
+
+  // Phase 3c: start gh broker + dispatcher if runners are available.
+  // Absence of codex/claude is non-fatal; the daemon still runs as
+  // read-only (poller + http).
+  let broker: RunningBroker | null = null;
+  let dispatcher: Dispatcher | null = null;
+  try {
+    const runners = detectAvailableRunners();
+    const realGh = findExecutable("gh");
+    if (runners.length > 0 && realGh) {
+      const runnerHome = resolveRunnerHome();
+      const brokerDir = join(runnerHome, "broker");
+      const identity = resolveDaemonIdentity({ host: config.host });
+      const executor = new GhExecutor({
+        realGh,
+        writeCooldownMs: 1_000,
+        signal: controller.signal,
+      });
+      broker = await startGhBroker({
+        brokerDir,
+        executor,
+        logger: {
+          warn: (line) => logger.warn(`broker: ${line}`),
+          error: (line) => logger.error(`broker: ${line}`),
+        },
+      });
+      const workspaceManager = new WorkspaceManager({
+        reposDir: join(runnerHome, "repos"),
+        workspacesDir: join(runnerHome, "workspaces"),
+        identity: { host: identity.host, login: identity.login },
+      });
+      dispatcher = new Dispatcher({
+        runnerHome,
+        identity: { host: identity.host, login: identity.login },
+        runners,
+        workspaceManager,
+        bus,
+        ghShimDir: broker.shimDir,
+        ghBrokerDir: broker.brokerDir,
+        claimsDir: paths.claimsDir,
+        disclosureText:
+          "This reply was drafted by breeze, an autonomous agent running on behalf of the account owner.",
+        maxParallel: 2,
+        taskTimeoutMs: config.taskTimeoutSec * 1_000,
+        logger,
+      });
+      logger.info(
+        `breeze daemon: dispatcher ready (runners=${runners.map((r) => r.kind).join(",")}, broker=${broker.shimDir})`,
+      );
+    } else {
+      const missing: string[] = [];
+      if (runners.length === 0) missing.push("no codex/claude on PATH");
+      if (!realGh) missing.push("no gh on PATH");
+      logger.warn(
+        `breeze daemon: skipping broker/dispatcher (${missing.join("; ")})`,
+      );
+    }
+  } catch (err) {
+    logger.error(
+      `failed to start broker/dispatcher: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    // Continue without dispatcher; still run poller + http.
+  }
+
   // Phase 3b: start the read-only HTTP + SSE server.
-  // Phase 3c will replace the inbox-mtime stub bus with the real
-  // broker-driven in-process bus. The http layer itself does NOT need
-  // to change when that lands.
-  //
   // If the shared controller is already aborted (tests inject a
   // pre-aborted signal; real SIGTERM arrives later), skip binding: we
   // would close immediately anyway and we'd rather not touch the
@@ -240,6 +323,7 @@ export async function runDaemon(
         httpPort: config.httpPort,
         inboxPath: paths.inbox,
         activityLogPath: paths.activityLog,
+        bus: toSseBus(bus),
         signal: controller.signal,
         logger,
       });
@@ -247,11 +331,12 @@ export async function runDaemon(
       logger.error(
         `failed to start http server: ${err instanceof Error ? err.message : String(err)}`,
       );
+      if (dispatcher) await dispatcher.stop();
+      if (broker) await broker.stop();
       if (uninstallHandlers) uninstallHandlers();
       return 1;
     }
   }
-  // TODO(Phase 3c): start broker gh-serializer + bus + dispatcher.
 
   let exitCode = 0;
   try {
@@ -268,14 +353,32 @@ export async function runDaemon(
     );
     exitCode = 1;
   } finally {
-    // Shutdown order (pinned by Phase 3a contract):
+    // Shutdown order:
     //   SIGTERM -> stop poller (above) -> flush store (poller's atomic
-    //   tmp+rename drains in updateInbox) -> stop http -> exit.
+    //   tmp+rename drains in updateInbox) -> stop dispatcher (aborts
+    //   in-flight runner tasks) -> stop broker (drains serve loop) ->
+    //   stop http -> close bus -> exit.
+    if (!controller.signal.aborted) controller.abort();
+    if (dispatcher) {
+      try {
+        await dispatcher.stop();
+      } catch (err) {
+        logger.warn(
+          `dispatcher shutdown failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+    if (broker) {
+      try {
+        await broker.stop();
+      } catch (err) {
+        logger.warn(
+          `broker shutdown failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
     if (httpServer) {
       try {
-        // Ensure the shared controller is aborted so liveStreams cancel
-        // even if we got here via an exception rather than SIGTERM.
-        if (!controller.signal.aborted) controller.abort();
         await httpServer.done;
       } catch (err) {
         logger.warn(
@@ -283,11 +386,52 @@ export async function runDaemon(
         );
       }
     }
+    bus.close();
     if (uninstallHandlers) uninstallHandlers();
   }
 
   logger.info("breeze daemon: shutdown complete");
   return exitCode;
+}
+
+/**
+ * Walk PATH looking for a best-effort set of agent binaries. Returns
+ * the specs in the order we'd prefer as the primary runner. Missing
+ * binaries are silently omitted — the caller decides whether that is
+ * fatal.
+ */
+export function detectAvailableRunners(): RunnerSpec[] {
+  const runners: RunnerSpec[] = [];
+  if (findExecutable("codex")) runners.push({ kind: "codex" });
+  if (findExecutable("claude")) runners.push({ kind: "claude" });
+  return runners;
+}
+
+/** Return the absolute path to `name` on PATH, or null if not found. */
+export function findExecutable(name: string): string | null {
+  try {
+    const out = execSync(`command -v ${name}`, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return out.length > 0 ? out : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * `$BREEZE_HOME` or `$BREEZE_DIR/runner`, defaulting to
+ * `~/.breeze/runner`. Matches `resolve_inbox_dir` in Rust `fetcher.rs`.
+ */
+export function resolveRunnerHome(
+  env: (name: string) => string | undefined = (n) => process.env[n],
+): string {
+  const breezeHome = env("BREEZE_HOME");
+  if (breezeHome && breezeHome.length > 0) return breezeHome;
+  const breezeDir = env("BREEZE_DIR");
+  if (breezeDir && breezeDir.length > 0) return join(breezeDir, "runner");
+  return join(homedir(), ".breeze", "runner");
 }
 
 export default runDaemon;

--- a/src/products/breeze/daemon/runner.ts
+++ b/src/products/breeze/daemon/runner.ts
@@ -1,0 +1,406 @@
+/**
+ * Phase 3c: per-task agent runner.
+ *
+ * Port of `first-tree-breeze/breeze-runner/src/runner.rs`.
+ *
+ * Each dispatched task picks one or more runner specs from the pool,
+ * builds a prompt, writes it to `<task-dir>/prompt.txt`, and execs the
+ * agent binary (`codex` or `claude`). Stdout/stderr go to
+ * `runner-stdout.log` / `runner-stderr.log`; `runner-output.txt`
+ * holds the agent's final message (codex writes it via
+ * `--output-last-message`, claude's stdout is copied there post-exit).
+ *
+ * The dispatcher iterates runners in `executionOrder()` until one
+ * returns successfully, mirroring Rust's fallback chain. Only the
+ * first runner is recorded as "selected" in task metadata.
+ *
+ * Phase 3c adds a per-task timeout (spec doc 4 §11, §8). Rust's
+ * runner had no timeout; the TS version always enforces one, with a
+ * default in `core/config.ts::DAEMON_CONFIG_DEFAULTS.taskTimeoutSec`.
+ */
+
+import {
+  createWriteStream,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  type WriteStream,
+} from "node:fs";
+import { spawn, type ChildProcess } from "node:child_process";
+import { join } from "node:path";
+
+export type RunnerKind = "codex" | "claude";
+
+export interface RunnerSpec {
+  kind: RunnerKind;
+  model?: string;
+}
+
+export interface AgentIdentity {
+  login: string;
+  host: string;
+}
+
+export interface RunnerTask {
+  repo: string;
+  workspaceRepo: string;
+  kind: string;
+  title: string;
+  /** Preferred anchored URL (comment link if known). */
+  taskUrl: string;
+}
+
+export interface RunnerRequest {
+  task: RunnerTask;
+  taskId: string;
+  taskDir: string;
+  workspaceDir: string;
+  snapshotDir: string;
+  ghShimDir: string;
+  ghBrokerDir: string;
+  identity: AgentIdentity;
+  disclosureText: string;
+}
+
+export interface RunnerOutcome {
+  status: string;
+  summary: string;
+  outputPath: string;
+}
+
+export type RunnerSpawner = (args: {
+  spec: RunnerSpec;
+  request: RunnerRequest;
+  promptPath: string;
+  promptText: string;
+  outputPath: string;
+  stdoutPath: string;
+  stderrPath: string;
+}) => Promise<{ statusCode: number | null }>;
+
+export interface ExecuteOptions {
+  /** Kill the subprocess if it runs longer than this many ms. */
+  timeoutMs: number;
+  /** Injected spawner. Production uses `defaultRunnerSpawner`. */
+  spawner?: RunnerSpawner;
+  /** Abort signal. Triggers the same kill path as the timeout. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Execute one runner. Writes the prompt + logs + parses the result.
+ * Throws on non-zero exit so the dispatcher can try the next runner.
+ */
+export async function executeRunner(
+  spec: RunnerSpec,
+  request: RunnerRequest,
+  options: ExecuteOptions,
+): Promise<RunnerOutcome> {
+  const promptText = buildPrompt(request);
+  const promptPath = join(request.taskDir, "prompt.txt");
+  const outputPath = join(request.taskDir, "runner-output.txt");
+  const stdoutPath = join(request.taskDir, "runner-stdout.log");
+  const stderrPath = join(request.taskDir, "runner-stderr.log");
+
+  writeFileSync(promptPath, promptText);
+
+  const spawner = options.spawner ?? defaultRunnerSpawner;
+  const { statusCode } = await spawner({
+    spec,
+    request,
+    promptPath,
+    promptText,
+    outputPath,
+    stdoutPath,
+    stderrPath,
+  });
+
+  // Claude doesn't emit --output-last-message; copy stdout into
+  // runner-output.txt so parse_result can find the final BREEZE_RESULT
+  // line consistently.
+  if (spec.kind === "claude") {
+    const stdout = existsSync(stdoutPath)
+      ? readFileSync(stdoutPath, "utf8")
+      : "";
+    writeFileSync(outputPath, stdout);
+  }
+
+  if (statusCode !== 0) {
+    throw new Error(
+      `${spec.kind} runner exited with status ${statusCode ?? "unknown"}`,
+    );
+  }
+
+  const response = existsSync(outputPath)
+    ? readFileSync(outputPath, "utf8")
+    : "";
+  const { status, summary } = parseResult(response);
+  return { status, summary, outputPath };
+}
+
+export function buildPrompt(request: RunnerRequest): string {
+  const task = request.task;
+  const workingRepoLine =
+    task.workspaceRepo !== task.repo
+      ? `- Working repository: ${task.workspaceRepo}\n`
+      : "";
+  return (
+    `This is breeze and you are a team of agents representing ${request.identity.login}.\n` +
+    `\n` +
+    `This is breeze's code repo:\n` +
+    `https://github.com/agent-team-foundation/breeze\n` +
+    `\n` +
+    `Your job is addressing any comments / discussions / review request / task request / pull request etc. (basically any GitHub notifications) related to GitHub id: ${request.identity.login}. When reviewing pull requests, follow the principle here: https://google.github.io/eng-practices/review/\n` +
+    `\n` +
+    `The web URL for the current GitHub task that you need to solve and reply is: ${task.taskUrl}\n` +
+    `\n` +
+    `Local context:\n` +
+    `- Task ID: ${request.taskId}\n` +
+    `- Repository: ${task.repo}\n` +
+    workingRepoLine +
+    `- Type: ${task.kind}\n` +
+    `- Workspace: ${request.workspaceDir}\n` +
+    `- Snapshot directory: ${request.snapshotDir}\n` +
+    `- Task artifacts directory: ${request.taskDir}\n` +
+    `\n` +
+    `Do not stop unless\n` +
+    `0. Read carefully about the request and gather all the needed context\n` +
+    `1. Task / Request in the GitHub message has been done completely\n` +
+    `2. Message has been properly replied on GitHub\n` +
+    `\n` +
+    `If you find a task / message has already been replied by ${request.identity.login}, then you can skip it. Do not send out duplicated replies.\n` +
+    `\n` +
+    `Read the local snapshot files first. Only call \`gh\` when you need fresh data or to publish the final result.\n` +
+    `\n` +
+    `Status labeling rule (REQUIRED): label the issue / pull request with your current status using exactly one of:\n` +
+    `- \`breeze:wip\` — you are actively working on it\n` +
+    `- \`breeze:human\` — you need human input or judgment to proceed\n` +
+    `- \`breeze:done\` — you have finished handling it\n` +
+    `\n` +
+    `Apply the label via \`gh\`, for example:\n` +
+    `  gh issue edit <number> --repo <owner>/<repo> --add-label "breeze:<status>"\n` +
+    `  gh pr edit   <number> --repo <owner>/<repo> --add-label "breeze:<status>"\n` +
+    `Remove any previous \`breeze:*\` label when the status changes so only one \`breeze:*\` label remains on the item. Set \`breeze:wip\` as soon as you start real work, and set \`breeze:done\` or \`breeze:human\` before you stop.\n` +
+    `\n` +
+    `If you post a public GitHub reply, review, or comment, include this exact disclosure sentence once: ${request.disclosureText}\n` +
+    `\n` +
+    `When you are done, finish with exactly one line in this format:\n` +
+    `BREEZE_RESULT: status=<handled|skipped|failed> summary=<one-line summary>`
+  );
+}
+
+/**
+ * Scan bottom-up for the last `BREEZE_RESULT:` line. Mirrors Rust
+ * `parse_result`. If missing, default to `handled` with the last line
+ * of output as the summary.
+ *
+ * Phase 3c bug-fix note (spec doc 4 §11): Rust silently treats
+ * crashes-without-BREEZE_RESULT as `handled`. The dispatcher layer can
+ * re-classify these by inspecting exit status; this function preserves
+ * the Rust default for parity.
+ */
+export function parseResult(output: string): {
+  status: string;
+  summary: string;
+} {
+  const lines = output.split(/\r?\n/);
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const trimmed = lines[i].trim();
+    if (!trimmed.startsWith("BREEZE_RESULT:")) continue;
+    const payload = trimmed.slice("BREEZE_RESULT:".length).trim();
+    const status =
+      payload
+        .split(/\s+/)
+        .find((p) => p.startsWith("status="))
+        ?.slice("status=".length) ?? "handled";
+    const summary = (() => {
+      const idx = payload.indexOf("summary=");
+      if (idx === -1) return "completed";
+      return payload.slice(idx + "summary=".length).trim();
+    })();
+    return { status, summary };
+  }
+  const nonEmpty = lines
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+  const summary = nonEmpty[nonEmpty.length - 1] ?? "completed";
+  return { status: "handled", summary };
+}
+
+/**
+ * Rotate through the runner list, returning the sequence of specs to
+ * try for the next task. Subsequent calls rotate by one so codex /
+ * claude alternate as primary across tasks.
+ */
+export class RunnerPool {
+  private readonly runners: readonly RunnerSpec[];
+  private nextIndex = 0;
+
+  constructor(runners: readonly RunnerSpec[]) {
+    if (runners.length === 0) {
+      throw new Error(
+        "no configured runner binary is available in PATH (need codex and/or claude)",
+      );
+    }
+    this.runners = runners;
+  }
+
+  availableNames(): RunnerKind[] {
+    return this.runners.map((r) => r.kind);
+  }
+
+  executionOrder(): RunnerSpec[] {
+    const n = this.runners.length;
+    const start = this.nextIndex % n;
+    this.nextIndex = (this.nextIndex + 1) % n;
+    return Array.from({ length: n }, (_, offset) => ({
+      ...this.runners[(start + offset) % n],
+    }));
+  }
+}
+
+/**
+ * Spawn codex or claude with the agent's env. Handles timeout via
+ * `setTimeout(kill, timeoutMs)` and propagates an AbortSignal the same
+ * way. Returns the exit status.
+ */
+export const defaultRunnerSpawner: RunnerSpawner = async ({
+  spec,
+  request,
+  promptPath,
+  promptText,
+  outputPath,
+  stdoutPath,
+  stderrPath,
+}) => {
+  const env = buildAgentEnv(request);
+  const { cmd, args, cwd } = buildCommand({
+    spec,
+    request,
+    promptPath,
+    promptText,
+    outputPath,
+  });
+
+  const stdout = createWriteStream(stdoutPath);
+  const stderr = createWriteStream(stderrPath);
+
+  const child = spawn(cmd, args, {
+    cwd,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stdout?.pipe(stdout);
+  child.stderr?.pipe(stderr);
+
+  return new Promise((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", (code) => {
+      closeStreams([stdout, stderr]).then(() =>
+        resolve({ statusCode: code }),
+      );
+    });
+  });
+};
+
+export function buildCommand(args: {
+  spec: RunnerSpec;
+  request: RunnerRequest;
+  promptPath: string;
+  promptText: string;
+  outputPath: string;
+}): { cmd: string; args: string[]; cwd?: string } {
+  const { spec, request, promptPath, promptText, outputPath } = args;
+  if (spec.kind === "codex") {
+    const argv = [
+      "exec",
+      "--cd",
+      request.workspaceDir,
+      "--dangerously-bypass-approvals-and-sandbox",
+      "--output-last-message",
+      outputPath,
+    ];
+    if (spec.model) argv.push("--model", spec.model);
+    argv.push(promptPath);
+    return { cmd: "codex", args: argv };
+  }
+  // Claude
+  const argv = ["-p", "--permission-mode", "bypassPermissions"];
+  if (spec.model) argv.push("--model", spec.model);
+  argv.push(promptText);
+  return { cmd: "claude", args: argv, cwd: request.workspaceDir };
+}
+
+export function buildAgentEnv(
+  request: RunnerRequest,
+): NodeJS.ProcessEnv {
+  const existingPath = process.env.PATH ?? "";
+  return {
+    ...process.env,
+    PATH: `${request.ghShimDir}:${existingPath}`,
+    BREEZE_BROKER_DIR: request.ghBrokerDir,
+    BREEZE_SNAPSHOT_DIR: request.snapshotDir,
+    BREEZE_TASK_DIR: request.taskDir,
+  };
+}
+
+async function closeStreams(streams: WriteStream[]): Promise<void> {
+  await Promise.all(
+    streams.map(
+      (s) =>
+        new Promise<void>((resolve) => {
+          s.end(() => resolve());
+        }),
+    ),
+  );
+}
+
+/** Run a spec with a timeout. Used by the dispatcher. */
+export async function runWithTimeout<T>(args: {
+  run: () => Promise<T>;
+  kill: () => void;
+  timeoutMs: number;
+  signal?: AbortSignal;
+}): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      args.kill();
+      reject(new Error(`timed out after ${args.timeoutMs}ms`));
+    }, args.timeoutMs);
+    const onAbort = (): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      args.kill();
+      reject(new Error("aborted"));
+    };
+    if (args.signal) {
+      if (args.signal.aborted) {
+        clearTimeout(timer);
+        args.kill();
+        reject(new Error("aborted"));
+        return;
+      }
+      args.signal.addEventListener("abort", onAbort, { once: true });
+    }
+    args
+      .run()
+      .then((value) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        args.signal?.removeEventListener("abort", onAbort);
+        resolve(value);
+      })
+      .catch((err) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        args.signal?.removeEventListener("abort", onAbort);
+        reject(err);
+      });
+  });
+}

--- a/src/products/breeze/daemon/workspace.ts
+++ b/src/products/breeze/daemon/workspace.ts
@@ -1,0 +1,306 @@
+/**
+ * Phase 3c: workspace manager for agent task execution.
+ *
+ * Port of `first-tree-breeze/breeze-runner/src/workspace.rs`.
+ *
+ * Each dispatched task gets a detached-HEAD git worktree at
+ * `<workspacesDir>/<slug>/<kind>-<stableId>`, backed by a bare mirror
+ * at `<reposDir>/<slug>.git`. The mirror is kept up-to-date via
+ * `git remote update --prune`; PR-targeted tasks additionally fetch
+ * `refs/pull/<n>/head` into a local tracking ref.
+ *
+ * We shell out to `git` and `gh` exactly like the Rust version. All
+ * auth-ish commands (`clone`, `fetch`, `remote update`) are run with
+ * `GIT_TERMINAL_PROMPT=0` and the `credential.helper=!gh auth
+ * git-credential` trick so they work against `github.com` without
+ * requiring the user's global git config to know about `gh`.
+ *
+ * Tests use an injected `runGit` to avoid hitting the network.
+ */
+
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { spawn } from "node:child_process";
+
+export interface WorkspaceCandidate {
+  repo: string;
+  /** "issue" | "pr" | "review" | "mention" | ... */
+  kind: string;
+  /** Derived id safe for filesystem use. */
+  stableId: string;
+  /** Optional PR number (numbers only; 0 or undefined for non-PR). */
+  prNumber?: number;
+  /** Workspace repo (defaults to `repo` when absent). */
+  workspaceRepo?: string;
+}
+
+export interface WorkspaceIdentity {
+  host: string;
+  login: string;
+}
+
+export interface WorkspaceLease {
+  mirrorDir: string;
+  workspaceDir: string;
+  repoUrl: string;
+}
+
+export interface GitRunResult {
+  stdout: string;
+  stderr: string;
+  statusCode: number;
+}
+
+export type GitRunner = (args: {
+  args: string[];
+  env?: Record<string, string>;
+}) => Promise<GitRunResult>;
+
+export interface WorkspaceManagerOptions {
+  reposDir: string;
+  workspacesDir: string;
+  identity: WorkspaceIdentity;
+  /** Injected git runner. Production uses `defaultGitRunner`. */
+  runGit?: GitRunner;
+}
+
+export class WorkspaceManager {
+  private readonly reposDir: string;
+  private readonly workspacesDir: string;
+  private readonly identity: WorkspaceIdentity;
+  private readonly runGit: GitRunner;
+
+  constructor(options: WorkspaceManagerOptions) {
+    this.reposDir = options.reposDir;
+    this.workspacesDir = options.workspacesDir;
+    this.identity = options.identity;
+    this.runGit = options.runGit ?? defaultGitRunner;
+  }
+
+  async prepare(task: WorkspaceCandidate): Promise<WorkspaceLease> {
+    const workspaceRepo = task.workspaceRepo ?? task.repo;
+    if (!workspaceRepo) {
+      throw new Error("task does not include a repository");
+    }
+    mkdirSync(this.reposDir, { recursive: true });
+    mkdirSync(this.workspacesDir, { recursive: true });
+
+    const slug = sanitizeFilename(workspaceRepo.replace(/\//g, "__"));
+    const mirrorDir = join(this.reposDir, `${slug}.git`);
+    const repoUrl = `https://${this.identity.host}/${workspaceRepo}.git`;
+    await this.ensureMirror(mirrorDir, repoUrl);
+    const checkoutRef = await this.prepareRef(mirrorDir, task);
+
+    const workspaceDir = join(
+      this.workspacesDir,
+      slug,
+      `${task.kind}-${task.stableId}`,
+    );
+    await this.pruneStaleWorktreeEntry(mirrorDir, workspaceDir);
+    if (existsSync(workspaceDir)) {
+      rmSync(workspaceDir, { recursive: true, force: true });
+    }
+    mkdirSync(dirname(workspaceDir), { recursive: true });
+
+    await this.runChecked({
+      args: [
+        "--git-dir",
+        mirrorDir,
+        "worktree",
+        "add",
+        "--force",
+        "--detach",
+        workspaceDir,
+        checkoutRef,
+      ],
+      context: "create task workspace",
+    });
+
+    await this.seedGitIdentity(workspaceDir);
+
+    return { mirrorDir, workspaceDir, repoUrl };
+  }
+
+  private async ensureMirror(
+    mirrorDir: string,
+    repoUrl: string,
+  ): Promise<void> {
+    if (!existsSync(mirrorDir)) {
+      await this.runChecked({
+        args: this.authArgs([
+          "clone",
+          "--bare",
+          repoUrl,
+          mirrorDir,
+        ]),
+        env: AUTH_ENV,
+        context: "clone bare mirror",
+      });
+    }
+    await this.normalizeRepositoryCache(mirrorDir);
+    await this.runChecked({
+      args: this.authArgs([
+        "--git-dir",
+        mirrorDir,
+        "remote",
+        "update",
+        "--prune",
+      ]),
+      env: AUTH_ENV,
+      context: "update bare mirror",
+    });
+  }
+
+  private async prepareRef(
+    mirrorDir: string,
+    task: WorkspaceCandidate,
+  ): Promise<string> {
+    if (task.prNumber && task.prNumber > 0) {
+      const refName = `refs/remotes/origin/breeze-runner-pr-${task.prNumber}`;
+      await this.runChecked({
+        args: this.authArgs([
+          "--git-dir",
+          mirrorDir,
+          "fetch",
+          "origin",
+          `+refs/pull/${task.prNumber}/head:${refName}`,
+        ]),
+        env: AUTH_ENV,
+        context: "fetch pull request head",
+      });
+      return refName;
+    }
+    const { stdout } = await this.runChecked({
+      args: ["--git-dir", mirrorDir, "rev-parse", "HEAD"],
+      context: "resolve mirror HEAD",
+    });
+    const revision = stdout.split("\n", 1)[0]?.trim() ?? "";
+    if (!revision) throw new Error("mirror HEAD could not be resolved");
+    return revision;
+  }
+
+  private async seedGitIdentity(workspaceDir: string): Promise<void> {
+    await this.runGit({
+      args: [
+        "-C",
+        workspaceDir,
+        "config",
+        "user.name",
+        `${this.identity.login} via breeze-runner`,
+      ],
+    });
+    await this.runGit({
+      args: [
+        "-C",
+        workspaceDir,
+        "config",
+        "user.email",
+        `${this.identity.login}@users.noreply.github.com`,
+      ],
+    });
+  }
+
+  private async normalizeRepositoryCache(mirrorDir: string): Promise<void> {
+    await this.runGit({
+      args: [
+        "--git-dir",
+        mirrorDir,
+        "config",
+        "--unset-all",
+        "remote.origin.mirror",
+      ],
+    });
+    await this.runGit({
+      args: [
+        "--git-dir",
+        mirrorDir,
+        "config",
+        "--unset-all",
+        "remote.origin.fetch",
+      ],
+    });
+    for (const fetch of [
+      "+refs/heads/*:refs/remotes/origin/*",
+      "+refs/tags/*:refs/tags/*",
+    ]) {
+      await this.runChecked({
+        args: [
+          "--git-dir",
+          mirrorDir,
+          "config",
+          "--add",
+          "remote.origin.fetch",
+          fetch,
+        ],
+        context: "configure repository cache fetch refspec",
+      });
+    }
+  }
+
+  private async pruneStaleWorktreeEntry(
+    mirrorDir: string,
+    workspaceDir: string,
+  ): Promise<void> {
+    await this.runGit({
+      args: ["--git-dir", mirrorDir, "worktree", "prune"],
+    });
+    await this.runGit({
+      args: [
+        "--git-dir",
+        mirrorDir,
+        "worktree",
+        "remove",
+        "--force",
+        workspaceDir,
+      ],
+    });
+  }
+
+  private authArgs(base: string[]): string[] {
+    return ["-c", "credential.helper=!gh auth git-credential", ...base];
+  }
+
+  private async runChecked(opts: {
+    args: string[];
+    env?: Record<string, string>;
+    context: string;
+  }): Promise<GitRunResult> {
+    const result = await this.runGit({ args: opts.args, env: opts.env });
+    if (result.statusCode !== 0) {
+      throw new Error(
+        `${opts.context} failed (exit ${result.statusCode}): ${result.stderr || result.stdout}`,
+      );
+    }
+    return result;
+  }
+}
+
+const AUTH_ENV: Record<string, string> = { GIT_TERMINAL_PROMPT: "0" };
+
+/** Strip filesystem-unsafe characters from a slug (matches Rust util). */
+export function sanitizeFilename(raw: string): string {
+  const cleaned = raw.replace(/[^A-Za-z0-9._-]/g, "_");
+  return cleaned.length === 0 ? "_" : cleaned;
+}
+
+/** Default git runner; spawns real `git`. */
+export const defaultGitRunner: GitRunner = async ({ args, env }) => {
+  return new Promise((resolve, reject) => {
+    const child = spawn("git", args, {
+      env: { ...process.env, ...(env ?? {}) },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolve({ stdout, stderr, statusCode: code ?? 1 });
+    });
+  });
+};

--- a/tests/breeze-daemon-broker.test.ts
+++ b/tests/breeze-daemon-broker.test.ts
@@ -1,0 +1,343 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  GhExecutor,
+  type GhCommandSpec,
+  type ExecOutput,
+} from "../src/products/breeze/daemon/gh-executor.js";
+import {
+  MUTATION_CACHE_TTL_MS,
+  SHIM_SCRIPT,
+  mutationFingerprint,
+  readCachedMutationResponse,
+  stableFileId,
+  startGhBroker,
+  writeCachedMutationResponse,
+} from "../src/products/breeze/daemon/broker.js";
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  while (tempRoots.length) {
+    const dir = tempRoots.pop();
+    if (dir && existsSync(dir)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), `breeze-broker-${prefix}-`));
+  tempRoots.push(dir);
+  return dir;
+}
+
+function buildExecutor(responses: ExecOutput[]): {
+  executor: GhExecutor;
+  calls: GhCommandSpec[];
+} {
+  const calls: GhCommandSpec[] = [];
+  const queue = [...responses];
+  const executor = new GhExecutor({
+    realGh: "/usr/bin/gh",
+    writeCooldownMs: 0,
+    spawnGh: async (spec) => {
+      calls.push(spec);
+      const next = queue.shift();
+      if (!next) throw new Error("no scripted response");
+      return next;
+    },
+    now: () => 0,
+    sleep: async () => {},
+  });
+  return { executor, calls };
+}
+
+describe("SHIM_SCRIPT", () => {
+  it("references BREEZE_BROKER_DIR and writes argv.txt", () => {
+    expect(SHIM_SCRIPT).toContain("BREEZE_BROKER_DIR");
+    expect(SHIM_SCRIPT).toContain("argv.txt");
+  });
+});
+
+describe("mutationFingerprint", () => {
+  it("returns undefined for read-only commands", () => {
+    expect(
+      mutationFingerprint({
+        context: "",
+        args: ["api", "/notifications"],
+        mutating: false,
+        bucket: "core",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("hashes --body so retries with the same text hit cache", () => {
+    const base: GhCommandSpec = {
+      context: "",
+      args: ["issue", "comment", "1", "--body", "hello"],
+      mutating: true,
+      bucket: "write",
+    };
+    const other: GhCommandSpec = {
+      ...base,
+      args: ["issue", "comment", "1", "--body", "hello"],
+    };
+    expect(mutationFingerprint(base)).toEqual(mutationFingerprint(other));
+  });
+
+  it("hashes --body-file contents not path", () => {
+    const cwd = makeTempDir("fp");
+    const a = join(cwd, "a.txt");
+    const b = join(cwd, "b.txt");
+    writeFileSync(a, "same body");
+    writeFileSync(b, "same body");
+    const specA: GhCommandSpec = {
+      context: "",
+      cwd,
+      args: ["pr", "review", "1", "--body-file", "a.txt"],
+      mutating: true,
+      bucket: "write",
+      envs: { GH_REPO: "owner/repo" },
+    };
+    const specB: GhCommandSpec = {
+      ...specA,
+      args: ["pr", "review", "1", "--body-file", "b.txt"],
+    };
+    expect(mutationFingerprint(specA)).toEqual(mutationFingerprint(specB));
+  });
+
+  it("includes sorted env and cwd", () => {
+    const fp1 = mutationFingerprint({
+      context: "",
+      cwd: "/tmp/x",
+      args: ["pr", "create", "--title", "t"],
+      envs: { GH_HOST: "github.com", GH_REPO: "o/r" },
+      mutating: true,
+      bucket: "write",
+    });
+    const fp2 = mutationFingerprint({
+      context: "",
+      cwd: "/tmp/x",
+      args: ["pr", "create", "--title", "t"],
+      envs: { GH_REPO: "o/r", GH_HOST: "github.com" },
+      mutating: true,
+      bucket: "write",
+    });
+    expect(fp1).toEqual(fp2);
+    expect(fp1).toContain("env:GH_HOST=github.com");
+    expect(fp1).toContain("cwd:/tmp/x");
+  });
+});
+
+describe("cache round-trip", () => {
+  it("reads back a success within TTL and drops after expiry", () => {
+    const historyDir = makeTempDir("cache");
+    const clock = { now: 1_000 };
+    writeCachedMutationResponse({
+      historyDir,
+      fingerprint: "foo",
+      stdout: "ok",
+      stderr: "",
+      statusCode: 0,
+      now: () => clock.now,
+    });
+
+    const hit = readCachedMutationResponse({
+      historyDir,
+      fingerprint: "foo",
+      now: () => clock.now + 1_000,
+    });
+    expect(hit?.stdout).toBe("ok");
+
+    const miss = readCachedMutationResponse({
+      historyDir,
+      fingerprint: "foo",
+      now: () => clock.now + MUTATION_CACHE_TTL_MS + 1,
+    });
+    expect(miss).toBeUndefined();
+  });
+
+  it("drops non-zero status codes from cache", () => {
+    const historyDir = makeTempDir("cache-bad");
+    writeCachedMutationResponse({
+      historyDir,
+      fingerprint: "bad",
+      stdout: "",
+      stderr: "oops",
+      statusCode: 1,
+      now: () => 1,
+    });
+    expect(
+      readCachedMutationResponse({
+        historyDir,
+        fingerprint: "bad",
+        now: () => 2,
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("stableFileId", () => {
+  it("is deterministic for identical inputs", () => {
+    expect(stableFileId("hello")).toBe(stableFileId("hello"));
+  });
+  it("differs across inputs", () => {
+    expect(stableFileId("a")).not.toBe(stableFileId("b"));
+  });
+});
+
+describe("startGhBroker serve loop", () => {
+  it("installs shim with exec permissions and purges stale requests", async () => {
+    const brokerDir = makeTempDir("serve");
+    // Plant a stale request dir; broker.start() should purge on boot.
+    const stale = join(brokerDir, "requests", "stale");
+    mkdirSync(stale, { recursive: true });
+    writeFileSync(join(stale, "argv.txt"), "issue\nlist\n");
+
+    const { executor } = buildExecutor([]);
+    const broker = await startGhBroker({
+      brokerDir,
+      executor,
+      pollIntervalMs: 10,
+    });
+    try {
+      expect(existsSync(join(broker.shimDir, "gh"))).toBe(true);
+      expect(existsSync(stale)).toBe(false);
+    } finally {
+      await broker.stop();
+    }
+  });
+
+  it("handles a request end-to-end, writing response.env", async () => {
+    const brokerDir = makeTempDir("e2e");
+    const { executor, calls } = buildExecutor([
+      { stdout: "hello", stderr: "", statusCode: 0 },
+    ]);
+    const broker = await startGhBroker({
+      brokerDir,
+      executor,
+      pollIntervalMs: 5,
+    });
+    try {
+      const reqDir = join(brokerDir, "requests", "req-1");
+      mkdirSync(reqDir, { recursive: true });
+      writeFileSync(join(reqDir, "cwd.txt"), "/tmp\n");
+      writeFileSync(join(reqDir, "argv.txt"), "api\n/notifications\n");
+      await waitFor(
+        () => existsSync(join(reqDir, "response.env")),
+        2_000,
+      );
+      const env = readFileSync(join(reqDir, "response.env"), "utf8");
+      expect(env).toContain("status_code=0");
+      expect(readFileSync(join(reqDir, "stdout.txt"), "utf8")).toBe("hello");
+      expect(calls).toHaveLength(1);
+      expect(calls[0].args).toEqual(["api", "/notifications"]);
+    } finally {
+      await broker.stop();
+    }
+  });
+
+  it("serves a cached response without re-invoking gh", async () => {
+    const brokerDir = makeTempDir("cached");
+    const { executor, calls } = buildExecutor([
+      { stdout: "first", stderr: "", statusCode: 0 },
+    ]);
+    const broker = await startGhBroker({
+      brokerDir,
+      executor,
+      pollIntervalMs: 5,
+    });
+    try {
+      // First request: hits gh, stores in cache.
+      const reqA = join(brokerDir, "requests", "req-A");
+      mkdirSync(reqA, { recursive: true });
+      writeFileSync(
+        join(reqA, "argv.txt"),
+        "issue\ncomment\n1\n--body\nhello\n",
+      );
+      writeFileSync(join(reqA, "cwd.txt"), "/tmp\n");
+      await waitFor(
+        () => existsSync(join(reqA, "response.env")),
+        2_000,
+      );
+      expect(readFileSync(join(reqA, "stdout.txt"), "utf8")).toBe("first");
+      expect(calls).toHaveLength(1);
+
+      // Second request with same body: served from cache. Executor was
+      // only primed with one response; a second spawnGh call would throw.
+      const reqB = join(brokerDir, "requests", "req-B");
+      mkdirSync(reqB, { recursive: true });
+      writeFileSync(
+        join(reqB, "argv.txt"),
+        "issue\ncomment\n1\n--body\nhello\n",
+      );
+      writeFileSync(join(reqB, "cwd.txt"), "/tmp\n");
+      await waitFor(
+        () => existsSync(join(reqB, "response.env")),
+        2_000,
+      );
+      expect(readFileSync(join(reqB, "stdout.txt"), "utf8")).toBe("first");
+      expect(calls).toHaveLength(1);
+    } finally {
+      await broker.stop();
+    }
+  });
+
+  it("writes failure response when executor throws", async () => {
+    const brokerDir = makeTempDir("fail");
+    const executor = new GhExecutor({
+      realGh: "/usr/bin/gh",
+      writeCooldownMs: 0,
+      spawnGh: async () => {
+        throw new Error("boom");
+      },
+      now: () => 0,
+      sleep: async () => {},
+    });
+    const broker = await startGhBroker({
+      brokerDir,
+      executor,
+      pollIntervalMs: 5,
+    });
+    try {
+      const reqDir = join(brokerDir, "requests", "req-fail");
+      mkdirSync(reqDir, { recursive: true });
+      writeFileSync(join(reqDir, "argv.txt"), "api\n/notifications\n");
+      writeFileSync(join(reqDir, "cwd.txt"), "/tmp\n");
+      await waitFor(
+        () => existsSync(join(reqDir, "response.env")),
+        2_000,
+      );
+      const env = readFileSync(join(reqDir, "response.env"), "utf8");
+      expect(env).toContain("status_code=1");
+      expect(readFileSync(join(reqDir, "stderr.txt"), "utf8")).toContain(
+        "boom",
+      );
+    } finally {
+      await broker.stop();
+    }
+  });
+});
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs: number,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  throw new Error(`condition not met within ${timeoutMs}ms`);
+}

--- a/tests/breeze-daemon-bus.test.ts
+++ b/tests/breeze-daemon-bus.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Phase 3c contract tests for the in-process event bus.
+ *
+ * The bus is the Node equivalent of `first-tree-breeze/breeze-runner/src/bus.rs`.
+ * It fans out broker/poller events to any number of read-only subscribers
+ * (HTTP SSE stream, in-process task monitors) without allowing them to
+ * mutate `inbox.json`. The single-writer rule (see `daemon/bus.ts` header)
+ * is covered by the fact that the module exports no store writers.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { createBus, toSseBus, type BusEvent } from "../src/products/breeze/daemon/bus.js";
+
+describe("createBus", () => {
+  it("delivers events to every live subscriber in subscription order", () => {
+    const bus = createBus();
+    const a: BusEvent[] = [];
+    const b: BusEvent[] = [];
+    bus.subscribe((ev) => a.push(ev));
+    bus.subscribe((ev) => b.push(ev));
+
+    bus.publish({ kind: "activity", line: "one" });
+    bus.publish({ kind: "activity", line: "two" });
+
+    expect(a).toEqual([
+      { kind: "activity", line: "one" },
+      { kind: "activity", line: "two" },
+    ]);
+    expect(b).toEqual([
+      { kind: "activity", line: "one" },
+      { kind: "activity", line: "two" },
+    ]);
+  });
+
+  it("returns a working unsubscribe that stops further delivery", () => {
+    const bus = createBus();
+    const a: BusEvent[] = [];
+    const unsub = bus.subscribe((ev) => a.push(ev));
+
+    bus.publish({ kind: "activity", line: "before" });
+    unsub();
+    bus.publish({ kind: "activity", line: "after" });
+
+    expect(a).toEqual([{ kind: "activity", line: "before" }]);
+    expect(bus.subscriberCount()).toBe(0);
+  });
+
+  it("snapshots subscribers before iteration so unsubscribe-during-publish still delivers", () => {
+    const bus = createBus();
+    const received: string[] = [];
+    let unsubB: (() => void) | null = null;
+    bus.subscribe((ev) => {
+      if (ev.kind === "activity") received.push(`a:${ev.line}`);
+      // Unsubscribe b mid-publish — Rust `retain`-style semantics keep b
+      // scheduled for this delivery because we snapshotted first.
+      if (unsubB) unsubB();
+    });
+    unsubB = bus.subscribe((ev) => {
+      if (ev.kind === "activity") received.push(`b:${ev.line}`);
+    });
+
+    bus.publish({ kind: "activity", line: "snap" });
+    expect(received).toEqual(["a:snap", "b:snap"]);
+
+    bus.publish({ kind: "activity", line: "gone" });
+    expect(received).toEqual(["a:snap", "b:snap", "a:gone"]);
+  });
+
+  it("isolates subscriber errors so fan-out continues (matches Rust retain-on-send)", () => {
+    const errs: unknown[] = [];
+    const bus = createBus({
+      onListenerError: (err) => errs.push(err),
+    });
+    const good: BusEvent[] = [];
+    bus.subscribe(() => {
+      throw new Error("boom");
+    });
+    bus.subscribe((ev) => good.push(ev));
+
+    bus.publish({ kind: "inbox", last_poll: "t", total: 0, new_count: 0 });
+
+    expect(good).toHaveLength(1);
+    expect(errs).toHaveLength(1);
+    expect((errs[0] as Error).message).toBe("boom");
+  });
+
+  it("drops publishes after close (backpressure: subscribers must consume or be gone)", () => {
+    const bus = createBus();
+    const received: BusEvent[] = [];
+    bus.subscribe((ev) => received.push(ev));
+
+    bus.publish({ kind: "activity", line: "live" });
+    bus.close();
+    bus.publish({ kind: "activity", line: "after-close" });
+
+    expect(received).toEqual([{ kind: "activity", line: "live" }]);
+    expect(bus.isClosed()).toBe(true);
+    expect(bus.subscriberCount()).toBe(0);
+  });
+
+  it("subscribe after close returns a no-op unsubscribe", () => {
+    const bus = createBus();
+    bus.close();
+    const fn = vi.fn();
+    const unsub = bus.subscribe(fn);
+    bus.publish({ kind: "activity", line: "none" });
+    unsub();
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("carries broker task events with full shape", () => {
+    const bus = createBus();
+    const received: BusEvent[] = [];
+    bus.subscribe((ev) => received.push(ev));
+
+    bus.publish({
+      kind: "task",
+      phase: "dispatched",
+      task_id: "task-1",
+      thread_key: "repo/123",
+    });
+    bus.publish({
+      kind: "task",
+      phase: "failed",
+      task_id: "task-1",
+      thread_key: "repo/123",
+      status: "failed",
+      summary: "boom",
+    });
+
+    expect(received).toHaveLength(2);
+    expect(received[0]).toMatchObject({ kind: "task", phase: "dispatched" });
+    expect(received[1]).toMatchObject({
+      kind: "task",
+      phase: "failed",
+      summary: "boom",
+    });
+  });
+});
+
+describe("toSseBus", () => {
+  it("forwards inbox events unchanged", () => {
+    const bus = createBus();
+    const sse = toSseBus(bus);
+    const seen: unknown[] = [];
+    sse.subscribe((ev) => seen.push(ev));
+
+    bus.publish({
+      kind: "inbox",
+      last_poll: "2024-01-01T00:00:00Z",
+      total: 3,
+      new_count: 1,
+    });
+
+    expect(seen).toEqual([
+      {
+        kind: "inbox",
+        last_poll: "2024-01-01T00:00:00Z",
+        total: 3,
+        new_count: 1,
+      },
+    ]);
+  });
+
+  it("forwards activity events unchanged", () => {
+    const bus = createBus();
+    const sse = toSseBus(bus);
+    const seen: unknown[] = [];
+    sse.subscribe((ev) => seen.push(ev));
+
+    bus.publish({ kind: "activity", line: '{"event":"new","id":"abc"}' });
+    expect(seen).toEqual([
+      { kind: "activity", line: '{"event":"new","id":"abc"}' },
+    ]);
+  });
+
+  it("renders task events as compact-JSON activity lines", () => {
+    const bus = createBus();
+    const sse = toSseBus(bus);
+    const seen: { kind: string; line?: string }[] = [];
+    sse.subscribe((ev) => seen.push(ev as { kind: string; line?: string }));
+
+    bus.publish({
+      kind: "task",
+      phase: "completed",
+      task_id: "task-42",
+      thread_key: "owner/repo/7",
+      status: "handled",
+      summary: "done",
+    });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].kind).toBe("activity");
+    const parsed = JSON.parse(seen[0].line!) as Record<string, unknown>;
+    expect(parsed).toEqual({
+      event: "task_completed",
+      task_id: "task-42",
+      thread_key: "owner/repo/7",
+      status: "handled",
+      summary: "done",
+    });
+  });
+
+  it("omits optional status/summary from task activity lines when absent", () => {
+    const bus = createBus();
+    const sse = toSseBus(bus);
+    const seen: { kind: string; line?: string }[] = [];
+    sse.subscribe((ev) => seen.push(ev as { kind: string; line?: string }));
+
+    bus.publish({
+      kind: "task",
+      phase: "dispatched",
+      task_id: "task-7",
+      thread_key: "owner/repo/5",
+    });
+
+    expect(seen).toHaveLength(1);
+    const parsed = JSON.parse(seen[0].line!) as Record<string, unknown>;
+    expect(parsed).toEqual({
+      event: "task_dispatched",
+      task_id: "task-7",
+      thread_key: "owner/repo/5",
+    });
+  });
+});

--- a/tests/breeze-daemon-claim.test.ts
+++ b/tests/breeze-daemon-claim.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Phase 3c contract tests for the service-lock + per-notification-claim
+ * helpers in `daemon/claim.ts`. Port of the Rust `lock.rs` + the broker's
+ * in-memory `queued_threads` HashSet.
+ *
+ * Coverage:
+ *   - `acquireServiceLock`: fresh acquire, double-acquire refusal, stale
+ *     reclaim via heartbeat age, release.
+ *   - `tryClaim` / `releaseClaim`: first writer wins, contention, stale
+ *     reassignment at the claim TTL.
+ *   - `cleanupExpiredClaims`: sweeps stale dirs.
+ *   - `peekClaim`: read-only inspection.
+ */
+
+import { mkdtempSync, existsSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  CLAIM_STALE_AFTER_SEC,
+  LOCK_STALE_AFTER_SEC,
+  acquireServiceLock,
+  cleanupExpiredClaims,
+  findServiceLock,
+  isLockStale,
+  peekClaim,
+  releaseClaim,
+  tryClaim,
+} from "../src/products/breeze/daemon/claim.js";
+import type { DaemonIdentity } from "../src/products/breeze/daemon/identity.js";
+
+function mkScratch(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), `breeze-claim-${prefix}-`));
+}
+
+const IDENTITY: DaemonIdentity = {
+  host: "github.com",
+  login: "tester",
+  gitProtocol: "https",
+  scopes: ["repo", "notifications"],
+};
+
+describe("acquireServiceLock", () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkScratch("svc");
+  });
+  afterEach(() => {
+    try {
+      rmSync(root, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  it("creates the lock dir and writes lock.env with the current identity", async () => {
+    const handle = await acquireServiceLock({
+      baseDir: root,
+      identity: IDENTITY,
+      profile: "default",
+      note: "hello",
+    });
+
+    const info = handle.info();
+    expect(info.pid).toBe(process.pid);
+    expect(info.host).toBe("github.com");
+    expect(info.login).toBe("tester");
+    expect(info.profile).toBe("default");
+    expect(info.note).toBe("hello");
+    expect(info.heartbeat_epoch).toBeGreaterThan(0);
+
+    // Confirm file-backed state round-trips via findServiceLock.
+    const found = findServiceLock(root, IDENTITY, "default");
+    expect(found?.pid).toBe(process.pid);
+
+    await handle.release();
+    expect(findServiceLock(root, IDENTITY, "default")).toBeNull();
+  });
+
+  it("refuses to acquire when a live lock is held by another pid", async () => {
+    const first = await acquireServiceLock({
+      baseDir: root,
+      identity: IDENTITY,
+      profile: "default",
+    });
+    // Simulate another live daemon by writing a different pid into lock.env.
+    // Heartbeat stays recent so staleness does not trigger reclaim.
+    const otherPid = 1; // init is always alive and not us
+    const contents = readFileSync(join(first.dir, "lock.env"), "utf-8");
+    writeFileSync(
+      join(first.dir, "lock.env"),
+      contents.replace(/^pid=\d+/m, `pid=${otherPid}`),
+      "utf-8",
+    );
+
+    await expect(
+      acquireServiceLock({
+        baseDir: root,
+        identity: IDENTITY,
+        profile: "default",
+      }),
+    ).rejects.toThrow(/already running/i);
+
+    await first.release();
+  });
+
+  it("reclaims a stale lock when heartbeat is past the window", async () => {
+    // Seed a stale lock file by hand.
+    const stale: string = join(
+      root,
+      "github.com__tester__default".replace(/[^A-Za-z0-9_.-]/g, "_"),
+    );
+    // mkdir + lock.env with ancient heartbeat.
+    const { mkdirSync } = await import("node:fs");
+    mkdirSync(stale, { recursive: true });
+    const ancient = Math.floor(Date.now() / 1000) - (LOCK_STALE_AFTER_SEC + 60);
+    writeFileSync(
+      join(stale, "lock.env"),
+      [
+        "pid=999999",
+        "host=github.com",
+        "login=tester",
+        "profile=default",
+        `heartbeat_epoch=${ancient}`,
+        `started_epoch=${ancient}`,
+        "active_tasks=0",
+        "note=stale",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const handle = await acquireServiceLock({
+      baseDir: root,
+      identity: IDENTITY,
+      profile: "default",
+    });
+    expect(handle.info().pid).toBe(process.pid);
+    await handle.release();
+  });
+
+  it("refresh updates heartbeat + note + active_tasks in place", async () => {
+    const handle = await acquireServiceLock({
+      baseDir: root,
+      identity: IDENTITY,
+      profile: "default",
+    });
+    const before = handle.info();
+    // Wait a tiny bit so heartbeat_epoch can move forward (seconds precision).
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    handle.refresh(3, "working");
+    const after = handle.info();
+    expect(after.active_tasks).toBe(3);
+    expect(after.note).toBe("working");
+    expect(after.heartbeat_epoch).toBeGreaterThanOrEqual(before.heartbeat_epoch);
+
+    await handle.release();
+  });
+
+  it("release is idempotent", async () => {
+    const handle = await acquireServiceLock({
+      baseDir: root,
+      identity: IDENTITY,
+      profile: "default",
+    });
+    await handle.release();
+    await handle.release();
+    expect(findServiceLock(root, IDENTITY, "default")).toBeNull();
+  });
+});
+
+describe("isLockStale", () => {
+  it("returns true when heartbeat is older than the window", () => {
+    const now = 1_700_000_000;
+    const info = {
+      pid: process.pid,
+      host: "github.com",
+      login: "tester",
+      profile: "default",
+      heartbeat_epoch: now - (LOCK_STALE_AFTER_SEC + 1),
+      started_epoch: now - (LOCK_STALE_AFTER_SEC + 1),
+      active_tasks: 0,
+      note: "",
+    };
+    expect(isLockStale(info, now)).toBe(true);
+  });
+
+  it("returns false when heartbeat is fresh and process is alive", () => {
+    const now = Math.floor(Date.now() / 1000);
+    const info = {
+      pid: process.pid,
+      host: require("node:os").hostname() as string,
+      login: "tester",
+      profile: "default",
+      heartbeat_epoch: now,
+      started_epoch: now,
+      active_tasks: 0,
+      note: "",
+    };
+    expect(isLockStale(info, now)).toBe(false);
+  });
+});
+
+describe("tryClaim / releaseClaim", () => {
+  let claimsDir: string;
+  beforeEach(() => {
+    claimsDir = mkScratch("claim");
+  });
+  afterEach(() => {
+    try {
+      rmSync(claimsDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  it("first caller wins and writes claim metadata", () => {
+    const result = tryClaim({
+      claimsDir,
+      id: "notif-1",
+      sessionId: "session-a",
+      action: "dispatch",
+    });
+    expect(result.claimed).toBe(true);
+    const peek = peekClaim(claimsDir, "notif-1");
+    expect(peek?.owner).toBe("session-a");
+  });
+
+  it("second concurrent caller is rejected with owner metadata", () => {
+    const first = tryClaim({
+      claimsDir,
+      id: "notif-2",
+      sessionId: "session-a",
+    });
+    expect(first.claimed).toBe(true);
+
+    const second = tryClaim({
+      claimsDir,
+      id: "notif-2",
+      sessionId: "session-b",
+    });
+    expect(second.claimed).toBe(false);
+    expect(second.owner).toBe("session-a");
+    expect(second.ageSec).toBeDefined();
+  });
+
+  it("reassigns the claim when older than CLAIM_STALE_AFTER_SEC", () => {
+    // Fix "now" to simulate a stale first claim.
+    const baseNow = new Date("2024-01-01T00:00:00Z");
+    const first = tryClaim({
+      claimsDir,
+      id: "notif-3",
+      sessionId: "session-a",
+      now: () => baseNow,
+    });
+    expect(first.claimed).toBe(true);
+
+    const later = new Date(baseNow.getTime() + (CLAIM_STALE_AFTER_SEC + 5) * 1000);
+    const second = tryClaim({
+      claimsDir,
+      id: "notif-3",
+      sessionId: "session-b",
+      now: () => later,
+    });
+    expect(second.claimed).toBe(true);
+    expect(second.ageSec).toBeGreaterThanOrEqual(CLAIM_STALE_AFTER_SEC);
+
+    const peek = peekClaim(claimsDir, "notif-3");
+    expect(peek?.owner).toBe("session-b");
+  });
+
+  it("releaseClaim removes the directory and is idempotent", () => {
+    tryClaim({ claimsDir, id: "notif-4", sessionId: "s" });
+    releaseClaim(claimsDir, "notif-4");
+    releaseClaim(claimsDir, "notif-4"); // second call: no throw
+    expect(existsSync(join(claimsDir, "notif-4"))).toBe(false);
+  });
+
+  it("cleanupExpiredClaims removes stale entries only", () => {
+    const base = Date.now();
+    // Fresh claim.
+    tryClaim({
+      claimsDir,
+      id: "fresh",
+      sessionId: "s",
+      now: () => new Date(base),
+    });
+    // Stale claim via direct timestamp injection.
+    tryClaim({
+      claimsDir,
+      id: "stale",
+      sessionId: "s",
+      now: () => new Date(base - (CLAIM_STALE_AFTER_SEC + 10) * 1000),
+    });
+
+    const removed = cleanupExpiredClaims(
+      claimsDir,
+      CLAIM_STALE_AFTER_SEC,
+      base,
+    );
+    expect(removed).toBe(1);
+    expect(existsSync(join(claimsDir, "fresh"))).toBe(true);
+    expect(existsSync(join(claimsDir, "stale"))).toBe(false);
+  });
+});

--- a/tests/breeze-daemon-dispatcher.test.ts
+++ b/tests/breeze-daemon-dispatcher.test.ts
@@ -1,0 +1,485 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createBus, type BusEvent } from "../src/products/breeze/daemon/bus.js";
+import {
+  Dispatcher,
+  type CompletionRecord,
+  type TaskCandidate,
+} from "../src/products/breeze/daemon/dispatcher.js";
+import {
+  WorkspaceManager,
+  type GitRunner,
+} from "../src/products/breeze/daemon/workspace.js";
+import type { RunnerSpawner } from "../src/products/breeze/daemon/runner.js";
+import { tryClaim } from "../src/products/breeze/daemon/claim.js";
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  while (tempRoots.length) {
+    const dir = tempRoots.pop();
+    if (dir && existsSync(dir)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), `breeze-dispatch-${prefix}-`));
+  tempRoots.push(dir);
+  return dir;
+}
+
+function fakeCandidate(overrides: Partial<TaskCandidate> = {}): TaskCandidate {
+  return {
+    threadKey: "owner/repo#42",
+    notificationId: "nid-42",
+    repo: "owner/repo",
+    kind: "issue",
+    stableId: "42",
+    title: "Fix thing",
+    taskUrl: "https://github.com/owner/repo/issues/42",
+    priority: 1,
+    updatedAt: "2026-04-16T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function fakeGitRunner(): GitRunner {
+  return async ({ args }) => {
+    if (args.includes("rev-parse") && args.includes("HEAD")) {
+      return { stdout: "deadbeef\n", stderr: "", statusCode: 0 };
+    }
+    return { stdout: "", stderr: "", statusCode: 0 };
+  };
+}
+
+function makeWorkspaceManager(root: string): WorkspaceManager {
+  const reposDir = join(root, "repos");
+  const workspacesDir = join(root, "workspaces");
+  mkdirSync(reposDir, { recursive: true });
+  mkdirSync(join(reposDir, "owner__repo.git"), { recursive: true });
+  return new WorkspaceManager({
+    reposDir,
+    workspacesDir,
+    identity: { host: "github.com", login: "alice" },
+    runGit: fakeGitRunner(),
+  });
+}
+
+interface DispatcherEnv {
+  dispatcher: Dispatcher;
+  runnerHome: string;
+  claimsDir: string;
+  events: BusEvent[];
+  completions: CompletionRecord[];
+}
+
+function setupDispatcher(opts: {
+  spawner?: RunnerSpawner;
+  runners?: Array<{ kind: "codex" | "claude" }>;
+  maxParallel?: number;
+  taskTimeoutMs?: number;
+  dryRun?: boolean;
+} = {}): DispatcherEnv {
+  const root = makeTempDir("env");
+  const runnerHome = join(root, "runner-home");
+  const claimsDir = join(root, "claims");
+  mkdirSync(runnerHome, { recursive: true });
+  mkdirSync(claimsDir, { recursive: true });
+
+  const bus = createBus();
+  const events: BusEvent[] = [];
+  bus.subscribe((ev) => events.push(ev));
+  const completions: CompletionRecord[] = [];
+
+  const dispatcher = new Dispatcher({
+    runnerHome,
+    identity: { host: "github.com", login: "alice" },
+    runners: opts.runners ?? [{ kind: "codex" }],
+    workspaceManager: makeWorkspaceManager(root),
+    bus,
+    ghShimDir: join(root, "shim", "bin"),
+    ghBrokerDir: join(root, "shim"),
+    claimsDir,
+    disclosureText: "Agent note.",
+    maxParallel: opts.maxParallel ?? 2,
+    taskTimeoutMs: opts.taskTimeoutMs ?? 2_000,
+    spawner: opts.spawner,
+    dryRun: opts.dryRun,
+    onCompletion: (rec) => completions.push(rec),
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+  });
+
+  return { dispatcher, runnerHome, claimsDir, events, completions };
+}
+
+function waitForCompletions(
+  env: DispatcherEnv,
+  count: number,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const start = Date.now();
+  return new Promise((resolve, reject) => {
+    const tick = (): void => {
+      if (env.completions.length >= count) return resolve();
+      if (Date.now() - start > timeoutMs) {
+        return reject(
+          new Error(
+            `only ${env.completions.length}/${count} completions after ${timeoutMs}ms`,
+          ),
+        );
+      }
+      setTimeout(tick, 10);
+    };
+    tick();
+  });
+}
+
+describe("Dispatcher.submit", () => {
+  it("dedupes repeated candidates with the same threadKey", () => {
+    const spawner: RunnerSpawner = async ({ outputPath }) => {
+      writeFileSync(
+        outputPath,
+        "BREEZE_RESULT: status=handled summary=ok",
+      );
+      return { statusCode: 0 };
+    };
+    const env = setupDispatcher({ spawner });
+    env.dispatcher.submit(fakeCandidate());
+    env.dispatcher.submit(fakeCandidate()); // same threadKey
+    // First one launched immediately, so pending may be 0; but a 2nd of
+    // same key must not enter.
+    expect(env.dispatcher.activeCount() + env.dispatcher.pendingCount()).toBe(1);
+  });
+
+  it("sorts pending queue by priority (desc) then by updatedAt (asc)", async () => {
+    // Serial spawner: resolves one task at a time, waits for the next
+    // spawn before releasing. This exercises pump() ordering as slots free.
+    let resolver: ((v: { statusCode: number }) => void) | undefined;
+    const spawnedThreadKeys: string[] = [];
+    const spawner: RunnerSpawner = async ({ outputPath, request }) => {
+      spawnedThreadKeys.push(request.task.title);
+      return new Promise((resolve) => {
+        resolver = (v) => {
+          writeFileSync(
+            outputPath,
+            "BREEZE_RESULT: status=handled summary=ok",
+          );
+          resolve(v);
+        };
+      });
+    };
+    const env = setupDispatcher({ spawner, maxParallel: 1 });
+    env.dispatcher.submit(
+      fakeCandidate({
+        threadKey: "t-A",
+        notificationId: "n-A",
+        stableId: "A",
+        title: "A",
+        priority: 1,
+      }),
+    );
+    env.dispatcher.submit(
+      fakeCandidate({
+        threadKey: "t-low",
+        notificationId: "n-low",
+        stableId: "low",
+        title: "low",
+        priority: 0,
+        updatedAt: "2026-04-01T00:00:00Z",
+      }),
+    );
+    env.dispatcher.submit(
+      fakeCandidate({
+        threadKey: "t-hi",
+        notificationId: "n-hi",
+        stableId: "hi",
+        title: "hi",
+        priority: 5,
+        updatedAt: "2026-04-10T00:00:00Z",
+      }),
+    );
+    env.dispatcher.submit(
+      fakeCandidate({
+        threadKey: "t-mid",
+        notificationId: "n-mid",
+        stableId: "mid",
+        title: "mid",
+        priority: 2,
+        updatedAt: "2026-04-05T00:00:00Z",
+      }),
+    );
+
+    // Drain 4 tasks serially, waiting for each spawn before releasing.
+    for (let i = 0; i < 4; i++) {
+      const deadline = Date.now() + 1_000;
+      while (!resolver && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 5));
+      }
+      const r = resolver;
+      resolver = undefined;
+      r?.({ statusCode: 0 });
+    }
+
+    await waitForCompletions(env, 4);
+    expect(spawnedThreadKeys).toEqual(["A", "hi", "mid", "low"]);
+  });
+});
+
+describe("Dispatcher claim handling", () => {
+  it("skips dispatch when the claim is already held by someone else", async () => {
+    const spawner = vi.fn<RunnerSpawner>();
+    const env = setupDispatcher({ spawner });
+    // Pre-claim the notification as a different owner.
+    tryClaim({
+      claimsDir: env.claimsDir,
+      id: "nid-42",
+      sessionId: "laptop:someone-else",
+    });
+    env.dispatcher.submit(fakeCandidate());
+    // skipped-claim is synchronous in launch(); no wait needed.
+    expect(env.completions).toHaveLength(1);
+    expect(env.completions[0].phase).toBe("skipped-claim");
+    expect(spawner).not.toHaveBeenCalled();
+    // And no task event was published (skipped-claim is filtered out).
+    const taskEvents = env.events.filter((e) => e.kind === "task");
+    expect(taskEvents).toHaveLength(0);
+  });
+
+  it("releases the claim after task completes", async () => {
+    const spawner: RunnerSpawner = async ({ outputPath }) => {
+      writeFileSync(outputPath, "BREEZE_RESULT: status=handled summary=ok");
+      return { statusCode: 0 };
+    };
+    const env = setupDispatcher({ spawner });
+    env.dispatcher.submit(fakeCandidate());
+    await waitForCompletions(env, 1);
+    // Claim dir for this notification should be gone.
+    expect(existsSync(join(env.claimsDir, "nid-42"))).toBe(false);
+  });
+});
+
+describe("Dispatcher execution", () => {
+  it("respects maxParallel (holds extras in pending)", async () => {
+    const resolvers: Array<(v: { statusCode: number }) => void> = [];
+    const spawner: RunnerSpawner = async ({ outputPath }) =>
+      new Promise((resolve) => {
+        resolvers.push((v) => {
+          writeFileSync(
+            outputPath,
+            "BREEZE_RESULT: status=handled summary=ok",
+          );
+          resolve(v);
+        });
+      });
+    const env = setupDispatcher({ spawner, maxParallel: 2 });
+    env.dispatcher.submit(
+      fakeCandidate({ threadKey: "a", notificationId: "na", stableId: "a" }),
+    );
+    env.dispatcher.submit(
+      fakeCandidate({ threadKey: "b", notificationId: "nb", stableId: "b" }),
+    );
+    env.dispatcher.submit(
+      fakeCandidate({ threadKey: "c", notificationId: "nc", stableId: "c" }),
+    );
+    expect(env.dispatcher.activeCount()).toBe(2);
+    expect(env.dispatcher.pendingCount()).toBe(1);
+    // Drain resolvers as they appear until all three complete.
+    const deadline = Date.now() + 4_000;
+    while (env.completions.length < 3 && Date.now() < deadline) {
+      const r = resolvers.shift();
+      if (r) r({ statusCode: 0 });
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(env.completions.length).toBe(3);
+  });
+
+  it("marks completed and publishes task event", async () => {
+    const spawner: RunnerSpawner = async ({ outputPath }) => {
+      writeFileSync(
+        outputPath,
+        "BREEZE_RESULT: status=handled summary=all done",
+      );
+      return { statusCode: 0 };
+    };
+    const env = setupDispatcher({ spawner });
+    env.dispatcher.submit(fakeCandidate());
+    await waitForCompletions(env, 1);
+    const record = env.completions[0];
+    expect(record.phase).toBe("completed");
+    expect(record.status).toBe("handled");
+    expect(record.summary).toBe("all done");
+    expect(record.runnerName).toBe("codex");
+
+    const phases = env.events
+      .filter((e) => e.kind === "task")
+      .map((e) => (e as Extract<BusEvent, { kind: "task" }>).phase);
+    expect(phases).toEqual(["dispatched", "completed"]);
+  });
+
+  it("falls through to the next runner on non-timeout failure", async () => {
+    const calls: string[] = [];
+    const spawner: RunnerSpawner = async ({ spec, outputPath, stdoutPath }) => {
+      calls.push(spec.kind);
+      if (spec.kind === "codex") {
+        return { statusCode: 1 };
+      }
+      writeFileSync(
+        stdoutPath,
+        "BREEZE_RESULT: status=handled summary=secondary",
+      );
+      writeFileSync(outputPath, "");
+      return { statusCode: 0 };
+    };
+    const env = setupDispatcher({
+      spawner,
+      runners: [{ kind: "codex" }, { kind: "claude" }],
+    });
+    env.dispatcher.submit(fakeCandidate());
+    await waitForCompletions(env, 1);
+    expect(calls).toEqual(["codex", "claude"]);
+    expect(env.completions[0].phase).toBe("completed");
+    expect(env.completions[0].runnerName).toBe("claude");
+  });
+
+  it("publishes failed when every runner errors", async () => {
+    const spawner: RunnerSpawner = async () => ({ statusCode: 7 });
+    const env = setupDispatcher({
+      spawner,
+      runners: [{ kind: "codex" }, { kind: "claude" }],
+    });
+    env.dispatcher.submit(fakeCandidate());
+    await waitForCompletions(env, 1);
+    expect(env.completions[0].phase).toBe("failed");
+    expect(env.completions[0].error).toMatch(/codex:/);
+    expect(env.completions[0].error).toMatch(/claude:/);
+    const taskEvents = env.events.filter((e) => e.kind === "task");
+    expect(
+      taskEvents.map(
+        (e) => (e as Extract<BusEvent, { kind: "task" }>).phase,
+      ),
+    ).toEqual(["dispatched", "failed"]);
+  });
+
+  it("publishes timed_out and stops trying further runners when timeout fires", async () => {
+    const spawner: RunnerSpawner = () =>
+      new Promise(() => {
+        /* never resolves */
+      });
+    const env = setupDispatcher({
+      spawner,
+      runners: [{ kind: "codex" }, { kind: "claude" }],
+      taskTimeoutMs: 40,
+    });
+    env.dispatcher.submit(fakeCandidate());
+    await waitForCompletions(env, 1, 1_000);
+    expect(env.completions[0].phase).toBe("timed_out");
+    const taskEvents = env.events.filter((e) => e.kind === "task");
+    expect(
+      taskEvents.map(
+        (e) => (e as Extract<BusEvent, { kind: "task" }>).phase,
+      ),
+    ).toEqual(["dispatched", "timed_out"]);
+  });
+
+  it("dryRun short-circuits agent execution", async () => {
+    const spawner = vi.fn<RunnerSpawner>();
+    const env = setupDispatcher({ spawner, dryRun: true });
+    env.dispatcher.submit(fakeCandidate());
+    await waitForCompletions(env, 1);
+    expect(spawner).not.toHaveBeenCalled();
+    expect(env.completions[0].phase).toBe("completed");
+    expect(env.completions[0].status).toBe("simulated");
+  });
+});
+
+describe("Dispatcher.stop", () => {
+  it("aborts in-flight tasks and drains pending", async () => {
+    const spawner: RunnerSpawner = () =>
+      new Promise(() => {
+        /* never resolves */
+      });
+    const env = setupDispatcher({
+      spawner,
+      maxParallel: 1,
+      taskTimeoutMs: 10_000,
+    });
+    env.dispatcher.submit(
+      fakeCandidate({ threadKey: "a", notificationId: "na", stableId: "a" }),
+    );
+    env.dispatcher.submit(
+      fakeCandidate({ threadKey: "b", notificationId: "nb", stableId: "b" }),
+    );
+    expect(env.dispatcher.activeCount()).toBe(1);
+    expect(env.dispatcher.pendingCount()).toBe(1);
+    await env.dispatcher.stop();
+    expect(env.dispatcher.activeCount()).toBe(0);
+    expect(env.dispatcher.pendingCount()).toBe(0);
+    // Submissions after stop are ignored.
+    env.dispatcher.submit(
+      fakeCandidate({ threadKey: "c", notificationId: "nc", stableId: "c" }),
+    );
+    expect(env.dispatcher.activeCount()).toBe(0);
+    expect(env.dispatcher.pendingCount()).toBe(0);
+  });
+});
+
+describe("Dispatcher workspace failure", () => {
+  it("publishes failed phase when workspace preparation throws", async () => {
+    const badRunner: GitRunner = async ({ args }) => {
+      if (args.includes("rev-parse")) {
+        return { stdout: "", stderr: "boom", statusCode: 128 };
+      }
+      return { stdout: "", stderr: "", statusCode: 0 };
+    };
+    const root = makeTempDir("wsfail");
+    const reposDir = join(root, "repos");
+    mkdirSync(join(reposDir, "owner__repo.git"), { recursive: true });
+    const runnerHome = join(root, "runner-home");
+    const claimsDir = join(root, "claims");
+    mkdirSync(runnerHome, { recursive: true });
+    mkdirSync(claimsDir, { recursive: true });
+    const bus = createBus();
+    const events: BusEvent[] = [];
+    bus.subscribe((e) => events.push(e));
+    const completions: CompletionRecord[] = [];
+    const dispatcher = new Dispatcher({
+      runnerHome,
+      identity: { host: "github.com", login: "alice" },
+      runners: [{ kind: "codex" }],
+      workspaceManager: new WorkspaceManager({
+        reposDir,
+        workspacesDir: join(root, "workspaces"),
+        identity: { host: "github.com", login: "alice" },
+        runGit: badRunner,
+      }),
+      bus,
+      ghShimDir: join(root, "shim", "bin"),
+      ghBrokerDir: join(root, "shim"),
+      claimsDir,
+      disclosureText: "n",
+      maxParallel: 1,
+      taskTimeoutMs: 1_000,
+      spawner: vi.fn<RunnerSpawner>(),
+      onCompletion: (rec) => completions.push(rec),
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    });
+    dispatcher.submit(fakeCandidate());
+    const start = Date.now();
+    while (completions.length < 1 && Date.now() - start < 2_000) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(completions[0].phase).toBe("failed");
+    expect(completions[0].error).toMatch(/workspace prepare failed/);
+  });
+});

--- a/tests/breeze-daemon-gh-executor.test.ts
+++ b/tests/breeze-daemon-gh-executor.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  GhExecutor,
+  bucketForArgs,
+  commandIsMutating,
+  isRateLimited,
+  type ExecOutput,
+  type GhCommandSpec,
+} from "../src/products/breeze/daemon/gh-executor.js";
+
+describe("bucketForArgs", () => {
+  it("classifies search commands", () => {
+    expect(bucketForArgs(["search", "prs", "--review-requested=@me"])).toBe(
+      "search",
+    );
+  });
+
+  it("classifies api search/* paths as search", () => {
+    expect(bucketForArgs(["api", "search/issues?q=foo"])).toBe("search");
+    expect(bucketForArgs(["api", "/repos/x/y/search/issues"])).toBe("search");
+  });
+
+  it("classifies mutating commands as write", () => {
+    expect(
+      bucketForArgs(["issue", "comment", "1", "--body", "hi"]),
+    ).toBe("write");
+  });
+
+  it("classifies read commands as core", () => {
+    expect(bucketForArgs(["api", "/notifications"])).toBe("core");
+    expect(bucketForArgs(["pr", "view", "1"])).toBe("core");
+  });
+});
+
+describe("commandIsMutating", () => {
+  it("flags issue/pr/label mutating subcommands", () => {
+    expect(commandIsMutating(["issue", "comment", "1", "-b", "x"])).toBe(true);
+    expect(commandIsMutating(["pr", "merge", "1"])).toBe(true);
+    expect(commandIsMutating(["label", "create", "breeze:wip"])).toBe(true);
+  });
+
+  it("does not flag read subcommands", () => {
+    expect(commandIsMutating(["issue", "view", "1"])).toBe(false);
+    expect(commandIsMutating(["pr", "list"])).toBe(false);
+  });
+
+  it("treats api --method GET as read", () => {
+    expect(
+      commandIsMutating(["api", "/repos/x/y/issues", "-X", "GET"]),
+    ).toBe(false);
+  });
+
+  it("treats api --method POST as write", () => {
+    expect(
+      commandIsMutating(["api", "/repos/x/y/issues", "--method", "POST"]),
+    ).toBe(true);
+  });
+
+  it("treats api with -f/-F/--field as write", () => {
+    expect(
+      commandIsMutating([
+        "api",
+        "/repos/x/y/issues",
+        "-f",
+        "title=foo",
+      ]),
+    ).toBe(true);
+    expect(
+      commandIsMutating([
+        "api",
+        "/repos/x/y/issues",
+        "--field",
+        "title=foo",
+      ]),
+    ).toBe(true);
+    expect(
+      commandIsMutating(["api", "/repos/x/y/issues", "--input", "-"]),
+    ).toBe(true);
+  });
+});
+
+describe("isRateLimited", () => {
+  const mk = (stdout: string, stderr: string): ExecOutput => ({
+    stdout,
+    stderr,
+    statusCode: 1,
+  });
+
+  it("detects common rate-limit messages", () => {
+    expect(
+      isRateLimited(mk("", "API rate limit exceeded for this resource")),
+    ).toBe(true);
+    expect(isRateLimited(mk("secondary rate limit hit", ""))).toBe(true);
+    expect(isRateLimited(mk("", "abuse detection mechanism triggered"))).toBe(
+      true,
+    );
+    expect(isRateLimited(mk("", "retry after 30 seconds"))).toBe(true);
+  });
+
+  it("ignores unrelated errors", () => {
+    expect(isRateLimited(mk("", "could not resolve host"))).toBe(false);
+  });
+});
+
+describe("GhExecutor", () => {
+  /** Build an executor with a deterministic clock + injected spawn. */
+  function buildExecutor(opts: {
+    responses: ExecOutput[];
+    writeCooldownMs?: number;
+  }): {
+    executor: GhExecutor;
+    clock: { now: number };
+    sleeps: number[];
+    calls: GhCommandSpec[];
+  } {
+    const clock = { now: 1_000_000 };
+    const sleeps: number[] = [];
+    const calls: GhCommandSpec[] = [];
+    const responses = [...opts.responses];
+    const spawnGh = async (spec: GhCommandSpec): Promise<ExecOutput> => {
+      calls.push(spec);
+      const next = responses.shift();
+      if (!next) throw new Error("no scripted response left");
+      return next;
+    };
+    const sleep = async (ms: number): Promise<void> => {
+      sleeps.push(ms);
+      clock.now += ms;
+    };
+    const executor = new GhExecutor({
+      realGh: "/usr/bin/gh",
+      writeCooldownMs: opts.writeCooldownMs ?? 1_250,
+      spawnGh,
+      now: () => clock.now,
+      sleep,
+    });
+    return { executor, clock, sleeps, calls };
+  }
+
+  it("runs once on success and records write cooldown timestamp", async () => {
+    const { executor, clock, calls, sleeps } = buildExecutor({
+      responses: [{ stdout: "ok", stderr: "", statusCode: 0 }],
+    });
+    const output = await executor.run({
+      context: "test",
+      args: ["issue", "comment", "1", "-b", "hi"],
+    });
+    expect(output.statusCode).toBe(0);
+    expect(calls).toHaveLength(1);
+    expect(executor.getState().lastWriteEpochMs).toBe(clock.now);
+    expect(sleeps).toHaveLength(0);
+  });
+
+  it("retries on rate-limit and backs off with increasing streak", async () => {
+    const { executor, calls, sleeps } = buildExecutor({
+      responses: [
+        { stdout: "", stderr: "API rate limit exceeded", statusCode: 1 },
+        { stdout: "", stderr: "secondary rate limit", statusCode: 1 },
+        { stdout: "ok", stderr: "", statusCode: 0 },
+      ],
+    });
+    const output = await executor.run({
+      context: "test",
+      args: ["api", "/notifications"],
+    });
+    expect(output.statusCode).toBe(0);
+    expect(calls).toHaveLength(3);
+    // Streak should be zero on final success (registerCompletion clears it).
+    expect(executor.getState().rateLimitStreak).toBe(0);
+    // Backoff slept on attempts 1 and 2.
+    expect(sleeps.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("gives up after 3 rate-limited attempts", async () => {
+    const { executor, calls } = buildExecutor({
+      responses: [
+        { stdout: "", stderr: "API rate limit exceeded", statusCode: 1 },
+        { stdout: "", stderr: "API rate limit exceeded", statusCode: 1 },
+        { stdout: "", stderr: "API rate limit exceeded", statusCode: 1 },
+      ],
+    });
+    const output = await executor.run({
+      context: "test",
+      args: ["api", "/notifications"],
+    });
+    expect(output.statusCode).toBe(1);
+    expect(calls).toHaveLength(3);
+    expect(executor.getState().rateLimitStreak).toBeGreaterThanOrEqual(3);
+  });
+
+  it("waits writeCooldownMs between consecutive mutations", async () => {
+    const { executor, sleeps } = buildExecutor({
+      responses: [
+        { stdout: "ok", stderr: "", statusCode: 0 },
+        { stdout: "ok", stderr: "", statusCode: 0 },
+      ],
+      writeCooldownMs: 1_250,
+    });
+    await executor.run({
+      context: "first",
+      args: ["issue", "comment", "1", "-b", "a"],
+    });
+    await executor.run({
+      context: "second",
+      args: ["issue", "comment", "2", "-b", "b"],
+    });
+    // Second call should have slept at least once for the cooldown.
+    expect(sleeps.reduce((a, b) => a + b, 0)).toBeGreaterThanOrEqual(1_250);
+  });
+
+  it("runChecked throws on non-zero exit", async () => {
+    const { executor } = buildExecutor({
+      responses: [{ stdout: "", stderr: "nope", statusCode: 1 }],
+    });
+    await expect(
+      executor.runChecked({ context: "test", args: ["api", "/x"] }),
+    ).rejects.toThrow(/failed with exit code 1/);
+  });
+
+  it("respects abort signal and returns synthetic 124", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const executor = new GhExecutor({
+      realGh: "/usr/bin/gh",
+      writeCooldownMs: 0,
+      spawnGh: async () => {
+        throw new Error("should not spawn after abort");
+      },
+      now: () => 0,
+      sleep: async () => {},
+      signal: controller.signal,
+    });
+    const output = await executor.run({
+      context: "test",
+      args: ["api", "/notifications"],
+    });
+    expect(output.statusCode).toBe(124);
+  });
+});

--- a/tests/breeze-daemon-runner-agent.test.ts
+++ b/tests/breeze-daemon-runner-agent.test.ts
@@ -1,0 +1,291 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  RunnerPool,
+  buildAgentEnv,
+  buildCommand,
+  buildPrompt,
+  executeRunner,
+  parseResult,
+  runWithTimeout,
+  type RunnerRequest,
+  type RunnerSpawner,
+} from "../src/products/breeze/daemon/runner.js";
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  while (tempRoots.length) {
+    const dir = tempRoots.pop();
+    if (dir && existsSync(dir)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), `breeze-runner-${prefix}-`));
+  tempRoots.push(dir);
+  return dir;
+}
+
+function fakeRequest(overrides: Partial<RunnerRequest> = {}): RunnerRequest {
+  const base: RunnerRequest = {
+    task: {
+      repo: "owner/repo",
+      workspaceRepo: "owner/repo",
+      kind: "issue",
+      title: "Example",
+      taskUrl: "https://github.com/owner/repo/issues/1",
+    },
+    taskId: "task-1",
+    taskDir: makeTempDir("task"),
+    workspaceDir: "/tmp/workspace",
+    snapshotDir: "/tmp/snapshot",
+    ghShimDir: "/tmp/shim/bin",
+    ghBrokerDir: "/tmp/shim",
+    identity: { login: "alice", host: "github.com" },
+    disclosureText: "Agent note: this is breeze.",
+  };
+  return { ...base, ...overrides };
+}
+
+describe("parseResult", () => {
+  it("parses status and summary from last BREEZE_RESULT line", () => {
+    const { status, summary } = parseResult(
+      "working...\nBREEZE_RESULT: status=handled summary=reviewed and replied",
+    );
+    expect(status).toBe("handled");
+    expect(summary).toBe("reviewed and replied");
+  });
+
+  it("prefers the last BREEZE_RESULT when multiple appear", () => {
+    const { status } = parseResult(
+      "BREEZE_RESULT: status=failed summary=nope\nBREEZE_RESULT: status=handled summary=ok",
+    );
+    expect(status).toBe("handled");
+  });
+
+  it("falls back to handled + last line when missing", () => {
+    const { status, summary } = parseResult("done working\nall good");
+    expect(status).toBe("handled");
+    expect(summary).toBe("all good");
+  });
+
+  it("handles skipped status", () => {
+    const { status } = parseResult(
+      "BREEZE_RESULT: status=skipped summary=already handled",
+    );
+    expect(status).toBe("skipped");
+  });
+});
+
+describe("buildPrompt", () => {
+  it("includes identity, task URL, local context, disclosure", () => {
+    const prompt = buildPrompt(fakeRequest());
+    expect(prompt).toContain("representing alice");
+    expect(prompt).toContain("https://github.com/owner/repo/issues/1");
+    expect(prompt).toContain("- Task ID: task-1");
+    expect(prompt).toContain("Agent note: this is breeze.");
+    expect(prompt).toContain("BREEZE_RESULT: status=");
+  });
+
+  it("adds Working repository line only when it differs from repo", () => {
+    const same = buildPrompt(fakeRequest());
+    expect(same).not.toContain("Working repository:");
+
+    const differ = buildPrompt(
+      fakeRequest({
+        task: {
+          repo: "owner/original",
+          workspaceRepo: "alice/self",
+          kind: "issue",
+          title: "x",
+          taskUrl: "u",
+        },
+      }),
+    );
+    expect(differ).toContain("Working repository: alice/self");
+  });
+});
+
+describe("buildCommand", () => {
+  it("builds codex argv with --cd and --output-last-message", () => {
+    const request = fakeRequest();
+    const { cmd, args, cwd } = buildCommand({
+      spec: { kind: "codex", model: "gpt-5" },
+      request,
+      promptPath: "/tmp/prompt.txt",
+      promptText: "ignored for codex",
+      outputPath: "/tmp/out.txt",
+    });
+    expect(cmd).toBe("codex");
+    expect(args).toContain("--cd");
+    expect(args).toContain(request.workspaceDir);
+    expect(args).toContain("--output-last-message");
+    expect(args).toContain("/tmp/out.txt");
+    expect(args).toContain("--model");
+    expect(args).toContain("gpt-5");
+    expect(args[args.length - 1]).toBe("/tmp/prompt.txt");
+    expect(cwd).toBeUndefined();
+  });
+
+  it("builds claude argv with workspace cwd and prompt text", () => {
+    const request = fakeRequest();
+    const { cmd, args, cwd } = buildCommand({
+      spec: { kind: "claude" },
+      request,
+      promptPath: "/tmp/prompt.txt",
+      promptText: "hello world",
+      outputPath: "/tmp/out.txt",
+    });
+    expect(cmd).toBe("claude");
+    expect(args).toContain("-p");
+    expect(args).toContain("--permission-mode");
+    expect(args).toContain("bypassPermissions");
+    expect(args[args.length - 1]).toBe("hello world");
+    expect(cwd).toBe(request.workspaceDir);
+  });
+});
+
+describe("buildAgentEnv", () => {
+  it("prefixes shim dir to PATH and exports BREEZE_* env vars", () => {
+    const env = buildAgentEnv(
+      fakeRequest({
+        ghShimDir: "/opt/shim/bin",
+        ghBrokerDir: "/opt/shim",
+        snapshotDir: "/snap",
+        taskDir: "/task",
+      }),
+    );
+    expect(env.PATH).toMatch(/^\/opt\/shim\/bin:/);
+    expect(env.BREEZE_BROKER_DIR).toBe("/opt/shim");
+    expect(env.BREEZE_SNAPSHOT_DIR).toBe("/snap");
+    expect(env.BREEZE_TASK_DIR).toBe("/task");
+  });
+});
+
+describe("RunnerPool", () => {
+  it("rotates execution order across calls", () => {
+    const pool = new RunnerPool([
+      { kind: "codex" },
+      { kind: "claude" },
+    ]);
+    const first = pool.executionOrder().map((r) => r.kind);
+    const second = pool.executionOrder().map((r) => r.kind);
+    expect(first).toEqual(["codex", "claude"]);
+    expect(second).toEqual(["claude", "codex"]);
+  });
+
+  it("throws when no runners are configured", () => {
+    expect(() => new RunnerPool([])).toThrow(/no configured runner/);
+  });
+
+  it("exposes available names", () => {
+    const pool = new RunnerPool([{ kind: "claude" }]);
+    expect(pool.availableNames()).toEqual(["claude"]);
+  });
+});
+
+describe("executeRunner", () => {
+  it("writes prompt, invokes spawner, parses result", async () => {
+    const request = fakeRequest();
+    const spawner: RunnerSpawner = async ({ outputPath }) => {
+      writeFileSync(
+        outputPath,
+        "doing things\nBREEZE_RESULT: status=handled summary=all good",
+      );
+      return { statusCode: 0 };
+    };
+    const outcome = await executeRunner(
+      { kind: "codex" },
+      request,
+      { timeoutMs: 1_000, spawner },
+    );
+    expect(outcome.status).toBe("handled");
+    expect(outcome.summary).toBe("all good");
+    expect(existsSync(join(request.taskDir, "prompt.txt"))).toBe(true);
+  });
+
+  it("copies claude stdout into runner-output.txt", async () => {
+    const request = fakeRequest();
+    const spawner: RunnerSpawner = async ({ stdoutPath }) => {
+      writeFileSync(
+        stdoutPath,
+        "chatter\nBREEZE_RESULT: status=handled summary=ok",
+      );
+      return { statusCode: 0 };
+    };
+    const outcome = await executeRunner(
+      { kind: "claude" },
+      request,
+      { timeoutMs: 1_000, spawner },
+    );
+    expect(outcome.status).toBe("handled");
+    expect(
+      readFileSync(join(request.taskDir, "runner-output.txt"), "utf8"),
+    ).toContain("BREEZE_RESULT:");
+  });
+
+  it("throws on non-zero exit code", async () => {
+    const spawner: RunnerSpawner = async () => ({ statusCode: 42 });
+    await expect(
+      executeRunner({ kind: "codex" }, fakeRequest(), {
+        timeoutMs: 1_000,
+        spawner,
+      }),
+    ).rejects.toThrow(/exited with status 42/);
+  });
+});
+
+describe("runWithTimeout", () => {
+  it("resolves when the underlying promise finishes in time", async () => {
+    const value = await runWithTimeout({
+      run: async () => "done",
+      kill: () => {},
+      timeoutMs: 100,
+    });
+    expect(value).toBe("done");
+  });
+
+  it("rejects and calls kill when timeout elapses", async () => {
+    let killed = false;
+    await expect(
+      runWithTimeout({
+        run: () => new Promise(() => {}),
+        kill: () => {
+          killed = true;
+        },
+        timeoutMs: 20,
+      }),
+    ).rejects.toThrow(/timed out/);
+    expect(killed).toBe(true);
+  });
+
+  it("respects an already-aborted signal", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    let killed = false;
+    await expect(
+      runWithTimeout({
+        run: () => new Promise(() => {}),
+        kill: () => {
+          killed = true;
+        },
+        timeoutMs: 1_000,
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow(/aborted/);
+    expect(killed).toBe(true);
+  });
+});

--- a/tests/breeze-daemon-workspace.test.ts
+++ b/tests/breeze-daemon-workspace.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  WorkspaceManager,
+  sanitizeFilename,
+  type GitRunner,
+} from "../src/products/breeze/daemon/workspace.js";
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  while (tempRoots.length) {
+    const dir = tempRoots.pop();
+    if (dir && existsSync(dir)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), `breeze-ws-${prefix}-`));
+  tempRoots.push(dir);
+  return dir;
+}
+
+describe("sanitizeFilename", () => {
+  it("replaces unsafe chars with underscore", () => {
+    expect(sanitizeFilename("owner/repo")).toBe("owner_repo");
+    expect(sanitizeFilename("weird name!")).toBe("weird_name_");
+    expect(sanitizeFilename("")).toBe("_");
+  });
+});
+
+describe("WorkspaceManager.prepare", () => {
+  function makeFakeRunner(): {
+    runner: GitRunner;
+    calls: string[][];
+    rev: string;
+  } {
+    const calls: string[][] = [];
+    const runner: GitRunner = async ({ args }) => {
+      calls.push(args);
+      // Handle `rev-parse HEAD`: return a fake SHA.
+      if (args.includes("rev-parse") && args.includes("HEAD")) {
+        return { stdout: "deadbeefcafe\n", stderr: "", statusCode: 0 };
+      }
+      return { stdout: "", stderr: "", statusCode: 0 };
+    };
+    return { runner, calls, rev: "deadbeefcafe" };
+  }
+
+  it("creates a worktree for a non-PR task via HEAD", async () => {
+    const root = makeTempDir("nopr");
+    const reposDir = join(root, "repos");
+    const workspacesDir = join(root, "workspaces");
+    const { runner, calls, rev } = makeFakeRunner();
+
+    // Pre-create mirror dir so `ensureMirror` skips clone.
+    const mirrorDir = join(reposDir, "owner__repo.git");
+    mkdirSync(mirrorDir, { recursive: true });
+
+    const mgr = new WorkspaceManager({
+      reposDir,
+      workspacesDir,
+      identity: { host: "github.com", login: "bob" },
+      runGit: runner,
+    });
+
+    const lease = await mgr.prepare({
+      repo: "owner/repo",
+      kind: "issue",
+      stableId: "42",
+    });
+
+    expect(lease.mirrorDir).toBe(mirrorDir);
+    expect(lease.workspaceDir).toBe(
+      join(workspacesDir, "owner__repo", "issue-42"),
+    );
+    expect(lease.repoUrl).toBe("https://github.com/owner/repo.git");
+
+    // Worktree add should have been invoked with the resolved SHA.
+    const addCall = calls.find((c) => c.includes("worktree") && c.includes("add"));
+    expect(addCall).toBeDefined();
+    expect(addCall).toContain(rev);
+
+    // Git identity seeded.
+    expect(
+      calls.some(
+        (c) =>
+          c.includes("config") &&
+          c.includes("user.name") &&
+          c.some((a) => a.includes("bob via breeze-runner")),
+      ),
+    ).toBe(true);
+    expect(
+      calls.some(
+        (c) =>
+          c.includes("user.email") &&
+          c.some((a) => a.includes("bob@users.noreply.github.com")),
+      ),
+    ).toBe(true);
+  });
+
+  it("fetches PR head when prNumber is set", async () => {
+    const root = makeTempDir("pr");
+    const reposDir = join(root, "repos");
+    const workspacesDir = join(root, "workspaces");
+    const { runner, calls } = makeFakeRunner();
+    mkdirSync(join(reposDir, "o__r.git"), { recursive: true });
+
+    const mgr = new WorkspaceManager({
+      reposDir,
+      workspacesDir,
+      identity: { host: "github.com", login: "alice" },
+      runGit: runner,
+    });
+
+    const lease = await mgr.prepare({
+      repo: "o/r",
+      kind: "pr",
+      stableId: "pr-267",
+      prNumber: 267,
+    });
+
+    expect(lease.workspaceDir).toContain("pr-pr-267");
+
+    // Should fetch refs/pull/267/head:...breeze-runner-pr-267.
+    const fetchCall = calls.find(
+      (c) => c.includes("fetch") && c.some((a) => a.includes("refs/pull/267/head")),
+    );
+    expect(fetchCall).toBeDefined();
+    const addCall = calls.find((c) => c.includes("worktree") && c.includes("add"));
+    expect(addCall).toContain(
+      "refs/remotes/origin/breeze-runner-pr-267",
+    );
+  });
+
+  it("throws when a checked git command fails", async () => {
+    const root = makeTempDir("fail");
+    const reposDir = join(root, "repos");
+    mkdirSync(join(reposDir, "o__r.git"), { recursive: true });
+    const runner: GitRunner = async ({ args }) => {
+      if (args.includes("rev-parse")) {
+        return { stdout: "", stderr: "bad head", statusCode: 128 };
+      }
+      return { stdout: "", stderr: "", statusCode: 0 };
+    };
+    const mgr = new WorkspaceManager({
+      reposDir,
+      workspacesDir: join(root, "workspaces"),
+      identity: { host: "github.com", login: "alice" },
+      runGit: runner,
+    });
+    await expect(
+      mgr.prepare({ repo: "o/r", kind: "issue", stableId: "1" }),
+    ).rejects.toThrow(/resolve mirror HEAD/);
+  });
+});


### PR DESCRIPTION
## Summary

Port the Phase 3c broker + dispatcher surface of `first-tree-breeze` to the TypeScript daemon. Finishes the migration of `breeze-runner/src/{bus,lock,broker,gh_executor,workspace,runner}.rs` plus the dispatch loop from `service.rs`.

### Checkpoints

1. **In-process bus** (`daemon/bus.ts`) — already landed
2. **Service lock + per-notification claims** (`daemon/claim.ts`) — already landed
3. **gh broker + rate-limited executor** — this PR
   - `daemon/gh-executor.ts`: core/search/write rate buckets, exponential backoff on secondary-rate-limit detection, write cooldown, mutation classification.
   - `daemon/broker.ts`: POSIX shim binary + request/response directory protocol + 15-min mutation-response cache (byte-for-byte parity with Rust).
4. **Dispatcher + workspace + agent runner** — this PR
   - `daemon/workspace.ts`: bare-mirror + detached-HEAD worktree per task. PR tasks fetch `refs/pull/<n>/head`. Auth via `credential.helper=!gh auth git-credential`.
   - `daemon/runner.ts`: codex / claude subprocess with shared prompt, BREEZE_RESULT parsing, `runWithTimeout` safety net.
   - `daemon/dispatcher.ts`: priority-sorted queue, claim gating, concurrency cap, runner fallback chain, bus publication for `dispatched`/`completed`/`failed`/`timed_out`.
   - `daemon/runner-skeleton.ts`: wires bus + broker + dispatcher into the daemon startup with a proper shutdown cascade.

### Phase 3c bug-fix
Per-task timeout (spec doc 4 §8/§11) — Rust had no timeout; stuck agents could block dispatcher threads indefinitely. TS version enforces `DAEMON_CONFIG_DEFAULTS.taskTimeoutSec` (30min default) via `runWithTimeout` inside the dispatcher, with the broker-level abort signal cascaded so `stop()` unwinds cleanly.

### Out of scope (Phase 4)
Candidate production — turning polled notifications into `TaskCandidate`s for `dispatcher.submit()`. The dispatcher's public API is in place; a future poller hook wires the feed.

## Test plan
- [x] 64 new unit tests (gh-executor 17, broker 13, workspace 4, runner 18, dispatcher 12)
- [x] Full suite: 695/695 passing
- [x] `pnpm validate:skill`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm pack`