### PR TITLE
feat: link tree/breeze/gardener skills into .agents/ and .claude/

### DIFF
--- a/.agents/skills/breeze
+++ b/.agents/skills/breeze
@@ -1,0 +1,1 @@
+../../skills/breeze

--- a/.agents/skills/gardener
+++ b/.agents/skills/gardener
@@ -1,0 +1,1 @@
+../../skills/gardener

--- a/.agents/skills/tree
+++ b/.agents/skills/tree
@@ -1,0 +1,1 @@
+../../skills/tree

--- a/.claude/skills/breeze
+++ b/.claude/skills/breeze
@@ -1,0 +1,1 @@
+../../.agents/skills/breeze

--- a/.claude/skills/gardener
+++ b/.claude/skills/gardener
@@ -1,0 +1,1 @@
+../../.agents/skills/gardener

--- a/.claude/skills/tree
+++ b/.claude/skills/tree
@@ -1,0 +1,1 @@
+../../.agents/skills/tree

--- a/scripts/check-skill-sync.sh
+++ b/scripts/check-skill-sync.sh
@@ -119,7 +119,13 @@ require_file "$REPO_ROOT/evals/helpers/case-loader.ts"
 require_file "$REPO_ROOT/evals/scripts/tree-manager.ts"
 require_file "$REPO_ROOT/evals/tests/eval-helpers.test.ts"
 require_symlink_target "$REPO_ROOT/.agents/skills/first-tree" "../../skills/first-tree"
+require_symlink_target "$REPO_ROOT/.agents/skills/tree" "../../skills/tree"
+require_symlink_target "$REPO_ROOT/.agents/skills/breeze" "../../skills/breeze"
+require_symlink_target "$REPO_ROOT/.agents/skills/gardener" "../../skills/gardener"
 require_symlink_target "$REPO_ROOT/.claude/skills/first-tree" "../../.agents/skills/first-tree"
+require_symlink_target "$REPO_ROOT/.claude/skills/tree" "../../.agents/skills/tree"
+require_symlink_target "$REPO_ROOT/.claude/skills/breeze" "../../.agents/skills/breeze"
+require_symlink_target "$REPO_ROOT/.claude/skills/gardener" "../../.agents/skills/gardener"
 
 # Check for legacy artifacts that should not be committed. Skill payload
 # directories must contain only SKILL.md, VERSION, and (optionally)
@@ -166,8 +172,16 @@ require_file "$REPO_ROOT/skills/breeze/VERSION"
 require_file "$REPO_ROOT/skills/gardener/SKILL.md"
 require_file "$REPO_ROOT/skills/gardener/VERSION"
 
-tracked_aliases="$(git -C "$REPO_ROOT" ls-files .agents .claude)"
-expected_aliases=$'.agents/skills/first-tree\n.claude/skills/first-tree'
+tracked_aliases="$(git -C "$REPO_ROOT" ls-files .agents .claude | sort)"
+expected_aliases="$(printf '%s\n' \
+  .agents/skills/breeze \
+  .agents/skills/first-tree \
+  .agents/skills/gardener \
+  .agents/skills/tree \
+  .claude/skills/breeze \
+  .claude/skills/first-tree \
+  .claude/skills/gardener \
+  .claude/skills/tree | sort)"
 if [[ -n "$tracked_aliases" && "$tracked_aliases" != "$expected_aliases" ]]; then
   echo "Tracked .agents/.claude entries are out of sync with the expected local skill aliases." >&2
   printf 'Expected:\n%s\nGot:\n%s\n' "$expected_aliases" "$tracked_aliases" >&2

--- a/tests/skill-artifacts.test.ts
+++ b/tests/skill-artifacts.test.ts
@@ -109,11 +109,19 @@ describe("skill artifacts", () => {
     expect(
       existsSync(join(ROOT, "docs", "design-sync.md")),
     ).toBe(true);
+    const allowedAliases = new Set([
+      ".agents/skills/first-tree",
+      ".agents/skills/tree",
+      ".agents/skills/breeze",
+      ".agents/skills/gardener",
+      ".claude/skills/first-tree",
+      ".claude/skills/tree",
+      ".claude/skills/breeze",
+      ".claude/skills/gardener",
+    ]);
     expect(
       trackedEntriesInGit(".agents", ".claude").filter(
-        (entry) =>
-          entry !== ".agents/skills/first-tree"
-          && entry !== ".claude/skills/first-tree",
+        (entry) => !allowedAliases.has(entry),
       ),
     ).toEqual([]);
     expect(trackedEntriesInGit(".context-tree")).toEqual([]);


### PR DESCRIPTION
## Summary

Up to this point the source repo only maintained local alias symlinks for the `first-tree` entry-point skill. Now that all four skills exist under `skills/`, add the matching aliases so local agents (Claude Code, Codex, general-purpose agents) auto-discover every product skill via the conventional lookup paths:

```
.agents/skills/<name>/   → ../../skills/<name>/
.claude/skills/<name>/   → ../../.agents/skills/<name>/
```

This is the same two-hop pattern already in place for `first-tree`, now applied consistently to `tree`, `breeze`, and `gardener`.

## Enforcement

- `scripts/check-skill-sync.sh`
  - asserts each of the eight symlinks has the expected target
  - compares the full set of tracked aliases to the expected `4 + 4` list
- `tests/skill-artifacts.test.ts` — tracked-aliases allowlist accepts all four product entrypoints

## Editing

`.agents/` and `.claude/` contain **only** local alias symlinks — edit the real payload under `skills/<name>/`, not the alias entries.

## Test plan

- [x] `pnpm test` — 866 pass
- [x] `pnpm validate:skill` — passes `quick_validate.py` and `check-skill-sync.sh`