### PR TITLE
fix(gardener): tmpdir fallback for comment log dir

### DIFF
--- a/src/products/gardener/engine/comment.ts
+++ b/src/products/gardener/engine/comment.ts
@@ -41,6 +41,7 @@ import {
   readFileSync,
   writeFileSync,
 } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import {
@@ -877,7 +878,7 @@ async function fetchGardenerUser(
 
 function commentLogPath(env: NodeJS.ProcessEnv): string {
   if (env.COMMENT_LOG && env.COMMENT_LOG.length > 0) return env.COMMENT_LOG;
-  const home = env.HOME ?? env.USERPROFILE ?? process.cwd();
+  const home = env.HOME ?? env.USERPROFILE ?? tmpdir();
   return join(home, ".gardener", "comment-runs.jsonl");
 }
 


### PR DESCRIPTION
## Summary
- Fixes #159 (narrowed scope — `respond.ts` half is dropped per the issue's latest comment because the file is being removed under #162).
- `commentLogPath` in `src/products/gardener/engine/comment.ts` fell back to `process.cwd()` when neither `HOME` nor `USERPROFILE` was set, writing `.gardener/comment-runs.jsonl` into the caller's repo checkout on sandboxed CI runners. Swapped to `os.tmpdir()` so the log never lands in cwd.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (871 tests pass)
- [x] `pnpm validate:skill`
- [x] `pnpm build`