### PR TITLE
test(sync): golden-snapshot harness for sync --apply output

### DIFF
--- a/tests/fixtures/sync-golden/two-pr-apply.json
+++ b/tests/fixtures/sync-golden/two-pr-apply.json
@@ -1,0 +1,407 @@
+{
+  "exitCode": 0,
+  "calls": [
+    {
+      "command": "gh",
+      "args": [
+        "auth",
+        "status"
+      ],
+      "cwdLabel": null
+    },
+    {
+      "command": "claude",
+      "args": [
+        "--version"
+      ],
+      "cwdLabel": null
+    },
+    {
+      "command": "gh",
+      "args": [
+        "api",
+        "/repos/alice/source/commits/HEAD",
+        "--jq",
+        ".sha"
+      ],
+      "cwdLabel": null
+    },
+    {
+      "command": "gh",
+      "args": [
+        "api",
+        "/repos/alice/source/compare/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      ],
+      "cwdLabel": null
+    },
+    {
+      "command": "gh",
+      "args": [
+        "api",
+        "search/issues?q=repo:alice/source+is:pr+is:merged+merged:>=2026-04-01&per_page=100"
+      ],
+      "cwdLabel": null
+    },
+    {
+      "command": "gh",
+      "args": [
+        "api",
+        "/repos/alice/source/pulls/101/files",
+        "--paginate"
+      ],
+      "cwdLabel": null
+    },
+    {
+      "command": "gh",
+      "args": [
+        "api",
+        "/repos/alice/source/pulls/102/files",
+        "--paginate"
+      ],
+      "cwdLabel": null
+    },
+    {
+      "command": "claude",
+      "args": [
+        "-p",
+        "--output-format",
+        "json",
+        "You are a Context Tree maintenance agent. A Context Tree is a structured knowledge base (markdown NODE.md files) that captures product decisions, architecture, conventions, and domain knowledge for a codebase.\n\nYour job: given the tree's current nodes and a recently merged PR, determine whether the tree is MISSING knowledge that this PR introduced.\n\nContext: this PR has already been reviewed and approved (including context-fit review by gardener). It does not conflict with the tree. The only question is: did it introduce NEW knowledge that the tree doesn't yet capture?\n\nIMPORTANT:\n- For nodes marked with CONTENT below, read the content carefully. A node might exist for an area but NOT cover the specific feature this PR added.\n- If \"Changed files\" are listed below, use them to verify what the PR actually modified. Do NOT describe features not reflected in the changed file paths.\n- Be factually precise: only describe capabilities the source PR actually introduced. Do not extrapolate or generalize beyond what the diff shows.\n- For example, if an \"Authentication\" node only mentions JWT but the PR adds OAuth support, that is a TREE_MISS — the tree needs a new node (or the existing node needs supplementing, which counts as TREE_MISS for sync purposes).\n\nAsk yourself:\n- Did this PR add a new feature, module, convention, or architectural pattern that NO existing node covers in its content? → TREE_MISS\n- Do the existing nodes (including their content) already adequately describe what this PR introduced? → TREE_OK\n\nBias toward TREE_MISS. If in doubt, classify as TREE_MISS.\n\n## Current tree nodes (1 total, 0 with content shown)\n- NODE.md title=\"Example Tree\" owners=alice\n\n## Merged PR\ncommit 1111111 [pkg-a] feat(pkg-a): add thing (#101)\npr feat(pkg-a): add thing\n\n## Output format\nReturn a JSON array. Each element represents one area that needs a NEW tree node (NOT one per commit — group related changes):\n{\n  \"path\": \"suggested/node/path\",\n  \"type\": \"TREE_MISS\" | \"TREE_OK\",\n  \"rationale\": \"one sentence explaining why the tree needs this node\",\n  \"suggested_node_title\": \"Human-readable title for the node\",\n  \"suggested_node_body_markdown\": \"Draft NODE.md body content ONLY (2-5 paragraphs, no YAML frontmatter)\",\n  \"suggested_soft_links\": [\"other/tree/path\", \"another/one\"]\n}\n\nFor TREE_OK items, only path, type, and rationale are required (other fields can be empty strings or omitted).\n\nIMPORTANT:\n- Only return TREE_MISS or TREE_OK. Sync does not support in-place edits to existing NODE.md files, so do not propose supplement-style updates — if an existing node needs more content, classify as TREE_MISS with a new path and leave the existing node alone.\n- `suggested_node_body_markdown` must contain body content only. Do NOT include YAML frontmatter or code fences.\n- `suggested_soft_links` must list every tree path the body cross-references (other domains, governance, backend, etc.) so the new node shows up in the tree graph. Use paths from the \"Current tree nodes\" list above. Omit or use [] when the body does not reference other domains.\n\nReturn a JSON array only, no prose."
+      ],
+      "cwdLabel": null
+    },
+    {
+      "command": "claude",
+      "args": [
+        "-p",
+        "--output-format",
+        "json",
+        "You are a Context Tree maintenance agent. A Context Tree is a structured knowledge base (markdown NODE.md files) that captures product decisions, architecture, conventions, and domain knowledge for a codebase.\n\nYour job: given the tree's current nodes and a recently merged PR, determine whether the tree is MISSING knowledge that this PR introduced.\n\nContext: this PR has already been reviewed and approved (including context-fit review by gardener). It does not conflict with the tree. The only question is: did it introduce NEW knowledge that the tree doesn't yet capture?\n\nIMPORTANT:\n- For nodes marked with CONTENT below, read the content carefully. A node might exist for an area but NOT cover the specific feature this PR added.\n- If \"Changed files\" are listed below, use them to verify what the PR actually modified. Do NOT describe features not reflected in the changed file paths.\n- Be factually precise: only describe capabilities the source PR actually introduced. Do not extrapolate or generalize beyond what the diff shows.\n- For example, if an \"Authentication\" node only mentions JWT but the PR adds OAuth support, that is a TREE_MISS — the tree needs a new node (or the existing node needs supplementing, which counts as TREE_MISS for sync purposes).\n\nAsk yourself:\n- Did this PR add a new feature, module, convention, or architectural pattern that NO existing node covers in its content? → TREE_MISS\n- Do the existing nodes (including their content) already adequately describe what this PR introduced? → TREE_OK\n\nBias toward TREE_MISS. If in doubt, classify as TREE_MISS.\n\n## Current tree nodes (1 total, 0 with content shown)\n- NODE.md title=\"Example Tree\" owners=alice\n\n## Merged PR\ncommit 2222222 [pkg-b] feat(pkg-b): add thing (#102)\npr feat(pkg-b): add thing\n\n## Output format\nReturn a JSON array. Each element represents one area that needs a NEW tree node (NOT one per commit — group related changes):\n{\n  \"path\": \"suggested/node/path\",\n  \"type\": \"TREE_MISS\" | \"TREE_OK\",\n  \"rationale\": \"one sentence explaining why the tree needs this node\",\n  \"suggested_node_title\": \"Human-readable title for the node\",\n  \"suggested_node_body_markdown\": \"Draft NODE.md body content ONLY (2-5 paragraphs, no YAML frontmatter)\",\n  \"suggested_soft_links\": [\"other/tree/path\", \"another/one\"]\n}\n\nFor TREE_OK items, only path, type, and rationale are required (other fields can be empty strings or omitted).\n\nIMPORTANT:\n- Only return TREE_MISS or TREE_OK. Sync does not support in-place edits to existing NODE.md files, so do not propose supplement-style updates — if an existing node needs more content, classify as TREE_MISS with a new path and leave the existing node alone.\n- `suggested_node_body_markdown` must contain body content only. Do NOT include YAML frontmatter or code fences.\n- `suggested_soft_links` must list every tree path the body cross-references (other domains, governance, backend, etc.) so the new node shows up in the tree graph. Use paths from the \"Current tree nodes\" list above. Omit or use [] when the body does not reference other domains.\n\nReturn a JSON array only, no prose."
+      ],
+      "cwdLabel": null
+    },
+    {
+      "command": "git",
+      "args": [
+        "symbolic-ref",
+        "--quiet",
+        "--short",
+        "HEAD"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "gh",
+      "args": [
+        "pr",
+        "list",
+        "--search",
+        "sync(source-golden): from alice/source#101",
+        "--json",
+        "number",
+        "--limit",
+        "1"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "git",
+      "args": [
+        "checkout",
+        "-B",
+        "first-tree/sync-source-golden-pr101",
+        "main"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "git",
+      "args": [
+        "add",
+        "<TREE_ROOT>/pkg-a/NODE.md"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "git",
+      "args": [
+        "add",
+        "<TREE_ROOT>/NODE.md"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "git",
+      "args": [
+        "add",
+        "<TREE_ROOT>/.github/CODEOWNERS"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "git",
+      "args": [
+        "diff",
+        "--cached",
+        "--quiet"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "git",
+      "args": [
+        "commit",
+        "-m",
+        "<COMMIT_MSG_HASH:0217cf5ab0f427fc>"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "gh",
+      "args": [
+        "pr",
+        "list",
+        "--search",
+        "sync(source-golden): from alice/source#102",
+        "--json",
+        "number",
+        "--limit",
+        "1"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "git",
+      "args": [
+        "checkout",
+        "-B",
+        "first-tree/sync-source-golden-pr102",
+        "main"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "git",
+      "args": [
+        "add",
+        "<TREE_ROOT>/pkg-b/NODE.md"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "git",
+      "args": [
+        "add",
+        "<TREE_ROOT>/NODE.md"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "git",
+      "args": [
+        "add",
+        "<TREE_ROOT>/.github/CODEOWNERS"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "git",
+      "args": [
+        "diff",
+        "--cached",
+        "--quiet"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "git",
+      "args": [
+        "commit",
+        "-m",
+        "<COMMIT_MSG_HASH:4f58b50f16b07c57>"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "git",
+      "args": [
+        "checkout",
+        "main"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "git",
+      "args": [
+        "push",
+        "origin",
+        "first-tree/sync-source-golden-pr101"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "git",
+      "args": [
+        "push",
+        "origin",
+        "first-tree/sync-source-golden-pr102"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "gh",
+      "args": [
+        "pr",
+        "create",
+        "--head",
+        "first-tree/sync-source-golden-pr101",
+        "--title",
+        "sync(source-golden): feat(pkg-a): add thing (from alice/source#101)",
+        "--body",
+        "<BODY_HASH:e51af67dddca1c20>"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "gh",
+      "args": [
+        "pr",
+        "create",
+        "--head",
+        "first-tree/sync-source-golden-pr102",
+        "--title",
+        "sync(source-golden): feat(pkg-b): add thing (from alice/source#102)",
+        "--body",
+        "<BODY_HASH:b0f4343e58e66ccb>"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "gh",
+      "args": [
+        "label",
+        "create",
+        "first-tree:sync",
+        "--color",
+        "2ea44f",
+        "--description",
+        "Created by first-tree sync",
+        "--force"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "gh",
+      "args": [
+        "label",
+        "create",
+        "first-tree:sync",
+        "--color",
+        "2ea44f",
+        "--description",
+        "Created by first-tree sync",
+        "--force"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "gh",
+      "args": [
+        "pr",
+        "edit",
+        "https://github.com/alice/tree/pull/501",
+        "--add-label",
+        "first-tree:sync"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "gh",
+      "args": [
+        "pr",
+        "edit",
+        "https://github.com/alice/tree/pull/502",
+        "--add-label",
+        "first-tree:sync"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "git",
+      "args": [
+        "checkout",
+        "-B",
+        "first-tree/sync-source-golden-housekeeping",
+        "main"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "git",
+      "args": [
+        "add",
+        "-A"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "git",
+      "args": [
+        "diff",
+        "--cached",
+        "--quiet"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "git",
+      "args": [
+        "commit",
+        "-m",
+        "<COMMIT_MSG_HASH:6dde9c54721fee28>"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "git",
+      "args": [
+        "push",
+        "origin",
+        "HEAD"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "gh",
+      "args": [
+        "pr",
+        "create",
+        "--title",
+        "chore(sync): housekeeping for source-golden",
+        "--body",
+        "<BODY_HASH:ad8c287fdfc5d99a>"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "git",
+      "args": [
+        "checkout",
+        "main"
+      ],
+      "cwdLabel": "<tree-root>"
+    }
+  ],
+  "bodyHashes": {
+    "commit-msg::0": "0217cf5ab0f427fc",
+    "commit-msg::1": "4f58b50f16b07c57",
+    "pr-body::first-tree/sync-source-golden-pr101": "e51af67dddca1c20",
+    "pr-body::first-tree/sync-source-golden-pr102": "b0f4343e58e66ccb",
+    "commit-msg::2": "6dde9c54721fee28",
+    "pr-body::title:chore(sync): housekeeping for source-golden": "ad8c287fdfc5d99a"
+  },
+  "nodeMdFiles": {
+    "pkg-a": "d27a7d643355409c",
+    "pkg-b": "984a086d0ba85dfd"
+  }
+}

--- a/tests/sync-golden-snapshot.test.ts
+++ b/tests/sync-golden-snapshot.test.ts
@@ -1,0 +1,335 @@
+/**
+ * sync.ts golden snapshot — locks the external-effects shape of
+ * `first-tree sync --apply` so the Phase 3 refactor (factor out an
+ * `openTreePr` primitive for the gardener merge→issue worker path)
+ * cannot silently change what repo-gardener depends on.
+ *
+ * Repo-gardener (`agent-team-foundation/repo-gardener`) shells out to
+ * `first-tree sync --apply` on a schedule. If the CLI changes commit
+ * messages, PR titles, PR bodies, labels, branch names, or the order
+ * of git/gh calls, repo-gardener's scheduled runs would produce
+ * different PRs — a silent production break.
+ *
+ * This test captures EVERY git/gh call (args + key output hashes) made
+ * by sync.ts during a scripted "two merged source PRs → two tree PRs"
+ * flow, and asserts the capture matches a committed fixture
+ * (`tests/fixtures/sync-golden/two-pr-apply.json`).
+ *
+ * Updating the snapshot: run with `UPDATE_SYNC_GOLDEN=1` env var — this
+ * rewrites the fixture. Only do this when the change is *intentional*
+ * and coordinated with a repo-gardener-side update.
+ */
+
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  runSync,
+  type ShellResult,
+  type ShellRun,
+} from "#products/tree/engine/sync.js";
+import { writeTreeBinding } from "#products/tree/engine/runtime/binding-state.js";
+import { makeTreeMetadata, useTmpDir } from "./helpers.js";
+
+const FIXTURE_PATH = join(
+  __dirname,
+  "fixtures",
+  "sync-golden",
+  "two-pr-apply.json",
+);
+
+interface Captured {
+  command: string;
+  args: string[];
+  cwdLabel: string | null;
+}
+
+interface Snapshot {
+  exitCode: number;
+  calls: Captured[];
+  bodyHashes: Record<string, string>;
+  nodeMdFiles: Record<string, string>;
+}
+
+function hash(s: string): string {
+  return createHash("sha256").update(s).digest("hex").slice(0, 16);
+}
+
+function makeTreeShell(root: string): void {
+  makeTreeMetadata(root);
+  writeFileSync(
+    join(root, "NODE.md"),
+    "---\ntitle: Example Tree\nowners: [alice]\n---\n# Example Tree\n",
+  );
+  writeFileSync(
+    join(root, "AGENTS.md"),
+    "<!-- BEGIN CONTEXT-TREE FRAMEWORK -->\nx\n<!-- END CONTEXT-TREE FRAMEWORK -->\n",
+  );
+  writeFileSync(
+    join(root, "CLAUDE.md"),
+    "<!-- BEGIN CONTEXT-TREE FRAMEWORK -->\nx\n<!-- END CONTEXT-TREE FRAMEWORK -->\n",
+  );
+  mkdirSync(join(root, ".github"), { recursive: true });
+  writeFileSync(
+    join(root, ".github", "CODEOWNERS"),
+    "/pkg-a/ @alice\n/pkg-b/ @bob\n",
+  );
+}
+
+function makeRecordingShell(
+  tmpPath: string,
+  classifyResponses: string[],
+): { shellRun: ShellRun; captured: Captured[]; bodies: string[] } {
+  const captured: Captured[] = [];
+  const bodies: string[] = [];
+  let classifyIndex = 0;
+
+  const shellRun: ShellRun = async (command, args, options) => {
+    const cwdLabel =
+      options?.cwd === tmpPath
+        ? "<tree-root>"
+        : options?.cwd
+          ? "<other>"
+          : null;
+    captured.push({ command, args: [...args], cwdLabel });
+
+    if (command === "gh" && args[0] === "auth") {
+      return { stdout: "Logged in", stderr: "", code: 0 };
+    }
+    if (command === "claude" && args[0] === "--version") {
+      return { stdout: "1.0.0", stderr: "", code: 0 };
+    }
+    if (command === "gh" && args[0] === "api") {
+      const path = args[1] ?? "";
+      if (path === "/repos/alice/source/commits/HEAD") {
+        return { stdout: "bb".repeat(20) + "\n", stderr: "", code: 0 };
+      }
+      if (path.startsWith("/repos/alice/source/compare/")) {
+        return {
+          stdout: JSON.stringify({
+            commits: [
+              {
+                sha: "1".repeat(40),
+                commit: {
+                  message: "feat(pkg-a): add thing (#101)",
+                  author: { name: "a", date: "2026-04-01T00:00:00Z" },
+                },
+                files: [{ filename: "pkg-a/x.ts" }],
+              },
+              {
+                sha: "2".repeat(40),
+                commit: {
+                  message: "feat(pkg-b): add thing (#102)",
+                  author: { name: "b", date: "2026-04-02T00:00:00Z" },
+                },
+                files: [{ filename: "pkg-b/y.ts" }],
+              },
+            ],
+          }),
+          stderr: "",
+          code: 0,
+        };
+      }
+      if (path.startsWith("search/issues")) {
+        return {
+          stdout: JSON.stringify({
+            items: [
+              {
+                number: 101,
+                title: "feat(pkg-a): add thing",
+                pull_request: {
+                  merged_at: "2026-04-01T00:00:00Z",
+                  merge_commit_sha: "1".repeat(40),
+                },
+              },
+              {
+                number: 102,
+                title: "feat(pkg-b): add thing",
+                pull_request: {
+                  merged_at: "2026-04-02T00:00:00Z",
+                  merge_commit_sha: "2".repeat(40),
+                },
+              },
+            ],
+          }),
+          stderr: "",
+          code: 0,
+        };
+      }
+    }
+    if (command === "claude" && args[0] === "-p") {
+      const response = classifyResponses[classifyIndex] ?? classifyResponses[0];
+      classifyIndex += 1;
+      return { stdout: response, stderr: "", code: 0 };
+    }
+    if (command === "gh" && args[0] === "pr" && args[1] === "list") {
+      return { stdout: "[]", stderr: "", code: 0 };
+    }
+    if (command === "gh" && args[0] === "pr" && args[1] === "create") {
+      const bodyIdx = args.indexOf("--body");
+      if (bodyIdx >= 0 && args[bodyIdx + 1]) bodies.push(args[bodyIdx + 1]);
+      const headIdx = args.indexOf("--head");
+      const branch = headIdx >= 0 ? args[headIdx + 1] : "unknown";
+      return {
+        stdout: `https://github.com/alice/tree/pull/${branch.includes("pr101") ? 501 : 502}`,
+        stderr: "",
+        code: 0,
+      };
+    }
+    if (command === "gh" && args[0] === "pr" && args[1] === "edit") {
+      return { stdout: "", stderr: "", code: 0 };
+    }
+    if (command === "gh" && args[0] === "label") {
+      return { stdout: "", stderr: "", code: 0 };
+    }
+    if (command === "git") {
+      if (args[0] === "symbolic-ref") {
+        return { stdout: "main\n", stderr: "", code: 0 };
+      }
+      if (
+        args.includes("diff")
+        && args.includes("--cached")
+        && args.includes("--quiet")
+      ) {
+        return { stdout: "", stderr: "", code: 1 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    }
+    return {
+      stdout: "",
+      stderr: `no mock for ${command} ${args.join(" ")}`,
+      code: 1,
+    };
+  };
+
+  return { shellRun, captured, bodies };
+}
+
+function redact(calls: Captured[], treeRoot: string): Captured[] {
+  return calls.map((c) => {
+    const redactedArgs = c.args.map((a, i) => {
+      const prev = c.args[i - 1];
+      if (prev === "--body") return `<BODY_HASH:${hash(a)}>`;
+      if (prev === "-m") return `<COMMIT_MSG_HASH:${hash(a)}>`;
+      if (typeof a === "string" && a.startsWith(treeRoot)) {
+        return `<TREE_ROOT>${a.slice(treeRoot.length)}`;
+      }
+      return a;
+    });
+    return { command: c.command, args: redactedArgs, cwdLabel: c.cwdLabel };
+  });
+}
+
+function extractBodies(calls: Captured[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  let commitIdx = 0;
+  let prIdx = 0;
+  for (const c of calls) {
+    if (c.command === "gh" && c.args[0] === "pr" && c.args[1] === "create") {
+      const bodyIdx = c.args.indexOf("--body");
+      const titleIdx = c.args.indexOf("--title");
+      const headIdx = c.args.indexOf("--head");
+      const label =
+        headIdx >= 0
+          ? c.args[headIdx + 1]
+          : titleIdx >= 0
+            ? `title:${c.args[titleIdx + 1]}`
+            : `pr-${prIdx}`;
+      prIdx += 1;
+      if (bodyIdx >= 0) out[`pr-body::${label}`] = c.args[bodyIdx + 1];
+    }
+    if (c.command === "git" && c.args[0] === "commit") {
+      const mIdx = c.args.indexOf("-m");
+      if (mIdx >= 0) {
+        out[`commit-msg::${commitIdx}`] = c.args[mIdx + 1];
+        commitIdx += 1;
+      }
+    }
+  }
+  return out;
+}
+
+describe("sync --apply golden snapshot (Phase 0.a)", () => {
+  it("produces byte-identical git/gh call shape for two-PR scheduled sync", async () => {
+    const tmp = useTmpDir();
+    makeTreeShell(tmp.path);
+    writeTreeBinding(tmp.path, "source-golden", {
+      bindingMode: "standalone-source",
+      entrypoint: "/repos/source",
+      lastReconciledSourceCommit: "aa".repeat(20),
+      remoteUrl: "https://github.com/alice/source.git",
+      rootKind: "git-repo",
+      scope: "repo",
+      sourceId: "source-golden",
+      sourceName: "source",
+      sourceRootPath: "../source",
+      treeMode: "dedicated",
+      treeRepoName: "tree",
+    });
+
+    const classifyResponses = [
+      JSON.stringify([
+        {
+          path: "pkg-a",
+          type: "TREE_MISS",
+          target_node_path: null,
+          rationale: "No node for pkg-a",
+          suggested_node_title: "pkg-a",
+          suggested_node_body_markdown: "# pkg-a",
+        },
+      ]),
+      JSON.stringify([
+        {
+          path: "pkg-b",
+          type: "TREE_MISS",
+          target_node_path: null,
+          rationale: "No node for pkg-b",
+          suggested_node_title: "pkg-b",
+          suggested_node_body_markdown: "# pkg-b",
+        },
+      ]),
+    ];
+
+    const { shellRun, captured } = makeRecordingShell(tmp.path, classifyResponses);
+
+    const exitCode = await runSync(
+      tmp.path,
+      { source: undefined, propose: false, apply: true, dryRun: false },
+      { shellRun, verifyTree: () => 0 },
+    );
+
+    const bodies = extractBodies(captured);
+    const bodyHashes: Record<string, string> = {};
+    for (const [k, v] of Object.entries(bodies)) bodyHashes[k] = hash(v);
+
+    const nodeMdFiles: Record<string, string> = {};
+    for (const dir of ["pkg-a", "pkg-b"]) {
+      try {
+        const p = join(tmp.path, dir, "NODE.md");
+        nodeMdFiles[dir] = hash(readFileSync(p, "utf-8"));
+      } catch {
+        // node dir may not exist in all paths; record absence
+        nodeMdFiles[dir] = "<absent>";
+      }
+    }
+
+    const snapshot: Snapshot = {
+      exitCode,
+      calls: redact(captured, tmp.path),
+      bodyHashes,
+      nodeMdFiles,
+    };
+
+    if (process.env.UPDATE_SYNC_GOLDEN === "1") {
+      mkdirSync(join(__dirname, "fixtures", "sync-golden"), { recursive: true });
+      writeFileSync(FIXTURE_PATH, JSON.stringify(snapshot, null, 2) + "\n");
+      // eslint-disable-next-line no-console
+      console.log(`[golden] wrote fixture: ${FIXTURE_PATH}`);
+      return;
+    }
+
+    const expected: Snapshot = JSON.parse(readFileSync(FIXTURE_PATH, "utf-8"));
+    expect(snapshot).toEqual(expected);
+  });
+});


### PR DESCRIPTION
## Summary

Locks the external-effects shape of `first-tree sync --apply` (git/gh call sequence, arguments, commit messages, PR bodies, labels, branch names) behind a committed fixture so the Phase 3 refactor — factoring an `openTreePr` primitive out of `sync.ts` for the gardener merge→issue worker path — cannot silently change what `repo-gardener` depends on.

Tracking: #167
Design: #162 (plan step 4 prerequisite)

## Why this matters

`agent-team-foundation/repo-gardener` runs `first-tree sync --apply` on a schedule as a black-box CLI. If commit messages, PR titles/bodies, labels, branch names, or the order of git/gh calls change, its scheduled runs would produce different PRs — a silent prod break. This snapshot is the tripwire.

## What it does

- `tests/sync-golden-snapshot.test.ts` — mocks `ShellRun`, records every git/gh call during a scripted two-merged-PR → two-tree-PR flow, redacts tmp paths and hashes commit/body contents for determinism, and asserts equality against the committed fixture.
- `tests/fixtures/sync-golden/two-pr-apply.json` — the locked snapshot (exitCode, call list, body hashes, NODE.md file hashes).

Updating the fixture is an explicit opt-in: `UPDATE_SYNC_GOLDEN=1 pnpm test sync-golden-snapshot`. The docstring says this must only be done when the change is intentional and coordinated with a repo-gardener-side update.

## Tripwire verified

Modified `sync.ts` housekeeping commit message word locally → test failed with a clear diff. Restored → test passes.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test tests/sync-golden-snapshot.test.ts` passes in replay mode
- [x] `UPDATE_SYNC_GOLDEN=1` regenerates fixture cleanly
- [x] Tripwire: one-word change in sync.ts fails the snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)