### PR TITLE
test(gardener): regression coverage for comment log-dir fallback (#159)

### DIFF
--- a/src/products/gardener/engine/comment.ts
+++ b/src/products/gardener/engine/comment.ts
@@ -85,7 +85,8 @@ Environment:
                         and subject.json. When set, those files are
                         read instead of invoking \`gh\`.
   COMMENT_LOG           Path for JSONL run events (default
-                        $HOME/.gardener/comment-runs.jsonl).
+                        $HOME/.gardener/comment-runs.jsonl; falls
+                        back to \$TMPDIR when HOME is unset).
 
 Exit codes:
   0 handled/skipped/disabled
@@ -876,7 +877,7 @@ async function fetchGardenerUser(
 
 // ───────────────────────── Logging + BREEZE_RESULT ───────────────
 
-function commentLogPath(env: NodeJS.ProcessEnv): string {
+export function commentLogPath(env: NodeJS.ProcessEnv): string {
   if (env.COMMENT_LOG && env.COMMENT_LOG.length > 0) return env.COMMENT_LOG;
   const home = env.HOME ?? env.USERPROFILE ?? tmpdir();
   return join(home, ".gardener", "comment-runs.jsonl");

--- a/tests/gardener-comment.test.ts
+++ b/tests/gardener-comment.test.ts
@@ -6,6 +6,7 @@ import { GARDENER_USAGE, runGardener } from "#products/gardener/cli.js";
 import {
   buildCommentBody,
   COMMENT_USAGE,
+  commentLogPath,
   defaultClassifier,
   extractStateMarker,
   GARDENER_COMMAND_RE,
@@ -1028,5 +1029,35 @@ describe("gardener comment -- @gardener command detection ignores self-footer", 
     });
     // Marker hides it from userCommands → sha matches → skip.
     expect(action.kind).toBe("skip");
+  });
+});
+
+describe("commentLogPath (#159 — log-dir fallback)", () => {
+  it("uses COMMENT_LOG verbatim when set", () => {
+    const path = commentLogPath({ COMMENT_LOG: "/custom/path/log.jsonl" });
+    expect(path).toBe("/custom/path/log.jsonl");
+  });
+
+  it("uses HOME when set", () => {
+    const path = commentLogPath({ HOME: "/home/user" });
+    expect(path).toBe("/home/user/.gardener/comment-runs.jsonl");
+  });
+
+  it("falls back to USERPROFILE on Windows-style env", () => {
+    const path = commentLogPath({ USERPROFILE: "C:\\Users\\user" });
+    expect(path.startsWith("C:\\Users\\user")).toBe(true);
+    expect(path.endsWith("comment-runs.jsonl")).toBe(true);
+  });
+
+  it("falls back to os.tmpdir() when HOME and USERPROFILE are unset (regression for #159)", async () => {
+    const { tmpdir } = await import("node:os");
+    const path = commentLogPath({});
+    expect(path.startsWith(tmpdir())).toBe(true);
+    expect(path.endsWith("comment-runs.jsonl")).toBe(true);
+  });
+
+  it("never returns a path inside process.cwd() when HOME is unset (regression for #159)", () => {
+    const path = commentLogPath({});
+    expect(path.startsWith(process.cwd())).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #159 (test-coverage follow-up to #163).

## Context

@bingran-you shipped the code fix in #163 (which merged while this PR was in flight — thanks!). The 1-line code change (`process.cwd()` → `os.tmpdir()`) is already on main.

This PR layers regression-test coverage on top so the bug can't silently come back:

## Changes

1. **Export `commentLogPath`** — previously module-local, now exported so it can be unit-tested.
2. **Add 5 regression tests** in `tests/gardener-comment.test.ts`:
   - `COMMENT_LOG` wins when set
   - `HOME` honored when set
   - `USERPROFILE` honored (Windows-style) when `HOME` absent
   - Falls back to `os.tmpdir()` when both HOME and USERPROFILE are absent
   - **Never resolves to a path inside `process.cwd()`** — direct regression guard against the original #159 bug
3. **Document the TMPDIR fallback** in the `--help` output so users on HOME-less CI aren't surprised.

## Tests

- `pnpm typecheck` — clean.
- `pnpm vitest run tests/gardener-comment.test.ts` — 52/52 passed (5 new + 47 existing).
- Smoke: `env -i PATH=... node dist/cli.js gardener comment --help` — new TMPDIR line renders.
- E2E: ran CLI with `env -i` (no HOME/USERPROFILE) against `/tmp/gardener-e2e/snapshot-resumed` fixture — `BREEZE_RESULT: status=handled` returned, no `.gardener/` directory appeared in cwd, log landed at `$TMPDIR/.gardener/comment-runs.jsonl` as expected.

## Repo-gardener safety

Confirmed: repo-gardener runbooks do not invoke `first-tree gardener comment` and do not read/write `COMMENT_LOG`. Zero risk to the scheduled `first-tree sync --apply` pipeline.

## Test plan

- [ ] Reviewer confirms exporting `commentLogPath` for testability is acceptable.
- [ ] Reviewer confirms the regression guard (`never inside cwd`) is useful beyond the more specific `os.tmpdir()` assertion.

---
<sub>🌱 PR updated by Claude on behalf of @serenakeyitan via <a href="https://claude.com/claude-code">Claude Code</a></sub>