### PR TITLE
fix(gardener): comment skips first-tree:sync PRs + respond self-loop guard (addresses #134)

### DIFF
--- a/src/products/gardener/cli.ts
+++ b/src/products/gardener/cli.ts
@@ -9,6 +9,11 @@
  * Phase 1 ships the `respond` subcommand — a port of the
  * `gardener-respond-manual.md` runbook that fixes sync PRs based on
  * reviewer feedback.
+ *
+ * Phase 2 adds the `comment` subcommand — a port of the
+ * `gardener-comment-manual.md` runbook that reviews open PRs and issues
+ * on a source repo against a Context Tree and posts structured verdict
+ * comments.
  */
 
 import { readFileSync } from "node:fs";
@@ -22,6 +27,7 @@ export const GARDENER_USAGE = `usage: first-tree gardener <command>
 
 Commands:
   respond               Fix sync PRs based on reviewer feedback
+  comment               Review source-repo PRs/issues against the tree
 
 Options:
   --help, -h            Show this help message
@@ -31,6 +37,9 @@ Examples:
   first-tree gardener respond --help
   first-tree gardener respond --dry-run
   first-tree gardener respond --pr 123 --repo owner/name
+  first-tree gardener comment --help
+  first-tree gardener comment --pr 42 --repo owner/name
+  first-tree gardener comment --issue 7 --repo owner/name
 `;
 
 type Output = (text: string) => void;
@@ -76,6 +85,12 @@ export async function runGardener(
         "./engine/commands/respond.js"
       );
       return runRespond(args.slice(1), { write });
+    }
+    case "comment": {
+      const { runComment } = await import(
+        "./engine/commands/comment.js"
+      );
+      return runComment(args.slice(1), { write });
     }
     default:
       write(`Unknown gardener command: ${command}`);

--- a/src/products/gardener/engine/commands/comment.ts
+++ b/src/products/gardener/engine/commands/comment.ts
@@ -1,0 +1,1 @@
+export { runComment, COMMENT_USAGE } from "../comment.js";

--- a/src/products/gardener/engine/comment.ts
+++ b/src/products/gardener/engine/comment.ts
@@ -988,9 +988,14 @@ async function reviewOne(
 
   // Resolve state (Step 2).
   const view = type === "pr" ? bundle.prView : bundle.issueView;
+  // headIdentifier must match the reviewedFull marker format written below
+  // (line ~1019). PRs use raw 40-char SHA; issues use `issue@<iso>` so that
+  // `shaMatches` compares like-for-like and avoids re-reviewing on every scan.
   const headIdentifier = type === "pr"
     ? bundle.prView?.headRefOid
-    : bundle.issueView?.updatedAt;
+    : bundle.issueView?.updatedAt
+      ? `issue@${bundle.issueView.updatedAt}`
+      : undefined;
   const action = resolveState({
     comments: bundle.issueComments,
     gardenerUser,

--- a/src/products/gardener/engine/comment.ts
+++ b/src/products/gardener/engine/comment.ts
@@ -1,0 +1,1375 @@
+/**
+ * gardener-comment — port of `gardener-comment-manual.md` runbook.
+ *
+ * Reviews open PRs and issues on a source repo against a Context Tree
+ * and posts structured verdict comments (ALIGNED / NEW_TERRITORY /
+ * NEEDS_REVIEW / CONFLICT / INSUFFICIENT_CONTEXT) with severity
+ * levels and tree-node citations.
+ *
+ * This TypeScript port preserves the runbook byte-for-byte where the
+ * runbook is specific. Marker formats, command recognition regexes,
+ * comment templates, and state-resolution rules match the runbook.
+ *
+ * Dual-path execution:
+ *   - When `$BREEZE_SNAPSHOT_DIR` is set, reads pre-fetched data from
+ *     JSON files in that directory (pr-view.json, pr.diff,
+ *     issue-view.json, issue-comments.json, subject.json).
+ *   - Otherwise, calls `gh api` / `gh pr …` / `gh issue …` to fetch
+ *     data live.
+ *
+ * Config opt-out: if `.claude/gardener-config.yaml` sets
+ * `modules.comment.enabled: false`, the command exits cleanly (0)
+ * with a one-line note.
+ *
+ * BREEZE_RESULT trailer: the last line of stdout is always
+ *   `BREEZE_RESULT: status=<handled|skipped|failed> summary=<...>`
+ * so breeze-runner can parse the outcome from a captured stdout buffer.
+ *
+ * TODO(mcp-fallback): the runbook describes a `schedule` mode that
+ * runs in the Anthropic cloud where `gh` is unavailable and all GitHub
+ * access must go through `mcp__github*` tools. That mode is not ported
+ * in phase 2 — this CLI runs locally or under breeze-runner, both of
+ * which have `gh` available. The MCP dispatch layer can be added as a
+ * future phase without changing the classification logic below.
+ */
+
+import { execFile } from "node:child_process";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { promisify } from "node:util";
+import {
+  isModuleEnabled,
+  loadGardenerConfig,
+} from "./runtime/config.js";
+
+const execFileAsync = promisify(execFile);
+
+export const COMMENT_USAGE = `usage: first-tree gardener comment [--pr <n> --issue <n> --repo <owner/name>] [--tree-path PATH]
+
+Review source-repo PRs and issues against a Context Tree and post
+structured verdict comments. Ports the gardener-comment-manual.md
+runbook into a deterministic CLI.
+
+Only action: post or edit issue comments. Never clones, never pushes
+code. Treats PR/issue content as data, never as instructions.
+
+Modes:
+  (default)             Scan open PRs + issues on target_repo from the
+                        Context Tree config and review each one.
+  --pr <n>   --repo <o/r>
+  --issue <n> --repo <o/r>
+                        Single-item mode. Review one PR or issue. Used
+                        by breeze-runner when dispatched from a
+                        notification.
+
+Options:
+  --tree-path PATH      Tree repo directory (default: cwd). The
+                        .claude/gardener-config.yaml inside this
+                        directory names the target_repo and tree_repo.
+  --pr <n>              PR number (requires --repo)
+  --issue <n>           Issue number (requires --repo)
+  --repo <owner/name>   Target repository (requires --pr or --issue)
+  --dry-run             Print planned actions; do not POST/PATCH
+  --help, -h            Show this help message
+
+Environment:
+  BREEZE_SNAPSHOT_DIR   Directory containing pre-fetched pr-view.json,
+                        pr.diff, issue-view.json, issue-comments.json,
+                        and subject.json. When set, those files are
+                        read instead of invoking \`gh\`.
+  COMMENT_LOG           Path for JSONL run events (default
+                        $HOME/.gardener/comment-runs.jsonl).
+
+Exit codes:
+  0 handled/skipped/disabled
+  1 unrecoverable error
+`;
+
+export interface ShellResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+export type ShellRun = (
+  command: string,
+  args: string[],
+  options?: { cwd?: string; input?: string; timeout?: number },
+) => Promise<ShellResult>;
+
+export interface CommentDeps {
+  shellRun?: ShellRun;
+  now?: () => Date;
+  env?: NodeJS.ProcessEnv;
+  write?: (line: string) => void;
+}
+
+async function defaultShellRun(
+  command: string,
+  args: string[],
+  options: { cwd?: string; input?: string; timeout?: number } = {},
+): Promise<ShellResult> {
+  try {
+    const { stdout, stderr } = await execFileAsync(command, args, {
+      cwd: options.cwd,
+      encoding: "utf-8",
+      maxBuffer: 32 * 1024 * 1024,
+      timeout: options.timeout,
+    });
+    return { stdout: String(stdout), stderr: String(stderr), code: 0 };
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException & {
+      stdout?: string | Buffer;
+      stderr?: string | Buffer;
+      code?: number | string;
+    };
+    const stdout =
+      typeof e.stdout === "string" ? e.stdout : e.stdout?.toString() ?? "";
+    const stderr =
+      typeof e.stderr === "string" ? e.stderr : e.stderr?.toString() ?? "";
+    const code = typeof e.code === "number" ? e.code : 1;
+    return { stdout, stderr, code };
+  }
+}
+
+interface ParsedFlags {
+  help: boolean;
+  treePath?: string;
+  pr?: number;
+  issue?: number;
+  repo?: string;
+  dryRun: boolean;
+  unknown?: string;
+}
+
+function parseFlags(args: string[]): ParsedFlags {
+  const out: ParsedFlags = { help: false, dryRun: false };
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--help" || arg === "-h") {
+      out.help = true;
+      continue;
+    }
+    if (arg === "--dry-run") {
+      out.dryRun = true;
+      continue;
+    }
+    if (arg === "--tree-path") {
+      out.treePath = args[i + 1];
+      i += 1;
+      continue;
+    }
+    if (arg === "--pr") {
+      const n = Number(args[i + 1]);
+      if (!Number.isFinite(n)) {
+        out.unknown = `--pr requires a numeric argument`;
+        return out;
+      }
+      out.pr = n;
+      i += 1;
+      continue;
+    }
+    if (arg === "--issue") {
+      const n = Number(args[i + 1]);
+      if (!Number.isFinite(n)) {
+        out.unknown = `--issue requires a numeric argument`;
+        return out;
+      }
+      out.issue = n;
+      i += 1;
+      continue;
+    }
+    if (arg === "--repo") {
+      out.repo = args[i + 1];
+      i += 1;
+      continue;
+    }
+    out.unknown = arg;
+    return out;
+  }
+  return out;
+}
+
+export type CommentStatus = "handled" | "skipped" | "failed" | "disabled";
+
+export type Verdict =
+  | "ALIGNED"
+  | "NEW_TERRITORY"
+  | "NEEDS_REVIEW"
+  | "CONFLICT"
+  | "INSUFFICIENT_CONTEXT";
+
+export type Severity = "low" | "medium" | "high" | "critical";
+
+export type ItemType = "pr" | "issue";
+
+export interface PrView {
+  number: number;
+  title?: string;
+  body?: string;
+  headRefName?: string;
+  headRefOid?: string;
+  state?: string;
+  author?: { login?: string } | string;
+  additions?: number;
+  deletions?: number;
+  labels?: { name: string }[] | string[];
+  updatedAt?: string;
+}
+
+export interface IssueView {
+  number: number;
+  title?: string;
+  body?: string;
+  state?: string;
+  author?: { login?: string } | string;
+  labels?: { name: string }[] | string[];
+  updatedAt?: string;
+}
+
+export interface IssueComment {
+  id?: number;
+  user?: { login?: string };
+  body?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface SubjectMetadata {
+  /** The authenticated gardener user login (e.g. the bot account). */
+  gardenerUser?: string;
+  /** Item type (`pr` or `issue`) when the snapshot is for a single item. */
+  type?: ItemType;
+  /** Source repo slug when different from the config target_repo. */
+  repo?: string;
+  /** Pre-computed tree SHA for the snapshot run. */
+  treeSha?: string;
+  /** Pre-computed tree repo URL for footer attribution. */
+  treeRepoUrl?: string;
+}
+
+export interface SnapshotBundle {
+  subject: SubjectMetadata;
+  type: ItemType;
+  prView?: PrView;
+  issueView?: IssueView;
+  diff?: string;
+  issueComments: IssueComment[];
+}
+
+// ───────────────────────── Marker / regex primitives ────────────────────────
+
+export const GARDENER_STATE_MARKER_RE = /<!--\s*gardener:state[^>]*-->/;
+export const GARDENER_IGNORED_MARKER_RE = /<!--\s*gardener:ignored\s*-->/;
+export const GARDENER_PAUSED_MARKER_RE = /<!--\s*gardener:paused\s*-->/;
+export const GARDENER_LAST_CONSUMED_RE =
+  /gardener:last_consumed_rereview=(\d+)/;
+export const REVIEWED_SHA_RE = /reviewed=([A-Za-z0-9@:.-]+)/;
+export const VERDICT_IN_MARKER_RE = /verdict=([A-Z_]+)/;
+export const SEVERITY_IN_MARKER_RE = /severity=([a-z]+)/;
+export const TREE_SHA_IN_MARKER_RE = /tree_sha=([A-Za-z0-9]+)/;
+
+/**
+ * Recognizes `@gardener <command>` in user comments. Matches the
+ * runbook regex exactly so the CLI sees the same command set the
+ * runbook describes. The state marker's footer includes this same
+ * phrase but in a `<sub>` block; callers MUST exclude gardener's own
+ * comments (by author) before running this match to avoid the
+ * self-loop described in the runbook's Step 2 "Critical" note.
+ */
+export const GARDENER_COMMAND_RE = /@gardener (re-review|pause|resume|ignore)/;
+
+/** Severity strings gardener recognises, in ascending severity order. */
+export const SEVERITIES: Severity[] = ["low", "medium", "high", "critical"];
+
+/** Verdicts gardener recognises, in runbook order. */
+export const VERDICTS: Verdict[] = [
+  "ALIGNED",
+  "NEW_TERRITORY",
+  "NEEDS_REVIEW",
+  "CONFLICT",
+  "INSUFFICIENT_CONTEXT",
+];
+
+const VERDICT_EMOJI: Record<Verdict, string> = {
+  ALIGNED: "✅",
+  NEW_TERRITORY: "🆕",
+  NEEDS_REVIEW: "🔍",
+  CONFLICT: "⚠️",
+  INSUFFICIENT_CONTEXT: "❔",
+};
+
+const FIT_CELL: Record<Verdict, string> = {
+  ALIGNED: "✅ Aligned",
+  NEW_TERRITORY: "🆕 New",
+  NEEDS_REVIEW: "❓ Partial",
+  CONFLICT: "⚠️ Conflict",
+  INSUFFICIENT_CONTEXT: "❔ Insufficient",
+};
+
+// ───────────────────────── Body helpers ─────────────────────────
+
+function authorLogin(author: PrView["author"] | IssueView["author"]): string | undefined {
+  if (!author) return undefined;
+  if (typeof author === "string") return author;
+  return author.login;
+}
+
+function labelNames(
+  labels: PrView["labels"] | IssueView["labels"] | undefined,
+): string[] {
+  if (!labels) return [];
+  return labels.map((l) => (typeof l === "string" ? l : l?.name ?? ""))
+    .filter((n): n is string => n.length > 0);
+}
+
+export function hasReviewedLabel(
+  view: Pick<PrView, "labels"> | Pick<IssueView, "labels"> | undefined,
+): boolean {
+  if (!view) return false;
+  return labelNames(view.labels).includes("gardener:reviewed");
+}
+
+/**
+ * Extract the `gardener:state` marker line — the full `<!-- … -->`
+ * comment (not just the inside). Returns null when no marker is
+ * present. Used when re-constructing a PATCHed comment body so the
+ * HTML comment is preserved verbatim.
+ */
+export function extractStateMarker(body: string | undefined): string | null {
+  if (!body) return null;
+  const match = body.match(GARDENER_STATE_MARKER_RE);
+  return match ? match[0] : null;
+}
+
+/**
+ * Parse the inner fields of a `gardener:state` marker. Returns null
+ * when the marker is missing or unparseable.
+ */
+export function parseStateMarker(body: string | undefined): {
+  reviewed?: string;
+  verdict?: Verdict;
+  severity?: Severity;
+  treeSha?: string;
+} | null {
+  const marker = extractStateMarker(body);
+  if (!marker) return null;
+  const out: {
+    reviewed?: string;
+    verdict?: Verdict;
+    severity?: Severity;
+    treeSha?: string;
+  } = {};
+  const reviewed = marker.match(REVIEWED_SHA_RE);
+  if (reviewed) out.reviewed = reviewed[1];
+  const verdict = marker.match(VERDICT_IN_MARKER_RE);
+  if (verdict && VERDICTS.includes(verdict[1] as Verdict)) {
+    out.verdict = verdict[1] as Verdict;
+  }
+  const severity = marker.match(SEVERITY_IN_MARKER_RE);
+  if (severity && SEVERITIES.includes(severity[1] as Severity)) {
+    out.severity = severity[1] as Severity;
+  }
+  const treeSha = marker.match(TREE_SHA_IN_MARKER_RE);
+  if (treeSha) out.treeSha = treeSha[1];
+  return out;
+}
+
+export function hasIgnoredMarker(body: string | undefined): boolean {
+  if (!body) return false;
+  return GARDENER_IGNORED_MARKER_RE.test(body);
+}
+
+export function hasPausedMarker(body: string | undefined): boolean {
+  if (!body) return false;
+  return GARDENER_PAUSED_MARKER_RE.test(body);
+}
+
+export function readLastConsumedRereview(
+  body: string | undefined,
+): number | null {
+  if (!body) return null;
+  const match = body.match(GARDENER_LAST_CONSUMED_RE);
+  if (!match) return null;
+  const parsed = Number(match[1]);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * Compare two SHAs using prefix match so older 8-char markers still
+ * count as "same commit". Returns false if either input is empty.
+ */
+export function shaMatches(
+  head: string | undefined | null,
+  marker: string | undefined | null,
+): boolean {
+  if (!head || !marker) return false;
+  if (head === marker) return true;
+  if (marker.length < head.length) return head.startsWith(marker);
+  return marker.startsWith(head);
+}
+
+// ───────────────────────── State resolution ─────────────────────────
+
+/**
+ * Which gardener comment (by id) to act on, and how. The caller
+ * uses this to decide whether to POST a new comment, PATCH an
+ * existing one, or skip the item entirely.
+ */
+export type StateAction =
+  | { kind: "skip"; reason: string }
+  | { kind: "first_review" }
+  | {
+      kind: "rereview";
+      /** The id of the gardener:state comment to PATCH. */
+      commentId: number;
+      /** The id of the `@gardener re-review` comment, if this was triggered by one. */
+      consumedRereviewId?: number;
+      reason: string;
+    };
+
+export interface ResolveStateInput {
+  /** All comments on the item (already paginated into one flat array). */
+  comments: IssueComment[];
+  /** Login of the authenticated gardener user (for self-exclusion). */
+  gardenerUser: string;
+  /** HEAD SHA for PRs. For issues, pass `updatedAt` from issue-view. */
+  headIdentifier?: string;
+  /** Whether the item has the `gardener:reviewed` label set. */
+  hasReviewedLabel: boolean;
+}
+
+/**
+ * Resolve the action gardener should take on an item based on prior
+ * comments. Implements the runbook's Step 2 rules 1–5b in order:
+ *
+ *   1. gardener:ignored → skip forever
+ *   2. gardener:paused and no newer @gardener resume → skip
+ *   3. @gardener re-review not yet consumed → rereview
+ *   4. gardener:state sha matches head → skip; differs → rereview
+ *   5. gardener:reviewed label present, no new activity → skip
+ *   6. No state/label → first_review
+ *
+ * The runbook's rule 5 "issue infinite-loop" guard is handled in the
+ * caller (it needs the timeline API); here we treat issues the same
+ * as PRs: if the marker `reviewed=` value does not match the passed
+ * `headIdentifier`, we re-review.
+ */
+export function resolveState(input: ResolveStateInput): StateAction {
+  const { comments, gardenerUser, headIdentifier, hasReviewedLabel } = input;
+
+  // Find gardener's own comments (state comments) and user commands.
+  const gardenerComments = comments.filter(
+    (c) => c.user?.login === gardenerUser && c.body && c.body.length > 0,
+  );
+  const userCommands = comments.filter(
+    (c) =>
+      c.user?.login !== gardenerUser &&
+      typeof c.body === "string" &&
+      GARDENER_COMMAND_RE.test(c.body),
+  );
+
+  // Rule 1: ignored.
+  for (const c of gardenerComments) {
+    if (hasIgnoredMarker(c.body)) {
+      return { kind: "skip", reason: "ignored marker present" };
+    }
+  }
+
+  // Rule 2: paused (with resume override).
+  const latestByCmd = (cmd: "pause" | "resume"): string | null => {
+    let latest: string | null = null;
+    const re = new RegExp(`@gardener ${cmd}\\b`);
+    for (const c of userCommands) {
+      if (!c.body || !c.created_at) continue;
+      if (!re.test(c.body)) continue;
+      if (!latest || c.created_at > latest) latest = c.created_at;
+    }
+    return latest;
+  };
+
+  const hasPausedState = gardenerComments.some((c) => hasPausedMarker(c.body));
+  if (hasPausedState) {
+    const lastPause = latestByCmd("pause");
+    const lastResume = latestByCmd("resume");
+    if (lastPause && (!lastResume || lastResume <= lastPause)) {
+      return { kind: "skip", reason: "paused by user" };
+    }
+    // else fall through to rule 4 — resume is active.
+  }
+
+  // Rule 3: @gardener re-review — find newest re-review command and
+  // check the last_consumed_rereview marker on the latest state
+  // comment.
+  const rereviewRe = /@gardener re-review\b/;
+  const latestRereview = userCommands
+    .filter((c) => c.body && rereviewRe.test(c.body) && c.id !== undefined)
+    .sort((a, b) => (a.created_at ?? "").localeCompare(b.created_at ?? ""))
+    .pop();
+
+  // The "latest" gardener:state comment — by created_at descending.
+  const latestState = gardenerComments
+    .filter((c) => extractStateMarker(c.body) !== null)
+    .sort((a, b) => (a.created_at ?? "").localeCompare(b.created_at ?? ""))
+    .pop();
+
+  if (latestRereview && latestRereview.id !== undefined) {
+    const consumed = latestState
+      ? readLastConsumedRereview(latestState.body)
+      : null;
+    if (consumed !== latestRereview.id) {
+      return {
+        kind: "rereview",
+        commentId: latestState?.id ?? 0,
+        consumedRereviewId: latestRereview.id,
+        reason: `@gardener re-review #${latestRereview.id}`,
+      };
+    }
+    // else: already consumed, fall through.
+  }
+
+  // Rule 4: gardener:state sha comparison.
+  if (latestState) {
+    const parsed = parseStateMarker(latestState.body);
+    const markerSha = parsed?.reviewed;
+    if (markerSha && shaMatches(headIdentifier, markerSha)) {
+      return { kind: "skip", reason: "state sha matches head" };
+    }
+    if (latestState.id !== undefined) {
+      return {
+        kind: "rereview",
+        commentId: latestState.id,
+        reason: "state sha differs from head",
+      };
+    }
+  }
+
+  // Rule 5b: gardener:reviewed label and no new activity.
+  if (hasReviewedLabel) {
+    // We can't prove staleness without timeline data; conservative
+    // default is to skip (silent-aligned still valid). Callers can
+    // force a re-review by removing the label.
+    return { kind: "skip", reason: "gardener:reviewed label present" };
+  }
+
+  // Rule 6: first review.
+  return { kind: "first_review" };
+}
+
+// ───────────────────────── Classification (verdict) ────────────────
+
+export interface ClassifyInput {
+  type: ItemType;
+  prView?: PrView;
+  issueView?: IssueView;
+  diff?: string;
+  treeRoot: string;
+  treeSha?: string;
+}
+
+export interface ClassifyOutput {
+  verdict: Verdict;
+  severity: Severity;
+  /** One-line summary written into the comment body. */
+  summary: string;
+  /** Tree nodes cited in the comment body. */
+  treeNodes: Array<{ path: string; summary: string }>;
+}
+
+/**
+ * Classifier hook. The real verdict is a judgment call that belongs
+ * to an LLM (matching the runbook's "this is a judgment, not a pattern
+ * match" guidance). This default returns `NEW_TERRITORY` with low
+ * severity so the deterministic scaffolding is exercisable in tests
+ * and in CI without LLM access. Callers that want real verdicts
+ * should inject a classifier that reads the diff and the tree.
+ */
+export type Classifier = (input: ClassifyInput) => Promise<ClassifyOutput>;
+
+export const defaultClassifier: Classifier = async () => ({
+  verdict: "NEW_TERRITORY",
+  severity: "low",
+  summary: "Tree guidance not yet available for this area.",
+  treeNodes: [],
+});
+
+// ───────────────────────── Comment body construction ─────────────
+
+export interface BuildCommentInput {
+  verdict: Verdict;
+  severity: Severity;
+  summary: string;
+  treeNodes: Array<{ path: string; summary: string }>;
+  /** Short form of the reviewed commit / issue timestamp. */
+  reviewedShort: string;
+  /** Full 40-char SHA or `issue@<iso>` for the marker. */
+  reviewedFull: string;
+  /** Full tree SHA for the marker. */
+  treeSha: string;
+  /** Short form of the tree SHA for the footer. */
+  treeShaShort: string;
+  /** The re-review comment id we're consuming, if any. */
+  consumedRereviewId?: number;
+  /** Tree repo URL for footer attribution. */
+  treeRepoUrl?: string;
+  /** Tree owner/name slug for footer attribution. */
+  treeSlug?: string;
+  /** Whether this is for a PR (controls table header wording). */
+  itemType: ItemType;
+}
+
+export function buildCommentBody(input: BuildCommentInput): string {
+  const {
+    verdict,
+    severity,
+    summary,
+    treeNodes,
+    reviewedShort,
+    reviewedFull,
+    treeSha,
+    treeShaShort,
+    consumedRereviewId,
+    treeRepoUrl,
+    treeSlug,
+    itemType,
+  } = input;
+  const emoji = VERDICT_EMOJI[verdict];
+  const fitCell = FIT_CELL[verdict];
+  const isMinimalAligned = verdict === "ALIGNED" && severity === "low";
+  const consumedId =
+    consumedRereviewId !== undefined ? String(consumedRereviewId) : "none";
+  const headerLabel = itemType === "pr" ? "This PR" : "This PR/Issue";
+  const treeUrl = treeRepoUrl ?? "";
+  const treeNodeLinks =
+    treeNodes.length > 0
+      ? treeNodes
+          .map(
+            (n) =>
+              `- [\`${n.path}\`](${treeUrl}/blob/main/${n.path}) — ${n.summary}`,
+          )
+          .join("\n")
+      : `- _(no tree nodes cited — tree may be empty or irrelevant to this change)_`;
+  const markerLine1 = `<!-- gardener:state · reviewed=${reviewedFull} · verdict=${verdict} · severity=${severity} · tree_sha=${treeSha} -->`;
+  const markerLine2 = `<!-- gardener:last_consumed_rereview=${consumedId} -->`;
+
+  const detailsOpen = isMinimalAligned ? "<details>" : "<details open>";
+  const closing = isMinimalAligned
+    ? `No concerns. ${summary}`
+    : `### Recommendation\n\n**Why:** ${summary}\n\n**Suggested path forward:** _See the tree nodes cited above for the decision this touches._`;
+
+  const treeSlugLine = treeSlug && treeRepoUrl
+    ? `Reviews this repo against [${treeSlug}](${treeRepoUrl}), a user-maintained context tree. Not affiliated with this project's maintainers.`
+    : "Reviews this repo against a user-maintained context tree. Not affiliated with this project's maintainers.";
+
+  const lines = [
+    markerLine1,
+    markerLine2,
+    "",
+    `🌱 **gardener** · ${emoji} \`${verdict}\` · severity: \`${severity}\` · commit: \`${reviewedShort}\``,
+    "",
+    "> **What is this?** repo-gardener checks whether PRs and issues fit the project's **product decisions, architecture, and roadmap** — not code correctness. Think of it as a product-context review layer. For code review, see Greptile/CodeRabbit.",
+    "",
+    "### Context fit",
+    "",
+    detailsOpen,
+    "<summary><strong>Context match</strong></summary>",
+    "",
+    `| Area | ${headerLabel} | Tree guidance | Fit |`,
+    "|------|---------------|---------------|-----|",
+    `| overall | ${summary} | ${treeNodes[0]?.summary ?? "(none cited)"} | ${fitCell} |`,
+    "",
+    "</details>",
+    "",
+    "<details>",
+    "<summary><strong>Tree nodes referenced</strong></summary>",
+    "",
+    treeNodeLinks,
+    "",
+    "</details>",
+    "",
+    closing,
+    "",
+    "---",
+    "",
+    `<sub>Reviewed commit: <code>${reviewedShort}</code> · Tree snapshot: <code>${treeShaShort}</code> · Commands: <code>@gardener re-review</code> · <code>@gardener pause</code> · <code>@gardener ignore</code></sub>`,
+    "",
+    `<sub>🌱 Posted by [repo-gardener](https://github.com/agent-team-foundation/repo-gardener) — an open-source context-aware review bot built on [First-Tree](https://github.com/agent-team-foundation/first-tree). ${treeSlugLine}</sub>`,
+  ];
+  return lines.join("\n");
+}
+
+// ───────────────────────── Snapshot / gh I/O ─────────────────────
+
+function jsonTryParse<T>(text: string): T | null {
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read a snapshot bundle from `$BREEZE_SNAPSHOT_DIR`. Returns null if
+ * required files are missing — caller should fall back to live gh
+ * fetches. Required files depend on the type:
+ *   - PR: `pr-view.json`, `pr.diff`, `issue-comments.json`
+ *   - Issue: `issue-view.json`, `issue-comments.json`
+ * `subject.json` is optional and supplies gardener user + tree SHA.
+ */
+export function readSnapshot(dir: string): SnapshotBundle | null {
+  const prViewPath = join(dir, "pr-view.json");
+  const issueViewPath = join(dir, "issue-view.json");
+  const commentsPath = join(dir, "issue-comments.json");
+  const diffPath = join(dir, "pr.diff");
+  const subjectPath = join(dir, "subject.json");
+
+  const subject = existsSync(subjectPath)
+    ? jsonTryParse<SubjectMetadata>(readFileSync(subjectPath, "utf-8")) ?? {}
+    : {};
+
+  const issueComments = existsSync(commentsPath)
+    ? jsonTryParse<IssueComment[]>(readFileSync(commentsPath, "utf-8")) ?? []
+    : [];
+
+  if (existsSync(prViewPath)) {
+    const prView = jsonTryParse<PrView>(readFileSync(prViewPath, "utf-8"));
+    if (!prView) return null;
+    const diff = existsSync(diffPath) ? readFileSync(diffPath, "utf-8") : "";
+    return {
+      subject,
+      type: "pr",
+      prView,
+      diff,
+      issueComments,
+    };
+  }
+
+  if (existsSync(issueViewPath)) {
+    const issueView = jsonTryParse<IssueView>(
+      readFileSync(issueViewPath, "utf-8"),
+    );
+    if (!issueView) return null;
+    return {
+      subject,
+      type: "issue",
+      issueView,
+      issueComments,
+    };
+  }
+
+  return null;
+}
+
+async function fetchPrBundle(
+  shell: ShellRun,
+  repo: string,
+  pr: number,
+): Promise<SnapshotBundle | null> {
+  const viewRes = await shell("gh", [
+    "pr",
+    "view",
+    String(pr),
+    "--repo",
+    repo,
+    "--json",
+    "number,title,body,headRefName,headRefOid,state,author,additions,deletions,labels,updatedAt",
+  ]);
+  if (viewRes.code !== 0) return null;
+  const prView = jsonTryParse<PrView>(viewRes.stdout);
+  if (!prView) return null;
+
+  const commentsRes = await shell("gh", [
+    "api",
+    "--paginate",
+    `/repos/${repo}/issues/${pr}/comments`,
+  ]);
+  const issueComments = commentsRes.code === 0
+    ? jsonTryParse<IssueComment[]>(commentsRes.stdout) ?? []
+    : [];
+
+  const diffRes = await shell("gh", [
+    "pr",
+    "diff",
+    String(pr),
+    "--repo",
+    repo,
+  ]);
+  const diff = diffRes.code === 0 ? diffRes.stdout : "";
+
+  return { subject: {}, type: "pr", prView, diff, issueComments };
+}
+
+async function fetchIssueBundle(
+  shell: ShellRun,
+  repo: string,
+  issue: number,
+): Promise<SnapshotBundle | null> {
+  const viewRes = await shell("gh", [
+    "issue",
+    "view",
+    String(issue),
+    "--repo",
+    repo,
+    "--json",
+    "number,title,body,state,author,labels,updatedAt",
+  ]);
+  if (viewRes.code !== 0) return null;
+  const issueView = jsonTryParse<IssueView>(viewRes.stdout);
+  if (!issueView) return null;
+
+  const commentsRes = await shell("gh", [
+    "api",
+    "--paginate",
+    `/repos/${repo}/issues/${issue}/comments`,
+  ]);
+  const issueComments = commentsRes.code === 0
+    ? jsonTryParse<IssueComment[]>(commentsRes.stdout) ?? []
+    : [];
+
+  return { subject: {}, type: "issue", issueView, issueComments };
+}
+
+async function fetchGardenerUser(
+  shell: ShellRun,
+): Promise<string | undefined> {
+  const res = await shell("gh", ["api", "user", "--jq", ".login"]);
+  if (res.code !== 0) return undefined;
+  const login = res.stdout.trim();
+  return login.length > 0 ? login : undefined;
+}
+
+// ───────────────────────── Logging + BREEZE_RESULT ───────────────
+
+function commentLogPath(env: NodeJS.ProcessEnv): string {
+  if (env.COMMENT_LOG && env.COMMENT_LOG.length > 0) return env.COMMENT_LOG;
+  const home = env.HOME ?? env.USERPROFILE ?? process.cwd();
+  return join(home, ".gardener", "comment-runs.jsonl");
+}
+
+function logEvent(
+  env: NodeJS.ProcessEnv,
+  event: Record<string, unknown>,
+): void {
+  try {
+    const path = commentLogPath(env);
+    mkdirSync(dirname(path), { recursive: true });
+    const line = JSON.stringify({
+      ts: new Date().toISOString(),
+      ...event,
+    });
+    appendFileSync(path, `${line}\n`);
+  } catch {
+    // Best-effort — never fail a run because of log IO.
+  }
+}
+
+function emitBreezeResult(
+  write: (line: string) => void,
+  status: CommentStatus,
+  summary: string,
+): void {
+  const compact = summary.replace(/\s+/g, " ").trim() || "no-op";
+  write(`BREEZE_RESULT: status=${status} summary=${compact}`);
+}
+
+// ───────────────────────── Single-item review ─────────────────────
+
+interface ReviewOneInput {
+  repo: string;
+  number: number;
+  type: ItemType;
+  treeRoot: string;
+  dryRun: boolean;
+  shell: ShellRun;
+  env: NodeJS.ProcessEnv;
+  write: (line: string) => void;
+  now: () => Date;
+  classifier: Classifier;
+  treeRepoUrl?: string;
+  treeSlug?: string;
+  treeSha?: string;
+}
+
+async function reviewOne(
+  opts: ReviewOneInput,
+): Promise<{ status: CommentStatus; summary: string }> {
+  const {
+    repo,
+    number,
+    type,
+    treeRoot,
+    dryRun,
+    shell,
+    env,
+    write,
+    classifier,
+    treeRepoUrl,
+    treeSlug,
+  } = opts;
+
+  const snapshotDir = env.BREEZE_SNAPSHOT_DIR;
+  const bundle = snapshotDir
+    ? readSnapshot(snapshotDir)
+    : type === "pr"
+      ? await fetchPrBundle(shell, repo, number)
+      : await fetchIssueBundle(shell, repo, number);
+
+  if (!bundle) {
+    const msg = `Could not load ${type} data for ${repo}#${number}`;
+    write(msg);
+    logEvent(env, { kind: "error", message: msg });
+    return { status: "failed", summary: `fetch failed for ${repo}#${number}` };
+  }
+
+  // Resolve gardener user: from subject, env, or gh.
+  let gardenerUser = bundle.subject.gardenerUser;
+  if (!gardenerUser) gardenerUser = env.GARDENER_USER;
+  if (!gardenerUser) gardenerUser = await fetchGardenerUser(shell);
+  if (!gardenerUser) {
+    const msg = `Could not resolve gardener user (gh api user failed)`;
+    write(msg);
+    logEvent(env, { kind: "error", message: msg });
+    return { status: "failed", summary: msg };
+  }
+
+  // Freshness guard — skip merged/closed items (Step 4-pre).
+  const itemState = type === "pr"
+    ? bundle.prView?.state
+    : bundle.issueView?.state;
+  if (type === "pr" && (itemState === "MERGED" || itemState === "CLOSED")) {
+    const msg = `#${number}: ${itemState} since scan, skipping`;
+    write(`\u23ed ${msg}`);
+    logEvent(env, { kind: "skip", number, reason: "stale" });
+    return { status: "skipped", summary: msg };
+  }
+  if (type === "issue" && (itemState === "closed" || itemState === "CLOSED")) {
+    const msg = `#${number}: issue closed since scan, skipping`;
+    write(`\u23ed ${msg}`);
+    logEvent(env, { kind: "skip", number, reason: "stale" });
+    return { status: "skipped", summary: msg };
+  }
+
+  // Resolve state (Step 2).
+  const view = type === "pr" ? bundle.prView : bundle.issueView;
+  const headIdentifier = type === "pr"
+    ? bundle.prView?.headRefOid
+    : bundle.issueView?.updatedAt;
+  const action = resolveState({
+    comments: bundle.issueComments,
+    gardenerUser,
+    headIdentifier,
+    hasReviewedLabel: hasReviewedLabel(view),
+  });
+
+  if (action.kind === "skip") {
+    write(`\u23ed #${number}: ${action.reason}`);
+    logEvent(env, { kind: "skip", number, reason: action.reason });
+    return { status: "skipped", summary: action.reason };
+  }
+
+  // Classify (Step 4b).
+  const classification = await classifier({
+    type,
+    prView: bundle.prView,
+    issueView: bundle.issueView,
+    diff: bundle.diff,
+    treeRoot,
+    treeSha: opts.treeSha ?? bundle.subject.treeSha,
+  });
+
+  const reviewedFull = type === "pr"
+    ? bundle.prView?.headRefOid ?? "unknown"
+    : `issue@${bundle.issueView?.updatedAt ?? ""}`;
+  const reviewedShort = type === "pr"
+    ? (bundle.prView?.headRefOid ?? "").slice(0, 8) || "unknown"
+    : (bundle.issueView?.updatedAt ?? "").slice(0, 10) || "unknown";
+  const treeSha = opts.treeSha ?? bundle.subject.treeSha ?? "unknown";
+  const treeShaShort = treeSha === "unknown" ? "unknown" : treeSha.slice(0, 8);
+
+  // Silent-aligned path (Step 4c) — ALIGNED + low + first review + no
+  // consumed rereview + has write access. In the absence of a permission
+  // probe we treat the presence of `ALIGNED` + `low` + first_review
+  // without a re-review trigger as eligible for the label path.
+  if (
+    classification.verdict === "ALIGNED" &&
+    classification.severity === "low" &&
+    action.kind === "first_review"
+  ) {
+    const pr = bundle.prView;
+    const large = pr &&
+      (pr.additions ?? 0) + (pr.deletions ?? 0) > 500;
+    if (!large) {
+      write(
+        `\u2713 #${number}: ALIGNED + low → applying gardener:reviewed label (silent path)`,
+      );
+      if (!dryRun) {
+        const editCmd = type === "pr" ? "pr" : "issue";
+        await shell("gh", [
+          editCmd,
+          "edit",
+          String(number),
+          "--repo",
+          repo,
+          "--add-label",
+          "gardener:reviewed",
+        ]);
+      }
+      logEvent(env, {
+        kind: "item",
+        number,
+        type,
+        verdict: "ALIGNED",
+        severity: "low",
+        silent_aligned: true,
+      });
+      return { status: "handled", summary: `silent-aligned #${number}` };
+    }
+    // large PRs fall through to minimal comment.
+  }
+
+  const body = buildCommentBody({
+    verdict: classification.verdict,
+    severity: classification.severity,
+    summary: classification.summary,
+    treeNodes: classification.treeNodes,
+    reviewedShort,
+    reviewedFull,
+    treeSha,
+    treeShaShort,
+    consumedRereviewId:
+      action.kind === "rereview" ? action.consumedRereviewId : undefined,
+    treeRepoUrl,
+    treeSlug,
+    itemType: type,
+  });
+
+  if (action.kind === "rereview" && action.commentId > 0) {
+    // PATCH existing comment (Step 4e).
+    write(
+      `\u2712 #${number}: re-review → PATCH comment ${action.commentId} (${classification.verdict})`,
+    );
+    if (!dryRun) {
+      await shell("gh", [
+        "api",
+        "-X",
+        "PATCH",
+        `/repos/${repo}/issues/comments/${action.commentId}`,
+        "-f",
+        `body=${body}`,
+      ]);
+    }
+    logEvent(env, {
+      kind: "item",
+      number,
+      type,
+      verdict: classification.verdict,
+      severity: classification.severity,
+      patched: true,
+      comment_id: action.commentId,
+    });
+    return {
+      status: "handled",
+      summary: `patched #${number} verdict=${classification.verdict}`,
+    };
+  }
+
+  // First review — POST new comment.
+  write(
+    `\u2713 #${number}: first review → POST (${classification.verdict}/${classification.severity})`,
+  );
+  if (!dryRun) {
+    await shell("gh", [
+      "api",
+      "-X",
+      "POST",
+      `/repos/${repo}/issues/${number}/comments`,
+      "-f",
+      `body=${body}`,
+    ]);
+  }
+  logEvent(env, {
+    kind: "item",
+    number,
+    type,
+    verdict: classification.verdict,
+    severity: classification.severity,
+    patched: false,
+  });
+  return {
+    status: "handled",
+    summary: `posted #${number} verdict=${classification.verdict}`,
+  };
+}
+
+// ───────────────────────── Scan mode ─────────────────────────
+
+async function runScan(opts: {
+  treeRoot: string;
+  dryRun: boolean;
+  shell: ShellRun;
+  env: NodeJS.ProcessEnv;
+  write: (line: string) => void;
+  now: () => Date;
+  classifier: Classifier;
+  targetRepo: string;
+  treeRepoUrl?: string;
+  treeSlug?: string;
+  treeSha?: string;
+}): Promise<{ status: CommentStatus; summary: string }> {
+  const { shell, write, env, targetRepo } = opts;
+
+  const prsRes = await shell("gh", [
+    "pr",
+    "list",
+    "--repo",
+    targetRepo,
+    "--state",
+    "open",
+    "--limit",
+    "30",
+    "--json",
+    "number,title,headRefName,headRefOid,state,author,additions,deletions,labels,updatedAt",
+  ]);
+  const prs = prsRes.code === 0
+    ? jsonTryParse<PrView[]>(prsRes.stdout) ?? []
+    : [];
+
+  const issuesRes = await shell("gh", [
+    "issue",
+    "list",
+    "--repo",
+    targetRepo,
+    "--state",
+    "open",
+    "--limit",
+    "30",
+    "--json",
+    "number,title,author,state,labels,updatedAt",
+  ]);
+  const issues = issuesRes.code === 0
+    ? jsonTryParse<IssueView[]>(issuesRes.stdout) ?? []
+    : [];
+
+  const queue: Array<{ number: number; type: ItemType }> = [
+    ...prs.map((p): { number: number; type: ItemType } => ({
+      number: p.number,
+      type: "pr",
+    })),
+    ...issues.map((i): { number: number; type: ItemType } => ({
+      number: i.number,
+      type: "issue",
+    })),
+  ];
+
+  if (queue.length === 0) {
+    write(`\ud83c\udf31 Nothing to tend on ${targetRepo}`);
+    return { status: "skipped", summary: `no items on ${targetRepo}` };
+  }
+
+  let handled = 0;
+  let skipped = 0;
+  let failed = 0;
+  for (const item of queue) {
+    const result = await reviewOne({
+      repo: targetRepo,
+      number: item.number,
+      type: item.type,
+      treeRoot: opts.treeRoot,
+      dryRun: opts.dryRun,
+      shell,
+      env,
+      write,
+      now: opts.now,
+      classifier: opts.classifier,
+      treeRepoUrl: opts.treeRepoUrl,
+      treeSlug: opts.treeSlug,
+      treeSha: opts.treeSha,
+    });
+    if (result.status === "handled") handled += 1;
+    else if (result.status === "failed") failed += 1;
+    else skipped += 1;
+  }
+
+  const summary = `scanned=${queue.length} handled=${handled} skipped=${skipped} failed=${failed}`;
+  write(`gardener-comment run complete (scan)\n  Target repo: ${targetRepo}\n  ${summary}`);
+  logEvent(env, {
+    kind: "run",
+    target_repo: targetRepo,
+    scanned: queue.length,
+    handled,
+    skipped,
+    failed,
+  });
+  return {
+    status: failed > 0 ? "failed" : handled > 0 ? "handled" : "skipped",
+    summary,
+  };
+}
+
+// ───────────────────────── Top-level entry ─────────────────────────
+
+export interface RunCommentOptions extends CommentDeps {
+  classifier?: Classifier;
+}
+
+export async function runComment(
+  args: string[],
+  deps: RunCommentOptions = {},
+): Promise<number> {
+  const write = deps.write ?? ((line: string): void => console.log(line));
+  const shell = deps.shellRun ?? defaultShellRun;
+  const env = deps.env ?? process.env;
+  const now = deps.now ?? (() => new Date());
+  const classifier = deps.classifier ?? defaultClassifier;
+
+  const flags = parseFlags(args);
+  if (flags.help) {
+    write(COMMENT_USAGE);
+    emitBreezeResult(write, "skipped", "help requested");
+    return 0;
+  }
+  if (flags.unknown) {
+    write(`Unknown comment option: ${flags.unknown}`);
+    write(COMMENT_USAGE);
+    emitBreezeResult(write, "failed", `bad flag ${flags.unknown}`);
+    return 1;
+  }
+
+  const treeRoot = flags.treePath
+    ? resolve(process.cwd(), flags.treePath)
+    : process.cwd();
+
+  // Config opt-out.
+  const config = loadGardenerConfig(treeRoot);
+  if (!isModuleEnabled(config, "comment")) {
+    write(
+      "\u23ed gardener-comment is disabled via .claude/gardener-config.yaml",
+    );
+    emitBreezeResult(write, "skipped", "comment module disabled");
+    return 0;
+  }
+
+  // Derive tree-repo metadata for footer attribution when we can. The
+  // runbook's tree_repo is a URL; we accept either `owner/name` or a
+  // full URL and extract the slug/URL best-effort.
+  const { treeRepoUrl, treeSlug } = parseTreeRepo(config?.tree_repo);
+
+  try {
+    if (flags.pr !== undefined || flags.issue !== undefined) {
+      const type: ItemType = flags.pr !== undefined ? "pr" : "issue";
+      const number = (flags.pr ?? flags.issue) as number;
+      if (!flags.repo) {
+        write(`--repo is required with --pr/--issue`);
+        emitBreezeResult(write, "failed", "missing --repo");
+        return 1;
+      }
+      const result = await reviewOne({
+        repo: flags.repo,
+        number,
+        type,
+        treeRoot,
+        dryRun: flags.dryRun,
+        shell,
+        env,
+        write,
+        now,
+        classifier,
+        treeRepoUrl,
+        treeSlug,
+      });
+      emitBreezeResult(write, result.status, result.summary);
+      return result.status === "failed" ? 1 : 0;
+    }
+
+    // target_repo is a runbook-level field not exposed on GardenerConfig
+    // (which tracks target_repos plural). Read it directly from the YAML
+    // file, falling back to target_repos[0] from the typed loader.
+    const targetRepo = readTargetRepoFromYaml(treeRoot) ??
+      (config?.target_repos?.[0] ?? undefined);
+    if (!targetRepo) {
+      const msg = `target_repo not set in .claude/gardener-config.yaml — specify --pr/--issue --repo instead`;
+      write(msg);
+      emitBreezeResult(write, "failed", msg);
+      return 1;
+    }
+
+    const result = await runScan({
+      treeRoot,
+      dryRun: flags.dryRun,
+      shell,
+      env,
+      write,
+      now,
+      classifier,
+      targetRepo,
+      treeRepoUrl,
+      treeSlug,
+    });
+    emitBreezeResult(write, result.status, result.summary);
+    return result.status === "failed" ? 1 : 0;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    write(`\u274c gardener-comment failed: ${message}`);
+    logEvent(env, { kind: "error", message });
+    emitBreezeResult(write, "failed", message);
+    return 1;
+  }
+}
+
+/**
+ * Read the scalar `target_repo:` line directly from
+ * `.claude/gardener-config.yaml`. The shared loader tracks
+ * `target_repos` (plural) instead; `target_repo` is a runbook-level
+ * field we don't want to extend the loader for.
+ */
+function readTargetRepoFromYaml(treeRoot: string): string | undefined {
+  const path = join(treeRoot, ".claude", "gardener-config.yaml");
+  if (!existsSync(path)) return undefined;
+  try {
+    const text = readFileSync(path, "utf-8");
+    for (const line of text.split(/\r?\n/)) {
+      const match = line.match(/^\s*target_repo\s*:\s*(.+?)\s*(?:#.*)?$/);
+      if (match) {
+        const value = match[1].trim();
+        if (value.length === 0) continue;
+        if (
+          (value.startsWith('"') && value.endsWith('"')) ||
+          (value.startsWith("'") && value.endsWith("'"))
+        ) {
+          return value.slice(1, -1);
+        }
+        return value;
+      }
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function parseTreeRepo(raw: string | undefined): {
+  treeRepoUrl?: string;
+  treeSlug?: string;
+} {
+  if (!raw) return {};
+  if (raw.startsWith("http")) {
+    const match = raw.match(/github\.com\/([^/]+\/[^/]+?)(?:\.git)?\/?$/);
+    return {
+      treeRepoUrl: raw.replace(/\.git$/, ""),
+      treeSlug: match?.[1],
+    };
+  }
+  if (/^[^/]+\/[^/]+$/.test(raw)) {
+    return {
+      treeRepoUrl: `https://github.com/${raw}`,
+      treeSlug: raw,
+    };
+  }
+  return {};
+}

--- a/src/products/gardener/engine/comment.ts
+++ b/src/products/gardener/engine/comment.ts
@@ -465,12 +465,22 @@ export function resolveState(input: ResolveStateInput): StateAction {
   const { comments, gardenerUser, headIdentifier, hasReviewedLabel } = input;
 
   // Find gardener's own comments (state comments) and user commands.
+  // A comment is "from gardener" if EITHER the login matches OR the
+  // body carries a `<!-- gardener:` HTML marker (marker fallback handles
+  // comments authored under a different bot identity — self-loop guard
+  // from first-tree#134 / repo-gardener#22).
+  const hasGardenerMarker = (body: string | undefined): boolean =>
+    typeof body === "string" && /<!--\s*gardener:/.test(body);
   const gardenerComments = comments.filter(
-    (c) => c.user?.login === gardenerUser && c.body && c.body.length > 0,
+    (c) =>
+      (c.user?.login === gardenerUser || hasGardenerMarker(c.body)) &&
+      c.body &&
+      c.body.length > 0,
   );
   const userCommands = comments.filter(
     (c) =>
       c.user?.login !== gardenerUser &&
+      !hasGardenerMarker(c.body) &&
       typeof c.body === "string" &&
       GARDENER_COMMAND_RE.test(c.body),
   );
@@ -925,6 +935,27 @@ async function reviewOne(
     write(msg);
     logEvent(env, { kind: "error", message: msg });
     return { status: "failed", summary: `fetch failed for ${repo}#${number}` };
+  }
+
+  // Self-loop guard: gardener-comment is for source-repo PRs, not for
+  // gardener's own tree PRs. Tree PRs carry the `first-tree:sync` label
+  // — skip them here so the comment module never posts a verdict on a
+  // PR gardener opened. See: agent-team-foundation/first-tree#134,
+  // repo-gardener#22.
+  const prOrIssueView = type === "pr" ? bundle.prView : bundle.issueView;
+  const labels = labelNames(prOrIssueView?.labels);
+  if (labels.includes("first-tree:sync")) {
+    const msg = `#${number} has first-tree:sync label — gardener-comment skips sync PRs to avoid self-loops`;
+    write(`\u23ed ${msg}`);
+    logEvent(env, {
+      kind: "skip",
+      number,
+      reason: "first-tree:sync label",
+    });
+    return {
+      status: "skipped",
+      summary: `sync PR — not a comment-module target`,
+    };
   }
 
   // Resolve gardener user: from subject, env, or gh.

--- a/tests/gardener-comment.test.ts
+++ b/tests/gardener-comment.test.ts
@@ -207,6 +207,29 @@ describe("gardener comment -- state resolution", () => {
     }
   });
 
+  it("gardener:state for issue with matching issue@<iso> → skip (regression guard for #132 review)", () => {
+    // Issues store `issue@<iso-timestamp>` in the marker. reviewOne must pass
+    // the same form as headIdentifier so shaMatches compares like-for-like.
+    // Previously headIdentifier was raw ISO and marker was `issue@<iso>` —
+    // shaMatches never matched → every scan re-PATCHed historical issue comments.
+    const iso = "2026-04-15T10:00:00Z";
+    const action = resolveState({
+      comments: [
+        {
+          id: 7,
+          user: { login: gardenerUser },
+          body:
+            `<!-- gardener:state · reviewed=issue@${iso} · verdict=ALIGNED · severity=low · tree_sha=t -->`,
+          created_at: iso,
+        },
+      ],
+      gardenerUser,
+      headIdentifier: `issue@${iso}`,
+      hasReviewedLabel: false,
+    });
+    expect(action.kind).toBe("skip");
+  });
+
   it("no marker and no label → first_review", () => {
     const action = resolveState({
       comments: [],

--- a/tests/gardener-comment.test.ts
+++ b/tests/gardener-comment.test.ts
@@ -1,0 +1,783 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { runCli } from "../src/cli.js";
+import { GARDENER_USAGE, runGardener } from "#products/gardener/cli.js";
+import {
+  buildCommentBody,
+  COMMENT_USAGE,
+  defaultClassifier,
+  extractStateMarker,
+  GARDENER_COMMAND_RE,
+  GARDENER_IGNORED_MARKER_RE,
+  GARDENER_STATE_MARKER_RE,
+  hasIgnoredMarker,
+  hasPausedMarker,
+  hasReviewedLabel,
+  parseStateMarker,
+  readLastConsumedRereview,
+  readSnapshot,
+  resolveState,
+  runComment,
+  shaMatches,
+  type Classifier,
+  type ShellResult,
+  type ShellRun,
+} from "#products/gardener/engine/comment.js";
+import { useTmpDir } from "./helpers.js";
+
+function writeConfig(treeRoot: string, yaml: string): void {
+  const dir = join(treeRoot, ".claude");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "gardener-config.yaml"), yaml);
+}
+
+interface ShellCall {
+  command: string;
+  args: string[];
+  cwd?: string;
+}
+
+function makeShell(
+  handlers: Array<(call: ShellCall) => ShellResult | null>,
+  calls: ShellCall[] = [],
+): ShellRun {
+  return async (command, args, options) => {
+    const call: ShellCall = { command, args, cwd: options?.cwd };
+    calls.push(call);
+    for (const handler of handlers) {
+      const result = handler(call);
+      if (result) return result;
+    }
+    return {
+      stdout: "",
+      stderr: `no mock for ${command} ${args.join(" ")}`,
+      code: 1,
+    };
+  };
+}
+
+function captureWrite(): { write: (line: string) => void; lines: string[] } {
+  const lines: string[] = [];
+  return {
+    write: (line: string): void => {
+      for (const split of line.split("\n")) lines.push(split);
+    },
+    lines,
+  };
+}
+
+const alignedClassifier: Classifier = async () => ({
+  verdict: "ALIGNED",
+  severity: "low",
+  summary: "Fits the V1 scope decision.",
+  treeNodes: [{ path: "product/NODE.md", summary: "V1 scope summary" }],
+});
+
+const conflictClassifier: Classifier = async () => ({
+  verdict: "CONFLICT",
+  severity: "high",
+  summary: "Contradicts the thin-core decision.",
+  treeNodes: [{ path: "product/NODE.md", summary: "thin core principle" }],
+});
+
+// ─────────────────── 1. opt-out ───────────────────
+describe("gardener comment -- config opt-out", () => {
+  it("exits 0 with opt-out message and does not call gh", async () => {
+    const tmp = useTmpDir();
+    writeConfig(tmp.path, "modules:\n  comment:\n    enabled: false\n");
+    const calls: ShellCall[] = [];
+    const shell = makeShell([], calls);
+    const { write, lines } = captureWrite();
+    const code = await runComment(
+      ["--tree-path", tmp.path],
+      {
+        shellRun: shell,
+        write,
+        env: {},
+        now: () => new Date("2026-04-16T00:00:00Z"),
+      },
+    );
+    expect(code).toBe(0);
+    expect(calls).toHaveLength(0);
+    const joined = lines.join("\n");
+    expect(joined).toContain("gardener-comment is disabled via .claude/gardener-config.yaml");
+    expect(lines[lines.length - 1]).toMatch(/^BREEZE_RESULT: status=skipped /);
+  });
+});
+
+// ─────────────────── 2. --help ───────────────────
+describe("gardener comment -- --help", () => {
+  it("prints COMMENT_USAGE", async () => {
+    const { write, lines } = captureWrite();
+    const code = await runComment(["--help"], { write });
+    expect(code).toBe(0);
+    const joined = lines.join("\n");
+    expect(joined).toContain(COMMENT_USAGE);
+    expect(lines[lines.length - 1]).toMatch(/^BREEZE_RESULT: /);
+  });
+});
+
+// ─────────────────── 3. CLI dispatch ───────────────────
+describe("gardener CLI dispatch -- comment subcommand", () => {
+  it("runGardener(['comment', '--help']) prints COMMENT_USAGE", async () => {
+    const { write, lines } = captureWrite();
+    const code = await runGardener(["comment", "--help"], write);
+    expect(code).toBe(0);
+    expect(lines.join("\n")).toContain(COMMENT_USAGE);
+  });
+
+  it("runCli dispatches gardener comment --help", async () => {
+    const { write, lines } = captureWrite();
+    const code = await runCli(["gardener", "comment", "--help"], write);
+    expect(code).toBe(0);
+    expect(lines.join("\n")).toContain(COMMENT_USAGE);
+  });
+
+  it("GARDENER_USAGE lists the comment command", () => {
+    expect(GARDENER_USAGE).toContain("comment");
+    expect(GARDENER_USAGE).toContain("respond");
+  });
+});
+
+// ─────────────────── 4. state resolution ───────────────────
+describe("gardener comment -- state resolution", () => {
+  const gardenerUser = "repo-gardener";
+
+  it("ignored marker → skip forever", () => {
+    const action = resolveState({
+      comments: [
+        {
+          id: 1,
+          user: { login: gardenerUser },
+          body:
+            "<!-- gardener:state · reviewed=abc -->\n<!-- gardener:ignored -->",
+          created_at: "2026-04-15T00:00:00Z",
+        },
+      ],
+      gardenerUser,
+      headIdentifier: "xyz",
+      hasReviewedLabel: false,
+    });
+    expect(action.kind).toBe("skip");
+    if (action.kind === "skip") {
+      expect(action.reason).toContain("ignored");
+    }
+  });
+
+  it("gardener:state with matching SHA → skip", () => {
+    const action = resolveState({
+      comments: [
+        {
+          id: 2,
+          user: { login: gardenerUser },
+          body:
+            "<!-- gardener:state · reviewed=abcdef1234 · verdict=NEEDS_REVIEW · severity=low · tree_sha=t -->",
+          created_at: "2026-04-15T00:00:00Z",
+        },
+      ],
+      gardenerUser,
+      headIdentifier: "abcdef1234",
+      hasReviewedLabel: false,
+    });
+    expect(action.kind).toBe("skip");
+    if (action.kind === "skip") {
+      expect(action.reason).toContain("matches head");
+    }
+  });
+
+  it("gardener:state with different SHA → rereview (PATCH path)", () => {
+    const action = resolveState({
+      comments: [
+        {
+          id: 3,
+          user: { login: gardenerUser },
+          body:
+            "<!-- gardener:state · reviewed=oldshaabc · verdict=ALIGNED · severity=low · tree_sha=t -->",
+          created_at: "2026-04-15T00:00:00Z",
+        },
+      ],
+      gardenerUser,
+      headIdentifier: "newshaxyz",
+      hasReviewedLabel: false,
+    });
+    expect(action.kind).toBe("rereview");
+    if (action.kind === "rereview") {
+      expect(action.commentId).toBe(3);
+    }
+  });
+
+  it("no marker and no label → first_review", () => {
+    const action = resolveState({
+      comments: [],
+      gardenerUser,
+      headIdentifier: "abc",
+      hasReviewedLabel: false,
+    });
+    expect(action.kind).toBe("first_review");
+  });
+
+  it("paused marker without resume → skip", () => {
+    const action = resolveState({
+      comments: [
+        {
+          id: 10,
+          user: { login: gardenerUser },
+          body: "<!-- gardener:state · reviewed=abc -->\n<!-- gardener:paused -->",
+          created_at: "2026-04-10T00:00:00Z",
+        },
+        {
+          id: 11,
+          user: { login: "someone" },
+          body: "@gardener pause please",
+          created_at: "2026-04-14T00:00:00Z",
+        },
+      ],
+      gardenerUser,
+      headIdentifier: "xyz",
+      hasReviewedLabel: false,
+    });
+    expect(action.kind).toBe("skip");
+  });
+});
+
+// ─────────────────── 5. @gardener re-review ───────────────────
+describe("gardener comment -- @gardener re-review", () => {
+  const gardenerUser = "repo-gardener";
+
+  it("re-review command triggers rereview", () => {
+    const action = resolveState({
+      comments: [
+        {
+          id: 20,
+          user: { login: gardenerUser },
+          body:
+            "<!-- gardener:state · reviewed=abc · verdict=ALIGNED · severity=low · tree_sha=t -->\n<!-- gardener:last_consumed_rereview=none -->",
+          created_at: "2026-04-10T00:00:00Z",
+        },
+        {
+          id: 21,
+          user: { login: "maintainer" },
+          body: "@gardener re-review please",
+          created_at: "2026-04-14T00:00:00Z",
+        },
+      ],
+      gardenerUser,
+      headIdentifier: "abc",
+      hasReviewedLabel: false,
+    });
+    expect(action.kind).toBe("rereview");
+    if (action.kind === "rereview") {
+      expect(action.consumedRereviewId).toBe(21);
+      expect(action.commentId).toBe(20);
+    }
+  });
+
+  it("excludes self-authored @gardener command text from matching (critical)", () => {
+    // Gardener's own comment footer contains the literal
+    // "@gardener re-review" text — if resolveState matched it, every
+    // run would self-trigger a re-review forever.
+    const ownFooterBody =
+      "<!-- gardener:state · reviewed=abc · verdict=ALIGNED · severity=low · tree_sha=t -->\n" +
+      "Commands: @gardener re-review · @gardener pause · @gardener ignore";
+    const action = resolveState({
+      comments: [
+        {
+          id: 30,
+          user: { login: gardenerUser },
+          body: ownFooterBody,
+          created_at: "2026-04-10T00:00:00Z",
+        },
+      ],
+      gardenerUser,
+      headIdentifier: "abc",
+      hasReviewedLabel: false,
+    });
+    // Should NOT be rereview — SHA matches and self-footer is ignored.
+    expect(action.kind).toBe("skip");
+  });
+
+  it("marks re-review as consumed once last_consumed_rereview matches", () => {
+    const action = resolveState({
+      comments: [
+        {
+          id: 40,
+          user: { login: gardenerUser },
+          body:
+            "<!-- gardener:state · reviewed=abc · verdict=ALIGNED · severity=low · tree_sha=t -->\n<!-- gardener:last_consumed_rereview=41 -->",
+          created_at: "2026-04-14T10:00:00Z",
+        },
+        {
+          id: 41,
+          user: { login: "maintainer" },
+          body: "@gardener re-review please",
+          created_at: "2026-04-14T09:00:00Z",
+        },
+      ],
+      gardenerUser,
+      headIdentifier: "abc",
+      hasReviewedLabel: false,
+    });
+    // The re-review #41 has already been consumed — fall through to
+    // rule 4. SHA matches, so skip.
+    expect(action.kind).toBe("skip");
+  });
+});
+
+// ─────────────────── 6. verdict classification ───────────────────
+describe("gardener comment -- verdict classification", () => {
+  it("default classifier returns NEW_TERRITORY/low", async () => {
+    const out = await defaultClassifier({
+      type: "pr",
+      treeRoot: "/tmp",
+    });
+    expect(out.verdict).toBe("NEW_TERRITORY");
+    expect(out.severity).toBe("low");
+  });
+
+  const verdicts = [
+    "ALIGNED",
+    "NEW_TERRITORY",
+    "NEEDS_REVIEW",
+    "CONFLICT",
+    "INSUFFICIENT_CONTEXT",
+  ] as const;
+
+  it.each(verdicts)("accepts verdict %s from injected classifier", async (v) => {
+    const tmp = useTmpDir();
+    const snapshotDir = join(tmp.path, "snap");
+    mkdirSync(snapshotDir, { recursive: true });
+    writeFileSync(
+      join(snapshotDir, "pr-view.json"),
+      JSON.stringify({
+        number: 1,
+        title: "t",
+        headRefOid: "abcd",
+        state: "OPEN",
+        author: { login: "u" },
+        additions: 1,
+        deletions: 0,
+        updatedAt: "2026-04-16T00:00:00Z",
+      }),
+    );
+    writeFileSync(join(snapshotDir, "issue-comments.json"), JSON.stringify([]));
+    writeFileSync(
+      join(snapshotDir, "subject.json"),
+      JSON.stringify({ gardenerUser: "repo-gardener", treeSha: "tsha1234" }),
+    );
+    writeFileSync(join(snapshotDir, "pr.diff"), "");
+    const calls: ShellCall[] = [];
+    const shell = makeShell(
+      [() => ({ stdout: "", stderr: "", code: 0 })],
+      calls,
+    );
+    const { write, lines } = captureWrite();
+    const code = await runComment(
+      ["--pr", "1", "--repo", "o/r", "--tree-path", tmp.path],
+      {
+        shellRun: shell,
+        write,
+        env: { BREEZE_SNAPSHOT_DIR: snapshotDir },
+        now: () => new Date("2026-04-16T00:00:00Z"),
+        classifier: async () => ({
+          verdict: v,
+          severity: v === "CONFLICT" ? "high" : "low",
+          summary: `test ${v}`,
+          treeNodes: [],
+        }),
+      },
+    );
+    expect(code).toBe(0);
+    expect(lines[lines.length - 1]).toMatch(/^BREEZE_RESULT: /);
+  });
+});
+
+// ─────────────────── 7. silent-aligned path ───────────────────
+describe("gardener comment -- silent-aligned path", () => {
+  it("ALIGNED + low + small PR → label, no POST comment", async () => {
+    const tmp = useTmpDir();
+    const snapshotDir = join(tmp.path, "snap");
+    mkdirSync(snapshotDir, { recursive: true });
+    writeFileSync(
+      join(snapshotDir, "pr-view.json"),
+      JSON.stringify({
+        number: 7,
+        title: "small fix",
+        headRefOid: "abc123",
+        state: "OPEN",
+        additions: 5,
+        deletions: 2,
+        updatedAt: "2026-04-16T00:00:00Z",
+      }),
+    );
+    writeFileSync(join(snapshotDir, "issue-comments.json"), JSON.stringify([]));
+    writeFileSync(
+      join(snapshotDir, "subject.json"),
+      JSON.stringify({ gardenerUser: "repo-gardener" }),
+    );
+    writeFileSync(join(snapshotDir, "pr.diff"), "");
+
+    const calls: ShellCall[] = [];
+    const shell = makeShell(
+      [() => ({ stdout: "", stderr: "", code: 0 })],
+      calls,
+    );
+    const { write, lines } = captureWrite();
+    const code = await runComment(
+      ["--pr", "7", "--repo", "o/r", "--tree-path", tmp.path],
+      {
+        shellRun: shell,
+        write,
+        env: { BREEZE_SNAPSHOT_DIR: snapshotDir },
+        now: () => new Date("2026-04-16T00:00:00Z"),
+        classifier: alignedClassifier,
+      },
+    );
+    expect(code).toBe(0);
+    // Should have called `gh pr edit --add-label gardener:reviewed`.
+    const labelCalls = calls.filter(
+      (c) =>
+        c.command === "gh" &&
+        c.args[0] === "pr" &&
+        c.args[1] === "edit" &&
+        c.args.includes("gardener:reviewed"),
+    );
+    expect(labelCalls.length).toBe(1);
+    // Should NOT have POSTed a comment.
+    const postCalls = calls.filter(
+      (c) =>
+        c.command === "gh" &&
+        c.args[0] === "api" &&
+        c.args.includes("POST") &&
+        c.args.some((a) => a.includes("/comments") && !a.includes("comments/")),
+    );
+    expect(postCalls).toHaveLength(0);
+    expect(lines.some((l) => l.includes("silent path"))).toBe(true);
+  });
+
+  it("large ALIGNED PR falls through to minimal comment", async () => {
+    const tmp = useTmpDir();
+    const snapshotDir = join(tmp.path, "snap");
+    mkdirSync(snapshotDir, { recursive: true });
+    writeFileSync(
+      join(snapshotDir, "pr-view.json"),
+      JSON.stringify({
+        number: 8,
+        title: "large fix",
+        headRefOid: "def456",
+        state: "OPEN",
+        additions: 400,
+        deletions: 200,
+        updatedAt: "2026-04-16T00:00:00Z",
+      }),
+    );
+    writeFileSync(join(snapshotDir, "issue-comments.json"), JSON.stringify([]));
+    writeFileSync(
+      join(snapshotDir, "subject.json"),
+      JSON.stringify({ gardenerUser: "repo-gardener" }),
+    );
+    writeFileSync(join(snapshotDir, "pr.diff"), "");
+
+    const calls: ShellCall[] = [];
+    const shell = makeShell(
+      [() => ({ stdout: "", stderr: "", code: 0 })],
+      calls,
+    );
+    const { write } = captureWrite();
+    const code = await runComment(
+      ["--pr", "8", "--repo", "o/r", "--tree-path", tmp.path],
+      {
+        shellRun: shell,
+        write,
+        env: { BREEZE_SNAPSHOT_DIR: snapshotDir },
+        now: () => new Date("2026-04-16T00:00:00Z"),
+        classifier: alignedClassifier,
+      },
+    );
+    expect(code).toBe(0);
+    const postCalls = calls.filter(
+      (c) =>
+        c.command === "gh" &&
+        c.args[0] === "api" &&
+        c.args.includes("POST"),
+    );
+    expect(postCalls.length).toBeGreaterThan(0);
+  });
+});
+
+// ─────────────────── 8. comment format ───────────────────
+describe("gardener comment -- comment body format", () => {
+  it("includes HTML state marker, verdict header, and command footer", () => {
+    const body = buildCommentBody({
+      verdict: "CONFLICT",
+      severity: "high",
+      summary: "Contradicts thin-core decision.",
+      treeNodes: [
+        { path: "product/NODE.md", summary: "thin core principle" },
+      ],
+      reviewedShort: "abc12345",
+      reviewedFull: "abc123451234567890",
+      treeSha: "tsha12345678",
+      treeShaShort: "tsha1234",
+      treeRepoUrl: "https://github.com/acme/tree",
+      treeSlug: "acme/tree",
+      itemType: "pr",
+    });
+    expect(body).toContain("<!-- gardener:state ");
+    expect(body).toContain("verdict=CONFLICT");
+    expect(body).toContain("severity=high");
+    expect(body).toContain("gardener:last_consumed_rereview=none");
+    expect(body).toContain("@gardener re-review");
+    expect(body).toContain("@gardener pause");
+    expect(body).toContain("@gardener ignore");
+    expect(body).toContain("⚠️");
+    expect(body).toContain("acme/tree");
+    expect(body).toContain("### Recommendation");
+  });
+
+  it("ALIGNED + low comment uses 'No concerns' line and collapsed details", () => {
+    const body = buildCommentBody({
+      verdict: "ALIGNED",
+      severity: "low",
+      summary: "Fits V1.",
+      treeNodes: [],
+      reviewedShort: "abc12345",
+      reviewedFull: "abc123451234567890",
+      treeSha: "t",
+      treeShaShort: "t",
+      itemType: "pr",
+    });
+    expect(body).toContain("No concerns.");
+    expect(body).toContain("✅");
+    expect(body).not.toContain("### Recommendation");
+  });
+
+  it("captures consumedRereviewId in marker line 2", () => {
+    const body = buildCommentBody({
+      verdict: "ALIGNED",
+      severity: "medium",
+      summary: "s",
+      treeNodes: [],
+      reviewedShort: "s",
+      reviewedFull: "s",
+      treeSha: "t",
+      treeShaShort: "t",
+      consumedRereviewId: 777,
+      itemType: "pr",
+    });
+    expect(body).toContain("gardener:last_consumed_rereview=777");
+  });
+});
+
+// ─────────────────── 9. BREEZE_RESULT trailer ───────────────────
+describe("gardener comment -- BREEZE_RESULT trailer", () => {
+  it("emits on --help", async () => {
+    const { write, lines } = captureWrite();
+    await runComment(["--help"], { write });
+    expect(lines[lines.length - 1]).toMatch(/^BREEZE_RESULT: status=\w+ /);
+  });
+
+  it("emits on opt-out", async () => {
+    const tmp = useTmpDir();
+    writeConfig(tmp.path, "modules:\n  comment:\n    enabled: false\n");
+    const { write, lines } = captureWrite();
+    await runComment(["--tree-path", tmp.path], {
+      write,
+      shellRun: makeShell([]),
+      env: {},
+    });
+    expect(lines[lines.length - 1]).toMatch(/^BREEZE_RESULT: status=skipped /);
+  });
+
+  it("emits on bad flag", async () => {
+    const { write, lines } = captureWrite();
+    const code = await runComment(["--nope"], { write, env: {} });
+    expect(code).toBe(1);
+    expect(lines[lines.length - 1]).toMatch(/^BREEZE_RESULT: status=failed /);
+  });
+
+  it("emits on missing --repo", async () => {
+    const tmp = useTmpDir();
+    const { write, lines } = captureWrite();
+    const code = await runComment(
+      ["--pr", "1", "--tree-path", tmp.path],
+      {
+        write,
+        env: {},
+        shellRun: makeShell([]),
+      },
+    );
+    expect(code).toBe(1);
+    expect(lines[lines.length - 1]).toMatch(/^BREEZE_RESULT: status=failed /);
+  });
+});
+
+// ─────────────────── 10. snapshot dir mode ───────────────────
+describe("gardener comment -- snapshot mode", () => {
+  it("reads from BREEZE_SNAPSHOT_DIR and makes no gh api fetch calls for view/comments", async () => {
+    const tmp = useTmpDir();
+    const snapshotDir = join(tmp.path, "snap");
+    mkdirSync(snapshotDir, { recursive: true });
+    writeFileSync(
+      join(snapshotDir, "pr-view.json"),
+      JSON.stringify({
+        number: 42,
+        title: "snap",
+        headRefOid: "newsha",
+        state: "OPEN",
+        additions: 1,
+        deletions: 0,
+        updatedAt: "2026-04-16T00:00:00Z",
+      }),
+    );
+    writeFileSync(join(snapshotDir, "issue-comments.json"), JSON.stringify([]));
+    writeFileSync(
+      join(snapshotDir, "subject.json"),
+      JSON.stringify({ gardenerUser: "repo-gardener", treeSha: "abc" }),
+    );
+    writeFileSync(join(snapshotDir, "pr.diff"), "diff");
+
+    const calls: ShellCall[] = [];
+    const shell = makeShell(
+      [
+        (call) => {
+          // Guard: snapshot mode must not use gh api to fetch comments
+          // or view data via --paginate (writes are allowed: POST/PATCH).
+          if (
+            call.command === "gh" &&
+            call.args[0] === "api" &&
+            call.args.includes("--paginate")
+          ) {
+            throw new Error(
+              `snapshot mode leaked gh api fetch: ${call.args.join(" ")}`,
+            );
+          }
+          return { stdout: "", stderr: "", code: 0 };
+        },
+      ],
+      calls,
+    );
+    const { write, lines } = captureWrite();
+    const code = await runComment(
+      ["--pr", "42", "--repo", "o/r", "--tree-path", tmp.path],
+      {
+        shellRun: shell,
+        write,
+        env: { BREEZE_SNAPSHOT_DIR: snapshotDir },
+        now: () => new Date("2026-04-16T00:00:00Z"),
+        classifier: conflictClassifier,
+      },
+    );
+    expect(code).toBe(0);
+    expect(lines[lines.length - 1]).toMatch(/^BREEZE_RESULT: /);
+    // No gh api fetch calls should have happened for view/comments.
+    const fetchCalls = calls.filter(
+      (c) =>
+        c.command === "gh" &&
+        c.args[0] === "api" &&
+        c.args.some((a) => a.includes("--paginate")),
+    );
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("readSnapshot returns null when pr-view.json/issue-view.json are missing", () => {
+    const tmp = useTmpDir();
+    expect(readSnapshot(tmp.path)).toBeNull();
+  });
+
+  it("readSnapshot returns PR bundle when pr-view.json present", () => {
+    const tmp = useTmpDir();
+    writeFileSync(
+      join(tmp.path, "pr-view.json"),
+      JSON.stringify({ number: 1 }),
+    );
+    writeFileSync(join(tmp.path, "issue-comments.json"), "[]");
+    const bundle = readSnapshot(tmp.path);
+    expect(bundle?.type).toBe("pr");
+    expect(bundle?.prView?.number).toBe(1);
+  });
+
+  it("readSnapshot returns issue bundle when only issue-view.json present", () => {
+    const tmp = useTmpDir();
+    writeFileSync(
+      join(tmp.path, "issue-view.json"),
+      JSON.stringify({ number: 5 }),
+    );
+    writeFileSync(join(tmp.path, "issue-comments.json"), "[]");
+    const bundle = readSnapshot(tmp.path);
+    expect(bundle?.type).toBe("issue");
+    expect(bundle?.issueView?.number).toBe(5);
+  });
+});
+
+// ─────────────────── helpers ───────────────────
+describe("gardener comment -- marker helpers", () => {
+  it("extractStateMarker captures full HTML comment", () => {
+    const body =
+      "hello\n<!-- gardener:state · reviewed=abc · verdict=ALIGNED · severity=low · tree_sha=t -->\nworld";
+    expect(extractStateMarker(body)).toContain("gardener:state");
+  });
+
+  it("parseStateMarker returns reviewed/verdict/severity/treeSha", () => {
+    const parsed = parseStateMarker(
+      "<!-- gardener:state · reviewed=abcdef · verdict=CONFLICT · severity=high · tree_sha=deadbeef -->",
+    );
+    expect(parsed?.reviewed).toBe("abcdef");
+    expect(parsed?.verdict).toBe("CONFLICT");
+    expect(parsed?.severity).toBe("high");
+    expect(parsed?.treeSha).toBe("deadbeef");
+  });
+
+  it("hasIgnoredMarker / hasPausedMarker detect markers", () => {
+    expect(hasIgnoredMarker("<!-- gardener:ignored -->")).toBe(true);
+    expect(hasPausedMarker("<!-- gardener:paused -->")).toBe(true);
+    expect(hasIgnoredMarker("nothing here")).toBe(false);
+    expect(hasPausedMarker(undefined)).toBe(false);
+  });
+
+  it("readLastConsumedRereview parses numeric id", () => {
+    expect(
+      readLastConsumedRereview(
+        "<!-- gardener:last_consumed_rereview=12345 -->",
+      ),
+    ).toBe(12345);
+    expect(readLastConsumedRereview("none")).toBeNull();
+  });
+
+  it("shaMatches works with prefix (short 8-char vs full 40-char)", () => {
+    expect(shaMatches("abcdef1234567890", "abcdef12")).toBe(true);
+    expect(shaMatches("abcdef1234567890", "wxyz0000")).toBe(false);
+    expect(shaMatches(undefined, "abc")).toBe(false);
+    expect(shaMatches("abc", undefined)).toBe(false);
+  });
+
+  it("hasReviewedLabel detects gardener:reviewed", () => {
+    expect(
+      hasReviewedLabel({
+        labels: [{ name: "gardener:reviewed" }, { name: "bug" }],
+      }),
+    ).toBe(true);
+    expect(
+      hasReviewedLabel({ labels: ["gardener:reviewed"] }),
+    ).toBe(true);
+    expect(hasReviewedLabel({ labels: [] })).toBe(false);
+    expect(hasReviewedLabel(undefined)).toBe(false);
+  });
+
+  it("GARDENER_COMMAND_RE matches all four commands", () => {
+    expect(GARDENER_COMMAND_RE.test("@gardener re-review")).toBe(true);
+    expect(GARDENER_COMMAND_RE.test("@gardener pause")).toBe(true);
+    expect(GARDENER_COMMAND_RE.test("@gardener resume")).toBe(true);
+    expect(GARDENER_COMMAND_RE.test("@gardener ignore")).toBe(true);
+    expect(GARDENER_COMMAND_RE.test("@gardener unknown")).toBe(false);
+  });
+
+  it("state/ignored marker regexes work", () => {
+    expect(
+      GARDENER_STATE_MARKER_RE.test("<!-- gardener:state · reviewed=a -->"),
+    ).toBe(true);
+    expect(GARDENER_IGNORED_MARKER_RE.test("<!-- gardener:ignored -->")).toBe(
+      true,
+    );
+  });
+});

--- a/tests/gardener-comment.test.ts
+++ b/tests/gardener-comment.test.ts
@@ -781,3 +781,177 @@ describe("gardener comment -- marker helpers", () => {
     );
   });
 });
+
+// ─────────────── 10. self-loop guard — first-tree:sync label ───────────────
+describe("gardener comment -- self-loop guard (first-tree:sync label)", () => {
+  it("exits 0 with skip message when PR carries first-tree:sync, without calling classify", async () => {
+    const tmp = useTmpDir();
+    const snapshotDir = join(tmp.path, "snap");
+    mkdirSync(snapshotDir, { recursive: true });
+    writeFileSync(
+      join(snapshotDir, "pr-view.json"),
+      JSON.stringify({
+        number: 301,
+        title: "sync: tree content",
+        headRefName: "first-tree/sync-301",
+        headRefOid: "abcd1234",
+        state: "OPEN",
+        author: { login: "serenakeyitan" },
+        additions: 10,
+        deletions: 3,
+        labels: [{ name: "first-tree:sync" }],
+        updatedAt: "2026-04-16T00:00:00Z",
+      }),
+    );
+    writeFileSync(join(snapshotDir, "issue-comments.json"), JSON.stringify([]));
+    writeFileSync(
+      join(snapshotDir, "subject.json"),
+      JSON.stringify({ gardenerUser: "repo-gardener" }),
+    );
+    writeFileSync(join(snapshotDir, "pr.diff"), "");
+
+    const calls: ShellCall[] = [];
+    const shell = makeShell(
+      [() => ({ stdout: "", stderr: "", code: 0 })],
+      calls,
+    );
+    const { write, lines } = captureWrite();
+    let classifyCalled = false;
+    const code = await runComment(
+      ["--pr", "301", "--repo", "owner/tree", "--tree-path", tmp.path],
+      {
+        shellRun: shell,
+        write,
+        env: { BREEZE_SNAPSHOT_DIR: snapshotDir },
+        now: () => new Date("2026-04-16T00:00:00Z"),
+        classifier: async () => {
+          classifyCalled = true;
+          return {
+            verdict: "ALIGNED",
+            severity: "low",
+            summary: "should not run",
+            treeNodes: [],
+          };
+        },
+      },
+    );
+    expect(code).toBe(0);
+    expect(classifyCalled).toBe(false);
+    expect(
+      lines.some((l) => l.includes("first-tree:sync label")),
+    ).toBe(true);
+    const last = lines[lines.length - 1];
+    expect(last).toMatch(/^BREEZE_RESULT: status=skipped summary=sync PR/);
+    // No gh pr comment / api post should have been issued.
+    const writes = calls.filter(
+      (c) =>
+        c.command === "gh" &&
+        (c.args[0] === "pr" && c.args[1] === "comment") ||
+        (c.command === "gh" && c.args[0] === "api" && c.args.includes("POST")),
+    );
+    expect(writes).toHaveLength(0);
+  });
+
+  it("proceeds normally when PR carries other labels", async () => {
+    const tmp = useTmpDir();
+    const snapshotDir = join(tmp.path, "snap");
+    mkdirSync(snapshotDir, { recursive: true });
+    writeFileSync(
+      join(snapshotDir, "pr-view.json"),
+      JSON.stringify({
+        number: 302,
+        title: "feat: new feature",
+        headRefName: "feature/new",
+        headRefOid: "efgh5678",
+        state: "OPEN",
+        author: { login: "external-contrib" },
+        additions: 5,
+        deletions: 1,
+        labels: [{ name: "enhancement" }],
+        updatedAt: "2026-04-16T00:00:00Z",
+      }),
+    );
+    writeFileSync(join(snapshotDir, "issue-comments.json"), JSON.stringify([]));
+    writeFileSync(
+      join(snapshotDir, "subject.json"),
+      JSON.stringify({ gardenerUser: "repo-gardener", treeSha: "tsha1234" }),
+    );
+    writeFileSync(join(snapshotDir, "pr.diff"), "");
+
+    const calls: ShellCall[] = [];
+    const shell = makeShell(
+      [() => ({ stdout: "", stderr: "", code: 0 })],
+      calls,
+    );
+    const { write, lines } = captureWrite();
+    let classifyCalled = false;
+    const code = await runComment(
+      ["--pr", "302", "--repo", "owner/source", "--tree-path", tmp.path],
+      {
+        shellRun: shell,
+        write,
+        env: { BREEZE_SNAPSHOT_DIR: snapshotDir },
+        now: () => new Date("2026-04-16T00:00:00Z"),
+        classifier: async () => {
+          classifyCalled = true;
+          return {
+            verdict: "ALIGNED",
+            severity: "low",
+            summary: "Looks aligned.",
+            treeNodes: [],
+          };
+        },
+      },
+    );
+    expect(code).toBe(0);
+    expect(classifyCalled).toBe(true);
+    expect(
+      lines.some((l) => l.includes("first-tree:sync label")),
+    ).toBe(false);
+  });
+});
+
+describe("gardener comment -- @gardener command detection ignores self-footer", () => {
+  it("does not treat @gardener re-review inside gardener's own state comment as a user command", () => {
+    // Gardener's footer text includes `@gardener re-review` as a command
+    // hint — resolveState must NOT treat this as a fresh user-issued
+    // command. We verify by giving the only such comment a gardener
+    // login AND a gardener: marker, and asserting state falls through
+    // to the sha-match / reviewed-label path rather than rereview.
+    const action = resolveState({
+      comments: [
+        {
+          user: { login: "repo-gardener" },
+          body:
+            "<!-- gardener:state · reviewed=headSha -->\nverdict text\n<sub>Commands: <code>@gardener re-review</code></sub>",
+          created_at: "2026-04-16T00:00:00Z",
+        },
+      ],
+      gardenerUser: "repo-gardener",
+      headIdentifier: "headSha",
+      hasReviewedLabel: false,
+    });
+    expect(action.kind).toBe("skip");
+  });
+
+  it("does not treat @gardener re-review in a non-gardener-login comment that carries a gardener marker as user command", () => {
+    // Marker-fallback path: a comment carries `<!-- gardener:` even
+    // though login does not match gardenerUser (e.g. a bot identity
+    // swap). We must still exclude it from userCommands.
+    const action = resolveState({
+      comments: [
+        {
+          user: { login: "old-bot-identity" },
+          body:
+            "<!-- gardener:state · reviewed=headSha -->\nverdict text <code>@gardener re-review</code>",
+          created_at: "2026-04-16T00:00:00Z",
+        },
+      ],
+      gardenerUser: "repo-gardener",
+      headIdentifier: "headSha",
+      hasReviewedLabel: false,
+    });
+    // Marker hides it from userCommands → sha matches → skip.
+    expect(action.kind).toBe("skip");
+  });
+});


### PR DESCRIPTION
## Summary

Stacked fix addressing both halves of #134:

1. **respond self-loop guard** (same as #135) — `respond.ts` only counts non-gardener `CHANGES_REQUESTED` reviews and `@gardener fix` comments.
2. **comment module skip for tree PRs** — `comment.ts` early-exits when a PR carries the `first-tree:sync` label. That's gardener's own sync PR, not a source-repo target.

This PR also re-opens the comment CLI port that was closed along with #132 and delivers it with the self-loop guard applied.

## Changes

### `src/products/gardener/engine/comment.ts`

- After `bundle` is loaded in `reviewOne`, inspect `prOrIssueView.labels`. If `first-tree:sync` is present, log `⏭ #<n> has first-tree:sync label — gardener-comment skips sync PRs to avoid self-loops`, emit `BREEZE_RESULT: status=skipped summary=sync PR — not a comment-module target`, and return before `classifier` runs.
- Harden `resolveState`'s `userCommands` filter with a marker fallback: a comment that carries `<!-- gardener:` is treated as gardener's own even if the login does not match `gardenerUser`. Prevents bot-identity swaps from letting gardener's own footer register as a fresh `@gardener re-review` command.

### `src/products/gardener/engine/respond.ts`

Same changes as #135 (exported `isFromGardener`, login resolution, non-gardener filter, skip path).

### Tests

- `tests/gardener-comment.test.ts` — 4 new tests: sync-label skip (no classify call), non-sync label proceeds, gardener-footer \`@gardener re-review\` ignored, marker-fallback self-command ignored.
- `tests/gardener-respond.test.ts` — same 4 tests as #135.

## Verification

- `pnpm typecheck` ✓
- `pnpm vitest run tests/gardener-comment.test.ts tests/gardener-respond.test.ts` → 73/73 pass (29 respond + 44 comment)
- `pnpm build` ✓
- `node dist/cli.js gardener --help` ✓ (shows both `respond` and `comment`)

## Stack

- Depends on #135 (respond fix) — if #135 lands first, this PR simplifies to just the comment.ts changes plus the comment CLI port.
- Base: `main`. Branch contains both commits so it is mergeable standalone.

## Related

- Closes #134 (both halves)
- Re-delivery of closed #132 with self-loop guard applied
- Sibling runbook fix: agent-team-foundation/repo-gardener#23 (closes repo-gardener#22)

## Test plan

- [ ] Review both halves of the self-loop guard (respond + comment)
- [ ] Confirm `breeze:wip/human/done` label model is respected on both skip paths
- [ ] CI green

<sub>🌱 PR created by Claude on behalf of @serenakeyitan via <a href="https://claude.com/claude-code">Claude Code</a></sub>