### PR TITLE
chore(breeze): port install command to TS and sweep stale path refs

### DIFF
--- a/src/products/breeze/cli.ts
+++ b/src/products/breeze/cli.ts
@@ -57,10 +57,6 @@ Environment:
 
 type Output = (text: string) => void;
 
-type SetupTarget = {
-  kind: "setup";
-};
-
 type TsTarget = {
   kind: "ts";
   /** The node:module specifier to `await import()`. */
@@ -72,7 +68,8 @@ type TsTarget = {
     | "status"
     | "cleanup"
     | "start"
-    | "stop";
+    | "stop"
+    | "install";
 };
 
 type StatuslineTarget = {
@@ -85,10 +82,10 @@ type DaemonTarget = {
   once: boolean;
 };
 
-type Target = SetupTarget | TsTarget | StatuslineTarget | DaemonTarget;
+type Target = TsTarget | StatuslineTarget | DaemonTarget;
 
 const DISPATCH: Record<string, Target> = {
-  install: { kind: "setup" },
+  install: { kind: "ts", specifier: "install" },
 
   // Foreground loops — all TS-backed.
   run: { kind: "daemon", once: false },
@@ -160,11 +157,6 @@ export async function runBreeze(
 
   try {
     switch (target.kind) {
-      case "setup": {
-        const bridge = await import("./engine/bridge.js");
-        const setupPath = bridge.resolveBreezeSetupScript();
-        return bridge.spawnInherit("bash", [setupPath, ...rest]);
-      }
       case "ts": {
         // Lazy-import the TS command so startup stays cheap for workflows
         // that never touch the ported commands.
@@ -199,6 +191,10 @@ export async function runBreeze(
         if (target.specifier === "stop") {
           const mod = await import("./engine/commands/stop.js");
           return await mod.runStop(rest);
+        }
+        if (target.specifier === "install") {
+          const mod = await import("./engine/commands/install.js");
+          return mod.runInstall(rest);
         }
         // Exhaustiveness check.
         const _never: never = target.specifier;

--- a/src/products/breeze/engine/bridge.ts
+++ b/src/products/breeze/engine/bridge.ts
@@ -1,13 +1,9 @@
 /**
  * Thin process-spawn helpers used by the breeze CLI.
  *
- * Phase 8 retired the `breeze-runner` Rust binary and its resolution
- * helpers. What remains:
+ * What remains after the Rust daemon and bash setup script were retired:
  *   - `resolveFirstTreePackageRoot` — locate the npm package root so
- *     callers can find bundled assets (statusline dist bundle, setup
- *     script).
- *   - `resolveBreezeSetupScript` — path to the `first-tree-breeze/setup`
- *     bash installer (still wrapped as `first-tree breeze install`).
+ *     callers can find bundled assets (the statusline dist bundle).
  *   - `spawnInherit` — synchronous spawn with inherited stdio.
  */
 
@@ -19,8 +15,6 @@ import {
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-
-export type FileExistsFn = (path: string) => boolean;
 
 /**
  * Walk up from the current module until we find the npm package root
@@ -57,24 +51,6 @@ export function resolveFirstTreePackageRoot(
     }
     dir = parent;
   }
-}
-
-/**
- * Resolve the breeze setup script bundled under
- * `first-tree-breeze/setup`. Still a bash script.
- */
-export function resolveBreezeSetupScript(
-  deps: { packageRoot?: string; fileExists?: FileExistsFn } = {},
-): string {
-  const fileExists = deps.fileExists ?? existsSync;
-  const packageRoot = deps.packageRoot ?? resolveFirstTreePackageRoot();
-  const candidate = join(packageRoot, "first-tree-breeze", "setup");
-  if (!fileExists(candidate)) {
-    throw new Error(
-      `breeze setup script not found at ${candidate}. The \`first-tree-breeze/\` source directory is missing; reinstall or check out the repo source.`,
-    );
-  }
-  return candidate;
 }
 
 export type SpawnFn = (

--- a/src/products/breeze/engine/commands/doctor.ts
+++ b/src/products/breeze/engine/commands/doctor.ts
@@ -1,6 +1,6 @@
 /**
  * TS port of `Service::doctor` in
- * `first-tree-breeze/breeze-runner/src/service.rs:107-143`.
+ * `service.rs:107-143`.
  *
  * Prints a one-screen diagnostic of the daemon's local environment.
  * Designed for `first-tree breeze doctor` — no subprocesses the user

--- a/src/products/breeze/engine/commands/install.ts
+++ b/src/products/breeze/engine/commands/install.ts
@@ -1,0 +1,125 @@
+/**
+ * `first-tree breeze install` — first-run setup for the breeze daemon.
+ *
+ * Creates `~/.breeze/config.yaml` with defaults (if absent) and hands
+ * off daemon startup to `first-tree breeze start`.
+ *
+ * The pre-Phase-9 bash installer also symlinked three standalone skills
+ * into `~/.claude/skills`. That step is obsolete: the four first-tree
+ * skills now install into the caller's repo via `first-tree tree init`
+ * / `bind` / `upgrade` and do not require a separate machine-wide
+ * symlink step.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const DEFAULT_CONFIG = `# breeze configuration
+poll_interval_sec: 60
+task_timeout_sec: 1800
+log_level: info
+http_port: 7878
+host: github.com
+`;
+
+export interface InstallDeps {
+  breezeDir?: string;
+  write?: (text: string) => void;
+  spawn?: typeof spawnSync;
+  checkCommand?: (cmd: string) => boolean;
+  checkGhAuth?: () => boolean;
+}
+
+function defaultCheckCommand(cmd: string): boolean {
+  const result = spawnSync("command", ["-v", cmd], {
+    shell: true,
+    stdio: "ignore",
+  });
+  return result.status === 0;
+}
+
+function defaultCheckGhAuth(): boolean {
+  const result = spawnSync("gh", ["auth", "status"], { stdio: "ignore" });
+  return result.status === 0;
+}
+
+export function runInstall(
+  args: readonly string[],
+  deps: InstallDeps = {},
+): number {
+  if (args.length > 0 && (args[0] === "--help" || args[0] === "-h")) {
+    (deps.write ?? console.log)(`usage: first-tree breeze install
+
+  Bootstraps the local breeze daemon:
+
+    1. Checks for gh, jq, and gh auth status
+    2. Creates \`~/.breeze/config.yaml\` with defaults (if absent)
+    3. Starts the daemon via \`first-tree breeze start\`
+
+  Environment:
+    BREEZE_DIR            Override \`~/.breeze\` (store root)
+`);
+    return 0;
+  }
+
+  const write = deps.write ?? ((text: string) => process.stdout.write(text + "\n"));
+  const checkCommand = deps.checkCommand ?? defaultCheckCommand;
+  const checkGhAuth = deps.checkGhAuth ?? defaultCheckGhAuth;
+  const spawn = deps.spawn ?? spawnSync;
+  const breezeDir =
+    deps.breezeDir ?? process.env.BREEZE_DIR ?? join(homedir(), ".breeze");
+
+  write("=== breeze setup ===");
+  write("");
+  write("Checking prerequisites...");
+
+  if (!checkCommand("gh")) {
+    write("ERROR: gh CLI is not installed. Install it: https://cli.github.com/");
+    return 1;
+  }
+  if (!checkGhAuth()) {
+    write("ERROR: gh is not authenticated. Run `gh auth login` first.");
+    return 1;
+  }
+  if (!checkCommand("jq")) {
+    write(
+      "ERROR: jq is not installed. Install it: brew install jq (macOS) or apt install jq (Linux)",
+    );
+    return 1;
+  }
+  write("  gh CLI: OK");
+  write("  gh auth: OK");
+  write("  jq: OK");
+  write("");
+
+  write(`Setting up ${breezeDir}...`);
+  mkdirSync(breezeDir, { recursive: true });
+  const configPath = join(breezeDir, "config.yaml");
+  if (existsSync(configPath)) {
+    write(`  Config already exists at ${configPath}`);
+  } else {
+    writeFileSync(configPath, DEFAULT_CONFIG);
+    write(`  Created default config at ${configPath}`);
+  }
+  write("");
+
+  write("Starting the breeze daemon...");
+  const result = spawn("first-tree", ["breeze", "start"], { stdio: "inherit" });
+  if (result.status === 0) {
+    write("  Daemon started");
+  } else {
+    write("  WARN: daemon start failed; run `first-tree breeze start` manually");
+  }
+  write("");
+
+  write("=== breeze setup complete ===");
+  write("");
+  write("  Dashboard:  http://127.0.0.1:7878");
+  write("  Status:     first-tree breeze status");
+  write("  Stop:       first-tree breeze stop");
+  write("  Inspect:    first-tree breeze doctor");
+
+  return 0;
+}

--- a/src/products/breeze/engine/commands/poll.ts
+++ b/src/products/breeze/engine/commands/poll.ts
@@ -1,5 +1,5 @@
 /**
- * TS port of `first-tree-breeze/bin/breeze-poll`.
+ * TS port of `breeze-poll`.
  *
  * One-shot poll of GitHub notifications. Fetches the user's notifications
  * via `gh api`, enriches each PR/Issue with labels + state via a batched
@@ -7,16 +7,16 @@
  * and appends `new` / `transition` events to `activity.log`.
  *
  * Reuses the shared core modules:
- *   - `core/gh.ts`        : `gh` subprocess wrapper
- *   - `core/classifier.ts`: label → status derivation
- *   - `core/store.ts`     : atomic inbox writer under advisory lock
- *   - `core/activity-log.ts`: append-only JSONL writer
- *   - `core/paths.ts`     : `$BREEZE_DIR` layout
+ *   - `runtime/gh.ts`        : `gh` subprocess wrapper
+ *   - `runtime/classifier.ts`: label → status derivation
+ *   - `runtime/store.ts`     : atomic inbox writer under advisory lock
+ *   - `runtime/activity-log.ts`: append-only JSONL writer
+ *   - `runtime/paths.ts`     : `$BREEZE_DIR` layout
  *
  * Spec references:
  *   - `docs/migration/02-inbox-store-schema.md` §1 (inbox) and §2 (activity)
  *   - `docs/migration/03-status-state-machine.md` (classifier precedence)
- *   - Rust parity: `first-tree-breeze/breeze-runner/src/fetcher.rs::poll_once`
+ *   - Rust parity: `fetcher.rs::poll_once`
  *
  * Differences vs. the bash script:
  *   - No `.poll.pid` lockfile — we rely on `updateInbox`'s advisory lock.

--- a/src/products/breeze/engine/commands/status-manager.ts
+++ b/src/products/breeze/engine/commands/status-manager.ts
@@ -1,5 +1,5 @@
 /**
- * TS port of `first-tree-breeze/bin/breeze-status-manager`.
+ * TS port of `breeze-status-manager`.
  *
  * Surface mirrors the bash script exactly — same stdout, stderr, and
  * exit codes for every documented usage. Differences versus bash are

--- a/src/products/breeze/engine/commands/watch.tsx
+++ b/src/products/breeze/engine/commands/watch.tsx
@@ -1,5 +1,5 @@
 /**
- * TS port of `first-tree-breeze/bin/breeze-watch` + `WATCH_DESIGN.md`.
+ * TS port of `breeze-watch` + `WATCH_DESIGN.md`.
  *
  * A read-only TUI board rendered with `ink` (React-for-terminals):
  *   - header: "breeze status board" + status-count summary

--- a/src/products/breeze/engine/daemon/broker.ts
+++ b/src/products/breeze/engine/daemon/broker.ts
@@ -1,7 +1,7 @@
 /**
  * Phase 3c: cross-process `gh` broker for the TypeScript breeze daemon.
  *
- * Port of `first-tree-breeze/breeze-runner/src/broker.rs`.
+ * Port of `broker.rs`.
  *
  * Purpose
  * -------

--- a/src/products/breeze/engine/daemon/bus.ts
+++ b/src/products/breeze/engine/daemon/bus.ts
@@ -1,7 +1,7 @@
 /**
  * Phase 3c: in-process event bus for the TypeScript breeze daemon.
  *
- * Port of `first-tree-breeze/breeze-runner/src/bus.rs`.
+ * Port of `bus.rs`.
  *
  * SINGLE-WRITER RULE (spec doc 2 §1.3):
  * -------------------------------------

--- a/src/products/breeze/engine/daemon/claim.ts
+++ b/src/products/breeze/engine/daemon/claim.ts
@@ -2,7 +2,7 @@
  * Phase 3c: service-wide lock + per-notification claim helpers for the
  * TypeScript breeze daemon.
  *
- * Port of `first-tree-breeze/breeze-runner/src/lock.rs`.
+ * Port of `lock.rs`.
  *
  * SINGLE-WRITER RULE (spec doc 2 §1.3):
  * -------------------------------------
@@ -50,7 +50,7 @@ export const LOCK_STALE_AFTER_SEC = 20 * 60;
 
 /**
  * Per-notification claim staleness. Mirrors `CLAIM_TIMEOUT_SECS` in
- * `core/config.ts` (5 minutes) so the daemon and the skill agree on
+ * `runtime/config.ts` (5 minutes) so the daemon and the skill agree on
  * when a claim can be reassigned.
  */
 export const CLAIM_STALE_AFTER_SEC = 5 * 60;

--- a/src/products/breeze/engine/daemon/dispatcher.ts
+++ b/src/products/breeze/engine/daemon/dispatcher.ts
@@ -2,7 +2,7 @@
  * Phase 3c: task dispatcher.
  *
  * Port of the dispatch loop in
- * `first-tree-breeze/breeze-runner/src/service.rs::run_loop` +
+ * `service.rs::run_loop` +
  * `dispatch_pending` + `handle_completion`.
  *
  * Role:

--- a/src/products/breeze/engine/daemon/gh-client.ts
+++ b/src/products/breeze/engine/daemon/gh-client.ts
@@ -1,5 +1,5 @@
 /**
- * Phase 4: TS port of `first-tree-breeze/breeze-runner/src/gh.rs`.
+ * Phase 4: TS port of `gh.rs`.
  *
  * `GhClient` wraps a `GhExecutor` with the GitHub-specific query set
  * (notifications, review requests, assigned issues/PRs) and the

--- a/src/products/breeze/engine/daemon/gh-executor.ts
+++ b/src/products/breeze/engine/daemon/gh-executor.ts
@@ -1,7 +1,7 @@
 /**
  * Phase 3c: `gh` command executor with rate-limit throttling.
  *
- * Port of `first-tree-breeze/breeze-runner/src/gh_executor.rs`.
+ * Port of `gh_executor.rs`.
  *
  * This is the low-level `gh` runner used by the broker. It does two
  * things:

--- a/src/products/breeze/engine/daemon/http.ts
+++ b/src/products/breeze/engine/daemon/http.ts
@@ -1,12 +1,12 @@
 /**
  * Phase 3b: TypeScript port of the breeze daemon HTTP + SSE server.
  *
- * Source of truth: `first-tree-breeze/breeze-runner/src/http.rs` (384
+ * Source of truth: `http.rs` (384
  * lines). Contract pinned in `docs/migration/01-http-api-contract.md`.
  *
  * READ-ONLY DISCIPLINE:
  * ---------------------
- * This module NEVER calls `core/store.ts` writers. The HTTP server is
+ * This module NEVER calls `runtime/store.ts` writers. The HTTP server is
  * strictly a reader: it passes through `~/.breeze/inbox.json`, tails
  * `~/.breeze/activity.log`, and publishes SSE events produced by an
  * upstream bus. The single-writer rule for `inbox.json` (spec doc 2

--- a/src/products/breeze/engine/daemon/identity.ts
+++ b/src/products/breeze/engine/daemon/identity.ts
@@ -1,7 +1,7 @@
 /**
  * Daemon-level identity resolver.
  *
- * TS port of `first-tree-breeze/breeze-runner/src/identity.rs`.
+ * TS port of `identity.rs`.
  *
  * The daemon needs a richer identity than the one-shot commands:
  *   - `host`  — GitHub host (default `github.com`)
@@ -13,7 +13,7 @@
  *     lock directory (`~/.breeze/runner/locks/<lockKey>/`). Phase 3c
  *     consumes this; we produce it now so identity is stable.
  *
- * Caching: delegates to `core/identity-cache.ts`'s 24h-TTL JSON file at
+ * Caching: delegates to `runtime/identity-cache.ts`'s 24h-TTL JSON file at
  * `~/.breeze/identity.json`. The core cache only stores `{login, host,
  * fetched_at_ms}` because one-shot callers don't need scopes. The
  * daemon fetches the richer payload via `gh auth status --json hosts`

--- a/src/products/breeze/engine/daemon/launchd.ts
+++ b/src/products/breeze/engine/daemon/launchd.ts
@@ -5,7 +5,7 @@
  * `launchd_plist_contents`, `launchd_label`, `launchd_domain`,
  * `passthrough_launchd_env_vars`, `resolve_launchd_env_var`, and
  * `escape_xml` helpers from
- * `first-tree-breeze/breeze-runner/src/service.rs`.
+ * `service.rs`.
  *
  * Linux / Windows are intentional no-ops — callers should fall back to
  * a `nohup` spawn via `spawn(...)` with `detached: true` when

--- a/src/products/breeze/engine/daemon/poller.ts
+++ b/src/products/breeze/engine/daemon/poller.ts
@@ -1,6 +1,6 @@
 /**
  * TypeScript port of the Rust breeze daemon's notification poller
- * (`first-tree-breeze/breeze-runner/src/fetcher.rs`, ~981 lines).
+ * (`fetcher.rs`, ~981 lines).
  *
  * SINGLE-WRITER RULE (spec doc 2 §1.3, matches core/store.ts):
  * -------------------------------------------------------------
@@ -9,7 +9,7 @@
  * bus (Phase 3b/3c) are read-only with respect to the inbox.
  *
  * The on-disk format is bit-compatible with the Rust fetcher:
- * `core/store.ts` emits the same key order as `entry_to_json`, uses JSON
+ * `runtime/store.ts` emits the same key order as `entry_to_json`, uses JSON
  * `null` for nullable fields, and writes via atomic tmp+rename.
  *
  * Throttling (ported 1:1 from `gh_executor.rs`):

--- a/src/products/breeze/engine/daemon/runner.ts
+++ b/src/products/breeze/engine/daemon/runner.ts
@@ -1,7 +1,7 @@
 /**
  * Phase 3c: per-task agent runner.
  *
- * Port of `first-tree-breeze/breeze-runner/src/runner.rs`.
+ * Port of `runner.rs`.
  *
  * Each dispatched task picks one or more runner specs from the pool,
  * builds a prompt, writes it to `<task-dir>/prompt.txt`, and execs the
@@ -16,7 +16,7 @@
  *
  * Phase 3c adds a per-task timeout (spec doc 4 §11, §8). Rust's
  * runner had no timeout; the TS version always enforces one, with a
- * default in `core/config.ts::DAEMON_CONFIG_DEFAULTS.taskTimeoutSec`.
+ * default in `runtime/config.ts::DAEMON_CONFIG_DEFAULTS.taskTimeoutSec`.
  */
 
 import {

--- a/src/products/breeze/engine/daemon/scheduler.ts
+++ b/src/products/breeze/engine/daemon/scheduler.ts
@@ -1,7 +1,7 @@
 /**
  * Phase 5: the per-thread state machine that sits between the candidate
  * loop and the dispatcher. Mirrors the logic in
- * `first-tree-breeze/breeze-runner/src/service.rs`:
+ * `service.rs`:
  *   - `should_schedule`        — gate on ThreadRecord retry/backoff
  *   - `handle_completion`      — persist ThreadRecord + task.env updates
  *   - `record_setup_failure`   — workspace failures bump the retry counter

--- a/src/products/breeze/engine/daemon/sse.ts
+++ b/src/products/breeze/engine/daemon/sse.ts
@@ -2,7 +2,7 @@
  * SSE framing + stream helper for the Phase 3b daemon HTTP server.
  *
  * Byte-level parity with the Rust `send_sse` in
- * `first-tree-breeze/breeze-runner/src/http.rs:310-332` is a hard
+ * `http.rs:310-332` is a hard
  * requirement of Phase 3b. Any drift here leaks into the dashboard's
  * `EventSource` parsing.
  *
@@ -32,7 +32,7 @@
  * Keep-alive cadence: 15s of idle emits `: ping\n\n`, matching
  * `http.rs:282`.
  *
- * READ-ONLY MODULE: this file never touches `core/store.ts` writers.
+ * READ-ONLY MODULE: this file never touches `runtime/store.ts` writers.
  * The bus stub (`subscribeToInboxMtime`) is Phase 3b scaffolding —
  * Phase 3c replaces it with the real in-process `Bus`.
  */

--- a/src/products/breeze/engine/daemon/thread-store.ts
+++ b/src/products/breeze/engine/daemon/thread-store.ts
@@ -2,7 +2,7 @@
  * Phase 5: daemon-private persistence for thread records + task metadata.
  *
  * Port of the relevant parts of
- * `first-tree-breeze/breeze-runner/src/store.rs`:
+ * `store.rs`:
  *   - `thread_path`, `load_thread_record`, `save_thread_record`
  *   - `task_dir`, `write_task_metadata`, `read_task_metadata`,
  *     `list_task_metadata`

--- a/src/products/breeze/engine/daemon/workspace.ts
+++ b/src/products/breeze/engine/daemon/workspace.ts
@@ -1,7 +1,7 @@
 /**
  * Phase 3c: workspace manager for agent task execution.
  *
- * Port of `first-tree-breeze/breeze-runner/src/workspace.rs`.
+ * Port of `workspace.rs`.
  *
  * Each dispatched task gets a detached-HEAD git worktree at
  * `<workspacesDir>/<slug>/<kind>-<stableId>`, backed by a bare mirror

--- a/src/products/breeze/engine/runtime/classifier.ts
+++ b/src/products/breeze/engine/runtime/classifier.ts
@@ -2,7 +2,7 @@
  * Pure derivation of `breeze_status` from GitHub labels + PR/issue state.
  *
  * TS port of `compute_breeze_status` in
- * `first-tree-breeze/breeze-runner/src/fetcher.rs:353-368`.
+ * `fetcher.rs:353-368`.
  *
  * Spec: `docs/migration/03-status-state-machine.md` §2.
  *

--- a/src/products/breeze/engine/runtime/repo-filter.ts
+++ b/src/products/breeze/engine/runtime/repo-filter.ts
@@ -1,6 +1,6 @@
 /**
  * TS port of `RepoFilter` from
- * `first-tree-breeze/breeze-runner/src/config.rs:39-114`.
+ * `config.rs:39-114`.
  *
  * Allow-list with two shapes:
  *   - `owner/repo`  → exact match

--- a/src/products/breeze/engine/runtime/store.ts
+++ b/src/products/breeze/engine/runtime/store.ts
@@ -20,7 +20,7 @@
  *
  * Atomicity: write-to-`.tmp` + `rename` — POSIX rename is atomic w.r.t.
  * concurrent readers, matching `write_inbox` in
- * `first-tree-breeze/breeze-runner/src/fetcher.rs:583-599`.
+ * `fetcher.rs:583-599`.
  *
  * Format compatibility: encoder emits every key for every entry in the
  * order the Rust `entry_to_json` does (fetcher.rs:601-631), using JSON

--- a/src/products/breeze/engine/runtime/task-kind.ts
+++ b/src/products/breeze/engine/runtime/task-kind.ts
@@ -1,5 +1,5 @@
 /**
- * TS port of `first-tree-breeze/breeze-runner/src/classify.rs`.
+ * TS port of `classify.rs`.
  *
  * `TaskKind` classifies a GitHub notification subject + reason into the
  * breeze task taxonomy. `priority_for` returns the dispatcher priority;

--- a/src/products/breeze/engine/runtime/task-util.ts
+++ b/src/products/breeze/engine/runtime/task-util.ts
@@ -1,6 +1,6 @@
 /**
  * TS port of the string / id / timestamp helpers in
- * `first-tree-breeze/breeze-runner/src/util.rs`.
+ * `util.rs`.
  *
  * Ported functions:
  *   - `fnv1a64` + `stable_file_id`    — deterministic 16-hex-char id

--- a/src/products/breeze/engine/runtime/task.ts
+++ b/src/products/breeze/engine/runtime/task.ts
@@ -1,5 +1,5 @@
 /**
- * TS port of `first-tree-breeze/breeze-runner/src/task.rs`.
+ * TS port of `task.rs`.
  *
  * `TaskCandidate` is the canonical shape produced by the notification
  * poll / search path and consumed by the dispatcher. `ThreadRecord`

--- a/src/products/breeze/engine/runtime/types.ts
+++ b/src/products/breeze/engine/runtime/types.ts
@@ -24,7 +24,7 @@ export type GhState = z.infer<typeof GhStateSchema>;
 
 /**
  * Single inbox entry. Matches `entry_to_json` in
- * `first-tree-breeze/breeze-runner/src/fetcher.rs:601-631`.
+ * `fetcher.rs:601-631`.
  *
  * The encoder never omits keys; nullable fields are emitted as JSON `null`.
  */

--- a/src/products/breeze/engine/statusline.ts
+++ b/src/products/breeze/engine/statusline.ts
@@ -9,7 +9,7 @@
  *   - hand-rolled field extraction so we never parse the whole inbox
  *     (common case: a few hundred notifications)
  *
- * Behaviour is a line-for-line port of `first-tree-breeze/bin/breeze-status`
+ * Behaviour is a line-for-line port of `breeze-status`
  * +  `breeze-statusline-wrapper` (the wrapper just passes stdin through and
  * prints our output). Stdin is drained silently per the Claude Code
  * statusline contract.

--- a/tests/breeze-bridge.test.ts
+++ b/tests/breeze-bridge.test.ts
@@ -1,37 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
 import {
-  resolveBreezeSetupScript,
   resolveFirstTreePackageRoot,
   spawnInherit,
   type SpawnFn,
 } from "../src/products/breeze/engine/bridge.js";
-import { join } from "node:path";
 
 describe("resolveFirstTreePackageRoot", () => {
   it("returns a directory that contains the first-tree package.json", () => {
     const root = resolveFirstTreePackageRoot();
     expect(typeof root).toBe("string");
     expect(root.length).toBeGreaterThan(0);
-  });
-});
-
-describe("resolveBreezeSetupScript", () => {
-  it("throws a helpful error when the setup script is missing", () => {
-    expect(() =>
-      resolveBreezeSetupScript({
-        packageRoot: "/nowhere",
-        fileExists: () => false,
-      }),
-    ).toThrow(/breeze setup script not found/);
-  });
-
-  it("returns the path when the script is present", () => {
-    const path = resolveBreezeSetupScript({
-      packageRoot: "/pkg",
-      fileExists: (candidate: string): boolean =>
-        candidate === join("/pkg", "first-tree-breeze", "setup"),
-    });
-    expect(path).toBe(join("/pkg", "first-tree-breeze", "setup"));
   });
 });
 

--- a/tests/breeze-cli.test.ts
+++ b/tests/breeze-cli.test.ts
@@ -115,7 +115,6 @@ describe("runBreeze dispatcher", () => {
       resolveBundledBreezeScript: vi.fn(() => {
         throw new Error("statusline must not route through bundled scripts");
       }),
-      resolveBreezeSetupScript: vi.fn(),
       resolveFirstTreePackageRoot: resolvePackageRootSpy,
       spawnInherit: spawnSpy,
     }));
@@ -132,27 +131,20 @@ describe("runBreeze dispatcher", () => {
     ]);
   });
 
-  it("routes install through bash + resolveBreezeSetupScript", async () => {
-    const spawnSpy = vi.fn().mockReturnValue(0);
-    const resolveSetupSpy = vi.fn().mockReturnValue("/pkg/first-tree-breeze/setup");
-
-    vi.doMock("../src/products/breeze/engine/bridge.js", () => ({
-      resolveBreezeRunner: vi.fn(),
-      resolveBundledBreezeScript: vi.fn(),
-      resolveBreezeSetupScript: resolveSetupSpy,
-      resolveFirstTreePackageRoot: vi.fn(() => "/pkg"),
-      spawnInherit: spawnSpy,
-    }));
+  it("routes install through the TS install command", async () => {
+    const runInstallSpy = vi.fn().mockReturnValue(0);
+    vi.doMock(
+      "../src/products/breeze/engine/commands/install.js",
+      () => ({ runInstall: runInstallSpy }),
+    );
 
     const { runBreeze: freshRun } = await import(
       "../src/products/breeze/cli.js"
     );
 
-    await freshRun(["install"], () => {});
-    expect(resolveSetupSpy).toHaveBeenCalled();
-    expect(spawnSpy).toHaveBeenCalledWith("bash", [
-      "/pkg/first-tree-breeze/setup",
-    ]);
+    const code = await freshRun(["install"], () => {});
+    expect(code).toBe(0);
+    expect(runInstallSpy).toHaveBeenCalledWith([]);
   });
 
   it("routes poll through the TS port (not the runner)", async () => {
@@ -161,7 +153,6 @@ describe("runBreeze dispatcher", () => {
         throw new Error("poll must not route through the runner bridge");
       }),
       resolveBundledBreezeScript: vi.fn(),
-      resolveBreezeSetupScript: vi.fn(),
       resolveFirstTreePackageRoot: vi.fn(() => "/pkg"),
       spawnInherit: vi.fn(() => {
         throw new Error("poll must not route through the runner bridge");
@@ -187,7 +178,6 @@ describe("runBreeze dispatcher", () => {
       resolveBundledBreezeScript: vi.fn(() => {
         throw new Error("watch must not route through the bundled script bridge");
       }),
-      resolveBreezeSetupScript: vi.fn(),
       resolveFirstTreePackageRoot: vi.fn(() => "/pkg"),
       spawnInherit: vi.fn(() => {
         throw new Error("watch must not route through the bundled script bridge");
@@ -227,7 +217,6 @@ describe("runBreeze dispatcher", () => {
       resolveBundledBreezeScript: vi.fn(() => {
         throw new Error("should not be called for status-manager");
       }),
-      resolveBreezeSetupScript: vi.fn(),
       resolveFirstTreePackageRoot: vi.fn(() => "/pkg"),
       spawnInherit: vi.fn(() => {
         throw new Error("should not be called for status-manager");

--- a/tests/breeze-daemon-bus.test.ts
+++ b/tests/breeze-daemon-bus.test.ts
@@ -1,7 +1,7 @@
 /**
  * Phase 3c contract tests for the in-process event bus.
  *
- * The bus is the Node equivalent of `first-tree-breeze/breeze-runner/src/bus.rs`.
+ * The bus is the Node equivalent of `bus.rs`.
  * It fans out broker/poller events to any number of read-only subscribers
  * (HTTP SSE stream, in-process task monitors) without allowing them to
  * mutate `inbox.json`. The single-writer rule (see `daemon/bus.ts` header)

--- a/tests/breeze-daemon-config.test.ts
+++ b/tests/breeze-daemon-config.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for the Phase 3a daemon config loader.
  *
- * Verifies the priority pipeline documented in `core/config.ts`:
+ * Verifies the priority pipeline documented in `runtime/config.ts`:
  *   CLI overrides > env vars > yaml > defaults.
  */
 

--- a/tests/breeze-daemon-http.test.ts
+++ b/tests/breeze-daemon-http.test.ts
@@ -3,7 +3,7 @@
  * HTTP + SSE server.
  *
  * Spec: `docs/migration/01-http-api-contract.md`. Source of truth:
- * `first-tree-breeze/breeze-runner/src/http.rs`.
+ * `http.rs`.
  *
  * Per route, the test asserts status code, key headers, and body shape
  * against the contract. The SSE test additionally pins byte-exact


### PR DESCRIPTION
## Summary

The `first-tree-breeze/` top-level directory was removed in #143, but two kinds of dangling references remained:

### 1. Runtime reference — `breeze install` was silently broken

`first-tree breeze install` called `bridge.resolveBreezeSetupScript()` which looked for `first-tree-breeze/setup` — a bash script deleted in #143. The command would throw "breeze setup script not found".

**Fix:** port the still-relevant setup logic to TS:

- new `src/products/breeze/engine/commands/install.ts`
- checks `gh` / `gh auth` / `jq` prerequisites
- writes `~/.breeze/config.yaml` defaults if absent
- hands off daemon startup to `first-tree breeze start`
- **drops** the obsolete "symlink three legacy skills into `~/.claude/skills`" step (the four first-tree skills now install into the caller's repo via `first-tree tree init/bind/upgrade` — see #153)

`bridge.ts::resolveBreezeSetupScript` and its tests are deleted; the CLI dispatcher routes `install` via the new TS command.

### 2. Comment references

~30 file-header comments still said things like `TS port of \`first-tree-breeze/breeze-runner/src/fetcher.rs:353-368\`` even though that directory is gone. Strip the deleted-directory prefix so comments read `TS port of \`fetcher.rs:353-368\`` — still meaningful as a historical pointer, no longer a dangling repo path.

Also sweeps `core/X.ts` → `runtime/X.ts` in comments (the directory was renamed in #146; code imports were updated but doc comments had not been).

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` — 866 pass
- [x] New `install` command tested via updated `breeze-cli.test.ts` case