### PR TITLE
fix(gardener): address bingran #132 review items (treeRepoUrl, paused, classifier)

### DIFF
--- a/src/products/gardener/engine/comment.ts
+++ b/src/products/gardener/engine/comment.ts
@@ -493,6 +493,14 @@ export function resolveState(input: ResolveStateInput): StateAction {
   }
 
   // Rule 2: paused (with resume override).
+  //
+  // Semantics: the presence of a `gardener:paused` marker on gardener's own
+  // comment IS the paused state. gardener only writes that marker in
+  // response to a valid `@gardener pause` command, so the marker itself is
+  // the authoritative record. Do NOT require the `@gardener pause` comment
+  // to still exist — a user may have edited or deleted it.
+  //
+  // Only a `@gardener resume` command newer than the marker clears the state.
   const latestByCmd = (cmd: "pause" | "resume"): string | null => {
     let latest: string | null = null;
     const re = new RegExp(`@gardener ${cmd}\\b`);
@@ -504,14 +512,21 @@ export function resolveState(input: ResolveStateInput): StateAction {
     return latest;
   };
 
-  const hasPausedState = gardenerComments.some((c) => hasPausedMarker(c.body));
-  if (hasPausedState) {
-    const lastPause = latestByCmd("pause");
+  const latestPausedMarkerTime = gardenerComments
+    .filter((c) => hasPausedMarker(c.body))
+    .reduce<string | null>((latest, c) => {
+      const ts = c.created_at ?? null;
+      if (!ts) return latest;
+      if (!latest || ts > latest) return ts;
+      return latest;
+    }, null);
+
+  if (latestPausedMarkerTime) {
     const lastResume = latestByCmd("resume");
-    if (lastPause && (!lastResume || lastResume <= lastPause)) {
+    if (!lastResume || lastResume <= latestPausedMarkerTime) {
       return { kind: "skip", reason: "paused by user" };
     }
-    // else fall through to rule 4 — resume is active.
+    // else fall through to rule 4 — resume is newer than paused marker.
   }
 
   // Rule 3: @gardener re-review — find newest re-review command and
@@ -595,17 +610,20 @@ export interface ClassifyOutput {
 /**
  * Classifier hook. The real verdict is a judgment call that belongs
  * to an LLM (matching the runbook's "this is a judgment, not a pattern
- * match" guidance). This default returns `NEW_TERRITORY` with low
- * severity so the deterministic scaffolding is exercisable in tests
- * and in CI without LLM access. Callers that want real verdicts
- * should inject a classifier that reads the diff and the tree.
+ * match" guidance). This default returns `INSUFFICIENT_CONTEXT` with
+ * low severity — semantically honest, since no LLM has been consulted.
+ * Previously this returned `NEW_TERRITORY/low`, which misrepresented
+ * "no judgment made" as "judged this is a new area" and would send a
+ * misleading signal if ever posted to a real PR. Callers must inject
+ * a real classifier to get meaningful verdicts.
  */
 export type Classifier = (input: ClassifyInput) => Promise<ClassifyOutput>;
 
 export const defaultClassifier: Classifier = async () => ({
-  verdict: "NEW_TERRITORY",
+  verdict: "INSUFFICIENT_CONTEXT",
   severity: "low",
-  summary: "Tree guidance not yet available for this area.",
+  summary:
+    "No classifier was injected; gardener cannot judge this PR without one.",
   treeNodes: [],
 });
 
@@ -655,15 +673,16 @@ export function buildCommentBody(input: BuildCommentInput): string {
   const consumedId =
     consumedRereviewId !== undefined ? String(consumedRereviewId) : "none";
   const headerLabel = itemType === "pr" ? "This PR" : "This PR/Issue";
-  const treeUrl = treeRepoUrl ?? "";
+  // If treeRepoUrl is missing (no tree_repo in config, or unparseable), render
+  // tree node paths as plain inline code — DO NOT produce `[`path`](/blob/main/path)`
+  // which GitHub resolves relative to the current repo and 404s.
+  const renderNode = (n: { path: string; summary: string }): string =>
+    treeRepoUrl
+      ? `- [\`${n.path}\`](${treeRepoUrl}/blob/main/${n.path}) — ${n.summary}`
+      : `- \`${n.path}\` — ${n.summary}`;
   const treeNodeLinks =
     treeNodes.length > 0
-      ? treeNodes
-          .map(
-            (n) =>
-              `- [\`${n.path}\`](${treeUrl}/blob/main/${n.path}) — ${n.summary}`,
-          )
-          .join("\n")
+      ? treeNodes.map(renderNode).join("\n")
       : `- _(no tree nodes cited — tree may be empty or irrelevant to this change)_`;
   const markerLine1 = `<!-- gardener:state · reviewed=${reviewedFull} · verdict=${verdict} · severity=${severity} · tree_sha=${treeSha} -->`;
   const markerLine2 = `<!-- gardener:last_consumed_rereview=${consumedId} -->`;

--- a/tests/gardener-comment-e2e.test.ts
+++ b/tests/gardener-comment-e2e.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { buildCommentBody } from "../src/products/gardener/engine/comment.js";
+
+describe("E2E: gardener comment body rendering (from PR #157 fixes)", () => {
+  it("Fix #1: tree_repo absent → plain inline code (no broken /blob/main links)", () => {
+    const body = buildCommentBody({
+      verdict: "INSUFFICIENT_CONTEXT",
+      severity: "low",
+      summary: "No classifier was injected.",
+      treeNodes: [
+        { path: "engineering/auth/NODE.md", summary: "Auth architecture" },
+        { path: "security/secrets.md", summary: "Secret handling" },
+      ],
+      reviewedShort: "abc12345",
+      reviewedFull: "abc1234567890abc1234567890abc1234567890a",
+      treeSha: "deadbeefcafebabe",
+      treeShaShort: "deadbeef",
+      itemType: "pr",
+      // treeRepoUrl omitted
+    });
+
+    console.log("\n=== Fix #1: tree_repo ABSENT ===\n" + body + "\n===\n");
+
+    // Plain inline-code rendering, no broken links.
+    expect(body).toContain("- `engineering/auth/NODE.md` — Auth architecture");
+    expect(body).toContain("- `security/secrets.md` — Secret handling");
+    expect(body).not.toMatch(/\]\(\/blob\/main\//); // no broken relative link
+    expect(body).not.toMatch(/\]\(undefined\//); // no literal undefined
+    // Header + marker + verdict should still be present.
+    expect(body).toContain("<!-- gardener:state ");
+    expect(body).toContain("verdict=INSUFFICIENT_CONTEXT");
+  });
+
+  it("Fix #1 baseline: tree_repo present → clickable links", () => {
+    const body = buildCommentBody({
+      verdict: "INSUFFICIENT_CONTEXT",
+      severity: "low",
+      summary: "No classifier was injected.",
+      treeNodes: [
+        { path: "engineering/auth/NODE.md", summary: "Auth architecture" },
+      ],
+      reviewedShort: "abc12345",
+      reviewedFull: "abc1234567890abc1234567890abc1234567890a",
+      treeSha: "deadbeefcafebabe",
+      treeShaShort: "deadbeef",
+      itemType: "pr",
+      treeRepoUrl: "https://github.com/example-org/example-tree",
+      treeSlug: "example-org/example-tree",
+    });
+
+    console.log("\n=== Fix #1 baseline: tree_repo PRESENT ===\n" + body + "\n===\n");
+
+    expect(body).toContain(
+      "- [`engineering/auth/NODE.md`](https://github.com/example-org/example-tree/blob/main/engineering/auth/NODE.md)",
+    );
+  });
+
+  it("Fix #1 edge: empty treeNodes list shows explanatory bullet", () => {
+    const body = buildCommentBody({
+      verdict: "NEW_TERRITORY",
+      severity: "medium",
+      summary: "This area isn't yet captured on the tree.",
+      treeNodes: [],
+      reviewedShort: "abc12345",
+      reviewedFull: "abc1234567890abc1234567890abc1234567890a",
+      treeSha: "deadbeefcafebabe",
+      treeShaShort: "deadbeef",
+      itemType: "pr",
+    });
+    expect(body).toContain("_(no tree nodes cited");
+  });
+});

--- a/tests/gardener-comment.test.ts
+++ b/tests/gardener-comment.test.ts
@@ -262,6 +262,55 @@ describe("gardener comment -- state resolution", () => {
     });
     expect(action.kind).toBe("skip");
   });
+
+  it("paused marker alone (no surviving pause command) → still skip (regression for #132 review)", () => {
+    // User deleted the @gardener pause command after gardener acknowledged it.
+    // The marker is the authoritative record — we must still treat as paused.
+    const action = resolveState({
+      comments: [
+        {
+          id: 10,
+          user: { login: gardenerUser },
+          body: "<!-- gardener:state · reviewed=abc -->\n<!-- gardener:paused -->",
+          created_at: "2026-04-10T00:00:00Z",
+        },
+        // No @gardener pause command anywhere.
+      ],
+      gardenerUser,
+      headIdentifier: "xyz",
+      hasReviewedLabel: false,
+    });
+    expect(action.kind).toBe("skip");
+    if (action.kind === "skip") expect(action.reason).toContain("paused");
+  });
+
+  it("paused marker cleared by newer @gardener resume → fall through (not skipped for paused)", () => {
+    const action = resolveState({
+      comments: [
+        {
+          id: 10,
+          user: { login: gardenerUser },
+          body: "<!-- gardener:state · reviewed=abc -->\n<!-- gardener:paused -->",
+          created_at: "2026-04-10T00:00:00Z",
+        },
+        {
+          id: 12,
+          user: { login: "someone" },
+          body: "@gardener resume",
+          created_at: "2026-04-15T00:00:00Z",
+        },
+      ],
+      gardenerUser,
+      headIdentifier: "abc", // matches marker → skip for "matches head"
+      hasReviewedLabel: false,
+    });
+    // Should NOT be "skip: paused". It skips for "matches head" (rule 4) since
+    // the state marker's SHA equals headIdentifier. That's the fall-through path.
+    expect(action.kind).toBe("skip");
+    if (action.kind === "skip") {
+      expect(action.reason).not.toContain("paused");
+    }
+  });
 });
 
 // ─────────────────── 5. @gardener re-review ───────────────────
@@ -349,12 +398,15 @@ describe("gardener comment -- @gardener re-review", () => {
 
 // ─────────────────── 6. verdict classification ───────────────────
 describe("gardener comment -- verdict classification", () => {
-  it("default classifier returns NEW_TERRITORY/low", async () => {
+  it("default classifier returns INSUFFICIENT_CONTEXT/low (semantically honest when no LLM is wired)", async () => {
     const out = await defaultClassifier({
       type: "pr",
       treeRoot: "/tmp",
     });
-    expect(out.verdict).toBe("NEW_TERRITORY");
+    // Previously returned NEW_TERRITORY which misrepresented "no judgment
+    // made" as "judged this is new". INSUFFICIENT_CONTEXT accurately
+    // signals that no real classifier has been wired.
+    expect(out.verdict).toBe("INSUFFICIENT_CONTEXT");
     expect(out.severity).toBe("low");
   });
 


### PR DESCRIPTION
Fixes #161.

Follow-up to #136 addressing the three non-blocker items from @bingran-you's review on the closed #132 comment-CLI PR.

## Summary

1. **treeRepoUrl empty case** — when `tree_repo` is missing or unparseable from config, render tree node paths as plain inline `` `code` `` instead of `` [`path`](/blob/main/path) ``. Previously the broken relative link would 404 against the current repo.

2. **Paused semantics marker-first** — the `<!-- gardener:paused -->` marker on gardener's own comment IS the authoritative paused state. Don't require the `@gardener pause` command to still exist (user may have deleted it). Only a newer `@gardener resume` clears the state.

3. **`defaultClassifier` → `INSUFFICIENT_CONTEXT`** — previously returned `NEW_TERRITORY/low`, which misrepresented "no judgment made" as "judged this is new territory". Now returns `INSUFFICIENT_CONTEXT/low` — semantically honest when no LLM classifier is wired.

## Tests

- Updated classifier default test for new verdict.
- Added two regression tests in state-resolution: paused marker alone still skips; paused cleared by newer resume falls through.
- Added three E2E rendering tests (`tests/gardener-comment-e2e.test.ts`) that verify the actual rendered comment body for both treeRepoUrl absent/present paths.
- Manual E2E against fixture snapshots confirmed Fix #2: `paused alone → skip`, `resume newer → fall through and patch`.
- `pnpm vitest run tests/gardener-comment*.test.ts` — 50 passed.
- `pnpm typecheck` — clean.
- CI — green.

## Test plan

- [ ] Reviewer confirms paused-marker-first semantics match intent (user can delete the pause command, gardener stays paused).
- [ ] Reviewer confirms `INSUFFICIENT_CONTEXT/low` is the right default verdict when no real classifier is wired.
- [ ] Reviewer confirms tree-node rendering degrades gracefully when `tree_repo` is absent.

---
<sub>🌱 PR created by Claude on behalf of @serenakeyitan via <a href="https://claude.com/claude-code">Claude Code</a></sub>