### PR TITLE
feat(installer): install all four skills, not just first-tree

### DIFF
--- a/src/products/manifest.ts
+++ b/src/products/manifest.ts
@@ -52,7 +52,7 @@ export const PRODUCTS: readonly ProductDefinition[] = [
     },
     autoUpgradeOnInvoke: false,
     hasAssets: true,
-    hasSkill: false,
+    hasSkill: true,
   },
   {
     name: "gardener",
@@ -64,7 +64,7 @@ export const PRODUCTS: readonly ProductDefinition[] = [
     },
     autoUpgradeOnInvoke: false,
     hasAssets: false,
-    hasSkill: false,
+    hasSkill: true,
   },
 ];
 

--- a/src/products/tree/engine/runtime/asset-loader.ts
+++ b/src/products/tree/engine/runtime/asset-loader.ts
@@ -10,6 +10,20 @@ export const BUNDLED_SKILL_ROOT = join("skills", SKILL_NAME);
 export const SKILL_ROOT = join(".agents", "skills", SKILL_NAME);
 export const CLAUDE_SKILL_ROOT = join(".claude", "skills", SKILL_NAME);
 export const INSTALLED_SKILL_ROOTS = [SKILL_ROOT, CLAUDE_SKILL_ROOT] as const;
+
+/**
+ * All four skill payload names shipped by the first-tree package:
+ * the entry-point skill plus one operational skill per product. The
+ * installer copies every one of these into user repos when they exist
+ * in the source package — the entry-point skill is the only one that
+ * must be present; others are installed best-effort if found.
+ */
+export const ALL_SKILL_NAMES = [
+  SKILL_NAME, // entry-point skill (required)
+  "tree",
+  "breeze",
+  "gardener",
+] as const;
 export const INSTALLED_SKILL_REQUIRED_FILES = [
   "SKILL.md",
   "VERSION",

--- a/src/products/tree/engine/runtime/installer.ts
+++ b/src/products/tree/engine/runtime/installer.ts
@@ -12,6 +12,7 @@ import {
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  ALL_SKILL_NAMES,
   BUNDLED_SKILL_ROOT,
   CLAUDE_SKILL_ROOT,
   INSTALLED_SKILL_ROOTS,
@@ -92,12 +93,13 @@ export function readSkillVersion(sourceRoot: string): string {
  */
 export function wipeInstalledSkill(targetRoot: string): string[] {
   const removed: string[] = [];
-  const candidates = [
-    SKILL_ROOT, // .agents/skills/first-tree/
-    CLAUDE_SKILL_ROOT, // .claude/skills/first-tree/
-    LEGACY_REPO_SKILL_ROOT, // skills/first-tree/ (legacy)
-    ".context-tree", // oldest legacy layout
-  ];
+  const candidates: string[] = [];
+  for (const skillName of ALL_SKILL_NAMES) {
+    candidates.push(join(".agents", "skills", skillName));
+    candidates.push(join(".claude", "skills", skillName));
+  }
+  candidates.push(LEGACY_REPO_SKILL_ROOT); // skills/first-tree/ (legacy)
+  candidates.push(".context-tree"); // oldest legacy layout
   for (const relPath of candidates) {
     const fullPath = join(targetRoot, relPath);
     if (existsSync(fullPath) || isSymlink(fullPath)) {
@@ -109,31 +111,66 @@ export function wipeInstalledSkill(targetRoot: string): string[] {
 }
 
 export function copyCanonicalSkill(sourceRoot: string, targetRoot: string): void {
-  const src = resolveCanonicalSkillRoot(sourceRoot);
+  // The entry-point skill (first-tree) is the only one that must exist in
+  // the source package; we fail fast here if it is missing.
+  const primarySrc = resolveCanonicalSkillRoot(sourceRoot);
   const sourceRepoSkillRoot = join(targetRoot, BUNDLED_SKILL_ROOT);
-  const useSourceRepoAliases = resolve(sourceRepoSkillRoot) === resolve(src);
-  for (const relPath of [
-    ...INSTALLED_SKILL_ROOTS,
-    ...(useSourceRepoAliases ? [] : [LEGACY_REPO_SKILL_ROOT]),
-  ]) {
-    const fullPath = join(targetRoot, relPath);
-    if (existsSync(fullPath) || isSymlink(fullPath)) {
-      rmSync(fullPath, { recursive: true, force: true });
+  const useSourceRepoAliases =
+    resolve(sourceRepoSkillRoot) === resolve(primarySrc);
+
+  // Phase 1: wipe previously installed skill roots (and the legacy
+  // vendored copy if we're not running inside the source repo). This
+  // covers every skill name, not just the entry-point — otherwise an
+  // upgrade from a pre-multi-skill install would leave orphaned copies
+  // of the old per-product skills around.
+  for (const skillName of ALL_SKILL_NAMES) {
+    const agentsPath = join(targetRoot, ".agents", "skills", skillName);
+    const claudePath = join(targetRoot, ".claude", "skills", skillName);
+    for (const fullPath of [agentsPath, claudePath]) {
+      if (existsSync(fullPath) || isSymlink(fullPath)) {
+        rmSync(fullPath, { recursive: true, force: true });
+      }
     }
   }
-  const primaryDst = join(targetRoot, SKILL_ROOT);
-  mkdirSync(dirname(primaryDst), { recursive: true });
-  if (useSourceRepoAliases) {
-    const relTarget = relative(dirname(primaryDst), src);
-    symlinkSync(relTarget, primaryDst);
-  } else {
-    cpSync(src, primaryDst, { recursive: true });
+  if (!useSourceRepoAliases) {
+    const legacyPath = join(targetRoot, LEGACY_REPO_SKILL_ROOT);
+    if (existsSync(legacyPath) || isSymlink(legacyPath)) {
+      rmSync(legacyPath, { recursive: true, force: true });
+    }
   }
 
-  const symlinkDst = join(targetRoot, CLAUDE_SKILL_ROOT);
-  mkdirSync(dirname(symlinkDst), { recursive: true });
-  const relTarget = relative(dirname(symlinkDst), primaryDst);
-  symlinkSync(relTarget, symlinkDst);
+  // Phase 2: install every skill the source package ships. The
+  // entry-point skill is required; per-product skills are installed
+  // best-effort so test fixtures and older source packages that ship
+  // only the entry-point skill continue to work.
+  for (const skillName of ALL_SKILL_NAMES) {
+    const skillSrc =
+      skillName === "first-tree"
+        ? primarySrc
+        : join(sourceRoot, "skills", skillName);
+    if (!existsSync(join(skillSrc, "SKILL.md"))) {
+      if (skillName === "first-tree") {
+        throw new Error(
+          `Canonical skill not found under ${sourceRoot}. Reinstall the \`first-tree\` package and try again.`,
+        );
+      }
+      continue;
+    }
+
+    const primaryDst = join(targetRoot, ".agents", "skills", skillName);
+    mkdirSync(dirname(primaryDst), { recursive: true });
+    if (useSourceRepoAliases) {
+      const relTarget = relative(dirname(primaryDst), skillSrc);
+      symlinkSync(relTarget, primaryDst);
+    } else {
+      cpSync(skillSrc, primaryDst, { recursive: true });
+    }
+
+    const symlinkDst = join(targetRoot, ".claude", "skills", skillName);
+    mkdirSync(dirname(symlinkDst), { recursive: true });
+    const relTarget = relative(dirname(symlinkDst), primaryDst);
+    symlinkSync(relTarget, symlinkDst);
+  }
 }
 
 function isSymlink(path: string): boolean {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -222,6 +222,24 @@ export function makeSourceSkill(root: string, version = "0.2.0"): void {
   );
 }
 
+/**
+ * Seed the three per-product skill payloads (tree, breeze, gardener) at
+ * the source-package-relative layout the installer expects. `makeSourceSkill`
+ * only creates the first-tree entry-point skill; call this in addition when
+ * a test needs the full four-skill install to succeed.
+ */
+export function makeProductSkills(root: string, version = "0.2.0"): void {
+  for (const name of ["tree", "breeze", "gardener"] as const) {
+    const dir = join(root, "skills", name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "SKILL.md"),
+      `---\nname: ${name}\ndescription: test stub for ${name}\n---\n`,
+    );
+    writeFileSync(join(dir, "VERSION"), `${version}\n`);
+  }
+}
+
 export function makeNode(
   root: string,
   opts?: { placeholder?: boolean },

--- a/tests/upgrade.test.ts
+++ b/tests/upgrade.test.ts
@@ -35,6 +35,7 @@ import {
   makeSourceRepo,
   makeLegacyFramework,
   makeLegacyRepoFramework,
+  makeProductSkills,
   makeSourceSkill,
   makeTreeMetadata,
   useTmpDir,
@@ -202,6 +203,45 @@ describe("runUpgrade", () => {
       "../../.agents/skills/first-tree",
     );
     expect(readFileSync(join(repoDir.path, INSTALLED_SKILL_VERSION), "utf-8").trim()).toBe("0.2.0");
+  });
+
+  it("installs all four skill payloads into a user repo when the source ships them", () => {
+    const repoDir = useTmpDir();
+    const sourceDir = useTmpDir();
+    makeSourceSkill(sourceDir.path, "0.2.0");
+    makeProductSkills(sourceDir.path, "0.2.0");
+
+    copyCanonicalSkill(sourceDir.path, repoDir.path);
+
+    for (const name of ["first-tree", "tree", "breeze", "gardener"]) {
+      expect(
+        existsSync(join(repoDir.path, ".agents", "skills", name, "SKILL.md")),
+      ).toBe(true);
+      expect(
+        lstatSync(join(repoDir.path, ".claude", "skills", name)).isSymbolicLink(),
+      ).toBe(true);
+      expect(
+        readlinkSync(join(repoDir.path, ".claude", "skills", name)),
+      ).toBe(join("..", "..", ".agents", "skills", name));
+    }
+  });
+
+  it("still installs when only the entry-point skill is available in the source package", () => {
+    const repoDir = useTmpDir();
+    const sourceDir = useTmpDir();
+    makeSourceSkill(sourceDir.path, "0.2.0");
+    // Deliberately skip makeProductSkills() — source has only first-tree.
+
+    copyCanonicalSkill(sourceDir.path, repoDir.path);
+
+    expect(
+      existsSync(join(repoDir.path, ".agents", "skills", "first-tree", "SKILL.md")),
+    ).toBe(true);
+    for (const name of ["tree", "breeze", "gardener"]) {
+      expect(
+        existsSync(join(repoDir.path, ".agents", "skills", name)),
+      ).toBe(false);
+    }
   });
 
   it("refreshes a dedicated tree repo and installs the tree-repo skill", () => {


### PR DESCRIPTION
## Summary

Before this PR, `copyCanonicalSkill` (called from `tree init/bind/upgrade`) only installed the `first-tree` entry-point skill into user repos. After the skill restructure (#148–#151) the package ships four skills, but running `first-tree tree init` only installed one of them — users had no path to discover or keep fresh the `tree`/`breeze`/`gardener` skills.

This PR closes that gap: the installer now installs every skill the source package ships into both `.agents/skills/<name>/` and `.claude/skills/<name>/`.

## Behavior

- Installed to user repos:
  ```
  .agents/skills/{first-tree,tree,breeze,gardener}/   (payload)
  .claude/skills/{first-tree,tree,breeze,gardener}/   (symlink)
  ```
- The `first-tree` entry-point skill is required — missing it still fails fast with the same error as before.
- The three per-product skills are installed **best-effort**, so test fixtures and older source packages that ship only the entry-point skill continue to work without changes.
- `wipeInstalledSkill` is extended to the same four-skill set so upgrade flows do not leave orphaned skill copies around.

## Other changes

- `src/products/manifest.ts` — set `hasSkill: true` on `breeze` and `gardener` (they now have skill payloads).
- `src/products/tree/engine/runtime/asset-loader.ts` — new `ALL_SKILL_NAMES` constant as the single source of truth for the installer's skill list.
- `tests/helpers.ts` — new `makeProductSkills()` helper that seeds the three per-product skill stubs for tests that need the full four-skill install to succeed.
- `tests/upgrade.test.ts` — new cases covering "all four skills" and "entry-point skill only" install paths.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` — 868 pass (866 existing + 2 new)
- [x] `pnpm build` — clean
- [x] `pnpm validate:skill` — passes `quick_validate.py` and `check-skill-sync.sh`