### PR TITLE
Phase 4: port gh.rs + task.rs and feed the dispatcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist/
 .first-tree/local-tree.json
 .first-tree/tmp/
 /.claude/worktrees
+.gardener/

--- a/src/products/breeze/core/repo-filter.ts
+++ b/src/products/breeze/core/repo-filter.ts
@@ -1,0 +1,126 @@
+/**
+ * TS port of `RepoFilter` from
+ * `first-tree-breeze/breeze-runner/src/config.rs:39-114`.
+ *
+ * Allow-list with two shapes:
+ *   - `owner/repo`  → exact match
+ *   - `owner/*`     → all repos under `owner`
+ *
+ * Empty filter = "match everything". Used to scope notification polls,
+ * search queries, and snapshot hydration.
+ */
+
+export class RepoFilter {
+  private readonly allowedOwners: string[];
+  private readonly allowedRepos: string[];
+
+  private constructor(owners: string[], repos: string[]) {
+    this.allowedOwners = owners;
+    this.allowedRepos = repos;
+  }
+
+  static empty(): RepoFilter {
+    return new RepoFilter([], []);
+  }
+
+  /**
+   * Parse a comma-separated list. Throws on an invalid pattern (not
+   * `owner/repo` and not `owner/*`).
+   */
+  static parseCsv(value: string): RepoFilter {
+    const owners: string[] = [];
+    const repos: string[] = [];
+    for (const raw of value.split(",")) {
+      const trimmed = raw.trim();
+      if (trimmed.length === 0) continue;
+      if (trimmed.endsWith("/*")) {
+        const owner = trimmed.slice(0, -2);
+        if (owner.length === 0) {
+          throw new Error(`invalid repo allow pattern \`${trimmed}\``);
+        }
+        if (!owners.includes(owner)) owners.push(owner);
+        continue;
+      }
+      if (trimmed.split("/").length === 2) {
+        if (!repos.includes(trimmed)) repos.push(trimmed);
+        continue;
+      }
+      throw new Error(
+        `invalid repo allow pattern \`${trimmed}\`; use owner/repo or owner/*`,
+      );
+    }
+    return new RepoFilter(owners, repos);
+  }
+
+  merge(other: RepoFilter): RepoFilter {
+    const owners = [...this.allowedOwners];
+    const repos = [...this.allowedRepos];
+    for (const o of other.allowedOwners) {
+      if (!owners.includes(o)) owners.push(o);
+    }
+    for (const r of other.allowedRepos) {
+      if (!repos.includes(r)) repos.push(r);
+    }
+    return new RepoFilter(owners, repos);
+  }
+
+  isEmpty(): boolean {
+    return this.allowedOwners.length === 0 && this.allowedRepos.length === 0;
+  }
+
+  matchesRepo(repo: string): boolean {
+    if (this.isEmpty()) return true;
+    if (this.allowedRepos.includes(repo)) return true;
+    const slash = repo.indexOf("/");
+    if (slash <= 0) return false;
+    const owner = repo.slice(0, slash);
+    return this.allowedOwners.includes(owner);
+  }
+
+  owners(): readonly string[] {
+    return this.allowedOwners;
+  }
+
+  repos(): readonly string[] {
+    return this.allowedRepos;
+  }
+
+  /** Human-readable patterns joined by `, `. */
+  displayPatterns(): string {
+    return [
+      ...this.allowedRepos,
+      ...this.allowedOwners.map((o) => `${o}/*`),
+    ].join(", ");
+  }
+
+  /** CLI-shaped value (comma-separated). */
+  cliValue(): string {
+    return [
+      ...this.allowedRepos,
+      ...this.allowedOwners.map((o) => `${o}/*`),
+    ].join(",");
+  }
+}
+
+export type SearchScope =
+  | { kind: "all" }
+  | { kind: "owner"; owner: string }
+  | { kind: "repo"; repo: string };
+
+/**
+ * Compute the list of `gh search` scopes implied by a filter. Matches
+ * `GhClient::search_scopes` in Rust: empty filter → `[All]`; owners
+ * + explicit repos each get their own scope.
+ */
+export function searchScopesFor(filter: RepoFilter): SearchScope[] {
+  if (filter.isEmpty()) return [{ kind: "all" }];
+  const scopes: SearchScope[] = [];
+  for (const owner of filter.owners()) {
+    scopes.push({ kind: "owner", owner });
+  }
+  for (const repo of filter.repos()) {
+    scopes.push({ kind: "repo", repo });
+  }
+  if (scopes.length === 0) return [{ kind: "all" }];
+  return scopes;
+}

--- a/src/products/breeze/core/task-kind.ts
+++ b/src/products/breeze/core/task-kind.ts
@@ -1,0 +1,96 @@
+/**
+ * TS port of `first-tree-breeze/breeze-runner/src/classify.rs`.
+ *
+ * `TaskKind` classifies a GitHub notification subject + reason into the
+ * breeze task taxonomy. `priority_for` returns the dispatcher priority;
+ * `should_process_reason` gates which notification reasons get a task.
+ *
+ * Pure. No I/O. Safe to import from anywhere.
+ */
+
+export type TaskKind =
+  | "review_request"
+  | "mention"
+  | "comment"
+  | "assigned_issue"
+  | "assigned_pull_request"
+  | "discussion"
+  | "other";
+
+export const ALL_TASK_KINDS: readonly TaskKind[] = [
+  "review_request",
+  "mention",
+  "comment",
+  "assigned_issue",
+  "assigned_pull_request",
+  "discussion",
+  "other",
+];
+
+export function taskKindFromString(value: string): TaskKind | undefined {
+  return (ALL_TASK_KINDS as readonly string[]).includes(value)
+    ? (value as TaskKind)
+    : undefined;
+}
+
+/**
+ * Whitelist of notification `reason`s that merit dispatch. Mirrors
+ * `should_process_reason` in Rust — anything outside this list is
+ * ignored (ci_activity, subscribed, state_change, etc.).
+ */
+export function shouldProcessReason(reason: string): boolean {
+  switch (reason) {
+    case "review_requested":
+    case "comment":
+    case "mention":
+    case "team_mention":
+    case "assign":
+    case "author":
+    case "manual":
+      return true;
+    default:
+      return false;
+  }
+}
+
+/** Dispatcher priority (higher wins). Mirrors `priority_for`. */
+export function priorityFor(kind: TaskKind, reason: string): number {
+  switch (kind) {
+    case "review_request":
+      return 100;
+    case "mention":
+      return 95;
+    case "discussion":
+      return 90;
+    case "comment":
+      return 85;
+    case "assigned_pull_request":
+      return 80;
+    case "assigned_issue":
+      return 70;
+    case "other":
+      return reason === "review_requested" ? 100 : 50;
+  }
+}
+
+/**
+ * Map subject_type + reason to a TaskKind. Review_requested wins
+ * ahead of subject type; Discussion wins ahead of generic comment.
+ */
+export function classifyNotification(
+  subjectType: string,
+  reason: string,
+): TaskKind {
+  if (reason === "review_requested") return "review_request";
+  if (reason === "mention" || reason === "team_mention") return "mention";
+  if (subjectType.includes("Discussion")) return "discussion";
+  if (reason === "comment" || reason === "author" || reason === "manual") {
+    return "comment";
+  }
+  if (reason === "assign") {
+    return subjectType === "PullRequest"
+      ? "assigned_pull_request"
+      : "assigned_issue";
+  }
+  return "other";
+}

--- a/src/products/breeze/core/task-util.ts
+++ b/src/products/breeze/core/task-util.ts
@@ -1,0 +1,219 @@
+/**
+ * TS port of the string / id / timestamp helpers in
+ * `first-tree-breeze/breeze-runner/src/util.rs`.
+ *
+ * Ported functions:
+ *   - `fnv1a64` + `stable_file_id`    — deterministic 16-hex-char id
+ *   - `canonical_api_path`            — strip `https://api.github.com` prefix
+ *   - `parse_tsv_line` + `unescape_jq_field` — read `@tsv` jq output
+ *   - `encode_multiline` / `decode_multiline` — escape `\n` in kv lines
+ *   - `shell_quote`                   — POSIX single-quote-safe rendering
+ *   - `parse_github_timestamp_epoch` / `is_recent_github_timestamp`
+ *   - `parse_kv_lines`                — read `key=value\n` blocks
+ *
+ * All pure, no I/O.
+ */
+
+/** FNV-1a 64-bit hash (matches Rust `fnv1a64`). */
+export function fnv1a64(value: string): bigint {
+  const FNV_OFFSET = 0xcbf29ce484222325n;
+  const FNV_PRIME = 0x100000001b3n;
+  const MASK = (1n << 64n) - 1n;
+  let hash = FNV_OFFSET;
+  const bytes = new TextEncoder().encode(value);
+  for (const byte of bytes) {
+    hash ^= BigInt(byte);
+    hash = (hash * FNV_PRIME) & MASK;
+  }
+  return hash;
+}
+
+/** Lowercase 16-hex-char stable id derived from `fnv1a64`. */
+export function stableFileId(value: string): string {
+  const h = fnv1a64(value);
+  return h.toString(16).padStart(16, "0");
+}
+
+/**
+ * Strip the canonical GitHub prefix from a URL and trim trailing `/`.
+ * Used to derive `thread_key` from an `api_url` (so the same thread
+ * key is stable across the REST host and the web host).
+ */
+export function canonicalApiPath(url: string): string {
+  const trimmed = url.trim();
+  const stripped = trimmed.startsWith("https://api.github.com")
+    ? trimmed.slice("https://api.github.com".length)
+    : trimmed.startsWith("https://github.com")
+      ? trimmed.slice("https://github.com".length)
+      : trimmed;
+  return stripped.trim().replace(/\/+$/, "");
+}
+
+/** Split a `\t`-separated line and unescape jq's `\n`/`\t`/`\\`/`\u00..`. */
+export function parseTsvLine(line: string): string[] {
+  return line.split("\t").map(unescapeJqField);
+}
+
+/**
+ * Decode jq `@tsv` escapes: `\n` → newline, `\t` → tab, `\\` → backslash,
+ * `\uXXXX` → code point, and anything else falls through literally.
+ */
+export function unescapeJqField(value: string): string {
+  let output = "";
+  for (let i = 0; i < value.length; i += 1) {
+    const c = value[i];
+    if (c !== "\\") {
+      output += c;
+      continue;
+    }
+    const next = value[i + 1];
+    i += 1;
+    switch (next) {
+      case "n":
+        output += "\n";
+        break;
+      case "r":
+        output += "\r";
+        break;
+      case "t":
+        output += "\t";
+        break;
+      case "\\":
+        output += "\\";
+        break;
+      case "b":
+        output += "\b";
+        break;
+      case "f":
+        output += "\f";
+        break;
+      case "u": {
+        const code = value.slice(i + 1, i + 5);
+        i += 4;
+        const n = Number.parseInt(code, 16);
+        if (Number.isFinite(n)) output += String.fromCodePoint(n);
+        break;
+      }
+      case undefined:
+        return output;
+      default:
+        output += next;
+        break;
+    }
+  }
+  return output;
+}
+
+/** Replace literal newlines with `\n` (kv-file friendly). */
+export function encodeMultiline(value: string): string {
+  return value.replace(/\n/g, "\\n");
+}
+
+/** Inverse of `encodeMultiline`. */
+export function decodeMultiline(value: string): string {
+  return value.replace(/\\n/g, "\n");
+}
+
+const SHELL_SAFE = /^[A-Za-z0-9\-_.\/:=,@]+$/;
+
+/**
+ * POSIX-safe shell quoting (single-quote form). Empty string renders
+ * as `''` so it stays a distinct argument. Mirrors Rust `shell_quote`.
+ */
+export function shellQuote(value: string): string {
+  if (value.length === 0) return "''";
+  if (SHELL_SAFE.test(value)) return value;
+  return `'${value.replace(/'/g, "'\"'\"'")}'`;
+}
+
+/** Parse a `key=value` block into a Map. Empty/invalid lines are skipped. */
+export function parseKvLines(contents: string): Array<[string, string]> {
+  const out: Array<[string, string]> = [];
+  for (const line of contents.split(/\r?\n/)) {
+    const eq = line.indexOf("=");
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key.length === 0) continue;
+    out.push([key, value]);
+  }
+  return out;
+}
+
+/**
+ * Parse a `YYYY-MM-DDTHH:MM:SSZ` GitHub timestamp to unix epoch seconds.
+ * Returns `undefined` on malformed input. Mirrors Rust `parse_github_timestamp_epoch`
+ * which is also strict about format length and separators.
+ */
+export function parseGithubTimestampEpoch(value: string): number | undefined {
+  if (value.length !== 20) return undefined;
+  if (
+    value[4] !== "-" ||
+    value[7] !== "-" ||
+    value[10] !== "T" ||
+    value[13] !== ":" ||
+    value[16] !== ":" ||
+    value[19] !== "Z"
+  ) {
+    return undefined;
+  }
+  const year = Number.parseInt(value.slice(0, 4), 10);
+  const month = Number.parseInt(value.slice(5, 7), 10);
+  const day = Number.parseInt(value.slice(8, 10), 10);
+  const hour = Number.parseInt(value.slice(11, 13), 10);
+  const minute = Number.parseInt(value.slice(14, 16), 10);
+  const second = Number.parseInt(value.slice(17, 19), 10);
+  if (
+    !Number.isFinite(year) ||
+    !Number.isFinite(month) ||
+    !Number.isFinite(day) ||
+    !Number.isFinite(hour) ||
+    !Number.isFinite(minute) ||
+    !Number.isFinite(second)
+  ) {
+    return undefined;
+  }
+  if (month < 1 || month > 12) return undefined;
+  if (hour > 23 || minute > 59 || second > 59) return undefined;
+  if (day < 1 || day > daysInMonth(year, month)) return undefined;
+  const ms = Date.UTC(year, month - 1, day, hour, minute, second);
+  if (!Number.isFinite(ms)) return undefined;
+  return Math.floor(ms / 1000);
+}
+
+/** True when `value` parses as a timestamp and lies within `lookbackSecs` of `nowEpoch`. */
+export function isRecentGithubTimestamp(
+  value: string,
+  nowEpoch: number,
+  lookbackSecs: number,
+): boolean {
+  const ts = parseGithubTimestampEpoch(value);
+  if (ts === undefined) return false;
+  return ts >= Math.max(0, nowEpoch - lookbackSecs);
+}
+
+function isLeapYear(year: number): boolean {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}
+
+function daysInMonth(year: number, month: number): number {
+  switch (month) {
+    case 1:
+    case 3:
+    case 5:
+    case 7:
+    case 8:
+    case 10:
+    case 12:
+      return 31;
+    case 4:
+    case 6:
+    case 9:
+    case 11:
+      return 30;
+    case 2:
+      return isLeapYear(year) ? 29 : 28;
+    default:
+      return 0;
+  }
+}

--- a/src/products/breeze/core/task.ts
+++ b/src/products/breeze/core/task.ts
@@ -1,0 +1,413 @@
+/**
+ * TS port of `first-tree-breeze/breeze-runner/src/task.rs`.
+ *
+ * `TaskCandidate` is the canonical shape produced by the notification
+ * poll / search path and consumed by the dispatcher. `ThreadRecord`
+ * is the per-thread retry/state record persisted under
+ * `<runnerHome>/threads/<id>.env`.
+ *
+ * This is a richer candidate than the dispatcher's minimal interface
+ * (`daemon/dispatcher.ts::TaskCandidate`) — it keeps the full API/web
+ * URL pair, reason, source, and lets callers derive stable IDs or
+ * comment-anchored task URLs. Use `toDispatcherCandidate()` to hand
+ * one to the dispatcher.
+ */
+
+import type { TaskCandidate as DispatchCandidate } from "../daemon/dispatcher.js";
+import {
+  classifyNotification,
+  priorityFor,
+  shouldProcessReason,
+  taskKindFromString,
+  type TaskKind,
+} from "./task-kind.js";
+import {
+  canonicalApiPath,
+  decodeMultiline,
+  encodeMultiline,
+  stableFileId,
+} from "./task-util.js";
+
+export interface TaskCandidate {
+  /** Origin: `notifications` | `review-search` | `assigned-search` | `recovered-running`. */
+  source: string;
+  /** Source repo (`owner/repo`). */
+  repo: string;
+  /** Operator-routing override (empty string = same as `repo`). */
+  workspaceRepo: string;
+  /** Canonical thread key — stable across hosts. */
+  threadKey: string;
+  kind: TaskKind;
+  /** GitHub notification `reason`; empty for search-derived tasks. */
+  reason: string;
+  title: string;
+  /** Browser-friendly URL (may be empty). */
+  webUrl: string;
+  /** `api.github.com` URL (may be empty for notifications w/o api_url). */
+  apiUrl: string;
+  /** API URL for the latest comment on this thread (may be empty). */
+  latestCommentApiUrl: string;
+  /** GitHub-supplied `updated_at` (ISO-8601). */
+  updatedAt: string;
+  priority: number;
+}
+
+/** Resolve effective workspace repo (falls back to `repo`). */
+export function effectiveWorkspaceRepo(task: TaskCandidate): string {
+  return task.workspaceRepo.trim().length > 0 ? task.workspaceRepo : task.repo;
+}
+
+/**
+ * Stable file-id per candidate. Uses fnv1a64 over (thread_key, updated_at,
+ * repo, kind, source) so two candidates with identical content share ids.
+ */
+export function stableIdFor(task: TaskCandidate): string {
+  return stableFileId(
+    `${task.threadKey}|${task.updatedAt}|${task.repo}|${task.kind}|${task.source}`,
+  );
+}
+
+/** Browser URL preferring `webUrl` then `apiUrl`. */
+export function displayUrl(task: TaskCandidate): string {
+  if (task.webUrl.length > 0) return task.webUrl;
+  if (task.apiUrl.length > 0) return task.apiUrl;
+  return "";
+}
+
+/**
+ * The URL the agent should actually open. Prefers an anchored link to
+ * the latest comment when the API url exposes the comment id.
+ */
+export function taskUrl(task: TaskCandidate): string {
+  const anchored = latestCommentWebUrl(task);
+  if (anchored !== undefined) return anchored;
+  return displayUrl(task);
+}
+
+/** Extract PR number from the task's URLs or thread key. */
+export function taskPrNumber(task: TaskCandidate): number | undefined {
+  for (const candidate of [task.webUrl, task.apiUrl, task.threadKey]) {
+    const n = extractPrNumber(candidate);
+    if (n !== undefined) return n;
+  }
+  return undefined;
+}
+
+/** Extract issue number similarly. */
+export function taskIssueNumber(task: TaskCandidate): number | undefined {
+  for (const candidate of [task.webUrl, task.apiUrl, task.threadKey]) {
+    const n = extractIssueNumber(candidate);
+    if (n !== undefined) return n;
+  }
+  return undefined;
+}
+
+function latestCommentWebUrl(task: TaskCandidate): string | undefined {
+  if (task.latestCommentApiUrl.length === 0) return undefined;
+  const commentId = extractIssueCommentId(task.latestCommentApiUrl);
+  if (commentId === undefined) return undefined;
+  const base =
+    task.webUrl.length > 0
+      ? task.webUrl
+      : deriveWebUrl("github.com", task.repo, task.threadKey);
+  if (base === undefined) return undefined;
+  return `${base}#issuecomment-${commentId}`;
+}
+
+/** Build a notifications-sourced candidate. Returns undefined when it should be dropped. */
+export function buildNotificationCandidate(args: {
+  host: string;
+  repo: string;
+  subjectType: string;
+  reason: string;
+  title: string;
+  apiUrl: string;
+  latestCommentApiUrl: string;
+  updatedAt: string;
+}): TaskCandidate | undefined {
+  const {
+    host,
+    repo,
+    subjectType,
+    reason,
+    title,
+    apiUrl,
+    latestCommentApiUrl,
+    updatedAt,
+  } = args;
+  if (repo.length === 0) return undefined;
+  const kind = classifyNotification(subjectType, reason);
+  if (kind === "other" || !shouldProcessReason(reason)) return undefined;
+
+  const threadKey =
+    apiUrl.length > 0
+      ? canonicalApiPath(apiUrl)
+      : latestCommentApiUrl.length > 0
+        ? canonicalApiPath(latestCommentApiUrl)
+        : `notification::${repo}::${subjectType}::${title}`;
+
+  const webUrl = deriveWebUrl(host, repo, threadKey) ?? "";
+
+  return {
+    source: "notifications",
+    repo,
+    workspaceRepo: repo,
+    threadKey,
+    kind,
+    reason,
+    title,
+    webUrl,
+    apiUrl,
+    latestCommentApiUrl,
+    updatedAt,
+    priority: priorityFor(kind, reason),
+  };
+}
+
+export function buildReviewRequestCandidate(args: {
+  repo: string;
+  number: number;
+  title: string;
+  webUrl: string;
+  updatedAt: string;
+}): TaskCandidate {
+  return {
+    source: "review-search",
+    repo: args.repo,
+    workspaceRepo: args.repo,
+    threadKey: `/repos/${args.repo}/pulls/${args.number}`,
+    kind: "review_request",
+    reason: "review_requested",
+    title: args.title,
+    webUrl: args.webUrl,
+    apiUrl: `https://api.github.com/repos/${args.repo}/pulls/${args.number}`,
+    latestCommentApiUrl: "",
+    updatedAt: args.updatedAt,
+    priority: priorityFor("review_request", "review_requested"),
+  };
+}
+
+export function buildAssignedCandidate(args: {
+  repo: string;
+  number: number;
+  title: string;
+  webUrl: string;
+  updatedAt: string;
+  isPullRequest: boolean;
+}): TaskCandidate {
+  const kind: TaskKind = args.isPullRequest
+    ? "assigned_pull_request"
+    : "assigned_issue";
+  const suffix = args.isPullRequest ? "pulls" : "issues";
+  return {
+    source: "assigned-search",
+    repo: args.repo,
+    workspaceRepo: args.repo,
+    threadKey: `/repos/${args.repo}/${suffix}/${args.number}`,
+    kind,
+    reason: "assigned",
+    title: args.title,
+    webUrl: args.webUrl,
+    apiUrl: `https://api.github.com/repos/${args.repo}/${suffix}/${args.number}`,
+    latestCommentApiUrl: "",
+    updatedAt: args.updatedAt,
+    priority: priorityFor(kind, "assigned"),
+  };
+}
+
+/** Convert a rich TaskCandidate into the dispatcher's minimal shape. */
+export function toDispatcherCandidate(task: TaskCandidate): DispatchCandidate {
+  const prNumber = taskPrNumber(task);
+  const stableId = stableIdFor(task);
+  return {
+    threadKey: task.threadKey,
+    notificationId: stableId,
+    repo: task.repo,
+    workspaceRepo: effectiveWorkspaceRepo(task),
+    kind: task.kind,
+    stableId,
+    prNumber,
+    title: task.title,
+    taskUrl: taskUrl(task),
+    priority: task.priority,
+    updatedAt: task.updatedAt,
+  };
+}
+
+/* -------------------------- ThreadRecord ----------------------------- */
+
+export interface ThreadRecord {
+  threadKey: string;
+  repo: string;
+  lastSeenUpdatedAt: string;
+  lastHandledUpdatedAt: string;
+  lastResult: string;
+  failureCount: number;
+  nextRetryEpoch: number;
+  lastTaskId: string;
+}
+
+export function defaultThreadRecord(): ThreadRecord {
+  return {
+    threadKey: "",
+    repo: "",
+    lastSeenUpdatedAt: "",
+    lastHandledUpdatedAt: "",
+    lastResult: "",
+    failureCount: 0,
+    nextRetryEpoch: 0,
+    lastTaskId: "",
+  };
+}
+
+/** Serialize to a `key=value` block (values are newline-escaped). */
+export function threadRecordToLines(record: ThreadRecord): string[] {
+  return [
+    `thread_key=${encodeMultiline(record.threadKey)}`,
+    `repo=${encodeMultiline(record.repo)}`,
+    `last_seen_updated_at=${encodeMultiline(record.lastSeenUpdatedAt)}`,
+    `last_handled_updated_at=${encodeMultiline(record.lastHandledUpdatedAt)}`,
+    `last_result=${encodeMultiline(record.lastResult)}`,
+    `failure_count=${record.failureCount}`,
+    `next_retry_epoch=${record.nextRetryEpoch}`,
+    `last_task_id=${encodeMultiline(record.lastTaskId)}`,
+  ];
+}
+
+export function threadRecordFromKv(
+  entries: readonly (readonly [string, string])[],
+): ThreadRecord {
+  const record = defaultThreadRecord();
+  for (const [key, value] of entries) {
+    switch (key) {
+      case "thread_key":
+        record.threadKey = decodeMultiline(value);
+        break;
+      case "repo":
+        record.repo = decodeMultiline(value);
+        break;
+      case "last_seen_updated_at":
+        record.lastSeenUpdatedAt = decodeMultiline(value);
+        break;
+      case "last_handled_updated_at":
+        record.lastHandledUpdatedAt = decodeMultiline(value);
+        break;
+      case "last_result":
+        record.lastResult = decodeMultiline(value);
+        break;
+      case "failure_count":
+        record.failureCount = toNonNegativeInt(value) ?? 0;
+        break;
+      case "next_retry_epoch":
+        record.nextRetryEpoch = toNonNegativeInt(value) ?? 0;
+        break;
+      case "last_task_id":
+        record.lastTaskId = decodeMultiline(value);
+        break;
+    }
+  }
+  return record;
+}
+
+/**
+ * Reconstruct a candidate from the persisted `task_metadata.env`.
+ * Mirrors `TaskCandidate::from_task_metadata` — used by service-start
+ * recovery so a daemon restart can retry in-flight tasks.
+ */
+export function candidateFromTaskMetadata(
+  metadata: ReadonlyMap<string, string>,
+  host: string,
+): TaskCandidate | undefined {
+  const repo = metadata.get("repo")?.trim() ?? "";
+  const threadKey = metadata.get("thread_key")?.trim() ?? "";
+  const kindRaw = metadata.get("kind")?.trim();
+  if (!repo || !threadKey || !kindRaw) return undefined;
+  const kind = taskKindFromString(kindRaw);
+  if (kind === undefined) return undefined;
+
+  const reason = metadata.get("reason") ?? "";
+  const title = decodeMultiline(metadata.get("title") ?? "");
+  const updatedAt = metadata.get("updated_at") ?? "";
+  const source = metadata.get("source") ?? "recovered-running";
+
+  const apiUrl = threadKey.startsWith("/repos/")
+    ? `https://api.github.com${threadKey}`
+    : metadata.get("api_url") ?? "";
+  const webUrlRaw = metadata.get("web_url") ?? "";
+  const webUrl =
+    webUrlRaw.trim().length > 0
+      ? webUrlRaw
+      : deriveWebUrl(host, repo, threadKey) ?? "";
+  const latestCommentApiUrl = metadata.get("latest_comment_api_url") ?? "";
+
+  const workspaceRepoRaw = metadata.get("workspace_repo") ?? "";
+  const workspaceRepo =
+    workspaceRepoRaw.trim().length > 0 ? workspaceRepoRaw : repo;
+
+  return {
+    source,
+    repo,
+    workspaceRepo,
+    threadKey,
+    kind,
+    reason,
+    title,
+    webUrl,
+    apiUrl,
+    latestCommentApiUrl,
+    updatedAt,
+    priority: priorityFor(kind, reason),
+  };
+}
+
+/* -------------------------- helpers ---------------------------------- */
+
+function extractPrNumber(value: string): number | undefined {
+  for (const marker of ["/pull/", "/pulls/"]) {
+    const idx = value.indexOf(marker);
+    if (idx === -1) continue;
+    const n = readLeadingDigits(value.slice(idx + marker.length));
+    if (n !== undefined) return n;
+  }
+  return undefined;
+}
+
+function extractIssueNumber(value: string): number | undefined {
+  const idx = value.indexOf("/issues/");
+  if (idx === -1) return undefined;
+  return readLeadingDigits(value.slice(idx + "/issues/".length));
+}
+
+function extractIssueCommentId(value: string): number | undefined {
+  const idx = value.indexOf("/issues/comments/");
+  if (idx === -1) return undefined;
+  return readLeadingDigits(value.slice(idx + "/issues/comments/".length));
+}
+
+function readLeadingDigits(value: string): number | undefined {
+  let i = 0;
+  while (i < value.length && value.charCodeAt(i) >= 48 && value.charCodeAt(i) <= 57) {
+    i += 1;
+  }
+  if (i === 0) return undefined;
+  const n = Number.parseInt(value.slice(0, i), 10);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function deriveWebUrl(
+  host: string,
+  repo: string,
+  threadKey: string,
+): string | undefined {
+  const pr = extractPrNumber(threadKey);
+  if (pr !== undefined) return `https://${host}/${repo}/pull/${pr}`;
+  const issue = extractIssueNumber(threadKey);
+  if (issue !== undefined) return `https://${host}/${repo}/issues/${issue}`;
+  return undefined;
+}
+
+function toNonNegativeInt(value: string): number | undefined {
+  const n = Number.parseInt(value.trim(), 10);
+  if (!Number.isFinite(n) || n < 0) return undefined;
+  return n;
+}

--- a/src/products/breeze/daemon/candidate-loop.ts
+++ b/src/products/breeze/daemon/candidate-loop.ts
@@ -1,0 +1,160 @@
+/**
+ * Phase 4: candidate-poll loop that feeds the dispatcher.
+ *
+ * Runs in parallel with the inbox poller (`daemon/poller.ts`). The
+ * inbox poller writes `~/.breeze/inbox.json` for the dashboard; this
+ * loop calls `GhClient.collectCandidates()` (broker-backed) and hands
+ * each candidate to `Dispatcher.submit()`.
+ *
+ * Shape deliberately mirrors `poller.ts` so the two loops share idioms:
+ *   - Single `run(options)` entry that returns when `signal` aborts.
+ *   - Rate-limit backoff via `rateLimitBackoffMs` from the poller module.
+ *   - Sleep is injectable for tests.
+ */
+
+import type { Bus } from "./bus.js";
+import type { Dispatcher } from "./dispatcher.js";
+import type { GhClient } from "./gh-client.js";
+import { rateLimitBackoffMs } from "./poller.js";
+import { toDispatcherCandidate } from "../core/task.js";
+
+export interface CandidateLoopLogger {
+  info: (line: string) => void;
+  warn: (line: string) => void;
+  error: (line: string) => void;
+}
+
+const DEFAULT_LOGGER: CandidateLoopLogger = {
+  info: (line) => process.stdout.write(`${line}\n`),
+  warn: (line) => process.stderr.write(`WARN: ${line}\n`),
+  error: (line) => process.stderr.write(`ERROR: ${line}\n`),
+};
+
+export interface CandidateLoopOptions {
+  client: GhClient;
+  dispatcher: Dispatcher;
+  /** Shared bus — warnings are published as `activity` lines. */
+  bus?: Bus;
+  /** Seconds between candidate polls. Rust default: 60s. */
+  pollIntervalSec: number;
+  /** Max items per `gh search` call. Rust default: 10. */
+  searchLimit: number;
+  /** Include the search-bucket queries (review_requests / assigned). */
+  includeSearch: boolean;
+  /** Lookback window for notifications, seconds. Rust default: 24h. */
+  lookbackSecs: number;
+  /** Abort signal from the shared shutdown controller. */
+  signal?: AbortSignal;
+  /** Injected epoch-seconds clock. */
+  nowSec?: () => number;
+  logger?: CandidateLoopLogger;
+  sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
+  /**
+   * Called after every cycle with the raw poll result so the caller
+   * can persist ThreadRecord state (Phase 5). Defaults to no-op.
+   */
+  onCycle?: (outcome: CandidateCycleOutcome) => void;
+}
+
+export interface CandidateCycleOutcome {
+  submitted: number;
+  warnings: string[];
+  rateLimited: boolean;
+}
+
+export async function runCandidateLoop(
+  options: CandidateLoopOptions,
+): Promise<void> {
+  const logger = options.logger ?? DEFAULT_LOGGER;
+  const nowSec = options.nowSec ?? (() => Math.floor(Date.now() / 1_000));
+  const sleep = options.sleep ?? defaultSleep;
+  const signal = options.signal;
+
+  let rateLimitStreak = 0;
+
+  while (!signal?.aborted) {
+    let outcome: CandidateCycleOutcome;
+    try {
+      outcome = await runCandidateCycle(options, nowSec);
+    } catch (err) {
+      logger.error(
+        `candidate cycle crashed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      await sleep(options.pollIntervalSec * 1_000, signal);
+      continue;
+    }
+
+    for (const warning of outcome.warnings) {
+      logger.warn(`candidates: ${warning}`);
+      options.bus?.publish({ kind: "activity", line: warning });
+    }
+
+    if (outcome.rateLimited) {
+      rateLimitStreak += 1;
+      const backoff = rateLimitBackoffMs(rateLimitStreak);
+      logger.warn(
+        `candidate search rate-limited; sleeping ${Math.round(backoff / 1000)}s (streak=${rateLimitStreak})`,
+      );
+      await sleep(backoff, signal);
+      continue;
+    }
+    rateLimitStreak = 0;
+    if (outcome.submitted > 0) {
+      logger.info(`candidates: submitted ${outcome.submitted} task(s)`);
+    }
+    await sleep(options.pollIntervalSec * 1_000, signal);
+  }
+}
+
+export async function runCandidateCycle(
+  options: Pick<
+    CandidateLoopOptions,
+    | "client"
+    | "dispatcher"
+    | "searchLimit"
+    | "includeSearch"
+    | "lookbackSecs"
+    | "onCycle"
+  >,
+  nowSec: () => number,
+): Promise<CandidateCycleOutcome> {
+  const poll = await options.client.collectCandidates({
+    limit: options.searchLimit,
+    includeSearch: options.includeSearch,
+    nowEpoch: nowSec(),
+    lookbackSecs: options.lookbackSecs,
+  });
+
+  let submitted = 0;
+  for (const candidate of poll.tasks) {
+    options.dispatcher.submit(toDispatcherCandidate(candidate));
+    submitted += 1;
+  }
+  const outcome: CandidateCycleOutcome = {
+    submitted,
+    warnings: poll.warnings,
+    rateLimited: poll.searchRateLimited,
+  };
+  options.onCycle?.(outcome);
+  return outcome;
+}
+
+async function defaultSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (ms <= 0) return;
+  if (signal?.aborted) return;
+  return new Promise<void>((resolve) => {
+    const handle = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+    const onAbort = (): void => {
+      clearTimeout(handle);
+      cleanup();
+      resolve();
+    };
+    const cleanup = (): void => {
+      if (signal) signal.removeEventListener("abort", onAbort);
+    };
+    if (signal) signal.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/src/products/breeze/daemon/gh-client.ts
+++ b/src/products/breeze/daemon/gh-client.ts
@@ -1,0 +1,627 @@
+/**
+ * Phase 4: TS port of `first-tree-breeze/breeze-runner/src/gh.rs`.
+ *
+ * `GhClient` wraps a `GhExecutor` with the GitHub-specific query set
+ * (notifications, review requests, assigned issues/PRs) and the
+ * snapshot-hydration path (`writeTaskSnapshot`). Rate limiting +
+ * write-cooldown are handled entirely by the executor; this module
+ * only builds argv.
+ *
+ * Pure behaviour, except for the file writes in `writeTaskSnapshot`.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  bucketForArgs,
+  isRateLimited,
+  type ExecOutput,
+  type GhCommandSpec,
+  type GhBucket,
+  type GhExecutor,
+} from "./gh-executor.js";
+import {
+  RepoFilter,
+  searchScopesFor,
+  type SearchScope,
+} from "../core/repo-filter.js";
+import {
+  buildAssignedCandidate,
+  buildNotificationCandidate,
+  buildReviewRequestCandidate,
+  taskIssueNumber,
+  taskPrNumber,
+  taskUrl,
+  type TaskCandidate,
+} from "../core/task.js";
+import {
+  canonicalApiPath,
+  isRecentGithubTimestamp,
+  parseTsvLine,
+  shellQuote,
+} from "../core/task-util.js";
+
+export interface ThreadActivity {
+  login: string;
+  userType: string;
+  updatedAt: string;
+}
+
+export interface CandidatePoll {
+  tasks: TaskCandidate[];
+  warnings: string[];
+  searchAttempted: boolean;
+  searchRateLimited: boolean;
+}
+
+export interface GhClientOptions {
+  host: string;
+  repoFilter: RepoFilter;
+  executor: GhExecutor;
+}
+
+export class GhClient {
+  private readonly host: string;
+  private readonly repoFilter: RepoFilter;
+  private readonly executor: GhExecutor;
+
+  constructor(options: GhClientOptions) {
+    this.host = options.host;
+    this.repoFilter = options.repoFilter;
+    this.executor = options.executor;
+  }
+
+  getExecutor(): GhExecutor {
+    return this.executor;
+  }
+
+  /** `GET /notifications` with lookback + repo-filter enforcement. */
+  async recentNotifications(
+    nowEpoch: number,
+    lookbackSecs: number,
+  ): Promise<TaskCandidate[]> {
+    const jq =
+      '.[] | [(.repository.full_name // ""), (.subject.type // ""), (.reason // ""), (.subject.title // ""), (.subject.url // ""), (.latest_comment_url // ""), (.updated_at // "")] | @tsv';
+    const stdout = await this.runChecked(
+      "read recent notifications",
+      [
+        "api",
+        "/notifications?all=true&participating=false&per_page=100",
+        "--paginate",
+        "-H",
+        "X-GitHub-Api-Version: 2022-11-28",
+        "--jq",
+        jq,
+      ],
+      "core",
+    );
+    const tasks: TaskCandidate[] = [];
+    for (const line of stdout.split("\n")) {
+      if (line.trim().length === 0) continue;
+      const fields = parseTsvLine(line);
+      if (fields.length < 7) continue;
+      const candidate = buildNotificationCandidate({
+        host: this.host,
+        repo: fields[0],
+        subjectType: fields[1],
+        reason: fields[2],
+        title: fields[3],
+        apiUrl: fields[4],
+        latestCommentApiUrl: fields[5],
+        updatedAt: fields[6],
+      });
+      if (!candidate) continue;
+      if (!this.repoFilter.matchesRepo(candidate.repo)) continue;
+      if (!isRecentGithubTimestamp(candidate.updatedAt, nowEpoch, lookbackSecs)) {
+        continue;
+      }
+      tasks.push(candidate);
+    }
+    return tasks;
+  }
+
+  /** `gh search prs --review-requested=@me`. */
+  async reviewRequests(limit: number): Promise<TaskCandidate[]> {
+    const jq =
+      '.[] | [(.repository.nameWithOwner // ""), ((.number | tostring) // "0"), (.title // ""), (.url // ""), (.updatedAt // "")] | @tsv';
+    const tasks: TaskCandidate[] = [];
+    for (const scope of searchScopesFor(this.repoFilter)) {
+      const stdout = await this.runChecked(
+        "search review requests",
+        withSearchScope(
+          [
+            "search",
+            "prs",
+            "--review-requested=@me",
+            "--state",
+            "open",
+            "--limit",
+            String(limit),
+            "--json",
+            "number,title,url,updatedAt,repository",
+            "--jq",
+            jq,
+          ],
+          scope,
+        ),
+        "search",
+      );
+      for (const line of stdout.split("\n")) {
+        if (line.trim().length === 0) continue;
+        const fields = parseTsvLine(line);
+        if (fields.length < 5) continue;
+        const number = Number.parseInt(fields[1], 10) || 0;
+        tasks.push(
+          buildReviewRequestCandidate({
+            repo: fields[0],
+            number,
+            title: fields[2],
+            webUrl: fields[3],
+            updatedAt: fields[4],
+          }),
+        );
+      }
+    }
+    return deduplicate(tasks);
+  }
+
+  /** `gh search issues --assignee=@me --include-prs`. */
+  async assignedItems(limit: number): Promise<TaskCandidate[]> {
+    const jq =
+      '.[] | [(.repository.nameWithOwner // ""), ((.number | tostring) // "0"), (.title // ""), (.url // ""), (.updatedAt // ""), (if .isPullRequest then "1" else "0" end)] | @tsv';
+    const tasks: TaskCandidate[] = [];
+    for (const scope of searchScopesFor(this.repoFilter)) {
+      const stdout = await this.runChecked(
+        "search assigned items",
+        withSearchScope(
+          [
+            "search",
+            "issues",
+            "--assignee=@me",
+            "--state",
+            "open",
+            "--include-prs",
+            "--limit",
+            String(limit),
+            "--json",
+            "number,title,url,updatedAt,repository,isPullRequest",
+            "--jq",
+            jq,
+          ],
+          scope,
+        ),
+        "search",
+      );
+      for (const line of stdout.split("\n")) {
+        if (line.trim().length === 0) continue;
+        const fields = parseTsvLine(line);
+        if (fields.length < 6) continue;
+        const number = Number.parseInt(fields[1], 10) || 0;
+        tasks.push(
+          buildAssignedCandidate({
+            repo: fields[0],
+            number,
+            title: fields[2],
+            webUrl: fields[3],
+            updatedAt: fields[4],
+            isPullRequest: fields[5] === "1",
+          }),
+        );
+      }
+    }
+    return deduplicate(tasks);
+  }
+
+  /** Last comment on `api_url`'s thread (empty api_url → null). */
+  async latestCommentActivity(apiUrl: string): Promise<ThreadActivity | null> {
+    if (apiUrl.trim().length === 0) return null;
+    const jq =
+      '[.user.login // "", .user.type // "", (.updated_at // .created_at // "")] | @tsv';
+    const stdout = await this.runChecked(
+      "inspect latest comment activity",
+      ["api", canonicalApiPath(apiUrl), "--jq", jq],
+      "core",
+    );
+    return parseThreadActivity(firstNonEmptyLine(stdout));
+  }
+
+  /** Last review on a PR. */
+  async latestReviewActivity(
+    repo: string,
+    prNumber: number,
+  ): Promise<ThreadActivity | null> {
+    const jq =
+      'if length == 0 then empty else .[-1] | [(.user.login // ""), (.user.type // ""), (.submitted_at // "")] | @tsv end';
+    const stdout = await this.runChecked(
+      "inspect latest review activity",
+      [
+        "api",
+        `/repos/${repo}/pulls/${prNumber}/reviews?per_page=100`,
+        "-H",
+        "X-GitHub-Api-Version: 2022-11-28",
+        "--jq",
+        jq,
+      ],
+      "core",
+    );
+    return parseThreadActivity(firstNonEmptyLine(stdout));
+  }
+
+  /** Max(latest comment, latest review). */
+  async latestVisibleActivity(
+    task: TaskCandidate,
+  ): Promise<ThreadActivity | null> {
+    const comment = await this.latestCommentActivity(task.latestCommentApiUrl);
+    const pr = taskPrNumber(task);
+    const review =
+      pr !== undefined ? await this.latestReviewActivity(task.repo, pr) : null;
+    return pickNewerActivity(comment, review);
+  }
+
+  /**
+   * Top-level candidate producer used by the dispatcher. Runs the
+   * notification poll and (optionally) the two search queries,
+   * aggregates, de-dups by thread_key, sorts.
+   */
+  async collectCandidates(options: {
+    limit: number;
+    includeSearch: boolean;
+    nowEpoch: number;
+    lookbackSecs: number;
+  }): Promise<CandidatePoll> {
+    const poll: CandidatePoll = {
+      tasks: [],
+      warnings: [],
+      searchAttempted: false,
+      searchRateLimited: false,
+    };
+
+    try {
+      const tasks = await this.recentNotifications(
+        options.nowEpoch,
+        options.lookbackSecs,
+      );
+      poll.tasks.push(...tasks);
+    } catch (err) {
+      poll.warnings.push(
+        `notifications: ${errMessage(err).trim()}`,
+      );
+    }
+
+    if (options.includeSearch) {
+      poll.searchAttempted = true;
+
+      try {
+        const tasks = await this.reviewRequests(options.limit);
+        poll.tasks.push(...tasks);
+      } catch (err) {
+        const message = errMessage(err);
+        if (isRateLimitError(message)) poll.searchRateLimited = true;
+        poll.warnings.push(`review search: ${message.trim()}`);
+      }
+
+      try {
+        const tasks = await this.assignedItems(options.limit);
+        poll.tasks.push(...tasks);
+      } catch (err) {
+        const message = errMessage(err);
+        if (isRateLimitError(message)) poll.searchRateLimited = true;
+        poll.warnings.push(`assignment search: ${message.trim()}`);
+      }
+    }
+
+    poll.tasks = poll.tasks.filter(
+      (task) =>
+        this.repoFilter.matchesRepo(task.repo) &&
+        isRecentGithubTimestamp(task.updatedAt, options.nowEpoch, options.lookbackSecs),
+    );
+    poll.tasks.sort(compareCandidates);
+    poll.tasks = deduplicate(poll.tasks);
+    return poll;
+  }
+
+  /**
+   * Write local snapshot files for a task under `<taskDir>/snapshot/`.
+   * Agents read these first to avoid redundant `gh` calls.
+   */
+  async writeTaskSnapshot(
+    task: TaskCandidate,
+    taskDir: string,
+  ): Promise<string> {
+    const snapshotDir = join(taskDir, "snapshot");
+    mkdirSync(snapshotDir, { recursive: true });
+
+    const summaryLines = [
+      `repo=${task.repo}`,
+      `thread_key=${task.threadKey}`,
+      `kind=${task.kind}`,
+      `title=${task.title}`,
+      `url=${taskUrl(task)}`,
+      `api_url=${task.apiUrl}`,
+      `latest_comment_api_url=${task.latestCommentApiUrl}`,
+      `updated_at=${task.updatedAt}`,
+    ];
+    writeFileSync(join(snapshotDir, "task-summary.env"), summaryLines.join("\n"));
+    writeFileSync(
+      join(snapshotDir, "README.txt"),
+      renderSnapshotReadme(task, snapshotDir),
+    );
+
+    if (task.apiUrl.length > 0) {
+      await this.captureSnapshot(snapshotDir, "subject.json", {
+        context: "hydrate task subject",
+        envs: this.hostEnv(),
+        args: [
+          "api",
+          canonicalApiPath(task.apiUrl),
+          "-H",
+          "X-GitHub-Api-Version: 2022-11-28",
+        ],
+        bucket: "core",
+        mutating: false,
+      });
+    }
+    if (task.latestCommentApiUrl.length > 0) {
+      await this.captureSnapshot(snapshotDir, "latest-comment.json", {
+        context: "hydrate latest comment",
+        envs: this.hostEnv(),
+        args: [
+          "api",
+          canonicalApiPath(task.latestCommentApiUrl),
+          "-H",
+          "X-GitHub-Api-Version: 2022-11-28",
+        ],
+        bucket: "core",
+        mutating: false,
+      });
+    }
+
+    const prNumber = taskPrNumber(task);
+    const issueNumber = taskIssueNumber(task);
+    if (prNumber !== undefined) {
+      await this.captureSnapshot(snapshotDir, "pr-view.json", {
+        context: "hydrate pr view",
+        envs: this.hostEnv(),
+        args: [
+          "pr",
+          "view",
+          String(prNumber),
+          "--repo",
+          task.repo,
+          "--json",
+          "number,title,body,author,headRefName,headRefOid,baseRefName,url,isDraft,state",
+        ],
+        bucket: "core",
+        mutating: false,
+      });
+      await this.captureSnapshot(snapshotDir, "pr.diff", {
+        context: "hydrate pr diff",
+        envs: this.hostEnv(),
+        args: ["pr", "diff", String(prNumber), "--repo", task.repo],
+        bucket: "core",
+        mutating: false,
+      });
+      await this.captureSnapshot(snapshotDir, "issue-comments.json", {
+        context: "hydrate issue comments",
+        envs: this.hostEnv(),
+        args: [
+          "api",
+          `/repos/${task.repo}/issues/${prNumber}/comments?per_page=100`,
+          "-H",
+          "X-GitHub-Api-Version: 2022-11-28",
+        ],
+        bucket: "core",
+        mutating: false,
+      });
+      await this.captureSnapshot(snapshotDir, "pr-reviews.json", {
+        context: "hydrate pr reviews",
+        envs: this.hostEnv(),
+        args: [
+          "api",
+          `/repos/${task.repo}/pulls/${prNumber}/reviews?per_page=100`,
+          "-H",
+          "X-GitHub-Api-Version: 2022-11-28",
+        ],
+        bucket: "core",
+        mutating: false,
+      });
+    } else if (issueNumber !== undefined) {
+      await this.captureSnapshot(snapshotDir, "issue-view.json", {
+        context: "hydrate issue view",
+        envs: this.hostEnv(),
+        args: [
+          "issue",
+          "view",
+          String(issueNumber),
+          "--repo",
+          task.repo,
+          "--json",
+          "number,title,body,author,labels,assignees,state,url",
+        ],
+        bucket: "core",
+        mutating: false,
+      });
+      await this.captureSnapshot(snapshotDir, "issue-comments.json", {
+        context: "hydrate issue comments",
+        envs: this.hostEnv(),
+        args: [
+          "api",
+          `/repos/${task.repo}/issues/${issueNumber}/comments?per_page=100`,
+          "-H",
+          "X-GitHub-Api-Version: 2022-11-28",
+        ],
+        bucket: "core",
+        mutating: false,
+      });
+    }
+
+    return snapshotDir;
+  }
+
+  private async captureSnapshot(
+    snapshotDir: string,
+    filename: string,
+    spec: Omit<GhCommandSpec, "cwd"> & { envs: Record<string, string> },
+  ): Promise<void> {
+    const output = await this.executor.run(spec);
+    writeFileSync(join(snapshotDir, filename), output.stdout);
+    const metaLines = [
+      `context=${spec.context}`,
+      `command=${spec.args.map(shellQuote).join(" ")}`,
+      `status_code=${output.statusCode}`,
+      `bucket=${spec.bucket ?? bucketForArgs(spec.args)}`,
+      `mutating=${spec.mutating ?? false}`,
+    ];
+    if (output.stderr.trim().length > 0) {
+      const stderrPath = join(snapshotDir, `${filename}.stderr`);
+      writeFileSync(stderrPath, output.stderr);
+      metaLines.push(`stderr_file=${stderrPath}`);
+    }
+    metaLines.push(
+      output.statusCode === 0
+        ? "snapshot_status=ok"
+        : "snapshot_status=partial",
+    );
+    writeFileSync(join(snapshotDir, `${filename}.meta`), metaLines.join("\n"));
+  }
+
+  private async runChecked(
+    context: string,
+    args: string[],
+    bucket: GhBucket,
+  ): Promise<string> {
+    return this.executor.runChecked({
+      context,
+      envs: this.hostEnv(),
+      args,
+      bucket,
+      mutating: false,
+    });
+  }
+
+  private hostEnv(): Record<string, string> {
+    return { GH_HOST: this.host };
+  }
+}
+
+/* ------------------------- utilities -------------------------------- */
+
+export function parseThreadActivity(line: string | undefined): ThreadActivity | null {
+  if (!line) return null;
+  const fields = parseTsvLine(line);
+  if (fields.length < 3) return null;
+  return { login: fields[0], userType: fields[1], updatedAt: fields[2] };
+}
+
+export function pickNewerActivity(
+  left: ThreadActivity | null,
+  right: ThreadActivity | null,
+): ThreadActivity | null {
+  if (left && right) return right.updatedAt > left.updatedAt ? right : left;
+  return left ?? right;
+}
+
+export function deduplicate(tasks: TaskCandidate[]): TaskCandidate[] {
+  const seen = new Set<string>();
+  const unique: TaskCandidate[] = [];
+  for (const task of tasks) {
+    if (seen.has(task.threadKey)) continue;
+    seen.add(task.threadKey);
+    unique.push(task);
+  }
+  return unique;
+}
+
+/** Skip mentions from self+bot; skip comment/other self-authored events. */
+export function shouldIgnoreSelfAuthored(
+  login: string,
+  latestCommentAuthor: string | undefined,
+  kind: TaskCandidate["kind"],
+): boolean {
+  switch (kind) {
+    case "review_request":
+    case "assigned_issue":
+    case "assigned_pull_request":
+      return false;
+    case "mention":
+      return latestCommentAuthor?.endsWith("[bot]") ?? false;
+    default:
+      if (!latestCommentAuthor) return false;
+      return (
+        latestCommentAuthor === login ||
+        latestCommentAuthor.endsWith("[bot]")
+      );
+  }
+}
+
+/** Ignore a thread when its latest visible activity was us (or a bot) and is current. */
+export function shouldIgnoreLatestSelfActivity(
+  login: string,
+  activity: ThreadActivity | null,
+  taskUpdatedAt: string,
+): boolean {
+  if (!activity) return false;
+  if (activity.updatedAt < taskUpdatedAt) return false;
+  const actorLogin = activity.login.trim();
+  if (actorLogin.length === 0) return false;
+  return (
+    actorLogin === login ||
+    actorLogin.endsWith("[bot]") ||
+    activity.userType === "Bot"
+  );
+}
+
+/** Mirrors Rust `is_rate_limit_error`: surfaces message-only secondary rate-limit detection. */
+export function isRateLimitError(message: string): boolean {
+  return isRateLimited({ stdout: "", stderr: message, statusCode: 1 });
+}
+
+function withSearchScope(base: string[], scope: SearchScope): string[] {
+  switch (scope.kind) {
+    case "all":
+      return base;
+    case "owner":
+      return [...base, "--owner", scope.owner];
+    case "repo":
+      return [...base, "--repo", scope.repo];
+  }
+}
+
+function compareCandidates(a: TaskCandidate, b: TaskCandidate): number {
+  if (a.priority !== b.priority) return b.priority - a.priority;
+  if (a.updatedAt !== b.updatedAt) return a.updatedAt < b.updatedAt ? 1 : -1;
+  return a.threadKey.localeCompare(b.threadKey);
+}
+
+function firstNonEmptyLine(stdout: string): string | undefined {
+  for (const line of stdout.split("\n")) {
+    if (line.trim().length > 0) return line;
+  }
+  return undefined;
+}
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function renderSnapshotReadme(task: TaskCandidate, snapshotDir: string): string {
+  return (
+    "breeze-runner prepared this local snapshot before the agent started.\n" +
+    "\n" +
+    "Use these files first to avoid redundant GitHub API calls.\n" +
+    "\n" +
+    `- Task summary: ${join(snapshotDir, "task-summary.env")}\n` +
+    `- Primary subject payload: ${join(snapshotDir, "subject.json")}\n` +
+    `- Latest comment payload: ${join(snapshotDir, "latest-comment.json")}\n` +
+    "- PR or issue material is stored next to those files when available.\n" +
+    "\n" +
+    "If you still need `gh`, breeze-runner will broker and pace the command automatically.\n" +
+    "\n" +
+    `Task: ${task.kind} in ${task.repo}\n` +
+    `Title: ${task.title}\n` +
+    `URL: ${taskUrl(task)}\n`
+  );
+}
+
+export { type GhBucket } from "./gh-executor.js";

--- a/src/products/breeze/daemon/runner-skeleton.ts
+++ b/src/products/breeze/daemon/runner-skeleton.ts
@@ -44,6 +44,9 @@ import { GhExecutor } from "./gh-executor.js";
 import { Dispatcher } from "./dispatcher.js";
 import { WorkspaceManager } from "./workspace.js";
 import type { RunnerSpec } from "./runner.js";
+import { GhClient as BrokerGhClient } from "./gh-client.js";
+import { runCandidateLoop } from "./candidate-loop.js";
+import { RepoFilter } from "../core/repo-filter.js";
 
 export interface DaemonCliOverrides {
   pollIntervalSec?: number;
@@ -253,6 +256,7 @@ export async function runDaemon(
   // read-only (poller + http).
   let broker: RunningBroker | null = null;
   let dispatcher: Dispatcher | null = null;
+  let candidateLoopDone: Promise<void> | null = null;
   try {
     const runners = detectAvailableRunners();
     const realGh = findExecutable("gh");
@@ -296,6 +300,28 @@ export async function runDaemon(
       logger.info(
         `breeze daemon: dispatcher ready (runners=${runners.map((r) => r.kind).join(",")}, broker=${broker.shimDir})`,
       );
+
+      // Phase 4: candidate loop — feeds the dispatcher from GitHub.
+      const candidateClient = new BrokerGhClient({
+        host: identity.host,
+        repoFilter: RepoFilter.empty(),
+        executor,
+      });
+      candidateLoopDone = runCandidateLoop({
+        client: candidateClient,
+        dispatcher,
+        bus,
+        pollIntervalSec: config.pollIntervalSec,
+        searchLimit: 10,
+        includeSearch: true,
+        lookbackSecs: 24 * 3_600,
+        signal: controller.signal,
+        logger,
+      }).catch((err) => {
+        logger.error(
+          `candidate loop crashed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
     } else {
       const missing: string[] = [];
       if (runners.length === 0) missing.push("no codex/claude on PATH");
@@ -359,6 +385,15 @@ export async function runDaemon(
     //   in-flight runner tasks) -> stop broker (drains serve loop) ->
     //   stop http -> close bus -> exit.
     if (!controller.signal.aborted) controller.abort();
+    if (candidateLoopDone) {
+      try {
+        await candidateLoopDone;
+      } catch (err) {
+        logger.warn(
+          `candidate loop shutdown failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
     if (dispatcher) {
       try {
         await dispatcher.stop();

--- a/tests/breeze-daemon-candidate-loop.test.ts
+++ b/tests/breeze-daemon-candidate-loop.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createBus } from "../src/products/breeze/daemon/bus.js";
+import {
+  Dispatcher,
+  type TaskCandidate as DispatchCandidate,
+} from "../src/products/breeze/daemon/dispatcher.js";
+import {
+  GhClient,
+  type CandidatePoll,
+} from "../src/products/breeze/daemon/gh-client.js";
+import {
+  runCandidateCycle,
+  runCandidateLoop,
+} from "../src/products/breeze/daemon/candidate-loop.js";
+import { buildReviewRequestCandidate } from "../src/products/breeze/core/task.js";
+import {
+  WorkspaceManager,
+  type GitRunner,
+} from "../src/products/breeze/daemon/workspace.js";
+import type { RunnerSpawner } from "../src/products/breeze/daemon/runner.js";
+import { RepoFilter } from "../src/products/breeze/core/repo-filter.js";
+import { GhExecutor } from "../src/products/breeze/daemon/gh-executor.js";
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  while (tempRoots.length) {
+    const dir = tempRoots.pop();
+    if (dir && existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), `breeze-candidate-${prefix}-`));
+  tempRoots.push(dir);
+  return dir;
+}
+
+function makeClientStub(poll: CandidatePoll): GhClient {
+  const executor = new GhExecutor({
+    realGh: "/usr/bin/gh",
+    writeCooldownMs: 0,
+    spawnGh: async () => ({ stdout: "", stderr: "", statusCode: 0 }),
+    now: () => 1_000_000,
+    sleep: async () => undefined,
+  });
+  const client = new GhClient({
+    host: "github.com",
+    repoFilter: RepoFilter.empty(),
+    executor,
+  });
+  // Override collectCandidates for the test.
+  (client as unknown as { collectCandidates: unknown }).collectCandidates =
+    async () => poll;
+  return client;
+}
+
+function makeDispatcher(): {
+  dispatcher: Dispatcher;
+  submitted: DispatchCandidate[];
+} {
+  const submitted: DispatchCandidate[] = [];
+  const root = makeTempDir("disp");
+  const reposDir = join(root, "repos");
+  const claimsDir = join(root, "claims");
+  mkdirSync(reposDir, { recursive: true });
+  mkdirSync(claimsDir, { recursive: true });
+  mkdirSync(join(reposDir, "owner__repo.git"), { recursive: true });
+  const git: GitRunner = async ({ args }) =>
+    args.includes("rev-parse")
+      ? { stdout: "deadbeef\n", stderr: "", statusCode: 0 }
+      : { stdout: "", stderr: "", statusCode: 0 };
+  const dispatcher = new Dispatcher({
+    runnerHome: join(root, "runner"),
+    identity: { host: "github.com", login: "alice" },
+    runners: [{ kind: "codex" }],
+    workspaceManager: new WorkspaceManager({
+      reposDir,
+      workspacesDir: join(root, "workspaces"),
+      identity: { host: "github.com", login: "alice" },
+      runGit: git,
+    }),
+    bus: createBus(),
+    ghShimDir: join(root, "shim", "bin"),
+    ghBrokerDir: join(root, "shim"),
+    claimsDir,
+    disclosureText: "n",
+    maxParallel: 1,
+    taskTimeoutMs: 1_000,
+    dryRun: true,
+    onCompletion: () => undefined,
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+  });
+  mkdirSync(join(root, "runner"), { recursive: true });
+  const submitOriginal = dispatcher.submit.bind(dispatcher);
+  dispatcher.submit = (c: DispatchCandidate): void => {
+    submitted.push(c);
+    submitOriginal(c);
+  };
+  return { dispatcher, submitted };
+}
+
+describe("runCandidateCycle", () => {
+  it("submits each candidate to the dispatcher and reports counts", async () => {
+    const candidate = buildReviewRequestCandidate({
+      repo: "owner/repo",
+      number: 42,
+      title: "Review",
+      webUrl: "https://github.com/owner/repo/pull/42",
+      updatedAt: "2026-04-15T12:00:00Z",
+    });
+    const poll: CandidatePoll = {
+      tasks: [candidate],
+      warnings: [],
+      searchAttempted: true,
+      searchRateLimited: false,
+    };
+    const client = makeClientStub(poll);
+    const { dispatcher, submitted } = makeDispatcher();
+    const outcome = await runCandidateCycle(
+      {
+        client,
+        dispatcher,
+        searchLimit: 10,
+        includeSearch: true,
+        lookbackSecs: 3600,
+      },
+      () => 1_700_000_000,
+    );
+    expect(outcome.submitted).toBe(1);
+    expect(submitted).toHaveLength(1);
+    expect(submitted[0].threadKey).toBe("/repos/owner/repo/pulls/42");
+  });
+
+  it("bubbles rate-limited + warning signals from the poll", async () => {
+    const client = makeClientStub({
+      tasks: [],
+      warnings: ["review search: rate limit"],
+      searchAttempted: true,
+      searchRateLimited: true,
+    });
+    const { dispatcher } = makeDispatcher();
+    const outcome = await runCandidateCycle(
+      {
+        client,
+        dispatcher,
+        searchLimit: 10,
+        includeSearch: true,
+        lookbackSecs: 3600,
+      },
+      () => 1_700_000_000,
+    );
+    expect(outcome.submitted).toBe(0);
+    expect(outcome.rateLimited).toBe(true);
+    expect(outcome.warnings).toEqual(["review search: rate limit"]);
+  });
+});
+
+describe("runCandidateLoop", () => {
+  it("exits cleanly when the signal aborts", async () => {
+    const client = makeClientStub({
+      tasks: [],
+      warnings: [],
+      searchAttempted: false,
+      searchRateLimited: false,
+    });
+    const { dispatcher } = makeDispatcher();
+    const controller = new AbortController();
+    const sleep = vi.fn(async (ms: number) => {
+      // Abort mid-loop so we don't wait the real interval.
+      controller.abort();
+    });
+    const done = runCandidateLoop({
+      client,
+      dispatcher,
+      pollIntervalSec: 1,
+      searchLimit: 10,
+      includeSearch: false,
+      lookbackSecs: 3600,
+      signal: controller.signal,
+      sleep,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    });
+    await done;
+    expect(sleep).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/breeze-daemon-gh-client.test.ts
+++ b/tests/breeze-daemon-gh-client.test.ts
@@ -1,0 +1,354 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  GhClient,
+  deduplicate,
+  isRateLimitError,
+  parseThreadActivity,
+  pickNewerActivity,
+  shouldIgnoreLatestSelfActivity,
+  shouldIgnoreSelfAuthored,
+} from "../src/products/breeze/daemon/gh-client.js";
+import {
+  GhExecutor,
+  type ExecOutput,
+  type GhCommandSpec,
+} from "../src/products/breeze/daemon/gh-executor.js";
+import { RepoFilter } from "../src/products/breeze/core/repo-filter.js";
+import {
+  buildNotificationCandidate,
+  buildReviewRequestCandidate,
+} from "../src/products/breeze/core/task.js";
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  while (tempRoots.length) {
+    const dir = tempRoots.pop();
+    if (dir && existsSync(dir)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), `breeze-gh-client-${prefix}-`));
+  tempRoots.push(dir);
+  return dir;
+}
+
+interface StubExecutor {
+  calls: GhCommandSpec[];
+  setResponses(responses: Array<Partial<ExecOutput>>): void;
+  setResponder(fn: (spec: GhCommandSpec) => Partial<ExecOutput>): void;
+}
+
+function makeStubExecutor(): { executor: GhExecutor; ctl: StubExecutor } {
+  const calls: GhCommandSpec[] = [];
+  let queue: Array<Partial<ExecOutput>> = [];
+  let responder:
+    | ((spec: GhCommandSpec) => Partial<ExecOutput>)
+    | undefined;
+  // Virtual clock that advances with each injected sleep. This lets
+  // the executor's rate-limit backoff path terminate in tests.
+  let nowMs = 1_000_000;
+  const executor = new GhExecutor({
+    realGh: "/usr/bin/gh",
+    writeCooldownMs: 0,
+    spawnGh: async (spec) => {
+      calls.push(spec);
+      const out = responder
+        ? responder(spec)
+        : queue.shift() ?? { stdout: "", stderr: "", statusCode: 0 };
+      return {
+        stdout: out.stdout ?? "",
+        stderr: out.stderr ?? "",
+        statusCode: out.statusCode ?? 0,
+      };
+    },
+    now: () => nowMs,
+    sleep: async (ms) => {
+      nowMs += ms;
+    },
+  });
+  return {
+    executor,
+    ctl: {
+      calls,
+      setResponses(responses) {
+        queue = [...responses];
+      },
+      setResponder(fn) {
+        responder = fn;
+      },
+    },
+  };
+}
+
+describe("GhClient.recentNotifications", () => {
+  it("parses @tsv output and applies repo filter + lookback", async () => {
+    const { executor, ctl } = makeStubExecutor();
+    // Two tab-separated rows: first passes filter + recent; second is filtered out.
+    ctl.setResponses([
+      {
+        stdout: [
+          "owner/repo\tPullRequest\tmention\tHello\thttps://api.github.com/repos/owner/repo/pulls/7\t\t2026-04-15T12:00:00Z",
+          "other/repo\tIssue\tmention\tSkip\thttps://api.github.com/repos/other/repo/issues/3\t\t2026-04-15T12:00:00Z",
+        ].join("\n"),
+      },
+    ]);
+    const client = new GhClient({
+      host: "github.com",
+      repoFilter: RepoFilter.parseCsv("owner/*"),
+      executor,
+    });
+    const now = Date.UTC(2026, 3, 15, 12, 0, 0) / 1000; // 2026-04-15T12:00:00Z
+    const tasks = await client.recentNotifications(now, 120);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].repo).toBe("owner/repo");
+    expect(tasks[0].kind).toBe("mention");
+    // Assert the argv sent to gh contains the paginate + notifications endpoint.
+    expect(ctl.calls[0].args).toContain("--paginate");
+    expect(ctl.calls[0].args).toContain("/notifications?all=true&participating=false&per_page=100");
+  });
+
+  it("drops lines that predate the lookback window", async () => {
+    const { executor, ctl } = makeStubExecutor();
+    ctl.setResponses([
+      {
+        stdout:
+          "owner/repo\tPullRequest\tmention\tOld\thttps://api.github.com/repos/owner/repo/pulls/7\t\t2026-04-01T00:00:00Z",
+      },
+    ]);
+    const client = new GhClient({
+      host: "github.com",
+      repoFilter: RepoFilter.empty(),
+      executor,
+    });
+    const now = Date.UTC(2026, 3, 15, 12, 0, 0) / 1000;
+    const tasks = await client.recentNotifications(now, 60);
+    expect(tasks).toEqual([]);
+  });
+});
+
+describe("GhClient.reviewRequests / assignedItems", () => {
+  it("fans out one call per search scope", async () => {
+    const { executor, ctl } = makeStubExecutor();
+    ctl.setResponder((spec) => {
+      if (spec.args[0] === "search" && spec.args[1] === "prs") {
+        return {
+          stdout: "o/r\t11\tReview me\thttps://github.com/o/r/pull/11\t2026-04-15T12:00:00Z",
+        };
+      }
+      return { stdout: "" };
+    });
+    const client = new GhClient({
+      host: "github.com",
+      repoFilter: RepoFilter.parseCsv("o/*,p/r"),
+      executor,
+    });
+    const tasks = await client.reviewRequests(10);
+    // Two scopes (owner "o", repo "p/r") → two calls; both return the same
+    // payload, so dedupe trims to one.
+    expect(ctl.calls.length).toBe(2);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].kind).toBe("review_request");
+  });
+
+  it("parses the isPullRequest flag for assigned items", async () => {
+    const { executor, ctl } = makeStubExecutor();
+    ctl.setResponses([
+      {
+        stdout: [
+          "o/r\t3\tBug\thttps://github.com/o/r/issues/3\t2026-04-15T12:00:00Z\t0",
+          "o/r\t4\tFeature\thttps://github.com/o/r/pull/4\t2026-04-15T12:00:00Z\t1",
+        ].join("\n"),
+      },
+    ]);
+    const client = new GhClient({
+      host: "github.com",
+      repoFilter: RepoFilter.empty(),
+      executor,
+    });
+    const tasks = await client.assignedItems(10);
+    expect(tasks.map((t) => t.kind)).toEqual([
+      "assigned_issue",
+      "assigned_pull_request",
+    ]);
+  });
+});
+
+describe("GhClient.collectCandidates", () => {
+  it("captures warnings but continues when notifications fail", async () => {
+    const { executor, ctl } = makeStubExecutor();
+    ctl.setResponder((spec) => {
+      if (spec.args[0] === "api") {
+        return { statusCode: 1, stderr: "notifications boom" };
+      }
+      if (spec.args[0] === "search" && spec.args[1] === "prs") {
+        return {
+          stdout: "o/r\t11\tReview me\thttps://github.com/o/r/pull/11\t2026-04-15T12:00:00Z",
+        };
+      }
+      return { stdout: "" };
+    });
+    const client = new GhClient({
+      host: "github.com",
+      repoFilter: RepoFilter.empty(),
+      executor,
+    });
+    const now = Date.UTC(2026, 3, 15, 12, 0, 0) / 1000;
+    const poll = await client.collectCandidates({
+      limit: 5,
+      includeSearch: true,
+      nowEpoch: now,
+      lookbackSecs: 3600,
+    });
+    expect(poll.warnings.length).toBeGreaterThan(0);
+    expect(poll.warnings[0]).toMatch(/notifications:/);
+    expect(poll.tasks.length).toBe(1);
+    expect(poll.searchAttempted).toBe(true);
+  });
+
+  it("marks searchRateLimited when a search error contains a rate-limit signature", async () => {
+    const { executor, ctl } = makeStubExecutor();
+    ctl.setResponder((spec) => {
+      if (spec.args[0] === "api") return { stdout: "" };
+      return { statusCode: 1, stderr: "secondary rate limit hit" };
+    });
+    const client = new GhClient({
+      host: "github.com",
+      repoFilter: RepoFilter.empty(),
+      executor,
+    });
+    const now = Date.UTC(2026, 3, 15, 12, 0, 0) / 1000;
+    const poll = await client.collectCandidates({
+      limit: 5,
+      includeSearch: true,
+      nowEpoch: now,
+      lookbackSecs: 3600,
+    });
+    expect(poll.searchRateLimited).toBe(true);
+  });
+});
+
+describe("GhClient.writeTaskSnapshot", () => {
+  it("writes task-summary + README and an `.meta` file per captured payload", async () => {
+    const { executor, ctl } = makeStubExecutor();
+    ctl.setResponder((spec) => {
+      if (spec.args[0] === "pr" && spec.args[1] === "view") {
+        return { stdout: '{"number":42}' };
+      }
+      return { stdout: "body" };
+    });
+    const client = new GhClient({
+      host: "github.com",
+      repoFilter: RepoFilter.empty(),
+      executor,
+    });
+    const candidate = buildReviewRequestCandidate({
+      repo: "o/r",
+      number: 42,
+      title: "Review",
+      webUrl: "https://github.com/o/r/pull/42",
+      updatedAt: "2026-04-15T12:00:00Z",
+    });
+    const taskDir = makeTempDir("snapshot");
+    const snapshotDir = await client.writeTaskSnapshot(candidate, taskDir);
+    const files = readdirSync(snapshotDir).sort();
+    expect(files).toContain("task-summary.env");
+    expect(files).toContain("README.txt");
+    expect(files).toContain("subject.json");
+    expect(files).toContain("pr-view.json");
+    expect(readFileSync(join(snapshotDir, "pr-view.json"), "utf8")).toBe(
+      '{"number":42}',
+    );
+    // Meta has bucket/status lines.
+    const meta = readFileSync(
+      join(snapshotDir, "pr-view.json.meta"),
+      "utf8",
+    );
+    expect(meta).toContain("bucket=core");
+    expect(meta).toContain("snapshot_status=ok");
+  });
+});
+
+describe("pure helpers", () => {
+  it("parseThreadActivity handles an empty line", () => {
+    expect(parseThreadActivity(undefined)).toBeNull();
+    expect(parseThreadActivity("a\tUser\t2026-04-15T00:00:00Z")).toEqual({
+      login: "a",
+      userType: "User",
+      updatedAt: "2026-04-15T00:00:00Z",
+    });
+  });
+
+  it("pickNewerActivity prefers the later updatedAt", () => {
+    const left = {
+      login: "a",
+      userType: "User",
+      updatedAt: "2026-04-15T10:00:00Z",
+    };
+    const right = {
+      login: "b",
+      userType: "User",
+      updatedAt: "2026-04-15T11:00:00Z",
+    };
+    expect(pickNewerActivity(left, right)).toEqual(right);
+    expect(pickNewerActivity(right, null)).toEqual(right);
+    expect(pickNewerActivity(null, null)).toBeNull();
+  });
+
+  it("deduplicate keeps first occurrence per thread_key", () => {
+    const a = buildNotificationCandidate({
+      host: "github.com",
+      repo: "o/r",
+      subjectType: "PullRequest",
+      reason: "mention",
+      title: "A",
+      apiUrl: "https://api.github.com/repos/o/r/pulls/1",
+      latestCommentApiUrl: "",
+      updatedAt: "2026-04-15T00:00:00Z",
+    })!;
+    const b = { ...a, title: "B" };
+    expect(deduplicate([a, b])).toHaveLength(1);
+    expect(deduplicate([a, b])[0].title).toBe("A");
+  });
+
+  it("shouldIgnoreSelfAuthored filters comments but not review requests", () => {
+    expect(shouldIgnoreSelfAuthored("alice", "alice", "comment")).toBe(true);
+    expect(shouldIgnoreSelfAuthored("alice", "alice", "review_request")).toBe(false);
+    expect(
+      shouldIgnoreSelfAuthored("alice", "github-actions[bot]", "mention"),
+    ).toBe(true);
+    expect(shouldIgnoreSelfAuthored("alice", "bob", "comment")).toBe(false);
+  });
+
+  it("shouldIgnoreLatestSelfActivity compares against task updated_at", () => {
+    const activity = {
+      login: "alice",
+      userType: "User",
+      updatedAt: "2026-04-15T12:00:00Z",
+    };
+    expect(
+      shouldIgnoreLatestSelfActivity("alice", activity, "2026-04-15T12:00:00Z"),
+    ).toBe(true);
+    expect(
+      shouldIgnoreLatestSelfActivity("alice", activity, "2026-04-15T13:00:00Z"),
+    ).toBe(false);
+  });
+
+  it("isRateLimitError detects secondary/abuse substrings", () => {
+    expect(isRateLimitError("secondary rate limit triggered")).toBe(true);
+    expect(isRateLimitError("something else")).toBe(false);
+  });
+});

--- a/tests/breeze-repo-filter.test.ts
+++ b/tests/breeze-repo-filter.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  RepoFilter,
+  searchScopesFor,
+} from "../src/products/breeze/core/repo-filter.js";
+
+describe("RepoFilter.parseCsv", () => {
+  it("accepts owner/repo and owner/*", () => {
+    const f = RepoFilter.parseCsv("agent-team-foundation/*,bingran-you/repo");
+    expect(f.owners()).toEqual(["agent-team-foundation"]);
+    expect(f.repos()).toEqual(["bingran-you/repo"]);
+  });
+
+  it("rejects junk patterns", () => {
+    expect(() => RepoFilter.parseCsv("not/a/valid/pattern")).toThrow(
+      /invalid repo allow pattern/,
+    );
+    expect(() => RepoFilter.parseCsv("/*")).toThrow(/invalid repo allow pattern/);
+  });
+
+  it("dedupes on parse", () => {
+    const f = RepoFilter.parseCsv("o/*,o/*,o/r,o/r");
+    expect(f.owners()).toEqual(["o"]);
+    expect(f.repos()).toEqual(["o/r"]);
+  });
+
+  it("treats empty or whitespace as empty filter", () => {
+    expect(RepoFilter.parseCsv("").isEmpty()).toBe(true);
+    expect(RepoFilter.parseCsv("  ,  ").isEmpty()).toBe(true);
+  });
+});
+
+describe("RepoFilter.matchesRepo", () => {
+  it("accepts all when empty", () => {
+    const f = RepoFilter.empty();
+    expect(f.matchesRepo("any/thing")).toBe(true);
+  });
+
+  it("matches owner/*", () => {
+    const f = RepoFilter.parseCsv("foo/*");
+    expect(f.matchesRepo("foo/bar")).toBe(true);
+    expect(f.matchesRepo("baz/qux")).toBe(false);
+  });
+
+  it("matches exact owner/repo", () => {
+    const f = RepoFilter.parseCsv("foo/bar");
+    expect(f.matchesRepo("foo/bar")).toBe(true);
+    expect(f.matchesRepo("foo/baz")).toBe(false);
+  });
+});
+
+describe("RepoFilter.merge", () => {
+  it("combines owners and repos without dupes", () => {
+    const a = RepoFilter.parseCsv("o/*,a/r");
+    const b = RepoFilter.parseCsv("p/*,a/r,b/r");
+    const merged = a.merge(b);
+    expect(merged.owners()).toEqual(["o", "p"]);
+    expect(merged.repos()).toEqual(["a/r", "b/r"]);
+  });
+});
+
+describe("RepoFilter display / cli", () => {
+  it("renders patterns joined with comma and space", () => {
+    const f = RepoFilter.parseCsv("o/r,p/*");
+    expect(f.displayPatterns()).toBe("o/r, p/*");
+    expect(f.cliValue()).toBe("o/r,p/*");
+  });
+});
+
+describe("searchScopesFor", () => {
+  it("returns all when filter is empty", () => {
+    expect(searchScopesFor(RepoFilter.empty())).toEqual([{ kind: "all" }]);
+  });
+
+  it("emits one scope per owner and explicit repo", () => {
+    const f = RepoFilter.parseCsv("o/*,p/r");
+    const scopes = searchScopesFor(f);
+    expect(scopes).toContainEqual({ kind: "owner", owner: "o" });
+    expect(scopes).toContainEqual({ kind: "repo", repo: "p/r" });
+  });
+});

--- a/tests/breeze-task-kind.test.ts
+++ b/tests/breeze-task-kind.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyNotification,
+  priorityFor,
+  shouldProcessReason,
+  taskKindFromString,
+  type TaskKind,
+} from "../src/products/breeze/core/task-kind.js";
+
+describe("classifyNotification", () => {
+  it("returns review_request when reason=review_requested even on Issue subjects", () => {
+    expect(classifyNotification("PullRequest", "review_requested")).toBe(
+      "review_request",
+    );
+    expect(classifyNotification("Issue", "review_requested")).toBe(
+      "review_request",
+    );
+  });
+
+  it("maps mention and team_mention to mention", () => {
+    expect(classifyNotification("Issue", "mention")).toBe("mention");
+    expect(classifyNotification("PullRequest", "team_mention")).toBe("mention");
+  });
+
+  it("classifies Discussion subjects as discussion", () => {
+    expect(classifyNotification("Discussion", "subscribed")).toBe("discussion");
+  });
+
+  it("classifies assign by subject type", () => {
+    expect(classifyNotification("PullRequest", "assign")).toBe(
+      "assigned_pull_request",
+    );
+    expect(classifyNotification("Issue", "assign")).toBe("assigned_issue");
+  });
+
+  it("classifies comment/author/manual as comment", () => {
+    expect(classifyNotification("Issue", "author")).toBe("comment");
+    expect(classifyNotification("PullRequest", "manual")).toBe("comment");
+    expect(classifyNotification("Issue", "comment")).toBe("comment");
+  });
+
+  it("returns other for unknown reasons", () => {
+    expect(classifyNotification("Commit", "ci_activity")).toBe("other");
+  });
+});
+
+describe("priorityFor", () => {
+  it("ranks in the canonical Rust order", () => {
+    expect(priorityFor("review_request", "review_requested")).toBe(100);
+    expect(priorityFor("mention", "mention")).toBe(95);
+    expect(priorityFor("discussion", "subscribed")).toBe(90);
+    expect(priorityFor("comment", "comment")).toBe(85);
+    expect(priorityFor("assigned_pull_request", "assign")).toBe(80);
+    expect(priorityFor("assigned_issue", "assign")).toBe(70);
+    expect(priorityFor("other", "ci_activity")).toBe(50);
+    expect(priorityFor("other", "review_requested")).toBe(100);
+  });
+});
+
+describe("shouldProcessReason", () => {
+  it("accepts the actionable set", () => {
+    for (const r of [
+      "review_requested",
+      "mention",
+      "team_mention",
+      "comment",
+      "assign",
+      "author",
+      "manual",
+    ]) {
+      expect(shouldProcessReason(r)).toBe(true);
+    }
+  });
+
+  it("rejects subscribed / ci_activity / empty", () => {
+    expect(shouldProcessReason("subscribed")).toBe(false);
+    expect(shouldProcessReason("ci_activity")).toBe(false);
+    expect(shouldProcessReason("")).toBe(false);
+  });
+});
+
+describe("taskKindFromString round trip", () => {
+  it("maps every kind back to itself", () => {
+    const kinds: TaskKind[] = [
+      "review_request",
+      "mention",
+      "comment",
+      "assigned_issue",
+      "assigned_pull_request",
+      "discussion",
+      "other",
+    ];
+    for (const kind of kinds) {
+      expect(taskKindFromString(kind)).toBe(kind);
+    }
+  });
+
+  it("returns undefined for unknown strings", () => {
+    expect(taskKindFromString("not_a_kind")).toBeUndefined();
+  });
+});

--- a/tests/breeze-task-util.test.ts
+++ b/tests/breeze-task-util.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canonicalApiPath,
+  decodeMultiline,
+  encodeMultiline,
+  fnv1a64,
+  isRecentGithubTimestamp,
+  parseGithubTimestampEpoch,
+  parseKvLines,
+  parseTsvLine,
+  shellQuote,
+  stableFileId,
+  unescapeJqField,
+} from "../src/products/breeze/core/task-util.js";
+
+describe("fnv1a64 / stableFileId", () => {
+  it("matches known FNV-1a 64 outputs", () => {
+    // Reference values (computed via Rust util.rs::fnv1a64).
+    expect(fnv1a64("").toString(16)).toBe("cbf29ce484222325");
+    expect(fnv1a64("a").toString(16)).toBe("af63dc4c8601ec8c");
+    expect(fnv1a64("foobar").toString(16)).toBe("85944171f73967e8");
+  });
+
+  it("stableFileId renders zero-padded 16-hex chars", () => {
+    expect(stableFileId("")).toBe("cbf29ce484222325");
+    expect(stableFileId("foobar")).toHaveLength(16);
+  });
+});
+
+describe("canonicalApiPath", () => {
+  it("strips api.github.com / github.com prefixes + trailing slashes", () => {
+    expect(
+      canonicalApiPath("https://api.github.com/repos/o/r/pulls/12/"),
+    ).toBe("/repos/o/r/pulls/12");
+    expect(canonicalApiPath("https://github.com/o/r/pull/3")).toBe(
+      "/o/r/pull/3",
+    );
+    expect(canonicalApiPath("/repos/o/r")).toBe("/repos/o/r");
+  });
+});
+
+describe("parseTsvLine / unescapeJqField", () => {
+  it("splits on tabs and unescapes \\n \\t \\\\", () => {
+    const line = "a\\nbc\tdef\\tghi\t\\\\end";
+    const fields = parseTsvLine(line);
+    expect(fields).toEqual(["a\nbc", "def\tghi", "\\end"]);
+  });
+
+  it("decodes \\uXXXX escapes", () => {
+    expect(unescapeJqField("\\u0041bc")).toBe("Abc");
+  });
+});
+
+describe("encodeMultiline / decodeMultiline", () => {
+  it("round-trips newlines through the \\n sentinel", () => {
+    const original = "line1\nline2\nend";
+    const encoded = encodeMultiline(original);
+    expect(encoded).toBe("line1\\nline2\\nend");
+    expect(decodeMultiline(encoded)).toBe(original);
+  });
+});
+
+describe("shellQuote", () => {
+  it("returns '' for empty", () => {
+    expect(shellQuote("")).toBe("''");
+  });
+
+  it("passes shell-safe strings through unchanged", () => {
+    expect(shellQuote("abc-DEF.123_/:=,@")).toBe("abc-DEF.123_/:=,@");
+  });
+
+  it("single-quotes unsafe strings and escapes embedded quotes", () => {
+    expect(shellQuote("hello world")).toBe("'hello world'");
+    expect(shellQuote("don't")).toBe(`'don'"'"'t'`);
+  });
+});
+
+describe("parseKvLines", () => {
+  it("extracts key/value pairs and skips malformed lines", () => {
+    const input = "a=1\nno-equals\nb=two\n  c  =  three\n";
+    expect(parseKvLines(input)).toEqual([
+      ["a", "1"],
+      ["b", "two"],
+      ["c", "three"],
+    ]);
+  });
+});
+
+describe("parseGithubTimestampEpoch / isRecentGithubTimestamp", () => {
+  it("parses a valid ISO-Z timestamp to unix seconds", () => {
+    expect(parseGithubTimestampEpoch("2026-01-02T03:04:05Z")).toBe(
+      Date.UTC(2026, 0, 2, 3, 4, 5) / 1000,
+    );
+  });
+
+  it("rejects wrong length / bad separators / invalid month", () => {
+    expect(parseGithubTimestampEpoch("2026-01-02T03:04:05")).toBeUndefined();
+    expect(parseGithubTimestampEpoch("2026-13-02T03:04:05Z")).toBeUndefined();
+    expect(parseGithubTimestampEpoch("2026-02-30T03:04:05Z")).toBeUndefined();
+  });
+
+  it("isRecentGithubTimestamp compares against now - lookback", () => {
+    const now = parseGithubTimestampEpoch("2026-04-15T12:00:00Z")!;
+    expect(
+      isRecentGithubTimestamp("2026-04-15T11:59:00Z", now, 120),
+    ).toBe(true);
+    expect(
+      isRecentGithubTimestamp("2026-04-15T11:57:00Z", now, 120),
+    ).toBe(false);
+  });
+});

--- a/tests/breeze-task.test.ts
+++ b/tests/breeze-task.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildAssignedCandidate,
+  buildNotificationCandidate,
+  buildReviewRequestCandidate,
+  candidateFromTaskMetadata,
+  displayUrl,
+  effectiveWorkspaceRepo,
+  stableIdFor,
+  taskIssueNumber,
+  taskPrNumber,
+  taskUrl,
+  threadRecordFromKv,
+  threadRecordToLines,
+  toDispatcherCandidate,
+  type ThreadRecord,
+} from "../src/products/breeze/core/task.js";
+
+describe("buildNotificationCandidate", () => {
+  it("extracts pr number and sets review-request priority for review_requested", () => {
+    const candidate = buildNotificationCandidate({
+      host: "github.com",
+      repo: "owner/repo",
+      subjectType: "PullRequest",
+      reason: "review_requested",
+      title: "Review me",
+      apiUrl: "https://api.github.com/repos/owner/repo/pulls/12",
+      latestCommentApiUrl: "",
+      updatedAt: "2026-01-01T00:00:00Z",
+    });
+    expect(candidate).toBeDefined();
+    expect(candidate!.kind).toBe("review_request");
+    expect(candidate!.priority).toBe(100);
+    expect(candidate!.threadKey).toBe("/repos/owner/repo/pulls/12");
+    expect(taskPrNumber(candidate!)).toBe(12);
+  });
+
+  it("builds candidates for mentions referencing comments with anchor urls", () => {
+    const candidate = buildNotificationCandidate({
+      host: "github.com",
+      repo: "agent-team-foundation/first-tree",
+      subjectType: "PullRequest",
+      reason: "mention",
+      title: "fix(sync): ...",
+      apiUrl: "https://api.github.com/repos/agent-team-foundation/first-tree/pulls/98",
+      latestCommentApiUrl:
+        "https://api.github.com/repos/agent-team-foundation/first-tree/issues/comments/4247540715",
+      updatedAt: "2026-04-14T22:18:56Z",
+    });
+    expect(candidate!.kind).toBe("mention");
+    expect(taskPrNumber(candidate!)).toBe(98);
+    expect(taskUrl(candidate!)).toBe(
+      "https://github.com/agent-team-foundation/first-tree/pull/98#issuecomment-4247540715",
+    );
+  });
+
+  it("returns undefined for non-actionable reasons", () => {
+    const out = buildNotificationCandidate({
+      host: "github.com",
+      repo: "o/r",
+      subjectType: "PullRequest",
+      reason: "subscribed",
+      title: "x",
+      apiUrl: "https://api.github.com/repos/o/r/pulls/1",
+      latestCommentApiUrl: "",
+      updatedAt: "2026-01-01T00:00:00Z",
+    });
+    expect(out).toBeUndefined();
+  });
+
+  it("returns undefined when repo is empty", () => {
+    const out = buildNotificationCandidate({
+      host: "github.com",
+      repo: "",
+      subjectType: "PullRequest",
+      reason: "mention",
+      title: "x",
+      apiUrl: "",
+      latestCommentApiUrl: "",
+      updatedAt: "2026-01-01T00:00:00Z",
+    });
+    expect(out).toBeUndefined();
+  });
+
+  it("falls back to the issue web url when no comment anchor is available", () => {
+    const candidate = buildNotificationCandidate({
+      host: "github.com",
+      repo: "o/r",
+      subjectType: "Issue",
+      reason: "comment",
+      title: "t",
+      apiUrl: "https://api.github.com/repos/o/r/issues/7",
+      latestCommentApiUrl: "",
+      updatedAt: "2026-01-01T00:00:00Z",
+    });
+    expect(taskUrl(candidate!)).toBe("https://github.com/o/r/issues/7");
+  });
+});
+
+describe("buildReviewRequestCandidate / buildAssignedCandidate", () => {
+  it("review request builds with pulls thread key + priority 100", () => {
+    const c = buildReviewRequestCandidate({
+      repo: "o/r",
+      number: 45,
+      title: "Handle review",
+      webUrl: "https://github.com/o/r/pull/45",
+      updatedAt: "2026-01-01T00:00:00Z",
+    });
+    expect(c.threadKey).toBe("/repos/o/r/pulls/45");
+    expect(c.priority).toBe(100);
+    expect(taskPrNumber(c)).toBe(45);
+  });
+
+  it("assigned issue vs pr is driven by isPullRequest", () => {
+    const issue = buildAssignedCandidate({
+      repo: "o/r",
+      number: 3,
+      title: "t",
+      webUrl: "u",
+      updatedAt: "u",
+      isPullRequest: false,
+    });
+    expect(issue.kind).toBe("assigned_issue");
+    expect(taskIssueNumber(issue)).toBe(3);
+
+    const pr = buildAssignedCandidate({
+      repo: "o/r",
+      number: 4,
+      title: "t",
+      webUrl: "u",
+      updatedAt: "u",
+      isPullRequest: true,
+    });
+    expect(pr.kind).toBe("assigned_pull_request");
+    expect(taskPrNumber(pr)).toBe(4);
+  });
+});
+
+describe("candidateFromTaskMetadata", () => {
+  it("derives api/web urls from thread_key for /repos/... entries", () => {
+    const meta = new Map<string, string>([
+      ["repo", "owner/repo"],
+      ["workspace_repo", "bingran-you/bingran-you"],
+      ["thread_key", "/repos/owner/repo/pulls/12"],
+      ["kind", "review_request"],
+      ["reason", "review_requested"],
+      ["title", "Recover me"],
+      ["updated_at", "2026-01-01T00:00:00Z"],
+      ["source", "review-search"],
+    ]);
+    const c = candidateFromTaskMetadata(meta, "github.com");
+    expect(c).toBeDefined();
+    expect(c!.kind).toBe("review_request");
+    expect(c!.apiUrl).toBe("https://api.github.com/repos/owner/repo/pulls/12");
+    expect(c!.webUrl).toBe("https://github.com/owner/repo/pull/12");
+    expect(effectiveWorkspaceRepo(c!)).toBe("bingran-you/bingran-you");
+  });
+
+  it("returns undefined when required fields are missing", () => {
+    expect(
+      candidateFromTaskMetadata(new Map([["kind", "mention"]]), "github.com"),
+    ).toBeUndefined();
+  });
+});
+
+describe("stableIdFor", () => {
+  it("is deterministic across equal candidates", () => {
+    const base = buildReviewRequestCandidate({
+      repo: "o/r",
+      number: 1,
+      title: "t",
+      webUrl: "u",
+      updatedAt: "2026-01-01T00:00:00Z",
+    });
+    expect(stableIdFor(base)).toBe(stableIdFor({ ...base }));
+    expect(stableIdFor(base)).toHaveLength(16);
+  });
+});
+
+describe("toDispatcherCandidate", () => {
+  it("exposes the minimal dispatcher shape including prNumber", () => {
+    const c = buildReviewRequestCandidate({
+      repo: "o/r",
+      number: 42,
+      title: "Review",
+      webUrl: "https://github.com/o/r/pull/42",
+      updatedAt: "2026-01-01T00:00:00Z",
+    });
+    const disp = toDispatcherCandidate(c);
+    expect(disp.prNumber).toBe(42);
+    expect(disp.stableId).toBe(disp.notificationId);
+    expect(disp.threadKey).toBe("/repos/o/r/pulls/42");
+    expect(disp.priority).toBe(100);
+  });
+});
+
+describe("ThreadRecord serialization", () => {
+  it("round-trips through to-lines/from-kv", () => {
+    const record: ThreadRecord = {
+      threadKey: "/repos/o/r/issues/1",
+      repo: "o/r",
+      lastSeenUpdatedAt: "2026-01-01T00:00:00Z",
+      lastHandledUpdatedAt: "2026-01-01T00:00:00Z",
+      lastResult: "handled",
+      failureCount: 2,
+      nextRetryEpoch: 1234,
+      lastTaskId: "task-1",
+    };
+    const lines = threadRecordToLines(record);
+    const kv: Array<[string, string]> = lines.map((line) => {
+      const eq = line.indexOf("=");
+      return [line.slice(0, eq), line.slice(eq + 1)];
+    });
+    const restored = threadRecordFromKv(kv);
+    expect(restored).toEqual(record);
+  });
+
+  it("preserves newlines in multiline values via encode/decode", () => {
+    const record: ThreadRecord = {
+      threadKey: "k",
+      repo: "o/r",
+      lastSeenUpdatedAt: "",
+      lastHandledUpdatedAt: "",
+      lastResult: "line1\nline2",
+      failureCount: 0,
+      nextRetryEpoch: 0,
+      lastTaskId: "",
+    };
+    const lines = threadRecordToLines(record);
+    const kv = lines.map((line) => {
+      const eq = line.indexOf("=");
+      return [line.slice(0, eq), line.slice(eq + 1)] as [string, string];
+    });
+    expect(threadRecordFromKv(kv).lastResult).toBe("line1\nline2");
+  });
+});
+
+describe("displayUrl fallback", () => {
+  it("returns webUrl when present, else apiUrl", () => {
+    const c = buildReviewRequestCandidate({
+      repo: "o/r",
+      number: 1,
+      title: "",
+      webUrl: "https://github.com/o/r/pull/1",
+      updatedAt: "",
+    });
+    expect(displayUrl(c)).toBe("https://github.com/o/r/pull/1");
+    const cNoWeb = { ...c, webUrl: "" };
+    expect(displayUrl(cNoWeb)).toBe(
+      "https://api.github.com/repos/o/r/pulls/1",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Port the candidate-production layer from Rust to TypeScript and wire the dispatcher's input. Before this, the dispatcher had no candidate source — Phase 3c set up the machine but nothing pumped it.

### New TS modules
- `core/task-kind.ts` — `TaskKind`, `classifyNotification`, `priorityFor`, `shouldProcessReason` (port of `classify.rs`).
- `core/task-util.ts` — fnv1a64, canonicalApiPath, tsv/jq escape, shell-quote, multiline encode/decode, strict GitHub ISO-Z timestamp parsing (port of `util.rs` helpers).
- `core/repo-filter.ts` — `owner/*` + `owner/repo` allow-list with `searchScopesFor` (port of `config.rs::RepoFilter`).
- `core/task.ts` — rich `TaskCandidate`, `ThreadRecord`, notification/review/assigned builders, `toDispatcherCandidate` adapter, `candidateFromTaskMetadata` recovery (port of `task.rs`).
- `daemon/gh-client.ts` — executor-backed GhClient with `recentNotifications`, `reviewRequests`, `assignedItems`, latest-comment/review activity, `collectCandidates`, `writeTaskSnapshot` (port of `gh.rs`).
- `daemon/candidate-loop.ts` — long-running loop calling `collectCandidates` and submitting to `Dispatcher.submit()` with rate-limit backoff.

### Wiring
`daemon/runner-skeleton.ts` now constructs a broker-backed `GhClient` from the same `GhExecutor` as the broker and starts `runCandidateLoop` alongside the inbox poller. Shutdown awaits the candidate loop before stopping the dispatcher.

### Out of scope (Phase 5)
ThreadRecord persistence and `should_schedule` retry/backoff are still deferred. This PR ships the candidate feed; every candidate currently fans out to the dispatcher regardless of prior state. Phase 5 will add an `onCompletion` bridge that writes ThreadRecord to disk and gates re-submission.

## Test plan
- [x] 63 new unit tests (task-kind 11, task-util 13, repo-filter 11, task 14, gh-client 13, candidate-loop 3)
- [x] Full suite: 789/789
- [x] `pnpm validate:skill`
- [x] `pnpm typecheck`
- [x] `pnpm build`