### PR TITLE
fix(gardener): run commitTime idempotency check in snapshot mode (#158)

### DIFF
--- a/src/products/breeze/engine/daemon/gh-client.ts
+++ b/src/products/breeze/engine/daemon/gh-client.ts
@@ -426,6 +426,22 @@ export class GhClient {
         bucket: "core",
         mutating: false,
       });
+      // Required by gardener respond's `commitTime > reviewTime` idempotency
+      // check in snapshot mode. Without it, a breeze-runner retry (network
+      // redelivery, crash recovery) would re-bump the attempts counter and
+      // post a duplicate reply comment. See #158.
+      await this.captureSnapshot(snapshotDir, "pr-commits.json", {
+        context: "hydrate pr commits",
+        envs: this.hostEnv(),
+        args: [
+          "api",
+          `/repos/${task.repo}/pulls/${prNumber}/commits?per_page=100`,
+          "-H",
+          "X-GitHub-Api-Version: 2022-11-28",
+        ],
+        bucket: "core",
+        mutating: false,
+      });
     } else if (issueNumber !== undefined) {
       await this.captureSnapshot(snapshotDir, "issue-view.json", {
         context: "hydrate issue view",

--- a/src/products/gardener/engine/respond.ts
+++ b/src/products/gardener/engine/respond.ts
@@ -64,9 +64,14 @@ Options:
 
 Environment:
   BREEZE_SNAPSHOT_DIR   Directory containing pre-fetched pr-view.json,
-                        pr.diff, pr-reviews.json, issue-comments.json.
-                        When set, those files are read instead of
-                        invoking \`gh\`.
+                        pr.diff, pr-reviews.json, issue-comments.json,
+                        and (optionally) pr-commits.json. When set, those
+                        files are read instead of invoking \`gh\`. If
+                        pr-commits.json is present, it enables the
+                        \`commitTime > reviewTime\` idempotency check in
+                        snapshot mode — without it, duplicate dispatches
+                        from breeze-runner would re-bump attempts and
+                        post duplicate reply comments.
   RESPOND_LOG           Path for JSONL run events (default
                         $HOME/.gardener/respond-runs.jsonl).
 
@@ -194,11 +199,25 @@ export interface PrIssueComment {
   created_at?: string;
 }
 
+export interface PrCommit {
+  commit?: {
+    committer?: { date?: string };
+    author?: { date?: string };
+  };
+}
+
 export interface SnapshotBundle {
   prView: PrView;
   diff: string;
   reviews: PrReview[];
   issueComments: PrIssueComment[];
+  /**
+   * Latest commit time on the PR head, derived from pr-commits.json in
+   * the snapshot dir. Null when the snapshot was produced by a
+   * breeze-runner that did not capture commits — callers must treat
+   * that as "unknown" and fall back to the live-gh path where possible.
+   */
+  latestCommitTime: string | null;
 }
 
 export const RESPOND_MAX_ATTEMPTS = 5;
@@ -340,6 +359,7 @@ export function readSnapshot(dir: string): SnapshotBundle | null {
   const reviewsPath = join(dir, "pr-reviews.json");
   const commentsPath = join(dir, "issue-comments.json");
   const diffPath = join(dir, "pr.diff");
+  const commitsPath = join(dir, "pr-commits.json");
   if (!existsSync(viewPath)) return null;
   const viewText = readFileSync(viewPath, "utf-8");
   const prView = jsonTryParse<PrView>(viewText);
@@ -351,7 +371,28 @@ export function readSnapshot(dir: string): SnapshotBundle | null {
     ? jsonTryParse<PrIssueComment[]>(readFileSync(commentsPath, "utf-8")) ?? []
     : [];
   const diff = existsSync(diffPath) ? readFileSync(diffPath, "utf-8") : "";
-  return { prView, diff, reviews, issueComments };
+  const commits = existsSync(commitsPath)
+    ? jsonTryParse<PrCommit[]>(readFileSync(commitsPath, "utf-8")) ?? []
+    : null;
+  const latestCommitTime = commits ? latestCommitTimeFromCommits(commits) : null;
+  return { prView, diff, reviews, issueComments, latestCommitTime };
+}
+
+/**
+ * Pick the latest commit time from a /repos/{owner}/{repo}/pulls/{n}/commits
+ * payload. Returns null if the array is empty or no entry carries a
+ * committer/author date.
+ */
+export function latestCommitTimeFromCommits(
+  commits: PrCommit[],
+): string | null {
+  let latest: string | null = null;
+  for (const c of commits) {
+    const d = c?.commit?.committer?.date ?? c?.commit?.author?.date ?? null;
+    if (!d) continue;
+    if (latest === null || d > latest) latest = d;
+  }
+  return latest;
 }
 
 async function fetchPrSnapshot(
@@ -398,7 +439,7 @@ async function fetchPrSnapshot(
   ]);
   const diff = diffRes.code === 0 ? diffRes.stdout : "";
 
-  return { prView, diff, reviews, issueComments };
+  return { prView, diff, reviews, issueComments, latestCommitTime: null };
 }
 
 function respondLogPath(env: NodeJS.ProcessEnv): string {
@@ -557,15 +598,14 @@ async function respondSinglePr(
   }
 
   // CHANGES_REQUESTED path — Step 3a idempotency.
+  // In snapshot mode, prefer the commit time captured by breeze-runner
+  // (pr-commits.json). Falling back to `null` would re-enable the
+  // double-dispatch bug from #158 — a retry/redelivery past the first
+  // fix would re-bump attempts and post a duplicate reply comment.
   const reviewTime = latestChangesRequestedAt(reviews);
-  let commitTime: string | null = null;
-  if (!snapshotDir) {
-    commitTime = await fetchLatestCommitTime(shell, repo, pr);
-  } else {
-    // Snapshot bundle does not include commit times; skip idempotency
-    // check — breeze-runner re-dispatches are expected to be fresh.
-    commitTime = null;
-  }
+  const commitTime = snapshotDir
+    ? bundle.latestCommitTime
+    : await fetchLatestCommitTime(shell, repo, pr);
   if (reviewTime && commitTime && commitTime > reviewTime) {
     write(`\u23ed #${pr}: fix already pushed, waiting for re-review`);
     logEvent(env, { kind: "skip", pr_number: pr, reason: "already_fixed" });

--- a/tests/breeze-daemon-gh-client.test.ts
+++ b/tests/breeze-daemon-gh-client.test.ts
@@ -272,6 +272,9 @@ describe("GhClient.writeTaskSnapshot", () => {
     expect(readFileSync(join(snapshotDir, "pr-view.json"), "utf8")).toBe(
       '{"number":42}',
     );
+    // pr-commits.json is required so gardener respond's idempotency
+    // check runs in snapshot mode — see #158.
+    expect(files).toContain("pr-commits.json");
     // Meta has bucket/status lines.
     const meta = readFileSync(
       join(snapshotDir, "pr-view.json.meta"),

--- a/tests/gardener-respond.test.ts
+++ b/tests/gardener-respond.test.ts
@@ -13,6 +13,7 @@ import {
   isFromGardener,
   isSyncPr,
   latestChangesRequestedAt,
+  latestCommitTimeFromCommits,
   readRespondAttempts,
   readSnapshot,
   RESPOND_MAX_ATTEMPTS,
@@ -257,6 +258,146 @@ describe("gardener respond -- snapshot mode", () => {
     );
     expect(apiCalls).toHaveLength(0);
     expect(lines[lines.length - 1]).toMatch(/^BREEZE_RESULT: /);
+  });
+
+  it("skips without double-bumping attempts when pr-commits.json shows the fix is already pushed (regression #158)", async () => {
+    const tmp = useTmpDir();
+    const snapshotDir = join(tmp.path, "snap");
+    mkdirSync(snapshotDir, { recursive: true });
+    const prView = {
+      number: 55,
+      title: "sync: something",
+      headRefName: "first-tree/sync-55",
+      reviewDecision: "CHANGES_REQUESTED",
+      body: "plain body",
+      updatedAt: "2026-04-15T00:00:00Z",
+    };
+    writeFileSync(join(snapshotDir, "pr-view.json"), JSON.stringify(prView));
+    writeFileSync(
+      join(snapshotDir, "pr-reviews.json"),
+      JSON.stringify([
+        {
+          user: { login: "bingran-you" },
+          state: "CHANGES_REQUESTED",
+          body: "fix this",
+          submitted_at: "2026-04-15T10:00:00Z",
+        },
+      ]),
+    );
+    writeFileSync(
+      join(snapshotDir, "issue-comments.json"),
+      JSON.stringify([]),
+    );
+    writeFileSync(join(snapshotDir, "pr.diff"), "");
+    // Latest commit is AFTER the CHANGES_REQUESTED review — simulates a
+    // duplicate dispatch (retry/webhook redelivery/crash recovery) after
+    // the first respond already pushed a fix.
+    writeFileSync(
+      join(snapshotDir, "pr-commits.json"),
+      JSON.stringify([
+        {
+          commit: {
+            committer: { date: "2026-04-15T10:30:00Z" },
+          },
+        },
+      ]),
+    );
+
+    const calls: ShellCall[] = [];
+    const shell = makeShell(
+      [() => ({ stdout: "", stderr: "", code: 0 })],
+      calls,
+    );
+    const { write, lines } = captureWrite();
+    const code = await runRespond(
+      ["--pr", "55", "--repo", "owner/name", "--tree-path", tmp.path],
+      {
+        shellRun: shell,
+        write,
+        env: { BREEZE_SNAPSHOT_DIR: snapshotDir },
+        now: () => new Date("2026-04-16T00:00:00Z"),
+      },
+    );
+    expect(code).toBe(0);
+    const last = lines[lines.length - 1];
+    expect(last).toMatch(
+      /^BREEZE_RESULT: status=skipped summary=already fixed/,
+    );
+    // No attempts bump and no duplicate reply: neither `gh pr edit` nor
+    // `gh pr comment` should have fired.
+    const writes = calls.filter(
+      (c) =>
+        c.command === "gh" &&
+        c.args[0] === "pr" &&
+        (c.args[1] === "edit" || c.args[1] === "comment"),
+    );
+    expect(writes).toHaveLength(0);
+  });
+
+  it("still proceeds when pr-commits.json shows the latest commit predates the review", async () => {
+    const tmp = useTmpDir();
+    const snapshotDir = join(tmp.path, "snap");
+    mkdirSync(snapshotDir, { recursive: true });
+    const prView = {
+      number: 56,
+      title: "sync: something",
+      headRefName: "first-tree/sync-56",
+      reviewDecision: "CHANGES_REQUESTED",
+      body: "plain body",
+      updatedAt: "2026-04-15T00:00:00Z",
+    };
+    writeFileSync(join(snapshotDir, "pr-view.json"), JSON.stringify(prView));
+    writeFileSync(
+      join(snapshotDir, "pr-reviews.json"),
+      JSON.stringify([
+        {
+          user: { login: "bingran-you" },
+          state: "CHANGES_REQUESTED",
+          body: "fix this",
+          submitted_at: "2026-04-15T10:00:00Z",
+        },
+      ]),
+    );
+    writeFileSync(
+      join(snapshotDir, "issue-comments.json"),
+      JSON.stringify([]),
+    );
+    writeFileSync(join(snapshotDir, "pr.diff"), "");
+    // Latest commit is BEFORE the review — the fix hasn't been pushed yet.
+    writeFileSync(
+      join(snapshotDir, "pr-commits.json"),
+      JSON.stringify([
+        {
+          commit: {
+            committer: { date: "2026-04-14T10:00:00Z" },
+          },
+        },
+      ]),
+    );
+
+    const calls: ShellCall[] = [];
+    const shell = makeShell(
+      [() => ({ stdout: "", stderr: "", code: 0 })],
+      calls,
+    );
+    const { write, lines } = captureWrite();
+    const code = await runRespond(
+      ["--pr", "56", "--repo", "owner/name", "--tree-path", tmp.path],
+      {
+        shellRun: shell,
+        write,
+        env: { BREEZE_SNAPSHOT_DIR: snapshotDir },
+        now: () => new Date("2026-04-16T00:00:00Z"),
+      },
+    );
+    expect(code).toBe(0);
+    expect(lines[lines.length - 1]).toMatch(
+      /^BREEZE_RESULT: status=handled/,
+    );
+    const edits = calls.filter(
+      (c) => c.command === "gh" && c.args[0] === "pr" && c.args[1] === "edit",
+    );
+    expect(edits.length).toBeGreaterThan(0);
   });
 
   it("calls gh when BREEZE_SNAPSHOT_DIR is unset", async () => {
@@ -575,6 +716,45 @@ describe("gardener respond -- helpers", () => {
   it("readSnapshot returns null when pr-view.json is missing", () => {
     const tmp = useTmpDir();
     expect(readSnapshot(tmp.path)).toBeNull();
+  });
+
+  it("latestCommitTimeFromCommits picks the max committer/author date", () => {
+    expect(
+      latestCommitTimeFromCommits([
+        { commit: { committer: { date: "2026-04-15T10:00:00Z" } } },
+        { commit: { committer: { date: "2026-04-15T11:00:00Z" } } },
+        { commit: { author: { date: "2026-04-15T09:00:00Z" } } },
+      ]),
+    ).toBe("2026-04-15T11:00:00Z");
+    expect(latestCommitTimeFromCommits([])).toBeNull();
+    expect(latestCommitTimeFromCommits([{ commit: {} }])).toBeNull();
+  });
+
+  it("readSnapshot populates latestCommitTime from pr-commits.json", () => {
+    const tmp = useTmpDir();
+    writeFileSync(
+      join(tmp.path, "pr-view.json"),
+      JSON.stringify({ number: 1 }),
+    );
+    writeFileSync(
+      join(tmp.path, "pr-commits.json"),
+      JSON.stringify([
+        { commit: { committer: { date: "2026-04-15T10:00:00Z" } } },
+        { commit: { committer: { date: "2026-04-15T12:00:00Z" } } },
+      ]),
+    );
+    const bundle = readSnapshot(tmp.path);
+    expect(bundle?.latestCommitTime).toBe("2026-04-15T12:00:00Z");
+  });
+
+  it("readSnapshot returns latestCommitTime=null when pr-commits.json is missing", () => {
+    const tmp = useTmpDir();
+    writeFileSync(
+      join(tmp.path, "pr-view.json"),
+      JSON.stringify({ number: 1 }),
+    );
+    const bundle = readSnapshot(tmp.path);
+    expect(bundle?.latestCommitTime).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- breeze-runner now captures `pr-commits.json` next to `pr-view.json` / `pr-reviews.json` when hydrating a PR snapshot.
- gardener `respond` reads that file via `readSnapshot` and uses the latest commit time for the `commitTime > reviewTime` idempotency check in snapshot mode — previously this check was skipped entirely, so a duplicate dispatch from breeze-runner (retry / webhook redelivery / crash recovery) would double-bump the attempts counter and post a duplicate reply comment.
- Backward compatible: if `pr-commits.json` is absent (older snapshot dirs), `latestCommitTime` is `null` and behavior matches the pre-change code.

Fixes #158.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (881/881)
- [x] `pnpm validate:skill`
- [x] `pnpm build`
- [x] New regression tests in `tests/gardener-respond.test.ts`:
  - duplicate-dispatch snapshot with commit newer than review → `status=skipped summary=already fixed`, no `gh pr edit`/`comment` fires.
  - snapshot with commit older than review → still `status=handled`, `gh pr edit` fires.
  - `readSnapshot` populates `latestCommitTime`; returns `null` when `pr-commits.json` is missing.
  - `latestCommitTimeFromCommits` picks max date across committer/author.
- [x] `tests/breeze-daemon-gh-client.test.ts` now asserts `pr-commits.json` is in the captured snapshot dir.