### PR TITLE
Phase 8: drop the Rust runner bridge

### DIFF
--- a/src/products/breeze/bridge.ts
+++ b/src/products/breeze/bridge.ts
@@ -1,15 +1,14 @@
 /**
- * Bridge to the existing breeze runtime.
+ * Thin process-spawn helpers used by the breeze CLI.
  *
- * This module centralises two pieces of phase-1 plumbing:
- *   - resolving the `breeze-runner` Rust binary and the bundled bash scripts
- *     under `assets/breeze/bin/`
- *   - spawning either of them with inherited stdio so TTY/colour/interactive
- *     behaviour passes through unchanged
- *
- * Nothing here reinterprets user args. `first-tree breeze run --foo` must
- * result in `breeze-runner run --foo` verbatim. The dispatcher in `cli.ts`
- * picks the target and forwards the trailing argv.
+ * Phase 8 retired the `breeze-runner` Rust binary and its resolution
+ * helpers. What remains:
+ *   - `resolveFirstTreePackageRoot` — locate the npm package root so
+ *     callers can find bundled assets (statusline dist bundle, setup
+ *     script).
+ *   - `resolveBreezeSetupScript` — path to the `first-tree-breeze/setup`
+ *     bash installer (still wrapped as `first-tree breeze install`).
+ *   - `spawnInherit` — synchronous spawn with inherited stdio.
  */
 
 import {
@@ -18,57 +17,19 @@ import {
   spawnSync,
 } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
-import { delimiter, dirname, join } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-export const BREEZE_RUNNER_BIN_NAME = "breeze-runner";
-
-/**
- * Name of the env var a user can set to hard-override the `breeze-runner`
- * lookup. Mirrors the `$BREEZE_RUNNER_BIN` convention already used by the
- * bash scripts.
- */
-export const BREEZE_RUNNER_ENV = "BREEZE_RUNNER_BIN";
-
-/**
- * Maintainer fallback: when `breeze-runner` is not installed globally, we
- * fall back to the locally-built binary inside the source tree. This path is
- * relative to the package root (i.e. the directory that contains this
- * package's `package.json`), not the runtime cwd.
- */
-export const MAINTAINER_RUNNER_RELATIVE_PATH = join(
-  "first-tree-breeze",
-  "breeze-runner",
-  "target",
-  "release",
-  BREEZE_RUNNER_BIN_NAME,
-);
-
-const INSTALLATION_HINT = `breeze-runner not found. Install with \`cd first-tree-breeze/breeze-runner && cargo install --path .\``;
-
 export type FileExistsFn = (path: string) => boolean;
-export type PathLookupFn = (binName: string) => string | null;
-export type EnvReader = (name: string) => string | undefined;
-
-export interface RunnerResolveDeps {
-  env?: EnvReader;
-  fileExists?: FileExistsFn;
-  pathLookup?: PathLookupFn;
-  packageRoot?: string;
-}
-
-export interface RunnerResolution {
-  path: string;
-  source: "env" | "path" | "maintainer-fallback";
-}
 
 /**
- * Walk up from the current module until we find the npm package root (the
- * directory containing the package.json whose `name` is `first-tree`).
+ * Walk up from the current module until we find the npm package root
+ * (the directory containing the package.json whose `name` is
+ * `first-tree`).
  *
- * We can't reuse `resolveBundledPackageRoot` from the tree product because
- * that one gates on the tree SKILL.md existing, which is a tree-product
- * concern.
+ * We can't reuse `resolveBundledPackageRoot` from the tree product
+ * because that one gates on the tree SKILL.md existing, which is a
+ * tree-product concern.
  */
 export function resolveFirstTreePackageRoot(
   startUrl: string = import.meta.url,
@@ -98,110 +59,9 @@ export function resolveFirstTreePackageRoot(
   }
 }
 
-function defaultPathLookup(
-  binName: string,
-  env: EnvReader,
-  fileExists: FileExistsFn,
-): string | null {
-  const pathVar = env("PATH");
-  if (!pathVar) {
-    return null;
-  }
-  const pathExt = process.platform === "win32" ? (env("PATHEXT") ?? "") : "";
-  const extensions =
-    pathExt.length > 0
-      ? pathExt.split(";").map((ext) => ext.toLowerCase())
-      : [""];
-  for (const dir of pathVar.split(delimiter)) {
-    if (!dir) continue;
-    for (const ext of extensions) {
-      const candidate = join(dir, ext === "" ? binName : `${binName}${ext}`);
-      if (fileExists(candidate)) {
-        return candidate;
-      }
-    }
-  }
-  return null;
-}
-
 /**
- * Resolve the `breeze-runner` binary path.
- *
- * Lookup order:
- *   1. `$BREEZE_RUNNER_BIN` (hard override; must point at an existing file)
- *   2. `which breeze-runner` on `$PATH`
- *   3. Maintainer fallback: `first-tree-breeze/breeze-runner/target/release/breeze-runner`
- *      resolved relative to the installed `first-tree` package root
- *
- * Throws a helpful error with an install hint if none of those resolve.
- */
-export function resolveBreezeRunner(
-  deps: RunnerResolveDeps = {},
-): RunnerResolution {
-  const env: EnvReader = deps.env ?? ((name) => process.env[name]);
-  const fileExists: FileExistsFn = deps.fileExists ?? existsSync;
-  const pathLookup: PathLookupFn =
-    deps.pathLookup ??
-    ((binName) => defaultPathLookup(binName, env, fileExists));
-
-  const override = env(BREEZE_RUNNER_ENV);
-  if (override && override.length > 0) {
-    if (!fileExists(override)) {
-      throw new Error(
-        `${BREEZE_RUNNER_ENV} is set to \`${override}\` but no file exists at that path.`,
-      );
-    }
-    return { path: override, source: "env" };
-  }
-
-  const onPath = pathLookup(BREEZE_RUNNER_BIN_NAME);
-  if (onPath) {
-    return { path: onPath, source: "path" };
-  }
-
-  let packageRoot: string | undefined = deps.packageRoot;
-  if (packageRoot === undefined) {
-    try {
-      packageRoot = resolveFirstTreePackageRoot();
-    } catch {
-      packageRoot = undefined;
-    }
-  }
-  if (packageRoot) {
-    const fallback = join(packageRoot, MAINTAINER_RUNNER_RELATIVE_PATH);
-    if (fileExists(fallback)) {
-      return { path: fallback, source: "maintainer-fallback" };
-    }
-  }
-
-  throw new Error(INSTALLATION_HINT);
-}
-
-/**
- * Resolve a bundled bash helper under `assets/breeze/bin/`. Used for
- * `breeze-watch`, `breeze-status-manager`, and `breeze-statusline-wrapper`.
- */
-export function resolveBundledBreezeScript(
-  scriptName: string,
-  deps: { packageRoot?: string; fileExists?: FileExistsFn } = {},
-): string {
-  const fileExists = deps.fileExists ?? existsSync;
-  const packageRoot = deps.packageRoot ?? resolveFirstTreePackageRoot();
-  const candidate = join(packageRoot, "assets", "breeze", "bin", scriptName);
-  if (!fileExists(candidate)) {
-    throw new Error(
-      `Bundled breeze script \`${scriptName}\` not found at ${candidate}. Reinstall first-tree.`,
-    );
-  }
-  return candidate;
-}
-
-/**
- * Resolve the setup script that installs breeze.
- *
- * Phase 1 still sources this from `first-tree-breeze/setup`: the setup
- * script reaches into adjacent Rust / skill directories and isn't self-
- * contained enough to bundle yet. Phase 2 will rewrite it.
+ * Resolve the breeze setup script bundled under
+ * `first-tree-breeze/setup`. Still a bash script.
  */
 export function resolveBreezeSetupScript(
   deps: { packageRoot?: string; fileExists?: FileExistsFn } = {},
@@ -228,9 +88,9 @@ export interface SpawnTargetDeps {
 }
 
 /**
- * Spawn `command args` synchronously with inherited stdio, propagating the
- * child's exit code (or remapping a signal termination to 128 + signo,
- * matching shell conventions).
+ * Spawn `command args` synchronously with inherited stdio, propagating
+ * the child's exit code (or remapping a signal termination to 1 as a
+ * safe fallback).
  */
 export function spawnInherit(
   command: string,
@@ -241,23 +101,13 @@ export function spawnInherit(
   const result = spawn(command, args, { stdio: "inherit" });
 
   if (result.error) {
-    // Surface spawn-level errors (ENOENT, EACCES, ...) as a non-zero exit
-    // code so callers can exit cleanly. The error message is already on
-    // stderr when stdio is inherited, so we just add a resolver hint.
     const err = result.error as NodeJS.ErrnoException;
     process.stderr.write(
       `first-tree breeze: failed to spawn \`${command}\`: ${err.message}\n`,
     );
     return 1;
   }
-
-  if (typeof result.status === "number") {
-    return result.status;
-  }
-  if (result.signal) {
-    // Shell convention: 128 + signal number. We don't have the signo handy
-    // in a portable way, so 1 is a safe fallback.
-    return 1;
-  }
+  if (typeof result.status === "number") return result.status;
+  if (result.signal) return 1;
   return 0;
 }

--- a/src/products/breeze/cli.ts
+++ b/src/products/breeze/cli.ts
@@ -1,18 +1,16 @@
 /**
  * Breeze product dispatcher.
  *
- * As of Phase 7 the TypeScript daemon is the default backend for
- * `first-tree breeze daemon`. `--backend=rust` stays wired so operators
- * who prefer the Rust binary can opt back in while we bake; passing
- * nothing picks TS.
+ * As of Phase 8 every breeze subcommand runs on the TypeScript daemon.
+ * `run` / `run-once` / `daemon` all route through `daemon/runner-skeleton.ts`;
+ * the historical `breeze-runner` Rust binary and the `--backend=` flag
+ * have been retired.
  *
- * Runner subcommands that still bridge to the Rust binary:
- *   - `run`, `run-once` — the long-running blocking loop flavours.
- *     Foreground: `breeze daemon` (TS) replaces `run`. Anyone who
- *     specifically wants the Rust loop can invoke `run` directly.
+ * Lifecycle + diagnostic subcommands (Phase 6): `start`, `stop`,
+ * `status`, `doctor`, `cleanup`, `poll-inbox`.
  *
- * Runner subcommands ported to TypeScript (Phase 6):
- *   - `start`, `stop`, `status`, `doctor`, `cleanup`, `poll-inbox`.
+ * Foreground loops (Phase 8): `run` = TS daemon forever; `run-once` =
+ * one poll cycle + drain + exit. `daemon` is an alias for `run`.
  *
  * Heavy deps (child_process, ink, react, daemon modules) live in the
  * dynamically-imported command modules so `first-tree breeze --help`
@@ -23,28 +21,24 @@ import { join } from "node:path";
 
 export const BREEZE_USAGE = `usage: first-tree breeze <command>
 
-  Breeze is the proposal/inbox agent.
+  Breeze is the proposal/inbox agent. Every subcommand runs on the
+  TypeScript daemon (\`~/.breeze/runner\`).
 
-Commands that run the Rust daemon (\`breeze-runner\`):
-  run                   Run the broker loop forever
-  run-once              Run a single broker iteration and exit
+Foreground daemon:
+  run, daemon           Run the broker loop forever (default)
+  run-once              Run one poll cycle, wait for drain, exit
 
-Commands ported to TypeScript (run against \`~/.breeze\`):
-  start                 Launch the TS daemon in the background (launchd on macOS)
-  stop                  Stop the TS daemon and remove its lock
+Background lifecycle:
+  start                 Launch the daemon in the background (launchd on macOS)
+  stop                  Stop the daemon and remove its lock
+
+Diagnostics:
   status                Print daemon lock + runtime/status.env
   doctor                Diagnose the local install
   cleanup               Remove stale workspaces + expired claims
   poll-inbox            Alias for \`poll\` (one-shot notification fetch)
 
-Daemon:
-  daemon [--backend=ts|rust]
-                        Run the breeze daemon in the foreground.
-                        Defaults to the TypeScript backend. Pass
-                        \`--backend=rust\` to route through the legacy
-                        \`breeze-runner\` binary (equivalent to \`run\`).
-
-TypeScript commands (no daemon required):
+One-shot commands (no daemon required):
   poll                  Poll GitHub notifications once and update the inbox
   watch                 Live TUI: status board + activity feed
   statusline            Claude Code statusline hook (single-line output)
@@ -57,20 +51,11 @@ Options:
   --help, -h            Show this help message
 
 Environment:
-  BREEZE_RUNNER_BIN     Override the path to the \`breeze-runner\` binary
   BREEZE_DIR            Override \`~/.breeze\` (store root)
+  BREEZE_HOME           Override \`~/.breeze/runner\` (daemon private state)
 `;
 
 type Output = (text: string) => void;
-
-// Keep in sync with the breeze-runner subcommand set in
-// first-tree-breeze/breeze-runner/src/lib.rs. The dispatcher table below
-// is the single source of truth for routing.
-type RunnerTarget = {
-  kind: "runner";
-  /** Subcommand name passed to `breeze-runner`. */
-  subcommand: string;
-};
 
 type SetupTarget = {
   kind: "setup";
@@ -96,22 +81,21 @@ type StatuslineTarget = {
 
 type DaemonTarget = {
   kind: "daemon";
+  /** `false` for `run`/`daemon`; `true` for `run-once`. */
+  once: boolean;
 };
 
-type Target =
-  | RunnerTarget
-  | SetupTarget
-  | TsTarget
-  | StatuslineTarget
-  | DaemonTarget;
+type Target = SetupTarget | TsTarget | StatuslineTarget | DaemonTarget;
 
 const DISPATCH: Record<string, Target> = {
   install: { kind: "setup" },
 
-  // breeze-runner subcommands — `run` / `run-once` still bridge to the
-  // Rust binary while Phase 3-7 overlap lands; the rest are TS.
-  run: { kind: "runner", subcommand: "run" },
-  "run-once": { kind: "runner", subcommand: "run-once" },
+  // Foreground loops — all TS-backed.
+  run: { kind: "daemon", once: false },
+  daemon: { kind: "daemon", once: false },
+  "run-once": { kind: "daemon", once: true },
+
+  // Lifecycle (Phase 6)
   start: { kind: "ts", specifier: "start" },
   stop: { kind: "ts", specifier: "stop" },
   status: { kind: "ts", specifier: "status" },
@@ -119,58 +103,38 @@ const DISPATCH: Record<string, Target> = {
   cleanup: { kind: "ts", specifier: "cleanup" },
   "poll-inbox": { kind: "ts", specifier: "poll" },
 
-  // TS ports
+  // One-shot TS commands
   "status-manager": { kind: "ts", specifier: "status-manager" },
   poll: { kind: "ts", specifier: "poll" },
   watch: { kind: "ts", specifier: "watch" },
 
   // Statusline gets its own tiny dist bundle for sub-30ms cold start.
   statusline: { kind: "statusline" },
-
-  // Phase 3a daemon (backend-switched).
-  daemon: { kind: "daemon" },
 };
 
 /**
- * Split `--backend=...` out of the argv. Supports both
- * `--backend=ts` and `--backend ts` forms. Unknown values fall through
- * to the default (`rust`) and leave the flag in the residual argv so
- * the chosen backend can reject/surface it.
+ * Historical `--backend=...` splitter. The flag is no longer meaningful
+ * (Phase 8 dropped the Rust backend), but we still strip any stray
+ * occurrence from the argv so existing scripts keep working.
  *
  * Exported for tests.
  */
 export function extractBackendFlag(args: readonly string[]): {
-  backend: "ts" | "rust";
+  backend: "ts";
   rest: string[];
 } {
   const rest: string[] = [];
-  let backend: "ts" | "rust" = "ts";
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
     if (arg === "--backend") {
-      const value = args[i + 1];
-      if (value === "ts" || value === "rust") {
-        backend = value;
-        i += 1;
-        continue;
-      }
-      // Unknown/missing value: keep the flag in `rest` so the backend
-      // complains with a full error message.
-      rest.push(arg);
+      // Drop both the flag and its value.
+      i += 1;
       continue;
     }
-    if (arg?.startsWith("--backend=")) {
-      const value = arg.slice("--backend=".length);
-      if (value === "ts" || value === "rust") {
-        backend = value;
-        continue;
-      }
-      rest.push(arg);
-      continue;
-    }
+    if (arg?.startsWith("--backend=")) continue;
     rest.push(arg);
   }
-  return { backend, rest };
+  return { backend: "ts", rest };
 }
 
 export async function runBreeze(
@@ -196,11 +160,6 @@ export async function runBreeze(
 
   try {
     switch (target.kind) {
-      case "runner": {
-        const bridge = await import("./bridge.js");
-        const runner = bridge.resolveBreezeRunner();
-        return bridge.spawnInherit(runner.path, [target.subcommand, ...rest]);
-      }
       case "setup": {
         const bridge = await import("./bridge.js");
         const setupPath = bridge.resolveBreezeSetupScript();
@@ -255,18 +214,10 @@ export async function runBreeze(
         return bridge.spawnInherit(process.execPath, [bundlePath, ...rest]);
       }
       case "daemon": {
-        const { backend, rest: residual } = extractBackendFlag(rest);
-        if (backend === "ts") {
-          // Default: TS daemon. Lazy-imported so the daemon modules
-          // never touch cold-start latency for non-daemon commands.
-          const mod = await import("./daemon/runner-skeleton.js");
-          return await mod.runDaemon(residual);
-        }
-        // Opt-in: route through the Rust runner's `run` subcommand for
-        // operators who still rely on the legacy binary.
-        const bridge = await import("./bridge.js");
-        const runner = bridge.resolveBreezeRunner();
-        return bridge.spawnInherit(runner.path, ["run", ...residual]);
+        // Strip any stray `--backend=` so existing scripts keep working.
+        const { rest: residual } = extractBackendFlag(rest);
+        const mod = await import("./daemon/runner-skeleton.js");
+        return await mod.runDaemon(residual, { once: target.once });
       }
     }
   } catch (err) {

--- a/src/products/breeze/daemon/runner-skeleton.ts
+++ b/src/products/breeze/daemon/runner-skeleton.ts
@@ -37,7 +37,9 @@ import { loadBreezeDaemonConfig, type DaemonConfig } from "../core/config.js";
 
 import { resolveDaemonIdentity, identityHasRequiredScope } from "./identity.js";
 import { startHttpServer, type RunningHttpServer } from "./http.js";
-import { runPoller, type PollerLogger } from "./poller.js";
+import { pollOnce, runPoller, type PollerLogger } from "./poller.js";
+import { GhClient as CoreGhClient } from "../core/gh.js";
+import type { BreezePaths } from "../core/paths.js";
 import { createBus, toSseBus, type Bus } from "./bus.js";
 import { startGhBroker, type RunningBroker } from "./broker.js";
 import { GhExecutor } from "./gh-executor.js";
@@ -68,6 +70,13 @@ export interface DaemonRunOptions {
   signal?: AbortSignal;
   /** Logger override for tests. */
   logger?: PollerLogger;
+  /**
+   * When true, do exactly one candidate-poll cycle, wait until the
+   * dispatcher drains (no active or pending tasks), then exit. Mirrors
+   * the Rust `run_loop(once=true)` semantics. Used by the `run-once`
+   * CLI command.
+   */
+  once?: boolean;
 }
 
 const DEFAULT_LOGGER: PollerLogger = {
@@ -382,13 +391,20 @@ export async function runDaemon(
 
   let exitCode = 0;
   try {
-    await runPoller({
-      pollIntervalSec: config.pollIntervalSec,
-      host: config.host,
-      paths,
-      signal: controller.signal,
-      logger,
-    });
+    if (options.once) {
+      // One-shot: run a single poll cycle, then wait for the
+      // dispatcher to drain. Mirrors Rust `run_loop(once=true)`.
+      await runPollerOnce(config, paths, controller.signal, logger);
+      if (dispatcher) await waitForDispatcherDrain(dispatcher, controller.signal);
+    } else {
+      await runPoller({
+        pollIntervalSec: config.pollIntervalSec,
+        host: config.host,
+        paths,
+        signal: controller.signal,
+        logger,
+      });
+    }
   } catch (err) {
     logger.error(
       `poller exited with error: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
@@ -483,6 +499,61 @@ export function resolveRunnerHome(
   const breezeDir = env("BREEZE_DIR");
   if (breezeDir && breezeDir.length > 0) return join(breezeDir, "runner");
   return join(homedir(), ".breeze", "runner");
+}
+
+/**
+ * Run exactly one inbox-poll cycle against `pollOnce`. Mirrors Rust
+ * `fetcher.poll_once`. Used by the `run-once` path.
+ */
+async function runPollerOnce(
+  config: DaemonConfig,
+  paths: BreezePaths,
+  signal: AbortSignal,
+  logger: PollerLogger,
+): Promise<void> {
+  if (signal.aborted) return;
+  try {
+    const outcome = await pollOnce({
+      gh: new CoreGhClient(),
+      paths,
+      host: config.host,
+      now: Date.now,
+    });
+    for (const warning of outcome.warnings) logger.warn(warning);
+    logger.info(
+      `breeze: polled ${outcome.total} notifications (${outcome.newCount} new)`,
+    );
+  } catch (err) {
+    logger.warn(
+      `run-once poll failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+/**
+ * Wait until the dispatcher has no active or pending tasks, or the
+ * signal fires. Polls the dispatcher counters every 250ms.
+ */
+async function waitForDispatcherDrain(
+  dispatcher: Dispatcher,
+  signal: AbortSignal,
+): Promise<void> {
+  while (!signal.aborted) {
+    if (dispatcher.activeCount() === 0 && dispatcher.pendingCount() === 0) {
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, 250);
+      signal.addEventListener(
+        "abort",
+        () => {
+          clearTimeout(timer);
+          resolve();
+        },
+        { once: true },
+      );
+    });
+  }
 }
 
 export default runDaemon;

--- a/tests/breeze-bridge.test.ts
+++ b/tests/breeze-bridge.test.ts
@@ -1,243 +1,75 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
-  BREEZE_RUNNER_BIN_NAME,
-  BREEZE_RUNNER_ENV,
-  MAINTAINER_RUNNER_RELATIVE_PATH,
-  resolveBreezeRunner,
-  resolveBundledBreezeScript,
   resolveBreezeSetupScript,
   resolveFirstTreePackageRoot,
   spawnInherit,
+  type SpawnFn,
 } from "../src/products/breeze/bridge.js";
-import type { SpawnFn } from "../src/products/breeze/bridge.js";
 import { join } from "node:path";
 
-function envReader(env: Record<string, string | undefined>) {
-  return (name: string) => env[name];
-}
-
-describe("resolveBreezeRunner", () => {
-  const originalEnv = { ...process.env };
-
-  beforeEach(() => {
-    // Tests never touch the real environment.
-  });
-
-  afterEach(() => {
-    process.env = { ...originalEnv };
-  });
-
-  it("honours BREEZE_RUNNER_BIN when the file exists", () => {
-    const resolved = resolveBreezeRunner({
-      env: envReader({ [BREEZE_RUNNER_ENV]: "/tmp/fake-runner" }),
-      fileExists: (p) => p === "/tmp/fake-runner",
-      pathLookup: () => "/usr/local/bin/breeze-runner",
-      packageRoot: "/pkg",
-    });
-    expect(resolved).toEqual({ path: "/tmp/fake-runner", source: "env" });
-  });
-
-  it("rejects BREEZE_RUNNER_BIN when the file does not exist", () => {
-    expect(() =>
-      resolveBreezeRunner({
-        env: envReader({ [BREEZE_RUNNER_ENV]: "/tmp/does-not-exist" }),
-        fileExists: () => false,
-        pathLookup: () => null,
-        packageRoot: "/pkg",
-      }),
-    ).toThrow(/BREEZE_RUNNER_BIN is set to/);
-  });
-
-  it("prefers PATH lookup when no env override is set", () => {
-    const resolved = resolveBreezeRunner({
-      env: envReader({}),
-      fileExists: () => true,
-      pathLookup: (name) =>
-        name === BREEZE_RUNNER_BIN_NAME
-          ? "/usr/local/bin/breeze-runner"
-          : null,
-      packageRoot: "/pkg",
-    });
-    expect(resolved).toEqual({
-      path: "/usr/local/bin/breeze-runner",
-      source: "path",
-    });
-  });
-
-  it("falls back to the maintainer-local release binary", () => {
-    const expected = join("/pkg", MAINTAINER_RUNNER_RELATIVE_PATH);
-    const resolved = resolveBreezeRunner({
-      env: envReader({}),
-      fileExists: (p) => p === expected,
-      pathLookup: () => null,
-      packageRoot: "/pkg",
-    });
-    expect(resolved).toEqual({
-      path: expected,
-      source: "maintainer-fallback",
-    });
-  });
-
-  it("throws the installation hint when nothing resolves", () => {
-    expect(() =>
-      resolveBreezeRunner({
-        env: envReader({}),
-        fileExists: () => false,
-        pathLookup: () => null,
-        packageRoot: "/pkg",
-      }),
-    ).toThrow(/cargo install --path \./);
-  });
-
-  it("priority: env beats PATH beats maintainer fallback", () => {
-    // env present + PATH hit + fallback present → env wins
-    const allPresent = resolveBreezeRunner({
-      env: envReader({ [BREEZE_RUNNER_ENV]: "/env/runner" }),
-      fileExists: () => true,
-      pathLookup: () => "/path/runner",
-      packageRoot: "/pkg",
-    });
-    expect(allPresent.source).toBe("env");
-
-    // no env + PATH hit + fallback present → PATH wins
-    const pathWins = resolveBreezeRunner({
-      env: envReader({}),
-      fileExists: () => true,
-      pathLookup: () => "/path/runner",
-      packageRoot: "/pkg",
-    });
-    expect(pathWins.source).toBe("path");
-
-    // no env + no PATH + fallback present → fallback
-    const fallbackWins = resolveBreezeRunner({
-      env: envReader({}),
-      fileExists: (p) => p === join("/pkg", MAINTAINER_RUNNER_RELATIVE_PATH),
-      pathLookup: () => null,
-      packageRoot: "/pkg",
-    });
-    expect(fallbackWins.source).toBe("maintainer-fallback");
-  });
-});
-
-describe("resolveBundledBreezeScript", () => {
-  it("resolves script paths relative to the package root", () => {
-    const p = resolveBundledBreezeScript("breeze-watch", {
-      packageRoot: "/pkg",
-      fileExists: (path) =>
-        path === "/pkg/assets/breeze/bin/breeze-watch",
-    });
-    expect(p).toBe("/pkg/assets/breeze/bin/breeze-watch");
-  });
-
-  it("throws a helpful error when the script is missing", () => {
-    expect(() =>
-      resolveBundledBreezeScript("breeze-watch", {
-        packageRoot: "/pkg",
-        fileExists: () => false,
-      }),
-    ).toThrow(/breeze-watch/);
+describe("resolveFirstTreePackageRoot", () => {
+  it("returns a directory that contains the first-tree package.json", () => {
+    const root = resolveFirstTreePackageRoot();
+    expect(typeof root).toBe("string");
+    expect(root.length).toBeGreaterThan(0);
   });
 });
 
 describe("resolveBreezeSetupScript", () => {
-  it("resolves first-tree-breeze/setup", () => {
-    const p = resolveBreezeSetupScript({
-      packageRoot: "/pkg",
-      fileExists: (path) => path === "/pkg/first-tree-breeze/setup",
-    });
-    expect(p).toBe("/pkg/first-tree-breeze/setup");
-  });
-
-  it("throws when setup is missing", () => {
+  it("throws a helpful error when the setup script is missing", () => {
     expect(() =>
       resolveBreezeSetupScript({
-        packageRoot: "/pkg",
+        packageRoot: "/nowhere",
         fileExists: () => false,
       }),
-    ).toThrow(/setup script not found/);
+    ).toThrow(/breeze setup script not found/);
   });
-});
 
-describe("resolveFirstTreePackageRoot", () => {
-  it("finds the real package root from this module", () => {
-    const root = resolveFirstTreePackageRoot();
-    // The real repo root always contains src/ and assets/breeze/.
-    expect(root).toMatch(/first-tree/);
+  it("returns the path when the script is present", () => {
+    const path = resolveBreezeSetupScript({
+      packageRoot: "/pkg",
+      fileExists: (candidate: string): boolean =>
+        candidate === join("/pkg", "first-tree-breeze", "setup"),
+    });
+    expect(path).toBe(join("/pkg", "first-tree-breeze", "setup"));
   });
 });
 
 describe("spawnInherit", () => {
-  it("forwards the child's exit code", () => {
-    const spawn = vi.fn().mockReturnValue({
-      status: 42,
-      signal: null,
-      error: undefined,
-    }) as unknown as SpawnFn;
-
-    const code = spawnInherit("/bin/echo", ["hi"], { spawn });
-    expect(code).toBe(42);
-    expect(spawn).toHaveBeenCalledWith("/bin/echo", ["hi"], {
-      stdio: "inherit",
-    });
+  it("returns the child exit code for a successful spawn", () => {
+    const spawn = vi.fn().mockReturnValue({ status: 13 }) as unknown as SpawnFn;
+    expect(spawnInherit("true", [], { spawn })).toBe(13);
+    expect(spawn).toHaveBeenCalledWith("true", [], { stdio: "inherit" });
   });
 
-  it("returns 0 when status is 0", () => {
-    const spawn = vi.fn().mockReturnValue({
-      status: 0,
-      signal: null,
-      error: undefined,
-    }) as unknown as SpawnFn;
-    expect(spawnInherit("/bin/true", [], { spawn })).toBe(0);
+  it("returns 0 when status is null and no signal/error is reported", () => {
+    const spawn = vi.fn().mockReturnValue({}) as unknown as SpawnFn;
+    expect(spawnInherit("true", [], { spawn })).toBe(0);
   });
 
-  it("passes args through verbatim without reinterpretation", () => {
+  it("returns 1 on spawn error and writes a hint to stderr", () => {
     const spawn = vi.fn().mockReturnValue({
-      status: 0,
-      signal: null,
-      error: undefined,
+      error: new Error("ENOENT"),
     }) as unknown as SpawnFn;
-
-    spawnInherit(
-      "/bin/breeze-runner",
-      ["run", "--foo=bar", "--flag", "positional"],
-      { spawn },
-    );
-    expect(spawn).toHaveBeenCalledWith(
-      "/bin/breeze-runner",
-      ["run", "--foo=bar", "--flag", "positional"],
-      { stdio: "inherit" },
-    );
-  });
-
-  it("returns 1 and writes a helpful error when spawn fails with ENOENT", () => {
-    const spawn = vi.fn().mockReturnValue({
-      status: null,
-      signal: null,
-      error: Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" }),
-    }) as unknown as SpawnFn;
-
     const writes: string[] = [];
-    const origWrite = process.stderr.write.bind(process.stderr);
+    const orig = process.stderr.write.bind(process.stderr);
     process.stderr.write = ((chunk: string | Uint8Array) => {
       writes.push(String(chunk));
       return true;
     }) as typeof process.stderr.write;
-
     try {
-      const code = spawnInherit("/does/not/exist", ["run"], { spawn });
+      const code = spawnInherit("missing-bin", [], { spawn });
       expect(code).toBe(1);
       expect(writes.join("")).toContain("failed to spawn");
     } finally {
-      process.stderr.write = origWrite;
+      process.stderr.write = orig;
     }
   });
 
-  it("maps signal termination to exit code 1", () => {
+  it("returns 1 when the child terminates via signal", () => {
     const spawn = vi.fn().mockReturnValue({
-      status: null,
       signal: "SIGTERM",
-      error: undefined,
     }) as unknown as SpawnFn;
-    expect(spawnInherit("/bin/breeze-runner", [], { spawn })).toBe(1);
+    expect(spawnInherit("sleep", [], { spawn })).toBe(1);
   });
 });

--- a/tests/breeze-cli.test.ts
+++ b/tests/breeze-cli.test.ts
@@ -33,8 +33,8 @@ describe("breeze cli USAGE", () => {
     for (const sub of subcommands) {
       expect(BREEZE_USAGE).toContain(sub);
     }
-    expect(BREEZE_USAGE).toContain("BREEZE_RUNNER_BIN");
     expect(BREEZE_USAGE).toContain("BREEZE_DIR");
+    expect(BREEZE_USAGE).toContain("BREEZE_HOME");
   });
 });
 
@@ -72,37 +72,37 @@ describe("runBreeze dispatcher", () => {
     expect(output.lines[1]).toBe(BREEZE_USAGE);
   });
 
-  it("routes runner subcommands through resolveBreezeRunner + spawnInherit", async () => {
-    const spawnSpy = vi.fn().mockReturnValue(7);
-    const resolveRunnerSpy = vi
-      .fn()
-      .mockReturnValue({ path: "/runner", source: "path" });
-
-    vi.doMock("../src/products/breeze/bridge.js", () => ({
-      resolveBreezeRunner: resolveRunnerSpy,
-      resolveBundledBreezeScript: vi.fn(),
-      resolveBreezeSetupScript: vi.fn(),
-      resolveFirstTreePackageRoot: vi.fn(() => "/pkg"),
-      spawnInherit: spawnSpy,
+  it("routes run / run-once / daemon through the TS daemon", async () => {
+    const runDaemonSpy = vi.fn(async () => 0);
+    vi.doMock("../src/products/breeze/daemon/runner-skeleton.js", () => ({
+      runDaemon: runDaemonSpy,
     }));
-
     const { runBreeze: freshRun } = await import(
       "../src/products/breeze/cli.js"
     );
 
-    // Phase 6: `start`/`stop`/`status`/`doctor`/`cleanup` were migrated
-    // to TS. Only `run` + `run-once` still bridge to the Rust binary.
-    const cases: Array<{ args: string[]; expected: string[] }> = [
-      { args: ["run"], expected: ["run"] },
-      { args: ["run-once", "--verbose"], expected: ["run-once", "--verbose"] },
+    const cases: Array<{
+      args: string[];
+      expectedArgs: string[];
+      once: boolean;
+    }> = [
+      { args: ["run"], expectedArgs: [], once: false },
+      {
+        args: ["run-once", "--verbose"],
+        expectedArgs: ["--verbose"],
+        once: true,
+      },
+      {
+        args: ["daemon", "--poll-interval-secs", "30"],
+        expectedArgs: ["--poll-interval-secs", "30"],
+        once: false,
+      },
     ];
-    for (const { args, expected } of cases) {
-      spawnSpy.mockClear();
-      resolveRunnerSpy.mockClear();
+    for (const { args, expectedArgs, once } of cases) {
+      runDaemonSpy.mockClear();
       const code = await freshRun(args, () => {});
-      expect(code).toBe(7);
-      expect(resolveRunnerSpy).toHaveBeenCalledOnce();
-      expect(spawnSpy).toHaveBeenCalledWith("/runner", expected);
+      expect(code).toBe(0);
+      expect(runDaemonSpy).toHaveBeenCalledWith(expectedArgs, { once });
     }
   });
 
@@ -207,18 +207,11 @@ describe("runBreeze dispatcher", () => {
     expect(runWatch).toHaveBeenCalledWith([]);
   });
 
-  it("propagates the child exit code for runner-bridged subcommands", async () => {
-    const spawnSpy = vi.fn().mockReturnValue(13);
-    vi.doMock("../src/products/breeze/bridge.js", () => ({
-      resolveBreezeRunner: vi
-        .fn()
-        .mockReturnValue({ path: "/runner", source: "path" }),
-      resolveBundledBreezeScript: vi.fn(),
-      resolveBreezeSetupScript: vi.fn(),
-      resolveFirstTreePackageRoot: vi.fn(() => "/pkg"),
-      spawnInherit: spawnSpy,
+  it("propagates the runDaemon exit code for `run`", async () => {
+    const runDaemonSpy = vi.fn(async () => 13);
+    vi.doMock("../src/products/breeze/daemon/runner-skeleton.js", () => ({
+      runDaemon: runDaemonSpy,
     }));
-
     const { runBreeze: freshRun } = await import(
       "../src/products/breeze/cli.js"
     );
@@ -254,17 +247,11 @@ describe("runBreeze dispatcher", () => {
     expect(runStatusManager).toHaveBeenCalledWith(["list"]);
   });
 
-  it("surfaces resolver errors to stderr and returns 1", async () => {
-    vi.doMock("../src/products/breeze/bridge.js", () => ({
-      resolveBreezeRunner: () => {
-        throw new Error(
-          "breeze-runner not found. Install with `cd first-tree-breeze/breeze-runner && cargo install --path .`",
-        );
+  it("surfaces runDaemon errors to stderr and returns 1", async () => {
+    vi.doMock("../src/products/breeze/daemon/runner-skeleton.js", () => ({
+      runDaemon: async () => {
+        throw new Error("daemon init failed");
       },
-      resolveBundledBreezeScript: vi.fn(),
-      resolveBreezeSetupScript: vi.fn(),
-      resolveFirstTreePackageRoot: vi.fn(() => "/pkg"),
-      spawnInherit: vi.fn(),
     }));
 
     const writes: string[] = [];
@@ -280,7 +267,7 @@ describe("runBreeze dispatcher", () => {
       );
       const code = await freshRun(["run"], () => {});
       expect(code).toBe(1);
-      expect(writes.join("")).toContain("cargo install --path .");
+      expect(writes.join("")).toContain("daemon init failed");
     } finally {
       process.stderr.write = origWrite;
     }

--- a/tests/breeze-daemon-runner.test.ts
+++ b/tests/breeze-daemon-runner.test.ts
@@ -61,34 +61,34 @@ describe("parseDaemonArgs", () => {
 });
 
 describe("extractBackendFlag", () => {
-  it("defaults to ts when no flag is present", () => {
+  it("passes argv through unchanged when no flag is present", () => {
     const { backend, rest } = extractBackendFlag(["run", "--foo"]);
     expect(backend).toBe("ts");
     expect(rest).toEqual(["run", "--foo"]);
   });
 
-  it("supports --backend=ts / --backend=rust", () => {
-    expect(extractBackendFlag(["--backend=ts"])).toEqual({
+  it("strips --backend=<value> forms", () => {
+    expect(extractBackendFlag(["--backend=ts", "--x"])).toEqual({
       backend: "ts",
-      rest: [],
+      rest: ["--x"],
     });
     expect(extractBackendFlag(["--backend=rust", "--verbose"])).toEqual({
-      backend: "rust",
+      backend: "ts",
       rest: ["--verbose"],
     });
   });
 
-  it("supports space-separated --backend rust", () => {
+  it("strips space-separated --backend <value> forms", () => {
     expect(extractBackendFlag(["--backend", "rust", "--x"])).toEqual({
-      backend: "rust",
+      backend: "ts",
       rest: ["--x"],
     });
   });
 
-  it("keeps unknown --backend values in rest and defaults to ts", () => {
+  it("also drops unknown --backend values", () => {
     const { backend, rest } = extractBackendFlag(["--backend=julia"]);
     expect(backend).toBe("ts");
-    expect(rest).toEqual(["--backend=julia"]);
+    expect(rest).toEqual([]);
   });
 });
 
@@ -129,7 +129,7 @@ describe("runDaemon end-to-end skeleton", () => {
   });
 });
 
-describe("cli dispatcher routes daemon --backend flag", () => {
+describe("cli dispatcher routes run / run-once / daemon to the TS runner", () => {
   beforeEach(() => {
     vi.resetModules();
   });
@@ -138,62 +138,36 @@ describe("cli dispatcher routes daemon --backend flag", () => {
     vi.restoreAllMocks();
   });
 
-  it("routes `daemon --backend=ts` to the TS runner", async () => {
+  it("routes `daemon` to runDaemon with once=false", async () => {
     const runDaemonSpy = vi.fn(async () => 0);
-
     vi.doMock("../src/products/breeze/daemon/runner-skeleton.js", () => ({
       runDaemon: runDaemonSpy,
     }));
-    vi.doMock("../src/products/breeze/bridge.js", () => ({
-      resolveBreezeRunner: vi.fn(() => {
-        throw new Error("TS backend must not call the Rust bridge");
-      }),
-      resolveBundledBreezeScript: vi.fn(),
-      resolveBreezeSetupScript: vi.fn(),
-      resolveFirstTreePackageRoot: vi.fn(() => "/pkg"),
-      spawnInherit: vi.fn(() => {
-        throw new Error("TS backend must not spawn");
-      }),
-    }));
-
     const { runBreeze } = await import("../src/products/breeze/cli.js");
-    const code = await runBreeze(
-      ["daemon", "--backend=ts", "--poll-interval-secs", "30"],
-      () => {},
+    await runBreeze(["daemon", "--poll-interval-secs", "30"], () => {});
+    expect(runDaemonSpy).toHaveBeenCalledWith(
+      ["--poll-interval-secs", "30"],
+      { once: false },
     );
-    expect(code).toBe(0);
-    expect(runDaemonSpy).toHaveBeenCalledWith([
-      "--poll-interval-secs",
-      "30",
-    ]);
   });
 
-  it("routes `daemon --backend=rust` through the Rust bridge's `run` subcommand", async () => {
-    const spawnSpy = vi.fn().mockReturnValue(0);
-    const resolveRunnerSpy = vi
-      .fn()
-      .mockReturnValue({ path: "/runner", source: "path" });
-
+  it("routes `run` to runDaemon with once=false and strips any stray --backend flag", async () => {
+    const runDaemonSpy = vi.fn(async () => 0);
     vi.doMock("../src/products/breeze/daemon/runner-skeleton.js", () => ({
-      runDaemon: vi.fn(() => {
-        throw new Error("Rust backend must not call the TS daemon");
-      }),
+      runDaemon: runDaemonSpy,
     }));
-    vi.doMock("../src/products/breeze/bridge.js", () => ({
-      resolveBreezeRunner: resolveRunnerSpy,
-      resolveBundledBreezeScript: vi.fn(),
-      resolveBreezeSetupScript: vi.fn(),
-      resolveFirstTreePackageRoot: vi.fn(() => "/pkg"),
-      spawnInherit: spawnSpy,
-    }));
-
     const { runBreeze } = await import("../src/products/breeze/cli.js");
-    const code = await runBreeze(
-      ["daemon", "--backend=rust", "--verbose"],
-      () => {},
-    );
-    expect(code).toBe(0);
-    expect(resolveRunnerSpy).toHaveBeenCalledOnce();
-    expect(spawnSpy).toHaveBeenCalledWith("/runner", ["run", "--verbose"]);
+    await runBreeze(["run", "--backend=rust", "--verbose"], () => {});
+    expect(runDaemonSpy).toHaveBeenCalledWith(["--verbose"], { once: false });
+  });
+
+  it("routes `run-once` to runDaemon with once=true", async () => {
+    const runDaemonSpy = vi.fn(async () => 0);
+    vi.doMock("../src/products/breeze/daemon/runner-skeleton.js", () => ({
+      runDaemon: runDaemonSpy,
+    }));
+    const { runBreeze } = await import("../src/products/breeze/cli.js");
+    await runBreeze(["run-once"], () => {});
+    expect(runDaemonSpy).toHaveBeenCalledWith([], { once: true });
   });
 });


### PR DESCRIPTION
## Summary

\`first-tree breeze\` no longer depends on the \`breeze-runner\` Rust binary. Every subcommand — including the previously bridged \`run\` / \`run-once\` — executes the TypeScript daemon.

### Changes
- \`daemon/runner-skeleton.ts\`: adds \`{ once: boolean }\`. When true, runs a single \`pollOnce\`, then waits for the dispatcher to drain (\`activeCount + pendingCount === 0\`) before exiting. Mirrors Rust \`run_loop(once=true)\`.
- \`cli.ts\`: \`run\`, \`daemon\`, \`run-once\` all route to \`runDaemon\`. \`--backend=…\` is silently stripped.
- \`bridge.ts\`: reduced to \`resolveFirstTreePackageRoot\`, \`resolveBreezeSetupScript\`, \`spawnInherit\`. Runner-resolution code is gone.
- Tests updated: runner-bridge tests replaced with runDaemon-routing tests; extractBackendFlag tests flipped to the new strip-only semantics.

### Knock-on effects
- \`BREEZE_RUNNER_BIN\` env var is no longer read (doc/usage updated).
- Maintainer fallback path (\`first-tree-breeze/breeze-runner/target/release\`) removed.
- Full suite: 816/816 passing.

## Test plan
- [x] 816/816 tests green, \`pnpm validate:skill\` / typecheck / build all green.