### PR TITLE
refactor: introduce src/products/manifest.ts as product single source of truth

### DIFF
--- a/scripts/check-skill-sync.sh
+++ b/scripts/check-skill-sync.sh
@@ -173,13 +173,21 @@ if ! grep -q '"assets"' "$REPO_ROOT/package.json"; then
   exit 1
 fi
 
-if ! grep -q './products/tree/cli.js' "$REPO_ROOT/src/cli.ts"; then
-  echo "src/cli.ts is not lazy-loading the tree product dispatcher." >&2
+MANIFEST_PATH="$REPO_ROOT/src/products/manifest.ts"
+require_file "$MANIFEST_PATH"
+
+if ! grep -q './tree/cli.js' "$MANIFEST_PATH"; then
+  echo "src/products/manifest.ts is not lazy-loading the tree product dispatcher." >&2
   exit 1
 fi
 
-if ! grep -q './products/breeze/cli.js' "$REPO_ROOT/src/cli.ts"; then
-  echo "src/cli.ts is not lazy-loading the breeze product dispatcher." >&2
+if ! grep -q './breeze/cli.js' "$MANIFEST_PATH"; then
+  echo "src/products/manifest.ts is not lazy-loading the breeze product dispatcher." >&2
+  exit 1
+fi
+
+if ! grep -q './gardener/cli.js' "$MANIFEST_PATH"; then
+  echo "src/products/manifest.ts is not lazy-loading the gardener product dispatcher." >&2
   exit 1
 fi
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,15 +4,32 @@ import { readFileSync, realpathSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-export const USAGE = `usage: first-tree <product> <command>
+import {
+  PRODUCTS,
+  getProduct,
+  readProductVersion,
+} from "./products/manifest.js";
+
+export const USAGE = buildUsage();
+
+function buildUsage(): string {
+  const productLines = PRODUCTS.map(
+    (p) => `  ${p.name.padEnd(20)}  ${p.description}`,
+  ).join("\n");
+  const gettingStarted = [
+    "  first-tree tree --help",
+    "  first-tree tree inspect --json",
+    "  first-tree tree init",
+    "  first-tree breeze --help",
+    "  first-tree breeze status",
+  ].join("\n");
+  return `usage: first-tree <product> <command>
 
   first-tree is an umbrella CLI that dispatches into product namespaces.
   This CLI is designed for agents, not humans. Let your agent handle it.
 
 Products:
-  tree                  Context Tree tooling (init, bind, sync, publish, ...)
-  breeze                Breeze proposal/inbox agent (install, run, status, watch, ...)
-  gardener              Context Tree maintenance agent (respond, ...)
+${productLines}
 
 Global options:
   --help, -h            Show this help message
@@ -20,12 +37,9 @@ Global options:
   --skip-version-check  Skip the auto-upgrade check (for latency-sensitive callers)
 
 Getting started:
-  first-tree tree --help
-  first-tree tree inspect --json
-  first-tree tree init
-  first-tree breeze --help
-  first-tree breeze status
+${gettingStarted}
 `;
+}
 
 type Output = (text: string) => void;
 
@@ -113,24 +127,13 @@ function readFirstTreeVersion(): string {
   }
 }
 
-function readProductVersion(productDir: string): string {
-  // VERSION files are siblings of the bundled product cli.ts. When the CLI
-  // runs from the published package they live under dist/products/<name>/;
-  // in the source tree they live under src/products/<name>/. Try both.
-  const here = dirname(fileURLToPath(import.meta.url));
-  const candidates = [
-    join(here, "products", productDir, "VERSION"),
-    join(here, "..", "src", "products", productDir, "VERSION"),
-    join(here, "..", "products", productDir, "VERSION"),
-  ];
-  for (const candidate of candidates) {
-    try {
-      return readFileSync(candidate, "utf-8").trim();
-    } catch {
-      // try next
-    }
+function formatVersionLine(): string {
+  const cliVersion = readFirstTreeVersion();
+  const parts = [`first-tree=${cliVersion}`];
+  for (const product of PRODUCTS) {
+    parts.push(`${product.name}=${readProductVersion(product.name)}`);
   }
-  return "unknown";
+  return parts.join(" ");
 }
 
 export async function runCli(
@@ -146,41 +149,27 @@ export async function runCli(
   }
 
   if (args[0] === "--version" || args[0] === "-v") {
-    const cliVersion = readFirstTreeVersion();
-    const treeVersion = readProductVersion("tree");
-    const breezeVersion = readProductVersion("breeze");
-    const gardenerVersion = readProductVersion("gardener");
-    write(
-      `first-tree=${cliVersion} tree=${treeVersion} breeze=${breezeVersion} gardener=${gardenerVersion}`,
-    );
+    write(formatVersionLine());
     return 0;
   }
 
-  const product = args[0];
+  const productName = args[0];
+  const product = getProduct(productName);
 
-  switch (product) {
-    case "tree": {
-      if (!skipVersionCheck) {
-        await runAutoUpgradeCheck();
-      }
-      const { runTree } = await import("./products/tree/cli.js");
-      return runTree(args.slice(1), write);
-    }
-    case "breeze": {
-      const { runBreeze } = await import("./products/breeze/cli.js");
-      return runBreeze(args.slice(1), write);
-    }
-    case "gardener": {
-      const { runGardener } = await import("./products/gardener/cli.js");
-      return runGardener(args.slice(1), write);
-    }
-    default:
-      write(`Unknown product: ${product}`);
-      write(
-        `Did you mean \`first-tree tree ${product}\`? Run \`first-tree --help\` for the list of products.`,
-      );
-      return 1;
+  if (!product) {
+    write(`Unknown product: ${productName}`);
+    write(
+      `Did you mean \`first-tree tree ${productName}\`? Run \`first-tree --help\` for the list of products.`,
+    );
+    return 1;
   }
+
+  if (product.autoUpgradeOnInvoke && !skipVersionCheck) {
+    await runAutoUpgradeCheck();
+  }
+
+  const { run } = await product.load();
+  return run(args.slice(1), write);
 }
 
 async function main(): Promise<number> {

--- a/src/products/manifest.ts
+++ b/src/products/manifest.ts
@@ -1,0 +1,100 @@
+/**
+ * Product manifest — single source of truth for the first-tree product set.
+ *
+ * The umbrella CLI (src/cli.ts), the skill tooling, and the maintainer
+ * validation scripts all iterate this list instead of hard-coding product
+ * names. Adding a new product means: create src/products/<name>/, add a
+ * matching entry here, and the rest of the machinery picks it up.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+type Output = (text: string) => void;
+type ProductRunner = (args: string[], output: Output) => Promise<number>;
+
+export interface ProductDefinition {
+  /** Subcommand name as typed on the CLI (`first-tree <name> ...`). */
+  readonly name: string;
+  /** One-line description shown in the umbrella `--help` usage block. */
+  readonly description: string;
+  /** Lazy loader for the product's CLI entrypoint. */
+  readonly load: () => Promise<{ run: ProductRunner }>;
+  /** Whether invoking this product should trigger the auto-upgrade check. */
+  readonly autoUpgradeOnInvoke: boolean;
+  /** Whether this product ships runtime assets under `assets/<name>/`. */
+  readonly hasAssets: boolean;
+  /** Whether this product ships a skill under `skills/<name>/`. */
+  readonly hasSkill: boolean;
+}
+
+export const PRODUCTS: readonly ProductDefinition[] = [
+  {
+    name: "tree",
+    description:
+      "Context Tree tooling (init, bind, sync, publish, ...)",
+    load: async () => {
+      const mod = await import("./tree/cli.js");
+      return { run: (args, output) => mod.runTree(args, output) };
+    },
+    autoUpgradeOnInvoke: true,
+    hasAssets: true,
+    hasSkill: true,
+  },
+  {
+    name: "breeze",
+    description:
+      "Breeze proposal/inbox agent (install, run, status, watch, ...)",
+    load: async () => {
+      const mod = await import("./breeze/cli.js");
+      return { run: (args, output) => mod.runBreeze(args, output) };
+    },
+    autoUpgradeOnInvoke: false,
+    hasAssets: true,
+    hasSkill: false,
+  },
+  {
+    name: "gardener",
+    description:
+      "Context Tree maintenance agent (respond, comment, ...)",
+    load: async () => {
+      const mod = await import("./gardener/cli.js");
+      return { run: (args, output) => mod.runGardener(args, output) };
+    },
+    autoUpgradeOnInvoke: false,
+    hasAssets: false,
+    hasSkill: false,
+  },
+];
+
+export function getProduct(name: string): ProductDefinition | undefined {
+  return PRODUCTS.find((p) => p.name === name);
+}
+
+export function listProductNames(): readonly string[] {
+  return PRODUCTS.map((p) => p.name);
+}
+
+/**
+ * Read a product's VERSION file. VERSION files live as siblings of the
+ * bundled product cli.ts. When the CLI runs from the published package
+ * they are under `dist/products/<name>/`; in the source tree they are
+ * under `src/products/<name>/`. We probe both.
+ */
+export function readProductVersion(productName: string): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    join(here, productName, "VERSION"),
+    join(here, "..", "..", "src", "products", productName, "VERSION"),
+    join(here, "..", "products", productName, "VERSION"),
+  ];
+  for (const candidate of candidates) {
+    try {
+      return readFileSync(candidate, "utf-8").trim();
+    } catch {
+      // try next
+    }
+  }
+  return "unknown";
+}


### PR DESCRIPTION
## Summary

The umbrella CLI was hard-coding product metadata (names, descriptions, entry points, auto-upgrade behavior) inside `src/cli.ts` with a switch statement. Every new product (most recently `gardener`) required updating the USAGE string, `--version` output, and dispatch switch in lockstep.

- Introduce `src/products/manifest.ts` — authoritative ordered list of `ProductDefinition` entries with `name`, `description`, lazy `load()`, `autoUpgradeOnInvoke`, `hasAssets`, `hasSkill`.
- `src/cli.ts` now iterates `PRODUCTS` to build USAGE, format the `--version` line, and dispatch subcommands.
- `scripts/check-skill-sync.sh` updated to grep `manifest.ts` for lazy-load paths, and extended to assert `gardener` is wired too.

Adding a new product is now a one-line addition to the manifest.

## No behavior changes

Output of `first-tree --help` and `first-tree --version` is byte-for-byte equivalent to main.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` — 866 pass
- [x] `pnpm build` — clean
- [x] Manual smoke: `node dist/cli.js --help` and `--version` match pre-refactor output