### PR TITLE
docs: refresh architecture docs for three products and four skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,46 +1,65 @@
 # Agent Instructions for first-tree
 
 This repo distributes the `first-tree` npm package: a thin umbrella CLI that
-dispatches into product namespaces (`tree`, `breeze`) plus lightweight skill
-payloads. It is not a user context tree. Maintaining this repo is different
-from using it — see the user-facing `skills/first-tree/SKILL.md` for what gets
-shipped as the Context Tree skill.
+dispatches into three product namespaces (`tree`, `breeze`, `gardener`) plus
+four lightweight skill payloads (`first-tree` entry point + one per product).
+It is not a user context tree. Maintaining this repo is different from using
+it — see the user-facing `skills/first-tree/SKILL.md` for what gets shipped
+as the entry-point skill.
 
 ## Start Here
 
 1. `docs/source-map.md` — maintainer entrypoint; it points to canonical Context Tree nodes first, then local implementation notes
-2. `skills/first-tree/SKILL.md` — the user-facing tree skill payload (read this so
-   you understand what ships to user repos)
-3. The specific Context Tree node or repo-local maintainer reference linked from the source map
-4. `skills/first-tree/references/source-workspace-installation.md` for the
+2. `src/products/manifest.ts` — the single source of truth for the three
+   products; all dispatch, version reporting, and skill management reads from
+   here
+3. `skills/first-tree/SKILL.md` — the user-facing entry-point skill (read
+   this so you understand what ships to user repos and how it routes to the
+   product skills)
+4. The specific Context Tree node or repo-local maintainer reference linked
+   from the source map
+5. `skills/first-tree/references/source-workspace-installation.md` for the
    user-facing install contract (also shipped to user repos)
 
 ## Rules
 
-- Treat the source repo as a TypeScript project, not a tree repo:
-  - `src/cli.ts` is the top-level umbrella dispatcher (`first-tree <product> <command>`)
-  - `src/products/tree/engine/` is the canonical tree CLI behavior (bundled into dist)
-  - `src/products/tree/cli.ts` is the tree product dispatcher (lazy-loaded)
-  - `src/products/breeze/cli.ts` is the breeze product dispatcher stub (Phase 1+)
-  - `assets/tree/` is the tree runtime asset payload (templates, workflows,
-    prompts, helpers, examples) read by the CLI at runtime
-  - `assets/breeze/` is the placeholder for breeze runtime assets
-  - `skills/first-tree/` is the lightweight tree skill payload that gets copied
-    verbatim to user repos (as `skills/first-tree/`) via `copyCanonicalSkill`.
-    It contains only `SKILL.md`, `VERSION`, and `references/` (user-facing
-    references only).
-  - `skills/breeze/` is the placeholder for the breeze skill payload
-  - `docs/` holds source-repo implementation notes and file maps; canonical
+- Treat the source repo as a TypeScript project, not a tree repo.
+- Canonical layout:
+  - `src/cli.ts` — top-level umbrella dispatcher (`first-tree <product> <command>`); delegates to the manifest
+  - `src/products/manifest.ts` — the product manifest (name, description,
+    lazy entrypoint, auto-upgrade, assets/skill flags)
+  - `src/products/<name>/` — one folder per product (`tree`, `breeze`,
+    `gardener`). Each has the same shape:
+    - `VERSION` — product version (separate from npm package version)
+    - `cli.ts` — thin arg-routing dispatcher, lazy-loads everything heavy
+    - `engine/commands/` — one file per subcommand
+    - `engine/runtime/` — runtime config, constants, paths (breeze calls
+      this `runtime/` too; it used to be `core/` before the shape was
+      unified)
+    - `engine/` root — business-logic modules (domain specific)
+    - Product-specific extras: `engine/daemon/` (breeze), `engine/rules/`
+      and `engine/validators/` (tree)
+  - `assets/<name>/` — runtime payloads read by the CLI at runtime. Only
+    `tree` ships real assets today; `breeze` ships just the SSE dashboard
+    HTML; `gardener` ships none.
+  - `skills/<name>/` — user-facing skill payloads. Four of them:
+    - `skills/first-tree/` — entry-point skill with all the shared
+      `references/` (whitepaper, principles, ownership, onboarding,
+      source-workspace-installation, upgrade-contract)
+    - `skills/tree/`, `skills/breeze/`, `skills/gardener/` — one-file
+      operational handbooks (`SKILL.md` + `VERSION`) for each product CLI
+  - `docs/` — source-repo implementation notes and file maps; canonical
     design/architecture decisions belong in the bound Context Tree under
     `first-tree-skill-cli/`
-  - `tests/` holds the test suite
-- The tracked `.agents/skills/first-tree` and `.claude/skills/first-tree`
-  entries in this repo are local alias symlinks for agent discovery; edit
-  `skills/first-tree/`, not the aliases.
-- Use `first-tree` for both the npm package and CLI command, and
-  `skills/first-tree/` when you mean the bundled skill payload path.
+  - `tests/` — the test suite
+- The tracked `.agents/skills/<name>` and `.claude/skills/<name>` entries in
+  this repo are local alias symlinks for agent discovery — there is one
+  alias per skill (four of each). Edit `skills/<name>/`, not the aliases.
+- Use `first-tree` for both the npm package and the CLI command. Use
+  `skills/first-tree/` when you mean the entry-point skill payload;
+  `skills/<product>/` when you mean a product operational handbook.
 - Never put engine code, test code, helpers, or maintainer docs inside
-  `skills/first-tree/` — that directory ships to user repos as-is.
+  `skills/<name>/` — those directories ship to user repos as-is.
 - Keep source/workspace installs limited to local skill integration; `NODE.md`,
   `members/`, and tree-scoped `AGENTS.md` belong only in a dedicated
   `*-context` repo. See `skills/first-tree/references/source-workspace-installation.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,23 +2,25 @@
 
 Thanks for helping improve `first-tree`.
 
-This repository ships one canonical `first-tree` skill plus a thin
-`first-tree` CLI shell.
+This repository ships a thin `first-tree` umbrella CLI over three products
+(`tree`, `breeze`, `gardener`) plus four lightweight skill payloads.
 
 Naming note:
 
 - `first-tree` is the npm package name.
 - `first-tree` is also the installed CLI command.
-- `skills/first-tree/` is the bundled tree skill path inside this repo.
-- `skills/breeze/` is the placeholder for the breeze skill payload.
-- This source repo also tracks `.agents/skills/first-tree/` and
-  `.claude/skills/first-tree/` as symlink aliases back to
-  `skills/first-tree/` for local agent discovery.
-- User trees install that payload into `.agents/skills/first-tree/` and
-  `.claude/skills/first-tree/` (the installed name is unchanged).
+- `skills/first-tree/` holds the entry-point skill payload (methodology,
+  shared `references/`, routing to the product skills).
+- `skills/tree/`, `skills/breeze/`, `skills/gardener/` hold the per-product
+  operational skills.
+- This source repo tracks `.agents/skills/<name>/` and `.claude/skills/<name>/`
+  symlink aliases for each of the four skills so local agents can discover
+  them without an install step.
+- User repos install the four payloads at the same paths
+  (`.agents/skills/<name>/` and `.claude/skills/<name>/`).
 
-Most changes should land in the canonical tree skill under `skills/first-tree/`,
-not in the local alias paths, root-level prose, or ad hoc helper files.
+Most skill content changes should land in `skills/<name>/SKILL.md`, not in
+the local alias paths, root-level prose, or ad hoc helper files.
 
 ## Before You Change Anything
 

--- a/README.md
+++ b/README.md
@@ -195,13 +195,20 @@ plus their own source/workspace binding state.
 
 - The npm package is `first-tree`.
 - The installed CLI command is also `first-tree`.
-- The published package keeps its bundled canonical source under
-  `skills/first-tree/` (shipped to user repos as `skills/first-tree/`).
-- In this source repo, `.agents/skills/first-tree/` and
-  `.claude/skills/first-tree/` are tracked symlink aliases back to
-  `skills/first-tree/` so local agents resolve the same `first-tree` skill
-  that ships in the package.
-- `npx -p first-tree first-tree <command>` is the recommended one-off entrypoint.
+- The CLI dispatches into three products: `tree`, `breeze`, `gardener`.
+  Run `first-tree --help` for the routing.
+- The published package ships four skill payloads, each with the same
+  name in the package and when installed into a user repo:
+  - `skills/first-tree/` — entry-point skill: methodology, references,
+    and routing to the product skills
+  - `skills/tree/` — operational handbook for the `first-tree tree` CLI
+  - `skills/breeze/` — operational handbook for the `first-tree breeze` CLI
+  - `skills/gardener/` — operational handbook for the `first-tree gardener` CLI
+- In this source repo, `.agents/skills/<name>/` and `.claude/skills/<name>/`
+  are tracked symlink aliases back to the four `skills/<name>/` payloads
+  so local agents resolve the same skills the package ships.
+- `npx -p first-tree first-tree <product> <command>` is the recommended
+  one-off entrypoint.
 
 ## Canonical Documentation
 

--- a/docs/maintainer-architecture.md
+++ b/docs/maintainer-architecture.md
@@ -6,28 +6,66 @@ the bound Context Tree.
 This file is source-repo-local. It maps the tree's architectural decisions onto
 the files maintainers edit in this repo.
 
+## Three Products, One Umbrella CLI
+
+`first-tree` is an umbrella CLI that dispatches into three products:
+
+- **`tree`** — Context Tree tooling (inspect / init / bind / verify / publish / upgrade / sync / ...)
+- **`breeze`** — Proposal / inbox daemon with a GitHub notifications statusline
+- **`gardener`** — Automated maintenance agent for tree sync PRs and source-repo review comments
+
+All three live under `src/products/<name>/` and share the same shape. The
+single source of truth for the product set is `src/products/manifest.ts` —
+the umbrella CLI, version reporting, and skill tooling read from there.
+
+## Four Skills
+
+The package ships four skill payloads under `skills/`:
+
+- **`skills/first-tree/`** — the entry-point skill: methodology, references
+  (whitepaper, principles, ownership, onboarding, source-workspace-installation,
+  upgrade-contract), and routing to the three product skills
+- **`skills/tree/`**, **`skills/breeze/`**, **`skills/gardener/`** — one-file
+  operational handbooks (`SKILL.md` + `VERSION`) for each product CLI; no
+  `references/` of their own
+
+Each skill has tracked alias symlinks at `.agents/skills/<name>/` and
+`.claude/skills/<name>/` so local agents discover every skill the package
+ships.
+
 ## Local Responsibility Map
 
 | Path | Local responsibility |
 | --- | --- |
-| `skills/first-tree/` | Canonical tree skill payload that ships verbatim to user repos (installed as `skills/first-tree/`) |
-| `skills/breeze/` | Placeholder for the breeze skill payload (Phase 1+) |
-| `assets/tree/` | Runtime assets for the tree product, installed or refreshed by the CLI |
-| `assets/breeze/` | Placeholder for breeze runtime assets |
-| `src/cli.ts` | Top-level umbrella dispatcher for `first-tree <product> <command>` |
-| `src/products/tree/engine/` | Tree command behavior, binding logic, verification, publish, and sync orchestration |
-| `src/products/tree/cli.ts` | Tree product dispatcher (lazy-loaded from the umbrella CLI) |
-| `src/products/breeze/cli.ts` | Breeze product dispatcher stub (Phase 1+) |
+| `src/cli.ts` | Top-level umbrella dispatcher for `first-tree <product> <command>`; iterates the product manifest |
+| `src/products/manifest.ts` | Single source of truth for the three products; add a new product by adding one entry here |
+| `src/products/tree/` | Tree product root (CLI dispatcher + `VERSION`) |
+| `src/products/tree/engine/` | Tree business logic: `commands/`, `runtime/`, `rules/`, `validators/`, plus `bind.ts`, `init.ts`, `verify.ts`, `publish.ts`, `sync.ts`, `workspace.ts`, `upgrade.ts`, `inspect.ts`, etc. |
+| `src/products/breeze/` | Breeze product: CLI dispatcher + `engine/` (commands, runtime, daemon, bridge, statusline) |
+| `src/products/gardener/` | Gardener product: CLI dispatcher + `engine/` (commands, runtime, comment, respond) |
+| `skills/first-tree/` | Entry-point skill payload that ships verbatim to user repos |
+| `skills/tree/`, `skills/breeze/`, `skills/gardener/` | Per-product operational skill payloads |
+| `assets/tree/` | Runtime assets for the tree product, installed or refreshed by the CLI (templates, workflows, prompts, helpers, examples) |
+| `assets/breeze/dashboard.html` | SSE dashboard served by the breeze daemon HTTP server |
 | `tests/` | Repo-local validation surface |
 | Root package files | Packaging, build, and shell entrypoints |
 
 ## Local Guardrails
 
-- Keep `.agents/skills/first-tree/` and `.claude/skills/first-tree/` as alias
-  symlinks; edit `skills/first-tree/`, not the aliases.
+- Keep `.agents/skills/<name>/` and `.claude/skills/<name>/` as alias
+  symlinks; edit `skills/<name>/`, not the aliases.
+- Product directories must share the same shape: `cli.ts` + `VERSION` at the
+  root, business logic under `engine/` (`commands/`, `runtime/`, and domain
+  subdirectories). Breeze uses `engine/daemon/`; tree uses `engine/rules/`
+  and `engine/validators/`. Do not place business logic at the product root
+  alongside `cli.ts`.
+- Every product must be listed in `src/products/manifest.ts` — `src/cli.ts`
+  iterates the manifest, so a missing entry means the product is invisible
+  to the umbrella.
 - Keep source/workspace repos free of tree content; tree nodes belong in the
   bound Context Tree repo.
 - Treat `source-repos.md` as generated output; tree-side truth still lives in
-  `.first-tree/tree.json` and `.first-tree/bindings/`.
+  `.first-tree/tree.json` and `.first-tree/bindings/`. Source-side truth
+  lives in `.first-tree/source.json` and `.first-tree/local-tree.json`.
 - When the binding schema or install contract changes, update the tree node,
   source docs, code, and tests together.

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -14,7 +14,11 @@ docs below only for source-repo implementation details.
 | `first-tree-skill-cli/build-and-distribution.md` | Packaging and release invariants |
 | `first-tree-skill-cli/validation-surface.md` | Validation philosophy and coverage expectations |
 | `first-tree-skill-cli/sync.md` | Authoritative product/architecture context for `first-tree sync` |
-| `skills/first-tree/SKILL.md` | User-facing tree skill workflow |
+| `src/products/manifest.ts` | Single source of truth for the three products (tree, breeze, gardener) |
+| `skills/first-tree/SKILL.md` | User-facing entry-point skill: methodology + routing to product skills |
+| `skills/tree/SKILL.md` | Operational handbook for the `first-tree tree` CLI |
+| `skills/breeze/SKILL.md` | Operational handbook for the `first-tree breeze` CLI |
+| `skills/gardener/SKILL.md` | Operational handbook for the `first-tree gardener` CLI |
 | `skills/first-tree/references/onboarding.md` | Repo, shared-tree, and workspace onboarding model |
 | `skills/first-tree/references/source-workspace-installation.md` | Binding model and source/workspace contract |
 | `skills/first-tree/references/upgrade-contract.md` | Installed layout and upgrade invariants |
@@ -35,15 +39,19 @@ docs below only for source-repo implementation details.
 | `assets/tree/prompts/` | Review prompt payload |
 | `assets/tree/examples/` | Agent integration examples |
 | `assets/tree/helpers/` | Shipped helper scripts and TS utilities |
-| `assets/breeze/` | Breeze runtime assets (Phase 1+ placeholder) |
+| `assets/breeze/dashboard.html` | SSE dashboard served by the breeze daemon HTTP server |
 
 ## Engine Surface
 
 | Path | Purpose |
 | --- | --- |
-| `src/cli.ts` | Top-level umbrella dispatcher for `first-tree <product> <command>` |
+| `src/cli.ts` | Top-level umbrella dispatcher for `first-tree <product> <command>`; reads from the product manifest |
+| `src/products/manifest.ts` | Product manifest (name, description, lazy entrypoint, auto-upgrade, asset/skill flags) |
 | `src/products/tree/cli.ts` | Tree product dispatcher (lazy-loaded) |
-| `src/products/breeze/cli.ts` | Breeze product dispatcher stub (Phase 1+) |
+| `src/products/breeze/cli.ts` | Breeze product dispatcher (lazy-loaded) |
+| `src/products/gardener/cli.ts` | Gardener product dispatcher (lazy-loaded) |
+| `src/products/breeze/engine/` | Breeze business logic: `commands/`, `runtime/`, `daemon/`, `bridge.ts`, `statusline.ts` |
+| `src/products/gardener/engine/` | Gardener business logic: `commands/`, `runtime/`, `comment.ts`, `respond.ts` |
 | `src/products/tree/engine/init.ts` | High-level onboarding wrapper plus low-level tree bootstrap |
 | `src/products/tree/engine/inspect.ts` | Root classification before onboarding |
 | `src/products/tree/engine/bind.ts` | Binding a source/workspace root to an existing tree |
@@ -76,6 +84,8 @@ docs below only for source-repo implementation details.
 - Keep decision-grade knowledge in the bound Context Tree under
   `first-tree-skill-cli/`.
 - Keep root `README.md` and `AGENTS.md` short and distribution-focused.
-- Keep shipped user knowledge in `skills/first-tree/references/`.
+- Keep shipped user knowledge in `skills/first-tree/references/` (shared
+  across all four skills; individual product skills have no `references/`
+  of their own).
 - Keep runtime metadata changes synchronized across tree nodes, local docs,
   tests, and code.

--- a/tests/skill-artifacts.test.ts
+++ b/tests/skill-artifacts.test.ts
@@ -221,7 +221,7 @@ describe("skill artifacts", () => {
     expect(read("README.md")).toContain("skills/first-tree/");
     expect(read("README.md")).toContain(".agents/skills/first-tree/");
     expect(read("README.md")).toContain(".claude/skills/first-tree/");
-    expect(read("README.md")).toContain("bundled canonical");
+    expect(read("README.md")).toContain("four skill payloads");
     expect(read("README.md")).toContain("dedicated tree repo");
     expect(read("README.md")).toContain("first-tree tree inspect");
     expect(read("README.md")).toContain("first-tree tree bind");
@@ -239,7 +239,7 @@ describe("skill artifacts", () => {
     expect(read("AGENTS.md")).toContain("docs/source-map.md");
     expect(read("AGENTS.md")).toContain("source-workspace-installation.md");
     expect(read("AGENTS.md")).toContain("first-tree-skill-cli/");
-    expect(read("AGENTS.md")).toContain("bundled skill payload path");
+    expect(read("AGENTS.md")).toContain("entry-point skill payload");
     expect(read("AGENTS.md")).not.toContain("### Running evals");
     expect(read("AGENTS.md")).not.toContain("EVALS_TREE_REPO");
     expect(read("src/cli.ts")).not.toContain("from upstream");


### PR DESCRIPTION
## Summary

After the skill restructure and the breeze `engine/` unification, several maintainer-facing documents were out of date:

- `AGENTS.md` still described two products (`tree`, `breeze`) and one skill, and hard-coded `src/products/tree/engine/` as "the canonical tree CLI behavior" with no mention of `gardener` or the manifest.
- `docs/source-map.md` Engine Surface pointed only at `tree` and a `breeze` stub, and did not list the four skill payloads at all.
- `docs/maintainer-architecture.md` still described a two-product layout with breeze as a Phase 1+ placeholder.
- `CONTRIBUTING.md` described "one canonical first-tree skill" when there are now four.
- `README.md`'s Package And Command section did not mention the three products or the four skill payloads.

## What's updated

- Three products (`tree`, `breeze`, `gardener`) with a unified `engine/` shape, dispatched from `src/products/manifest.ts`
- Four skills: `skills/first-tree/` (entry-point, holds shared `references/`) + `skills/tree/`, `skills/breeze/`, `skills/gardener/` (operational handbooks)
- Each skill has matching `.agents/skills/<name>/` and `.claude/skills/<name>/` alias symlinks
- New "Three Products, One Umbrella CLI" section in `maintainer-architecture.md` and a pointer to `manifest.ts` as the single source of truth

Also updates two brittle string assertions in `tests/skill-artifacts.test.ts` so they match the new prose without requiring the old phrasing verbatim.

## Test plan

- [x] `pnpm test` — 866 pass
- [x] `pnpm validate:skill` — passes both `quick_validate.py` and `check-skill-sync.sh`