### PR TITLE
chore: strip private workspace fields from committed source binding

### DIFF
--- a/.first-tree/source.json
+++ b/.first-tree/source.json
@@ -1,18 +1,16 @@
 {
-  "bindingMode": "workspace-member",
+  "bindingMode": "shared-source",
   "rootKind": "git-repo",
-  "scope": "workspace",
+  "scope": "repo",
   "sourceId": "first-tree-b27f27a6",
   "sourceName": "first-tree",
   "tree": {
-    "entrypoint": "/workspaces/first-tree-all/repos/first-tree",
+    "entrypoint": "/repos/first-tree",
     "localPath": "../first-tree-context",
     "remoteUrl": "https://github.com/agent-team-foundation/first-tree-context",
     "treeId": "first-tree-context",
     "treeMode": "shared",
     "treeRepoName": "first-tree-context"
   },
-  "workspaceId": "first-tree-all",
-  "workspaceRootPath": "..",
   "schemaVersion": 1
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,22 +96,21 @@ npx tsx evals/scripts/run-eval.ts --trials 3 --cases pydantic-importstring-error
 ```
 
 <!-- BEGIN FIRST-TREE-SOURCE-INTEGRATION -->
-FIRST-TREE-SOURCE-INTEGRATION: workspace member bound to shared tree repo `first-tree-context`
+FIRST-TREE-SOURCE-INTEGRATION: source repo bound to shared tree repo `first-tree-context`
 FIRST-TREE-TREE-REPO: `first-tree-context`
 FIRST-TREE-TREE-MODE: `shared`
-FIRST-TREE-BINDING-MODE: `workspace-member`
+FIRST-TREE-BINDING-MODE: `shared-source`
 FIRST-TREE-TREE-REPO-URL: `https://github.com/agent-team-foundation/first-tree-context`
-FIRST-TREE-ENTRYPOINT: `/workspaces/first-tree-all/repos/first-tree`
-FIRST-TREE-WORKSPACE-ID: `first-tree-all`
-FIRST-TREE-LOCAL-TREE-CONFIG: `.first-tree/local-tree.json`
+FIRST-TREE-ENTRYPOINT: `/repos/first-tree`
+FIRST-TREE-SOURCE-STATE: `.first-tree/source.json`
 
-This repo is a workspace member. Keep all Context Tree files only in the shared `first-tree-context` repo and follow the workspace root's binding for shared context updates in workspace `first-tree-all`.
+This repo is bound to an existing shared Context Tree. Keep all Context Tree files only in the shared `first-tree-context` repo.
 
 Before every task:
-- Read `.first-tree/local-tree.json` first. If it exists, resolve its `localPath` value from this repo root and treat that checkout as the canonical local tree repo.
+- Read `.first-tree/source.json` first. Resolve its `tree.localPath` value from this repo root and treat that checkout as the canonical local tree repo. If `.first-tree/source.local.json` exists, its `localPath` overrides the one in `source.json`.
 - If that configured checkout exists locally, update it before you read anything else.
 - If the configured checkout is missing, clone a temporary working copy from `https://github.com/agent-team-foundation/first-tree-context` into `.first-tree/tmp/first-tree-context/`, use it for the current task, and delete it before you finish.
-- Never commit `.first-tree/local-tree.json` or anything under `.first-tree/tmp/` to this repo. They are local-only workspace state.
+- Never commit `.first-tree/source.local.json` or anything under `.first-tree/tmp/` to this repo. They are local-only state.
 
 After every task:
 - Always ask whether the tree needs updating.


### PR DESCRIPTION
## Summary

- Rewrite `.first-tree/source.json` to a public `shared-source` binding: drop `workspaceId: first-tree-all`, `workspaceRootPath: ..`, and the sandbox-specific `entrypoint: /workspaces/first-tree-all/repos/first-tree`. Keep the discoverability-critical fields: `treeRepoName`, `treeId`, `treeMode: shared`, `remoteUrl`.
- Regenerate the `FIRST-TREE-SOURCE-INTEGRATION` block in `AGENTS.md` (and the `CLAUDE.md` symlink) to match — `BINDING-MODE: shared-source`, generic `ENTRYPOINT: /repos/first-tree`, no workspace-id line, and the "before every task" text now points at `.first-tree/source.json` + optional `.first-tree/source.local.json` overlay instead of the now-removed `local-tree.json`.

## Why

The committed binding was leaking the maintainer's private workspace layout (`first-tree-all`, `/workspaces/…`) into a public OSS repo. An external contributor cloning the repo would see markers they can't act on and a workspace-member binding mode that isn't true for their checkout. The one thing contributors actually need from this binding — the URL of `first-tree-context` so they can find the Context Tree — is preserved and now front-and-center without the noise around it.

## Maintainer-local overlay

The gitignore already excludes `.first-tree/source.local.json` (via the `.first-tree/* / !source.json` pattern). The CLI already reads `localPath` from that overlay in `local-tree-config.ts`. Maintainers who run this repo inside the `first-tree-all` workspace can drop a local overlay like:

```json
{
  "localPath": "../first-tree-context"
}
```

(Extending the overlay to also cover `entrypoint` / `workspaceId` / `bindingMode` so `first-tree inspect` reflects the maintainer's workspace view is a clean follow-up — out of scope for this PR.)

## Test plan

- [x] `pnpm install`
- [x] `pnpm typecheck`
- [x] `pnpm validate:skill`
- [x] `pnpm test` — 876 passed
- [x] `pnpm build`