### PR TITLE
feat(gardener): parse tree_issue_created marker field

### DIFF
--- a/src/products/gardener/engine/comment.ts
+++ b/src/products/gardener/engine/comment.ts
@@ -275,6 +275,8 @@ export const REVIEWED_SHA_RE = /reviewed=([A-Za-z0-9@:.-]+)/;
 export const VERDICT_IN_MARKER_RE = /verdict=([A-Z_]+)/;
 export const SEVERITY_IN_MARKER_RE = /severity=([a-z]+)/;
 export const TREE_SHA_IN_MARKER_RE = /tree_sha=([A-Za-z0-9]+)/;
+export const TREE_ISSUE_CREATED_IN_MARKER_RE =
+  /tree_issue_created=(https:\/\/github\.com\/[^\s·>]+)/;
 
 /**
  * Recognizes `@gardener <command>` in user comments. Matches the
@@ -358,6 +360,7 @@ export function parseStateMarker(body: string | undefined): {
   verdict?: Verdict;
   severity?: Severity;
   treeSha?: string;
+  treeIssueCreated?: string;
 } | null {
   const marker = extractStateMarker(body);
   if (!marker) return null;
@@ -366,6 +369,7 @@ export function parseStateMarker(body: string | undefined): {
     verdict?: Verdict;
     severity?: Severity;
     treeSha?: string;
+    treeIssueCreated?: string;
   } = {};
   const reviewed = marker.match(REVIEWED_SHA_RE);
   if (reviewed) out.reviewed = reviewed[1];
@@ -379,6 +383,8 @@ export function parseStateMarker(body: string | undefined): {
   }
   const treeSha = marker.match(TREE_SHA_IN_MARKER_RE);
   if (treeSha) out.treeSha = treeSha[1];
+  const treeIssue = marker.match(TREE_ISSUE_CREATED_IN_MARKER_RE);
+  if (treeIssue) out.treeIssueCreated = treeIssue[1];
   return out;
 }
 

--- a/tests/gardener-comment.test.ts
+++ b/tests/gardener-comment.test.ts
@@ -801,6 +801,42 @@ describe("gardener comment -- marker helpers", () => {
     expect(parsed?.verdict).toBe("CONFLICT");
     expect(parsed?.severity).toBe("high");
     expect(parsed?.treeSha).toBe("deadbeef");
+    expect(parsed?.treeIssueCreated).toBeUndefined();
+  });
+
+  it("parseStateMarker extracts tree_issue_created URL when present", () => {
+    const parsed = parseStateMarker(
+      "<!-- gardener:state · reviewed=abcdef · verdict=NEW_TERRITORY · severity=medium · tree_sha=deadbeef · tree_issue_created=https://github.com/alice/tree/issues/42 -->",
+    );
+    expect(parsed?.treeIssueCreated).toBe(
+      "https://github.com/alice/tree/issues/42",
+    );
+    expect(parsed?.reviewed).toBe("abcdef");
+    expect(parsed?.verdict).toBe("NEW_TERRITORY");
+  });
+
+  it("parseStateMarker leaves treeIssueCreated undefined when marker is pre-Phase-1 (backward compat)", () => {
+    const parsed = parseStateMarker(
+      "<!-- gardener:state · reviewed=abcdef · verdict=ALIGNED · severity=low · tree_sha=deadbeef -->",
+    );
+    expect(parsed?.treeIssueCreated).toBeUndefined();
+  });
+
+  it("parseStateMarker stops URL capture at the marker's ' · ' separator, not mid-URL", () => {
+    const parsed = parseStateMarker(
+      "<!-- gardener:state · tree_issue_created=https://github.com/alice/tree/issues/7 · reviewed=abcdef -->",
+    );
+    expect(parsed?.treeIssueCreated).toBe(
+      "https://github.com/alice/tree/issues/7",
+    );
+    expect(parsed?.reviewed).toBe("abcdef");
+  });
+
+  it("parseStateMarker ignores non-GitHub URLs in tree_issue_created (markers only carry github.com links)", () => {
+    const parsed = parseStateMarker(
+      "<!-- gardener:state · reviewed=abc · tree_issue_created=https://evil.example/issues/1 -->",
+    );
+    expect(parsed?.treeIssueCreated).toBeUndefined();
   });
 
   it("hasIgnoredMarker / hasPausedMarker detect markers", () => {


### PR DESCRIPTION
## Summary

Pure-parse change. Adds `tree_issue_created=<url>` as a recognized field in the gardener state marker, returning it via `parseStateMarker`. No writer, no behavioral change — ships the reader before Phase 2's writer so old markers and new ones both round-trip cleanly.

Fixes #170. Part of #162 (plan step 2).

## Why ship reader first

Phase 2 (MERGED-PR scan branch in `comment`) will write this field to deduplicate tree-repo issue creation on repeated scheduled runs. Shipping the parser first means:
- Phase 2 can't produce markers older gardener binaries fail to parse.
- Old markers (no `tree_issue_created`) stay valid — `treeIssueCreated` is optional.

## Regex boundary

`/tree_issue_created=(https:\/\/github\.com\/[^\s·>]+)/`

- Anchored on `https://github.com/` so non-GitHub URLs are rejected (markers only ever carry github.com links, and permissive capture would open a URL-shape spoofing surface).
- Terminates at whitespace, the ` · ` separator, or the marker's closing `-->`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run tests/gardener-comment.test.ts` — 51/51 pass (4 new)
- [x] Pre-existing failures in other test files (launchd plist, NODE.md frontmatter, breeze-statusline) confirmed on unmodified main — unrelated to this change
- [x] Backward compat: pre-Phase-1 markers still parse with `treeIssueCreated` undefined
- [x] URL capture stops at ` · ` separator (mid-marker placement works)
- [x] Non-GitHub URLs rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)