### PR TITLE
fix(gardener): respond skips when only gardener itself has reviewed (follow-up to #131)

### DIFF
--- a/src/products/gardener/engine/respond.ts
+++ b/src/products/gardener/engine/respond.ts
@@ -205,6 +205,32 @@ export const RESPOND_MAX_ATTEMPTS = 5;
 const ATTEMPTS_MARKER_RE = /<!--\s*gardener:respond-attempts=(\d+)\s*-->/;
 const SOURCE_PR_RE = /source_pr=(\d+)/;
 const GARDENER_FIX_RE = /@gardener\s+fix/i;
+const GARDENER_MARKER_RE = /<!--\s*gardener:/;
+
+/**
+ * True when a review or comment was authored by gardener itself.
+ *
+ * Two signals (either one fires):
+ *   - login match: entry.user.login === gardenerLogin (when known)
+ *   - HTML marker fallback: entry.body contains `<!-- gardener:`
+ *
+ * Used to filter self-authored feedback out of the "actionable review"
+ * count so gardener-respond never reacts to gardener-sync's own
+ * review-pass comment (self-loop guard — first-tree#134 / repo-gardener#22).
+ */
+export function isFromGardener(
+  entry: { user?: { login?: string }; body?: string },
+  gardenerLogin: string,
+): boolean {
+  if (gardenerLogin && entry.user?.login === gardenerLogin) return true;
+  if (entry.body && GARDENER_MARKER_RE.test(entry.body)) return true;
+  return false;
+}
+
+async function resolveGardenerLogin(shell: ShellRun): Promise<string> {
+  const res = await shell("gh", ["api", "user", "--jq", ".login"]);
+  return res.code === 0 ? res.stdout.trim() : "";
+}
 
 export function readRespondAttempts(body: string | undefined): number {
   if (!body) return 0;
@@ -432,12 +458,13 @@ interface RespondSinglePrOpts {
   env: NodeJS.ProcessEnv;
   write: (line: string) => void;
   now: () => Date;
+  gardenerLogin: string;
 }
 
 async function respondSinglePr(
   opts: RespondSinglePrOpts,
 ): Promise<{ status: RespondStatus; summary: string }> {
-  const { repo, pr, dryRun, shell, env, write, now } = opts;
+  const { repo, pr, dryRun, shell, env, write, now, gardenerLogin } = opts;
 
   const snapshotDir = env.BREEZE_SNAPSHOT_DIR;
   const bundle = snapshotDir
@@ -460,9 +487,44 @@ async function respondSinglePr(
     return { status: "skipped", summary: msg };
   }
 
-  const hasGardenerFix = issueComments.some((c) =>
-    c.body ? GARDENER_FIX_RE.test(c.body) : false,
+  // Self-loop guard: only count feedback from reviewers who are NOT
+  // gardener itself. Without this, gardener-sync's review-pass comment
+  // looks like reviewer feedback and respond would try to "fix" it,
+  // push a commit, re-trigger review → loop.
+  // See: agent-team-foundation/first-tree#134, repo-gardener#22.
+  const nonGardenerReviews = reviews.filter(
+    (r) => r.state === "CHANGES_REQUESTED" && !isFromGardener(r, gardenerLogin),
   );
+  const nonGardenerFixComments = issueComments.filter(
+    (c) => c.body && GARDENER_FIX_RE.test(c.body) && !isFromGardener(c, gardenerLogin),
+  );
+
+  // If the PR's review decision is CHANGES_REQUESTED but every
+  // CHANGES_REQUESTED entry is self-authored, and there are no
+  // non-gardener @gardener-fix mentions, skip to avoid self-loop.
+  const wantsChangesRequested =
+    prView.reviewDecision === "CHANGES_REQUESTED" ||
+    issueComments.some((c) => c.body && GARDENER_FIX_RE.test(c.body));
+  if (
+    wantsChangesRequested &&
+    nonGardenerReviews.length === 0 &&
+    nonGardenerFixComments.length === 0
+  ) {
+    write(
+      `\u23ed no non-gardener feedback on PR #${pr} — skipping to avoid self-loop`,
+    );
+    logEvent(env, {
+      kind: "skip",
+      pr_number: pr,
+      reason: "no_non_gardener_feedback",
+    });
+    return {
+      status: "skipped",
+      summary: `no non-gardener feedback`,
+    };
+  }
+
+  const hasGardenerFix = nonGardenerFixComments.length > 0;
   const decision = classifyReviewDecision(prView, hasGardenerFix);
 
   if (decision === "approved") {
@@ -600,9 +662,10 @@ async function respondScanMode(
     env: NodeJS.ProcessEnv;
     write: (line: string) => void;
     now: () => Date;
+    gardenerLogin: string;
   },
 ): Promise<{ status: RespondStatus; summary: string }> {
-  const { shell, write, env } = opts;
+  const { shell, write, env, gardenerLogin } = opts;
   // Best-effort: detect tree repo slug from `gh repo view`.
   const repoRes = await shell("gh", [
     "repo",
@@ -663,6 +726,7 @@ async function respondScanMode(
       env,
       write,
       now: opts.now,
+      gardenerLogin,
     });
     if (result.status === "handled") handled += 1;
     else if (result.status === "failed") failed += 1;
@@ -725,6 +789,16 @@ export async function runRespond(
     return 0;
   }
 
+  // Resolve gardener's own GitHub login once, so isFromGardener() can
+  // filter out self-authored feedback (self-loop guard — first-tree#134).
+  // In snapshot mode (breeze-runner) we prefer GARDENER_LOGIN from the
+  // environment to avoid an extra `gh api` call, and fall back to the
+  // marker-only path when unset.
+  let gardenerLogin = env.GARDENER_LOGIN?.trim() ?? "";
+  if (!gardenerLogin && !env.BREEZE_SNAPSHOT_DIR) {
+    gardenerLogin = await resolveGardenerLogin(shell);
+  }
+
   try {
     if (flags.pr !== undefined || flags.repo !== undefined) {
       if (flags.pr === undefined || !flags.repo) {
@@ -740,6 +814,7 @@ export async function runRespond(
         env,
         write,
         now,
+        gardenerLogin,
       });
       emitBreezeResult(write, result.status, result.summary);
       return result.status === "failed" ? 1 : 0;
@@ -752,6 +827,7 @@ export async function runRespond(
       env,
       write,
       now,
+      gardenerLogin,
     });
     emitBreezeResult(write, result.status, result.summary);
     return result.status === "failed" ? 1 : 0;

--- a/tests/gardener-respond.test.ts
+++ b/tests/gardener-respond.test.ts
@@ -10,6 +10,7 @@ import {
   classifyReviewDecision,
   extractSourcePr,
   hasSyncLabel,
+  isFromGardener,
   isSyncPr,
   latestChangesRequestedAt,
   readRespondAttempts,
@@ -348,7 +349,17 @@ describe("gardener respond -- attempts counter", () => {
       updatedAt: "2026-04-15T00:00:00Z",
     };
     writeFileSync(join(snapshotDir, "pr-view.json"), JSON.stringify(prView));
-    writeFileSync(join(snapshotDir, "pr-reviews.json"), JSON.stringify([]));
+    writeFileSync(
+      join(snapshotDir, "pr-reviews.json"),
+      JSON.stringify([
+        {
+          user: { login: "bingran-you" },
+          state: "CHANGES_REQUESTED",
+          body: "still broken",
+          submitted_at: "2026-04-15T10:00:00Z",
+        },
+      ]),
+    );
     writeFileSync(join(snapshotDir, "issue-comments.json"), JSON.stringify([]));
     writeFileSync(join(snapshotDir, "pr.diff"), "");
 
@@ -564,5 +575,243 @@ describe("gardener respond -- helpers", () => {
   it("readSnapshot returns null when pr-view.json is missing", () => {
     const tmp = useTmpDir();
     expect(readSnapshot(tmp.path)).toBeNull();
+  });
+});
+
+describe("gardener respond -- isFromGardener helper", () => {
+  it("matches by login when gardenerLogin is set", () => {
+    expect(
+      isFromGardener(
+        { user: { login: "serenakeyitan" }, body: "plain text" },
+        "serenakeyitan",
+      ),
+    ).toBe(true);
+    expect(
+      isFromGardener(
+        { user: { login: "someone-else" }, body: "plain text" },
+        "serenakeyitan",
+      ),
+    ).toBe(false);
+  });
+
+  it("falls back to HTML marker when login is empty or differs", () => {
+    // Marker present, login empty → still treated as gardener.
+    expect(
+      isFromGardener(
+        {
+          user: { login: "bot-identity" },
+          body: "looks good <!-- gardener:sync · source_pr=1 -->",
+        },
+        "",
+      ),
+    ).toBe(true);
+    // Marker present, login differs from gardenerLogin → still gardener.
+    expect(
+      isFromGardener(
+        {
+          user: { login: "different-bot" },
+          body: "<!-- gardener:review-pass -->",
+        },
+        "serenakeyitan",
+      ),
+    ).toBe(true);
+    // No marker, no login match → not gardener.
+    expect(
+      isFromGardener(
+        { user: { login: "bingran-you" }, body: "please fix" },
+        "serenakeyitan",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("gardener respond -- self-loop guard", () => {
+  it("skips when the only CHANGES_REQUESTED review is from gardener itself", async () => {
+    const tmp = useTmpDir();
+    const snapshotDir = join(tmp.path, "snap");
+    mkdirSync(snapshotDir, { recursive: true });
+    const prView = {
+      number: 201,
+      title: "sync: something",
+      headRefName: "first-tree/sync-201",
+      reviewDecision: "CHANGES_REQUESTED",
+      body: "plain body",
+      updatedAt: "2026-04-15T00:00:00Z",
+    };
+    writeFileSync(join(snapshotDir, "pr-view.json"), JSON.stringify(prView));
+    writeFileSync(
+      join(snapshotDir, "pr-reviews.json"),
+      JSON.stringify([
+        {
+          user: { login: "serenakeyitan" },
+          state: "CHANGES_REQUESTED",
+          body: "<!-- gardener:review-pass -->\nstructural check\n",
+          submitted_at: "2026-04-15T10:00:00Z",
+        },
+      ]),
+    );
+    writeFileSync(join(snapshotDir, "issue-comments.json"), JSON.stringify([]));
+    writeFileSync(join(snapshotDir, "pr.diff"), "");
+
+    const calls: ShellCall[] = [];
+    const shell = makeShell(
+      [() => ({ stdout: "", stderr: "", code: 0 })],
+      calls,
+    );
+    const { write, lines } = captureWrite();
+    const code = await runRespond(
+      ["--pr", "201", "--repo", "owner/name", "--tree-path", tmp.path],
+      {
+        shellRun: shell,
+        write,
+        env: {
+          BREEZE_SNAPSHOT_DIR: snapshotDir,
+          GARDENER_LOGIN: "serenakeyitan",
+        },
+        now: () => new Date("2026-04-16T00:00:00Z"),
+      },
+    );
+    expect(code).toBe(0);
+    expect(
+      lines.some((l) => l.includes("no non-gardener feedback")),
+    ).toBe(true);
+    const last = lines[lines.length - 1];
+    expect(last).toMatch(/^BREEZE_RESULT: status=skipped summary=no non-gardener feedback/);
+    // No gh pr edit / gh pr comment / git commit should have fired.
+    const writes = calls.filter(
+      (c) =>
+        (c.command === "gh" &&
+          c.args[0] === "pr" &&
+          (c.args[1] === "edit" || c.args[1] === "comment")) ||
+        c.command === "git",
+    );
+    expect(writes).toHaveLength(0);
+  });
+
+  it("proceeds when at least one non-gardener CHANGES_REQUESTED review exists", async () => {
+    const tmp = useTmpDir();
+    const snapshotDir = join(tmp.path, "snap");
+    mkdirSync(snapshotDir, { recursive: true });
+    const prView = {
+      number: 202,
+      title: "sync: something",
+      headRefName: "first-tree/sync-202",
+      reviewDecision: "CHANGES_REQUESTED",
+      body: "plain body",
+      updatedAt: "2026-04-15T00:00:00Z",
+    };
+    writeFileSync(join(snapshotDir, "pr-view.json"), JSON.stringify(prView));
+    writeFileSync(
+      join(snapshotDir, "pr-reviews.json"),
+      JSON.stringify([
+        {
+          user: { login: "serenakeyitan" },
+          state: "CHANGES_REQUESTED",
+          body: "<!-- gardener:review-pass -->",
+          submitted_at: "2026-04-15T10:00:00Z",
+        },
+        {
+          user: { login: "human-reviewer" },
+          state: "CHANGES_REQUESTED",
+          body: "please also rename the helper",
+          submitted_at: "2026-04-15T11:00:00Z",
+        },
+      ]),
+    );
+    writeFileSync(join(snapshotDir, "issue-comments.json"), JSON.stringify([]));
+    writeFileSync(join(snapshotDir, "pr.diff"), "");
+
+    const calls: ShellCall[] = [];
+    const shell = makeShell(
+      [() => ({ stdout: "", stderr: "", code: 0 })],
+      calls,
+    );
+    const { write, lines } = captureWrite();
+    const code = await runRespond(
+      ["--pr", "202", "--repo", "owner/name", "--tree-path", tmp.path],
+      {
+        shellRun: shell,
+        write,
+        env: {
+          BREEZE_SNAPSHOT_DIR: snapshotDir,
+          GARDENER_LOGIN: "serenakeyitan",
+        },
+        now: () => new Date("2026-04-16T00:00:00Z"),
+      },
+    );
+    expect(code).toBe(0);
+    expect(
+      lines.some((l) => l.includes("no non-gardener feedback")),
+    ).toBe(false);
+    // Normal fix path fires a pr edit (attempts counter) + pr comment.
+    const editCall = calls.find(
+      (c) => c.command === "gh" && c.args[0] === "pr" && c.args[1] === "edit",
+    );
+    const commentCall = calls.find(
+      (c) => c.command === "gh" && c.args[0] === "pr" && c.args[1] === "comment",
+    );
+    expect(editCall).toBeDefined();
+    expect(commentCall).toBeDefined();
+  });
+
+  it("skips when the only @gardener fix comment was posted by gardener itself", async () => {
+    const tmp = useTmpDir();
+    const snapshotDir = join(tmp.path, "snap");
+    mkdirSync(snapshotDir, { recursive: true });
+    const prView = {
+      number: 203,
+      title: "sync: something",
+      headRefName: "first-tree/sync-203",
+      // Note: reviewDecision is NOT CHANGES_REQUESTED here — the only
+      // reason respond would otherwise act is the @gardener fix mention.
+      reviewDecision: "",
+      body: "plain body",
+      updatedAt: "2026-04-15T00:00:00Z",
+    };
+    writeFileSync(join(snapshotDir, "pr-view.json"), JSON.stringify(prView));
+    writeFileSync(join(snapshotDir, "pr-reviews.json"), JSON.stringify([]));
+    writeFileSync(
+      join(snapshotDir, "issue-comments.json"),
+      JSON.stringify([
+        {
+          user: { login: "serenakeyitan" },
+          body:
+            "<!-- gardener:sync -->\nping @gardener fix (self-reminder)\n",
+          created_at: "2026-04-15T10:00:00Z",
+        },
+      ]),
+    );
+    writeFileSync(join(snapshotDir, "pr.diff"), "");
+
+    const calls: ShellCall[] = [];
+    const shell = makeShell(
+      [() => ({ stdout: "", stderr: "", code: 0 })],
+      calls,
+    );
+    const { write, lines } = captureWrite();
+    const code = await runRespond(
+      ["--pr", "203", "--repo", "owner/name", "--tree-path", tmp.path],
+      {
+        shellRun: shell,
+        write,
+        env: {
+          BREEZE_SNAPSHOT_DIR: snapshotDir,
+          GARDENER_LOGIN: "serenakeyitan",
+        },
+        now: () => new Date("2026-04-16T00:00:00Z"),
+      },
+    );
+    expect(code).toBe(0);
+    expect(
+      lines.some((l) => l.includes("no non-gardener feedback")),
+    ).toBe(true);
+    // No writes to the PR.
+    const writes = calls.filter(
+      (c) =>
+        c.command === "gh" &&
+        c.args[0] === "pr" &&
+        (c.args[1] === "edit" || c.args[1] === "comment"),
+    );
+    expect(writes).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to the merged #131 that adds the self-loop guard specified in #134. Without this, `gardener-respond` treats `gardener-sync`'s own review-pass comment as reviewer feedback, pushes a fix commit, re-triggers review, and loops.

A PR is now eligible for fix only when at least one non-gardener `CHANGES_REQUESTED` review (or `@gardener fix` mention) exists. Non-gardener detection = login mismatch AND no `<!-- gardener:` HTML marker.

## Changes

- `src/products/gardener/engine/respond.ts` — new `isFromGardener(entry, gardenerLogin)` helper (exported), `resolveGardenerLogin(shell)` at startup (skipped in snapshot mode or when `GARDENER_LOGIN` env var is set), and a `nonGardenerReviews` / `nonGardenerFixComments` filter in `respondSinglePr` before classification. Skip path: log `⏭ no non-gardener feedback on PR #<n> — skipping to avoid self-loop`, emit `BREEZE_RESULT: status=skipped summary=no non-gardener feedback`, and return without writes. **No `breeze:*` label mutation.**
- `tests/gardener-respond.test.ts` — 4 new tests:
  - `isFromGardener` login match
  - `isFromGardener` marker fallback (login empty / differs)
  - skip path: PR with only gardener-authored CHANGES_REQUESTED review → skip, no shell writes
  - proceed path: gardener review + non-gardener CHANGES_REQUESTED → fix path triggers
  - skip path: only self-authored `@gardener fix` comment → skip

## Verification

- `pnpm typecheck` ✓
- `pnpm vitest run tests/gardener-respond.test.ts` → 29/29 pass
- `pnpm build` ✓
- `node dist/cli.js gardener --help` ✓

## Related

- Closes part of #134 (respond half)
- Sibling runbook fix: agent-team-foundation/repo-gardener#23 (closes repo-gardener#22)

## Test plan

- [ ] Review diff for behavioral correctness on the edge cases in the test matrix
- [ ] Spot-check that `breeze:wip/human/done` labels are untouched on the skip path
- [ ] CI green

<sub>🌱 PR created by Claude on behalf of @serenakeyitan via <a href="https://claude.com/claude-code">Claude Code</a></sub>