### PR TITLE
Phase 5: port service.rs state machine (scheduler + thread store)

### DIFF
--- a/src/products/breeze/daemon/candidate-loop.ts
+++ b/src/products/breeze/daemon/candidate-loop.ts
@@ -16,7 +16,11 @@ import type { Bus } from "./bus.js";
 import type { Dispatcher } from "./dispatcher.js";
 import type { GhClient } from "./gh-client.js";
 import { rateLimitBackoffMs } from "./poller.js";
-import { toDispatcherCandidate } from "../core/task.js";
+import type { Scheduler } from "./scheduler.js";
+import {
+  toDispatcherCandidate,
+  type TaskCandidate,
+} from "../core/task.js";
 
 export interface CandidateLoopLogger {
   info: (line: string) => void;
@@ -54,6 +58,17 @@ export interface CandidateLoopOptions {
    * can persist ThreadRecord state (Phase 5). Defaults to no-op.
    */
   onCycle?: (outcome: CandidateCycleOutcome) => void;
+  /**
+   * Scheduler gate: dispatcher.submit is only called when
+   * `scheduler.shouldSchedule(candidate)` returns true. When absent,
+   * every candidate is submitted (back-compat with Phase 4).
+   */
+  scheduler?: Scheduler;
+  /**
+   * Recovery hook: called once before the first cycle to re-submit
+   * orphaned `status=running` tasks. Scheduler constructs these.
+   */
+  recoverableCandidates?: () => TaskCandidate[];
 }
 
 export interface CandidateCycleOutcome {
@@ -69,6 +84,19 @@ export async function runCandidateLoop(
   const nowSec = options.nowSec ?? (() => Math.floor(Date.now() / 1_000));
   const sleep = options.sleep ?? defaultSleep;
   const signal = options.signal;
+
+  // One-shot orphan recovery before the first cycle.
+  if (options.recoverableCandidates) {
+    for (const candidate of options.recoverableCandidates()) {
+      if (
+        options.scheduler &&
+        !(await options.scheduler.shouldSchedule(candidate))
+      ) {
+        continue;
+      }
+      options.dispatcher.submit(toDispatcherCandidate(candidate));
+    }
+  }
 
   let rateLimitStreak = 0;
 
@@ -115,6 +143,7 @@ export async function runCandidateCycle(
     | "includeSearch"
     | "lookbackSecs"
     | "onCycle"
+    | "scheduler"
   >,
   nowSec: () => number,
 ): Promise<CandidateCycleOutcome> {
@@ -127,6 +156,10 @@ export async function runCandidateCycle(
 
   let submitted = 0;
   for (const candidate of poll.tasks) {
+    if (options.scheduler) {
+      const ok = await options.scheduler.shouldSchedule(candidate);
+      if (!ok) continue;
+    }
     options.dispatcher.submit(toDispatcherCandidate(candidate));
     submitted += 1;
   }

--- a/src/products/breeze/daemon/runner-skeleton.ts
+++ b/src/products/breeze/daemon/runner-skeleton.ts
@@ -47,6 +47,8 @@ import type { RunnerSpec } from "./runner.js";
 import { GhClient as BrokerGhClient } from "./gh-client.js";
 import { runCandidateLoop } from "./candidate-loop.js";
 import { RepoFilter } from "../core/repo-filter.js";
+import { Scheduler } from "./scheduler.js";
+import { ThreadStore } from "./thread-store.js";
 
 export interface DaemonCliOverrides {
   pollIntervalSec?: number;
@@ -282,6 +284,21 @@ export async function runDaemon(
         workspacesDir: join(runnerHome, "workspaces"),
         identity: { host: identity.host, login: identity.login },
       });
+      // Phase 5: ThreadStore + Scheduler — gates dispatch on retry state.
+      const threadStore = new ThreadStore({ runnerHome });
+      const candidateClient = new BrokerGhClient({
+        host: identity.host,
+        repoFilter: RepoFilter.empty(),
+        executor,
+      });
+      const scheduler = new Scheduler({
+        store: threadStore,
+        ghClient: candidateClient,
+        identity: { host: identity.host, login: identity.login },
+        pollIntervalSec: config.pollIntervalSec,
+        logger,
+      });
+
       dispatcher = new Dispatcher({
         runnerHome,
         identity: { host: identity.host, login: identity.login },
@@ -296,17 +313,13 @@ export async function runDaemon(
         maxParallel: 2,
         taskTimeoutMs: config.taskTimeoutSec * 1_000,
         logger,
+        onCompletion: (record) => scheduler.handleCompletion(record),
       });
       logger.info(
         `breeze daemon: dispatcher ready (runners=${runners.map((r) => r.kind).join(",")}, broker=${broker.shimDir})`,
       );
 
       // Phase 4: candidate loop — feeds the dispatcher from GitHub.
-      const candidateClient = new BrokerGhClient({
-        host: identity.host,
-        repoFilter: RepoFilter.empty(),
-        executor,
-      });
       candidateLoopDone = runCandidateLoop({
         client: candidateClient,
         dispatcher,
@@ -317,6 +330,9 @@ export async function runDaemon(
         lookbackSecs: 24 * 3_600,
         signal: controller.signal,
         logger,
+        scheduler,
+        recoverableCandidates: () =>
+          scheduler.enqueueRecoverableTasks(identity.host),
       }).catch((err) => {
         logger.error(
           `candidate loop crashed: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/products/breeze/daemon/scheduler.ts
+++ b/src/products/breeze/daemon/scheduler.ts
@@ -1,0 +1,401 @@
+/**
+ * Phase 5: the per-thread state machine that sits between the candidate
+ * loop and the dispatcher. Mirrors the logic in
+ * `first-tree-breeze/breeze-runner/src/service.rs`:
+ *   - `should_schedule`        — gate on ThreadRecord retry/backoff
+ *   - `handle_completion`      — persist ThreadRecord + task.env updates
+ *   - `record_setup_failure`   — workspace failures bump the retry counter
+ *   - `enqueue_recoverable_tasks` — recover orphaned `running` tasks at boot
+ *   - `retry_delay(n)` = 60·2^min(n,6) seconds
+ *   - `operator_repo_for` / `should_route_to_operator_repo`
+ *
+ * The dispatcher itself stays minimal — it just runs agents. Scheduler
+ * decisions ride on top via:
+ *   - `shouldSchedule(candidate)` before `Dispatcher.submit`
+ *   - `handleCompletion(record)` in the dispatcher's `onCompletion` hook
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { CompletionRecord } from "./dispatcher.js";
+import type { GhClient } from "./gh-client.js";
+import type { ThreadStore } from "./thread-store.js";
+import { encodeMultiline } from "../core/task-util.js";
+import { shouldIgnoreLatestSelfActivity } from "./gh-client.js";
+import {
+  candidateFromTaskMetadata,
+  effectiveWorkspaceRepo,
+  toDispatcherCandidate,
+  type TaskCandidate,
+} from "../core/task.js";
+import type { TaskCandidate as DispatchCandidate } from "./dispatcher.js";
+import type { AgentIdentity } from "./runner.js";
+
+/**
+ * `60 · 2^min(failureCount, 6)` seconds. Matches Rust `retry_delay`.
+ * With the 6-shift cap, backoff saturates at 64 minutes.
+ */
+export function retryDelaySec(failureCount: number): number {
+  const shift = Math.max(0, Math.min(failureCount, 6));
+  return 60 * (1 << shift);
+}
+
+/** Poll-interval-bounded variant used in the actual retry write. */
+export function failureRetryDelaySec(
+  failureCount: number,
+  pollIntervalSec: number,
+): number {
+  return Math.min(retryDelaySec(failureCount), pollIntervalSec);
+}
+
+export interface SchedulerOptions {
+  store: ThreadStore;
+  ghClient?: GhClient;
+  identity: AgentIdentity;
+  /** Cap used by `failureRetryDelaySec`. Daemon passes `config.pollIntervalSec`. */
+  pollIntervalSec: number;
+  nowSec?: () => number;
+  logger?: {
+    warn: (line: string) => void;
+  };
+}
+
+export class Scheduler {
+  private readonly store: ThreadStore;
+  private readonly ghClient?: GhClient;
+  private readonly identity: AgentIdentity;
+  private readonly pollIntervalSec: number;
+  private readonly nowSec: () => number;
+  private readonly logger: { warn: (line: string) => void };
+
+  constructor(options: SchedulerOptions) {
+    this.store = options.store;
+    this.ghClient = options.ghClient;
+    this.identity = options.identity;
+    this.pollIntervalSec = options.pollIntervalSec;
+    this.nowSec = options.nowSec ?? (() => Math.floor(Date.now() / 1_000));
+    this.logger = options.logger ?? { warn: () => undefined };
+  }
+
+  /**
+   * Port of `Service::should_schedule`. Always touches the ThreadRecord
+   * so `last_seen_updated_at` reflects the most recent poll. Returns
+   * `false` when the thread is within its backoff window, already
+   * handled at this `updated_at`, or dominated by a current self/bot
+   * activity.
+   */
+  async shouldSchedule(candidate: TaskCandidate): Promise<boolean> {
+    const now = this.nowSec();
+    const record = this.store.loadThreadRecord(candidate.threadKey);
+    record.threadKey = candidate.threadKey;
+    record.repo = candidate.repo;
+    record.lastSeenUpdatedAt = candidate.updatedAt;
+    this.store.saveThreadRecord(record);
+
+    if (record.nextRetryEpoch > now) return false;
+    if (
+      record.lastHandledUpdatedAt.length > 0 &&
+      candidate.updatedAt <= record.lastHandledUpdatedAt
+    ) {
+      return false;
+    }
+
+    if (this.ghClient) {
+      let activity = null;
+      try {
+        activity = await this.ghClient.latestVisibleActivity(candidate);
+      } catch (err) {
+        this.logger.warn(
+          `scheduler: latestVisibleActivity failed for ${candidate.threadKey}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+      if (
+        shouldIgnoreLatestSelfActivity(
+          this.identity.login,
+          activity,
+          candidate.updatedAt,
+        )
+      ) {
+        record.lastHandledUpdatedAt = candidate.updatedAt;
+        record.lastResult = "skipped";
+        record.nextRetryEpoch = 0;
+        this.store.saveThreadRecord(record);
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Port of `Service::handle_completion`. Called from the dispatcher's
+   * `onCompletion` hook. Persists the task.env update and mutates the
+   * ThreadRecord backoff fields.
+   */
+  handleCompletion(record: CompletionRecord): void {
+    const now = this.nowSec();
+    const meta = this.store.readTaskMetadata(record.taskId);
+    meta.set("finished_at", String(now));
+
+    let threadRecord = this.store.loadThreadRecord(record.threadKey);
+    threadRecord.threadKey = record.threadKey;
+    threadRecord.repo = record.candidate.repo;
+    threadRecord.lastSeenUpdatedAt = record.candidate.updatedAt;
+    threadRecord.lastTaskId = record.taskId;
+
+    if (record.phase === "completed") {
+      const status = record.status ?? "handled";
+      meta.set("status", status);
+      if (record.summary) meta.set("summary", encodeMultiline(record.summary));
+      if (record.runnerOutputPath)
+        meta.set("runner_output_path", record.runnerOutputPath);
+      if (record.runnerName) meta.set("runner", record.runnerName);
+
+      if (status === "handled" || status === "skipped") {
+        threadRecord.lastHandledUpdatedAt = record.candidate.updatedAt;
+        threadRecord.failureCount = 0;
+        threadRecord.nextRetryEpoch = 0;
+      } else if (status === "failed") {
+        threadRecord.failureCount = safeAdd(threadRecord.failureCount, 1);
+        threadRecord.nextRetryEpoch =
+          now +
+          failureRetryDelaySec(threadRecord.failureCount, this.pollIntervalSec);
+      }
+      threadRecord.lastResult = status;
+    } else if (record.phase === "skipped-claim") {
+      // Claim held elsewhere — don't bump anything.
+      return;
+    } else {
+      // failed | timed_out: bump retry counter.
+      meta.set("status", record.phase === "timed_out" ? "timed_out" : "failed");
+      if (record.error) meta.set("summary", encodeMultiline(record.error));
+      threadRecord.failureCount = safeAdd(threadRecord.failureCount, 1);
+      threadRecord.nextRetryEpoch =
+        now +
+        failureRetryDelaySec(threadRecord.failureCount, this.pollIntervalSec);
+      threadRecord.lastResult = meta.get("status") ?? "failed";
+    }
+
+    this.store.writeTaskMetadata(record.taskId, mapToRecord(meta));
+    this.store.saveThreadRecord(threadRecord);
+  }
+
+  /**
+   * Port of `Service::record_setup_failure`. Invoked when workspace prep
+   * or snapshotting fails before the agent runs.
+   */
+  recordSetupFailure(args: {
+    taskId: string;
+    candidate: TaskCandidate;
+    error: string;
+  }): void {
+    const now = this.nowSec();
+    this.store.writeTaskMetadata(args.taskId, {
+      task_id: args.taskId,
+      status: "failed",
+      repo: args.candidate.repo,
+      workspace_repo: effectiveWorkspaceRepo(args.candidate),
+      thread_key: args.candidate.threadKey,
+      title: encodeMultiline(args.candidate.title),
+      kind: args.candidate.kind,
+      reason: args.candidate.reason,
+      started_at: String(now),
+      finished_at: String(now),
+      updated_at: args.candidate.updatedAt,
+      source: args.candidate.source,
+      summary: encodeMultiline(args.error),
+      runner_output_path: join(
+        this.store.taskDir(args.taskId),
+        "runner-output.txt",
+      ),
+    });
+
+    const record = this.store.loadThreadRecord(args.candidate.threadKey);
+    record.threadKey = args.candidate.threadKey;
+    record.repo = args.candidate.repo;
+    record.lastSeenUpdatedAt = args.candidate.updatedAt;
+    record.failureCount = safeAdd(record.failureCount, 1);
+    record.nextRetryEpoch =
+      now + failureRetryDelaySec(record.failureCount, this.pollIntervalSec);
+    record.lastResult = "failed";
+    record.lastTaskId = args.taskId;
+    this.store.saveThreadRecord(record);
+  }
+
+  /**
+   * Port of `Service::enqueue_recoverable_tasks`. Reads the on-disk
+   * task metadata and returns any candidate whose `status=running` and
+   * `finished_at` is unset — these are orphans from a crashed daemon.
+   * Marks them `orphaned` on disk before returning.
+   */
+  enqueueRecoverableTasks(host: string): TaskCandidate[] {
+    const now = this.nowSec();
+    const recovered: TaskCandidate[] = [];
+    for (const [taskId, metadata] of this.store.listTaskMetadata()) {
+      const status = metadata.get("status") ?? "";
+      if (status !== "running") continue;
+      const finished = metadata.get("finished_at") ?? "";
+      if (finished.trim().length > 0) continue;
+      const candidate = candidateFromTaskMetadata(metadata, host);
+      if (!candidate) continue;
+
+      metadata.set("status", "orphaned");
+      metadata.set("finished_at", String(now));
+      metadata.set(
+        "summary",
+        encodeMultiline(
+          "breeze-runner recovered this unfinished running task and re-queued it",
+        ),
+      );
+      this.store.writeTaskMetadata(taskId, mapToRecord(metadata));
+      recovered.push(candidate);
+    }
+    recovered.sort((a, b) => {
+      if (a.priority !== b.priority) return b.priority - a.priority;
+      if (a.updatedAt !== b.updatedAt) return a.updatedAt < b.updatedAt ? 1 : -1;
+      return a.threadKey.localeCompare(b.threadKey);
+    });
+    return recovered;
+  }
+
+  /**
+   * Snapshot an in-progress task on launch. Mirrors the `write_task_metadata`
+   * call inside `dispatch_pending`. Called by the scheduling glue just
+   * before `Dispatcher.submit()` returns.
+   */
+  writeRunningMetadata(args: {
+    taskId: string;
+    candidate: TaskCandidate;
+    runner: string;
+    workspacePath?: string;
+    mirrorDir?: string;
+    repoUrl?: string;
+    snapshotDir?: string;
+    ghShimDir?: string;
+  }): void {
+    const now = this.nowSec();
+    this.store.writeTaskMetadata(args.taskId, {
+      task_id: args.taskId,
+      status: "running",
+      repo: args.candidate.repo,
+      workspace_repo: effectiveWorkspaceRepo(args.candidate),
+      thread_key: args.candidate.threadKey,
+      title: encodeMultiline(args.candidate.title),
+      kind: args.candidate.kind,
+      reason: args.candidate.reason,
+      started_at: String(now),
+      updated_at: args.candidate.updatedAt,
+      source: args.candidate.source,
+      runner: args.runner,
+      ...(args.workspacePath ? { workspace_path: args.workspacePath } : {}),
+      ...(args.mirrorDir ? { mirror_dir: args.mirrorDir } : {}),
+      ...(args.repoUrl ? { repo_url: args.repoUrl } : {}),
+      ...(args.snapshotDir ? { snapshot_dir: args.snapshotDir } : {}),
+      ...(args.ghShimDir ? { gh_shim_dir: args.ghShimDir } : {}),
+    });
+  }
+
+  /** Convenience: convert to dispatcher shape. */
+  asDispatcherCandidate(candidate: TaskCandidate): DispatchCandidate {
+    return toDispatcherCandidate(candidate);
+  }
+}
+
+/* --------------------- operator-repo routing ------------------------- */
+
+/** `login/login` — the operator's home repo. */
+export function operatorRepoFor(login: string): string {
+  return `${login}/${login}`;
+}
+
+/**
+ * Read the raw text of any relevant snapshot files, lowercase, for
+ * substring matching. Used by `shouldRouteToOperatorRepo`.
+ */
+export function readRoutingSnapshotText(snapshotDir: string): string {
+  const files = [
+    "issue-view.json",
+    "pr-view.json",
+    "subject.json",
+    "latest-comment.json",
+    "issue-comments.json",
+    "pr-reviews.json",
+  ];
+  let combined = "";
+  for (const name of files) {
+    const path = join(snapshotDir, name);
+    if (!existsSync(path)) continue;
+    combined += readFileSync(path, "utf8");
+    combined += "\n";
+  }
+  return combined.toLowerCase();
+}
+
+/**
+ * Port of `should_route_to_operator_repo` — heuristic for spotting
+ * requests to reconfigure the breeze-runner itself.
+ */
+export function shouldRouteToOperatorRepo(
+  contents: string,
+  login: string,
+): boolean {
+  const lowerLogin = login.toLowerCase();
+  const asksForChange = [
+    "configure",
+    "update",
+    "change",
+    "fix",
+    "modify",
+    "adjust",
+    "tune",
+    "restart",
+  ].some((word) => contents.includes(word));
+  const mentionsBreezeRunner = contents.includes("breeze-runner");
+  const directsToOperator = [
+    `@${lowerLogin}`,
+    `${lowerLogin}'s agent`,
+    `${lowerLogin}/${lowerLogin}`,
+    "your agent",
+    "agent-team-foundation/breeze",
+    "breeze-runner service",
+  ].some((pattern) => contents.includes(pattern));
+  return mentionsBreezeRunner && asksForChange && directsToOperator;
+}
+
+/**
+ * Decide whether this candidate's workspace should redirect to the
+ * operator's home repo. Pure decision — call sites do the write.
+ */
+export function routeWorkspaceCandidate(args: {
+  candidate: TaskCandidate;
+  identityLogin: string;
+  snapshotDir?: string;
+}): TaskCandidate {
+  const operatorRepo = operatorRepoFor(args.identityLogin);
+  if (effectiveWorkspaceRepo(args.candidate) === operatorRepo) {
+    return { ...args.candidate, workspaceRepo: operatorRepo };
+  }
+  if (!args.snapshotDir) return args.candidate;
+  const routingText = readRoutingSnapshotText(args.snapshotDir);
+  if (shouldRouteToOperatorRepo(routingText, args.identityLogin)) {
+    return { ...args.candidate, workspaceRepo: operatorRepo };
+  }
+  return args.candidate;
+}
+
+/* ---------------------- local helpers -------------------------------- */
+
+function mapToRecord(map: Map<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of map) out[k] = v;
+  return out;
+}
+
+function safeAdd(a: number, b: number): number {
+  if (!Number.isFinite(a)) return b;
+  if (!Number.isFinite(b)) return a;
+  return a + b;
+}

--- a/src/products/breeze/daemon/thread-store.ts
+++ b/src/products/breeze/daemon/thread-store.ts
@@ -1,0 +1,172 @@
+/**
+ * Phase 5: daemon-private persistence for thread records + task metadata.
+ *
+ * Port of the relevant parts of
+ * `first-tree-breeze/breeze-runner/src/store.rs`:
+ *   - `thread_path`, `load_thread_record`, `save_thread_record`
+ *   - `task_dir`, `write_task_metadata`, `read_task_metadata`,
+ *     `list_task_metadata`
+ *   - `cleanup_old_workspaces`
+ *
+ * Directory layout under `<runnerHome>/`:
+ *   threads/<stableFileId(thread_key)>.env   — ThreadRecord
+ *   tasks/<task_id>/task.env                 — TaskMetadata
+ *   tasks/<task_id>/runner-output.txt        — agent final message (runner.ts)
+ *   repos/                                   — bare mirrors (workspace.ts)
+ *   workspaces/                              — live worktrees (workspace.ts)
+ *   broker/                                  — broker request + history (broker.ts)
+ *   locks/                                   — service lock (claim.ts)
+ *   runtime/status.env                       — operator-visible status
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+import {
+  parseKvLines,
+  stableFileId,
+} from "../core/task-util.js";
+import {
+  defaultThreadRecord,
+  threadRecordFromKv,
+  threadRecordToLines,
+  type ThreadRecord,
+} from "../core/task.js";
+
+export interface ThreadStoreOptions {
+  runnerHome: string;
+}
+
+export class ThreadStore {
+  readonly runnerHome: string;
+  readonly threadsDir: string;
+  readonly tasksDir: string;
+  readonly runtimePath: string;
+
+  constructor(options: ThreadStoreOptions) {
+    this.runnerHome = options.runnerHome;
+    this.threadsDir = join(this.runnerHome, "threads");
+    this.tasksDir = join(this.runnerHome, "tasks");
+    this.runtimePath = join(this.runnerHome, "runtime", "status.env");
+    mkdirSync(this.threadsDir, { recursive: true });
+    mkdirSync(this.tasksDir, { recursive: true });
+    mkdirSync(dirname(this.runtimePath), { recursive: true });
+  }
+
+  threadPath(threadKey: string): string {
+    return join(this.threadsDir, `${stableFileId(threadKey)}.env`);
+  }
+
+  loadThreadRecord(threadKey: string): ThreadRecord {
+    const path = this.threadPath(threadKey);
+    if (!existsSync(path)) {
+      return { ...defaultThreadRecord(), threadKey };
+    }
+    const contents = readFileSync(path, "utf8");
+    const record = threadRecordFromKv(parseKvLines(contents));
+    if (record.threadKey.length === 0) record.threadKey = threadKey;
+    return record;
+  }
+
+  saveThreadRecord(record: ThreadRecord): void {
+    const path = this.threadPath(record.threadKey);
+    writeFileSync(path, threadRecordToLines(record).join("\n"));
+  }
+
+  taskDir(taskId: string): string {
+    return join(this.tasksDir, taskId);
+  }
+
+  writeTaskMetadata(taskId: string, values: Record<string, string>): string {
+    const dir = this.taskDir(taskId);
+    mkdirSync(dir, { recursive: true });
+    const lines = Object.entries(values).map(([k, v]) => `${k}=${v}`);
+    const path = join(dir, "task.env");
+    writeFileSync(path, lines.join("\n"));
+    return path;
+  }
+
+  readTaskMetadata(taskId: string): Map<string, string> {
+    const path = join(this.taskDir(taskId), "task.env");
+    if (!existsSync(path)) return new Map();
+    return new Map(parseKvLines(readFileSync(path, "utf8")));
+  }
+
+  listTaskMetadata(): Array<[string, Map<string, string>]> {
+    if (!existsSync(this.tasksDir)) return [];
+    const out: Array<[string, Map<string, string>]> = [];
+    for (const name of readdirSync(this.tasksDir).sort()) {
+      const entryPath = join(this.tasksDir, name);
+      try {
+        if (!statSync(entryPath).isDirectory()) continue;
+      } catch {
+        continue;
+      }
+      out.push([name, this.readTaskMetadata(name)]);
+    }
+    return out;
+  }
+
+  writeRuntimeStatus(values: Record<string, string>): void {
+    const lines = Object.entries(values).map(([k, v]) => `${k}=${v}`);
+    writeFileSync(this.runtimePath, lines.join("\n"));
+  }
+
+  readRuntimeStatus(): Map<string, string> {
+    if (!existsSync(this.runtimePath)) return new Map();
+    return new Map(parseKvLines(readFileSync(this.runtimePath, "utf8")));
+  }
+
+  /**
+   * Remove workspace directories for finished tasks older than `ttlSecs`,
+   * skipping any workspace currently in `activeWorkspaces`. Returns the
+   * list of removed paths.
+   */
+  cleanupOldWorkspaces(
+    ttlSecs: number,
+    activeWorkspaces: readonly string[],
+    nowSec: number = Math.floor(Date.now() / 1_000),
+  ): string[] {
+    const removed: string[] = [];
+    const active = new Set(activeWorkspaces);
+    for (const [taskId, metadata] of this.listTaskMetadata()) {
+      void taskId;
+      const workspacePath = metadata.get("workspace_path");
+      if (!workspacePath) continue;
+      if (active.has(workspacePath)) continue;
+      const finishedAt = Number.parseInt(metadata.get("finished_at") ?? "", 10);
+      const mtimeSec =
+        Number.isFinite(finishedAt) && finishedAt > 0
+          ? finishedAt
+          : fileMtimeEpoch(workspacePath);
+      if (mtimeSec === undefined) continue;
+      if (nowSec - mtimeSec < ttlSecs) continue;
+      if (existsSync(workspacePath)) {
+        try {
+          rmSync(workspacePath, { recursive: true, force: true });
+        } catch {
+          /* ignore — next sweep retries */
+        }
+      }
+      removed.push(workspacePath);
+    }
+    return removed;
+  }
+}
+
+function fileMtimeEpoch(path: string): number | undefined {
+  try {
+    const st = statSync(path);
+    return Math.floor(st.mtimeMs / 1_000);
+  } catch {
+    return undefined;
+  }
+}

--- a/tests/breeze-daemon-scheduler.test.ts
+++ b/tests/breeze-daemon-scheduler.test.ts
@@ -1,0 +1,405 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  Scheduler,
+  failureRetryDelaySec,
+  operatorRepoFor,
+  readRoutingSnapshotText,
+  retryDelaySec,
+  routeWorkspaceCandidate,
+  shouldRouteToOperatorRepo,
+} from "../src/products/breeze/daemon/scheduler.js";
+import { ThreadStore } from "../src/products/breeze/daemon/thread-store.js";
+import {
+  buildReviewRequestCandidate,
+  toDispatcherCandidate,
+} from "../src/products/breeze/core/task.js";
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  while (tempRoots.length) {
+    const dir = tempRoots.pop();
+    if (dir && existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeHome(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), `breeze-sched-${prefix}-`));
+  tempRoots.push(dir);
+  return dir;
+}
+
+describe("retryDelaySec / failureRetryDelaySec", () => {
+  it("doubles per failure, saturates at 2^6 shift", () => {
+    expect(retryDelaySec(0)).toBe(60);
+    expect(retryDelaySec(1)).toBe(120);
+    expect(retryDelaySec(4)).toBe(60 * 16);
+    expect(retryDelaySec(6)).toBe(60 * 64);
+    expect(retryDelaySec(99)).toBe(60 * 64);
+  });
+
+  it("bounds by poll interval in failureRetryDelaySec", () => {
+    expect(failureRetryDelaySec(6, 300)).toBe(300);
+    expect(failureRetryDelaySec(1, 300)).toBe(120);
+  });
+});
+
+describe("Scheduler.shouldSchedule", () => {
+  it("returns true for a fresh thread and persists last_seen", async () => {
+    const store = new ThreadStore({ runnerHome: makeHome("fresh") });
+    const sched = new Scheduler({
+      store,
+      identity: { host: "github.com", login: "alice" },
+      pollIntervalSec: 60,
+      nowSec: () => 1_000,
+    });
+    const candidate = buildReviewRequestCandidate({
+      repo: "o/r",
+      number: 1,
+      title: "t",
+      webUrl: "u",
+      updatedAt: "2026-04-15T12:00:00Z",
+    });
+    expect(await sched.shouldSchedule(candidate)).toBe(true);
+    const record = store.loadThreadRecord(candidate.threadKey);
+    expect(record.lastSeenUpdatedAt).toBe("2026-04-15T12:00:00Z");
+  });
+
+  it("returns false while inside the backoff window", async () => {
+    const store = new ThreadStore({ runnerHome: makeHome("backoff") });
+    const sched = new Scheduler({
+      store,
+      identity: { host: "github.com", login: "alice" },
+      pollIntervalSec: 60,
+      nowSec: () => 1_000,
+    });
+    const candidate = buildReviewRequestCandidate({
+      repo: "o/r",
+      number: 2,
+      title: "t",
+      webUrl: "u",
+      updatedAt: "2026-04-15T12:00:00Z",
+    });
+    store.saveThreadRecord({
+      threadKey: candidate.threadKey,
+      repo: candidate.repo,
+      lastSeenUpdatedAt: candidate.updatedAt,
+      lastHandledUpdatedAt: "",
+      lastResult: "failed",
+      failureCount: 2,
+      nextRetryEpoch: 2_000,
+      lastTaskId: "t1",
+    });
+    expect(await sched.shouldSchedule(candidate)).toBe(false);
+  });
+
+  it("returns false when updated_at is not newer than last_handled", async () => {
+    const store = new ThreadStore({ runnerHome: makeHome("handled") });
+    const sched = new Scheduler({
+      store,
+      identity: { host: "github.com", login: "alice" },
+      pollIntervalSec: 60,
+      nowSec: () => 1_000_000,
+    });
+    const candidate = buildReviewRequestCandidate({
+      repo: "o/r",
+      number: 3,
+      title: "t",
+      webUrl: "u",
+      updatedAt: "2026-04-15T12:00:00Z",
+    });
+    store.saveThreadRecord({
+      threadKey: candidate.threadKey,
+      repo: candidate.repo,
+      lastSeenUpdatedAt: "",
+      lastHandledUpdatedAt: "2026-04-15T12:00:00Z",
+      lastResult: "handled",
+      failureCount: 0,
+      nextRetryEpoch: 0,
+      lastTaskId: "",
+    });
+    expect(await sched.shouldSchedule(candidate)).toBe(false);
+  });
+
+  it("short-circuits when latestVisibleActivity says we already replied", async () => {
+    const store = new ThreadStore({ runnerHome: makeHome("selfact") });
+    const ghClient = {
+      async latestVisibleActivity() {
+        return {
+          login: "alice",
+          userType: "User",
+          updatedAt: "2026-04-15T12:00:00Z",
+        };
+      },
+    } as never;
+    const sched = new Scheduler({
+      store,
+      ghClient,
+      identity: { host: "github.com", login: "alice" },
+      pollIntervalSec: 60,
+      nowSec: () => 1_000,
+    });
+    const candidate = buildReviewRequestCandidate({
+      repo: "o/r",
+      number: 4,
+      title: "t",
+      webUrl: "u",
+      updatedAt: "2026-04-15T12:00:00Z",
+    });
+    expect(await sched.shouldSchedule(candidate)).toBe(false);
+    const record = store.loadThreadRecord(candidate.threadKey);
+    expect(record.lastResult).toBe("skipped");
+    expect(record.lastHandledUpdatedAt).toBe(candidate.updatedAt);
+  });
+});
+
+describe("Scheduler.handleCompletion", () => {
+  function makeCandidate() {
+    const rich = buildReviewRequestCandidate({
+      repo: "o/r",
+      number: 5,
+      title: "t",
+      webUrl: "u",
+      updatedAt: "2026-04-15T12:00:00Z",
+    });
+    return toDispatcherCandidate(rich);
+  }
+
+  it("handled → resets failure_count and next_retry", () => {
+    const store = new ThreadStore({ runnerHome: makeHome("handled-ok") });
+    store.saveThreadRecord({
+      threadKey: "/repos/o/r/pulls/5",
+      repo: "o/r",
+      lastSeenUpdatedAt: "",
+      lastHandledUpdatedAt: "",
+      lastResult: "failed",
+      failureCount: 3,
+      nextRetryEpoch: 1_000,
+      lastTaskId: "",
+    });
+    const sched = new Scheduler({
+      store,
+      identity: { host: "github.com", login: "alice" },
+      pollIntervalSec: 60,
+      nowSec: () => 2_000,
+    });
+    sched.handleCompletion({
+      taskId: "task-1",
+      threadKey: "/repos/o/r/pulls/5",
+      candidate: makeCandidate(),
+      phase: "completed",
+      status: "handled",
+      summary: "ok",
+    });
+    const record = store.loadThreadRecord("/repos/o/r/pulls/5");
+    expect(record.failureCount).toBe(0);
+    expect(record.nextRetryEpoch).toBe(0);
+    expect(record.lastResult).toBe("handled");
+    expect(record.lastHandledUpdatedAt).toBe("2026-04-15T12:00:00Z");
+  });
+
+  it("failed status bumps failure_count and schedules retry", () => {
+    const store = new ThreadStore({ runnerHome: makeHome("failed-ok") });
+    const sched = new Scheduler({
+      store,
+      identity: { host: "github.com", login: "alice" },
+      pollIntervalSec: 3600,
+      nowSec: () => 5_000,
+    });
+    sched.handleCompletion({
+      taskId: "task-2",
+      threadKey: "/repos/o/r/pulls/5",
+      candidate: makeCandidate(),
+      phase: "completed",
+      status: "failed",
+      summary: "boom",
+    });
+    const record = store.loadThreadRecord("/repos/o/r/pulls/5");
+    expect(record.failureCount).toBe(1);
+    // failureRetryDelaySec(1, 3600) === 120
+    expect(record.nextRetryEpoch).toBe(5_120);
+  });
+
+  it("timed_out phase bumps failure_count and sets metadata status", () => {
+    const store = new ThreadStore({ runnerHome: makeHome("timed") });
+    const sched = new Scheduler({
+      store,
+      identity: { host: "github.com", login: "alice" },
+      pollIntervalSec: 60,
+      nowSec: () => 7_000,
+    });
+    sched.handleCompletion({
+      taskId: "task-3",
+      threadKey: "/repos/o/r/pulls/5",
+      candidate: makeCandidate(),
+      phase: "timed_out",
+      error: "timed out after 120000ms",
+    });
+    const meta = store.readTaskMetadata("task-3");
+    expect(meta.get("status")).toBe("timed_out");
+    const record = store.loadThreadRecord("/repos/o/r/pulls/5");
+    expect(record.failureCount).toBe(1);
+    expect(record.lastResult).toBe("timed_out");
+  });
+
+  it("skipped-claim is a no-op on ThreadRecord", () => {
+    const store = new ThreadStore({ runnerHome: makeHome("skipped") });
+    store.saveThreadRecord({
+      threadKey: "/repos/o/r/pulls/5",
+      repo: "o/r",
+      lastSeenUpdatedAt: "",
+      lastHandledUpdatedAt: "",
+      lastResult: "",
+      failureCount: 2,
+      nextRetryEpoch: 5_000,
+      lastTaskId: "",
+    });
+    const sched = new Scheduler({
+      store,
+      identity: { host: "github.com", login: "alice" },
+      pollIntervalSec: 60,
+      nowSec: () => 1_000,
+    });
+    sched.handleCompletion({
+      taskId: "task-4",
+      threadKey: "/repos/o/r/pulls/5",
+      candidate: makeCandidate(),
+      phase: "skipped-claim",
+    });
+    const record = store.loadThreadRecord("/repos/o/r/pulls/5");
+    expect(record.failureCount).toBe(2);
+    expect(record.nextRetryEpoch).toBe(5_000);
+  });
+});
+
+describe("Scheduler.recordSetupFailure", () => {
+  it("bumps failure_count and writes a failed task.env", () => {
+    const store = new ThreadStore({ runnerHome: makeHome("setup") });
+    const sched = new Scheduler({
+      store,
+      identity: { host: "github.com", login: "alice" },
+      pollIntervalSec: 60,
+      nowSec: () => 9_000,
+    });
+    const candidate = buildReviewRequestCandidate({
+      repo: "o/r",
+      number: 9,
+      title: "t",
+      webUrl: "u",
+      updatedAt: "2026-04-15T12:00:00Z",
+    });
+    sched.recordSetupFailure({
+      taskId: "task-setup",
+      candidate,
+      error: "workspace prepare failed: bad head",
+    });
+    const meta = store.readTaskMetadata("task-setup");
+    expect(meta.get("status")).toBe("failed");
+    expect(meta.get("summary")).toContain("workspace prepare failed");
+    const record = store.loadThreadRecord(candidate.threadKey);
+    expect(record.failureCount).toBe(1);
+    expect(record.lastResult).toBe("failed");
+    expect(record.nextRetryEpoch).toBe(9_060);
+  });
+});
+
+describe("Scheduler.enqueueRecoverableTasks", () => {
+  it("picks up status=running tasks with no finished_at and marks them orphaned", () => {
+    const store = new ThreadStore({ runnerHome: makeHome("recovery") });
+    store.writeTaskMetadata("running-1", {
+      task_id: "running-1",
+      status: "running",
+      repo: "o/r",
+      thread_key: "/repos/o/r/pulls/1",
+      kind: "review_request",
+      updated_at: "2026-04-15T12:00:00Z",
+      source: "review-search",
+      title: "Recover me",
+    });
+    store.writeTaskMetadata("done-1", {
+      task_id: "done-1",
+      status: "handled",
+      repo: "o/r",
+      thread_key: "/repos/o/r/pulls/2",
+      kind: "review_request",
+      updated_at: "2026-04-15T12:00:00Z",
+      source: "review-search",
+      finished_at: "42",
+      title: "Already done",
+    });
+    const sched = new Scheduler({
+      store,
+      identity: { host: "github.com", login: "alice" },
+      pollIntervalSec: 60,
+      nowSec: () => 99,
+    });
+    const candidates = sched.enqueueRecoverableTasks("github.com");
+    expect(candidates.map((c) => c.threadKey)).toEqual([
+      "/repos/o/r/pulls/1",
+    ]);
+    const meta = store.readTaskMetadata("running-1");
+    expect(meta.get("status")).toBe("orphaned");
+    expect(meta.get("finished_at")).toBe("99");
+  });
+});
+
+describe("operator-repo routing helpers", () => {
+  it("operatorRepoFor returns login/login", () => {
+    expect(operatorRepoFor("bingran-you")).toBe("bingran-you/bingran-you");
+  });
+
+  it("shouldRouteToOperatorRepo triggers only on self-maintenance", () => {
+    const yes = [
+      "@bingran-you please configure the breeze-runner to",
+      "can you fix the breeze-runner service for me",
+    ]
+      .join("\n")
+      .toLowerCase();
+    expect(shouldRouteToOperatorRepo(yes, "bingran-you")).toBe(true);
+
+    const no =
+      "please review this pull request — breeze-runner already commented.".toLowerCase();
+    expect(shouldRouteToOperatorRepo(no, "bingran-you")).toBe(false);
+  });
+
+  it("readRoutingSnapshotText concatenates known files lowercased", () => {
+    const dir = makeHome("route");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "subject.json"), "PLEASE RESTART BREEZE-RUNNER");
+    writeFileSync(join(dir, "latest-comment.json"), "Unrelated");
+    const text = readRoutingSnapshotText(dir);
+    expect(text).toContain("restart breeze-runner");
+    expect(text).toContain("unrelated");
+  });
+
+  it("routeWorkspaceCandidate routes when a snapshot asks for reconfiguration", () => {
+    const dir = makeHome("route2");
+    writeFileSync(
+      join(dir, "subject.json"),
+      "@bingran-you please configure the breeze-runner service",
+    );
+    const candidate = buildReviewRequestCandidate({
+      repo: "o/r",
+      number: 10,
+      title: "t",
+      webUrl: "u",
+      updatedAt: "2026-04-15T12:00:00Z",
+    });
+    const routed = routeWorkspaceCandidate({
+      candidate,
+      identityLogin: "bingran-you",
+      snapshotDir: dir,
+    });
+    expect(routed.workspaceRepo).toBe("bingran-you/bingran-you");
+  });
+});

--- a/tests/breeze-daemon-thread-store.test.ts
+++ b/tests/breeze-daemon-thread-store.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { ThreadStore } from "../src/products/breeze/daemon/thread-store.js";
+import {
+  defaultThreadRecord,
+  type ThreadRecord,
+} from "../src/products/breeze/core/task.js";
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  while (tempRoots.length) {
+    const dir = tempRoots.pop();
+    if (dir && existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeHome(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), `breeze-store-${prefix}-`));
+  tempRoots.push(dir);
+  return dir;
+}
+
+describe("ThreadStore.{load,save}ThreadRecord", () => {
+  it("returns a default record with the requested thread key when absent", () => {
+    const store = new ThreadStore({ runnerHome: makeHome("default") });
+    const record = store.loadThreadRecord("/repos/o/r/issues/1");
+    expect(record.threadKey).toBe("/repos/o/r/issues/1");
+    expect(record.failureCount).toBe(0);
+  });
+
+  it("round-trips a ThreadRecord to disk", () => {
+    const store = new ThreadStore({ runnerHome: makeHome("rt") });
+    const record: ThreadRecord = {
+      ...defaultThreadRecord(),
+      threadKey: "/repos/o/r/issues/9",
+      repo: "o/r",
+      lastSeenUpdatedAt: "2026-04-15T12:00:00Z",
+      lastHandledUpdatedAt: "2026-04-15T12:00:00Z",
+      lastResult: "handled",
+      failureCount: 2,
+      nextRetryEpoch: 1_234,
+      lastTaskId: "task-42",
+    };
+    store.saveThreadRecord(record);
+    const restored = store.loadThreadRecord(record.threadKey);
+    expect(restored).toEqual(record);
+  });
+});
+
+describe("ThreadStore.{write,read}TaskMetadata", () => {
+  it("persists and reads key/value entries under tasks/<id>/task.env", () => {
+    const store = new ThreadStore({ runnerHome: makeHome("task") });
+    store.writeTaskMetadata("task-7", {
+      task_id: "task-7",
+      status: "running",
+      repo: "o/r",
+    });
+    const metadata = store.readTaskMetadata("task-7");
+    expect(metadata.get("status")).toBe("running");
+    expect(metadata.get("repo")).toBe("o/r");
+    // File exists at the expected location.
+    expect(
+      existsSync(join(store.tasksDir, "task-7", "task.env")),
+    ).toBe(true);
+  });
+
+  it("listTaskMetadata returns each task dir sorted", () => {
+    const store = new ThreadStore({ runnerHome: makeHome("list") });
+    store.writeTaskMetadata("task-b", { status: "running" });
+    store.writeTaskMetadata("task-a", { status: "handled" });
+    const list = store.listTaskMetadata();
+    expect(list.map(([id]) => id)).toEqual(["task-a", "task-b"]);
+    expect(list[1][1].get("status")).toBe("running");
+  });
+});
+
+describe("ThreadStore.cleanupOldWorkspaces", () => {
+  it("removes workspace dirs belonging to finished tasks older than ttl", () => {
+    const home = makeHome("cleanup");
+    const store = new ThreadStore({ runnerHome: home });
+    const workspacePath = join(home, "workspaces", "task-old");
+    mkdirSync(workspacePath, { recursive: true });
+    writeFileSync(join(workspacePath, "marker"), "x");
+    store.writeTaskMetadata("task-old", {
+      status: "handled",
+      workspace_path: workspacePath,
+      finished_at: "1000",
+    });
+    const removed = store.cleanupOldWorkspaces(
+      60,
+      [],
+      10_000 /* nowSec */,
+    );
+    expect(removed).toEqual([workspacePath]);
+    expect(existsSync(workspacePath)).toBe(false);
+  });
+
+  it("keeps workspaces that are still active", () => {
+    const home = makeHome("active");
+    const store = new ThreadStore({ runnerHome: home });
+    const workspacePath = join(home, "workspaces", "task-live");
+    mkdirSync(workspacePath, { recursive: true });
+    store.writeTaskMetadata("task-live", {
+      status: "running",
+      workspace_path: workspacePath,
+      finished_at: "1000",
+    });
+    const removed = store.cleanupOldWorkspaces(
+      60,
+      [workspacePath],
+      10_000,
+    );
+    expect(removed).toEqual([]);
+    expect(existsSync(workspacePath)).toBe(true);
+  });
+
+  it("keeps workspaces whose finished_at is within ttl", () => {
+    const home = makeHome("fresh");
+    const store = new ThreadStore({ runnerHome: home });
+    const workspacePath = join(home, "workspaces", "task-fresh");
+    mkdirSync(workspacePath, { recursive: true });
+    store.writeTaskMetadata("task-fresh", {
+      status: "handled",
+      workspace_path: workspacePath,
+      finished_at: "9950",
+    });
+    const removed = store.cleanupOldWorkspaces(100, [], 10_000);
+    expect(removed).toEqual([]);
+    expect(existsSync(workspacePath)).toBe(true);
+  });
+});
+
+describe("ThreadStore.{write,read}RuntimeStatus", () => {
+  it("round-trips runtime/status.env", () => {
+    const store = new ThreadStore({ runnerHome: makeHome("rt-status") });
+    store.writeRuntimeStatus({ active: "2", queued: "1", note: "hi" });
+    const status = store.readRuntimeStatus();
+    expect(status.get("active")).toBe("2");
+    expect(status.get("note")).toBe("hi");
+    expect(readFileSync(store.runtimePath, "utf8")).toContain("note=hi");
+  });
+});


### PR DESCRIPTION
## Summary

Port the per-thread state machine and retry/backoff logic from `service.rs` (~450 lines) so the daemon dispatches intelligently — not every poll cycle hammers every candidate.

### What landed
- `daemon/thread-store.ts` — daemon-private persistence:
  - `threads/<stableFileId>.env` for `ThreadRecord`
  - `tasks/<task_id>/task.env` for metadata
  - `runtime/status.env` for operator-visible state
  - `cleanupOldWorkspaces` for Phase 7 cleanup
- `daemon/scheduler.ts` — state machine:
  - `shouldSchedule` / `handleCompletion` / `recordSetupFailure` / `enqueueRecoverableTasks`
  - `retryDelaySec(n) = 60·2^min(n,6)` + `failureRetryDelaySec` (capped by `pollIntervalSec`)
  - operator-repo routing (`operatorRepoFor`, `shouldRouteToOperatorRepo`, etc.)
- `daemon/candidate-loop.ts` — gates `dispatcher.submit` behind the scheduler and runs recovery before the first cycle.
- `daemon/runner-skeleton.ts` — wires everything; dispatcher `onCompletion` calls `scheduler.handleCompletion`.

## Test plan
- [x] 24 new unit tests (thread-store 8, scheduler 16)
- [x] Full suite: 813/813 (modulo flaky statusline perf)
- [x] \`pnpm validate:skill\` / typecheck / build