### PR TITLE
chore: stop shipping empty skills/breeze directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "files": [
     "dist",
     "skills/tree",
-    "skills/breeze",
     "assets"
   ],
   "scripts": {


### PR DESCRIPTION
## Summary

- `skills/breeze/` contained only a `.gitkeep` but was listed in `package.json` `"files"`, so every published tarball included an empty directory.
- Remove the empty dir and its `files` entry. When the real breeze skill content lands in a follow-up PR, both will be reintroduced together.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (866 passing; one flaky timeout on `skill-artifacts` passes on rerun, unrelated)