### PR TITLE
feat(gardener): Phase 2a — pure primitives for merged-PR tree-issue flow

### DIFF
--- a/src/products/gardener/engine/comment.ts
+++ b/src/products/gardener/engine/comment.ts
@@ -394,6 +394,158 @@ export function hasIgnoredMarker(body: string | undefined): boolean {
   return GARDENER_IGNORED_MARKER_RE.test(body);
 }
 
+/**
+ * Append `tree_issue_created=<url>` to an existing gardener:state
+ * marker. If the marker already has the field, the existing value is
+ * replaced (idempotent under duplicate dispatch: a retry after a
+ * successful issue create but failed marker PATCH sees the same URL
+ * and overwrites with the same URL).
+ *
+ * Returns null if `body` has no gardener:state marker — caller must
+ * decide how to recover (probably log & skip, not rewrite arbitrary
+ * comment bodies).
+ */
+export function withTreeIssueCreatedField(
+  body: string,
+  issueUrl: string,
+): string | null {
+  const marker = extractStateMarker(body);
+  if (!marker) return null;
+  const hasField = TREE_ISSUE_CREATED_IN_MARKER_RE.test(marker);
+  const newMarker = hasField
+    ? marker.replace(
+        TREE_ISSUE_CREATED_IN_MARKER_RE,
+        `tree_issue_created=${issueUrl}`,
+      )
+    : marker.replace(/\s*-->\s*$/, ` · tree_issue_created=${issueUrl} -->`);
+  return body.replace(marker, newMarker);
+}
+
+/**
+ * Parse a CODEOWNERS file and return the @-mentions that own the
+ * longest-prefix match of `path`. Matches GitHub's behavior: rules
+ * are evaluated top-to-bottom and the **last matching** rule wins.
+ *
+ * `path` is the tree-relative path the gardener verdict targets
+ * (e.g. `pkg-a/foo.ts` or `pkg-a/`). Directories must end with `/`.
+ * Returns @-prefixed logins ready to embed in an issue body.
+ *
+ * Pure string function — caller reads CODEOWNERS themselves (we don't
+ * do I/O here so this stays testable without fixtures).
+ */
+export function codeownersForPath(
+  codeownersText: string,
+  path: string,
+): string[] {
+  const normalized = path.startsWith("/") ? path : `/${path}`;
+  let winners: string[] = [];
+  for (const rawLine of codeownersText.split("\n")) {
+    const line = rawLine.split("#")[0].trim();
+    if (!line) continue;
+    const parts = line.split(/\s+/);
+    if (parts.length < 2) continue;
+    const pattern = parts[0];
+    const owners = parts.slice(1);
+    if (codeownersMatches(pattern, normalized)) winners = owners;
+  }
+  return winners
+    .map((o) => o.replace(/^@+/, ""))
+    .filter((o) => o.length > 0)
+    .map((o) => `@${o}`);
+}
+
+/**
+ * Minimal CODEOWNERS pattern matcher. Supports the subset
+ * `tree generate-codeowners` actually emits:
+ *   - `/dir/` — matches everything under /dir/
+ *   - `/file.ext` — exact file match
+ *   - `*` — root fallback (every path matches)
+ * Extra glob features (`**`, `*.ext`) are not emitted by our generator,
+ * so we don't try to replicate GitHub's full semantics.
+ */
+function codeownersMatches(pattern: string, path: string): boolean {
+  if (pattern === "*") return true;
+  if (pattern.endsWith("/")) return path.startsWith(pattern);
+  return path === pattern;
+}
+
+/**
+ * Build a tree-repo issue body describing a gardener verdict on a
+ * merged source PR. Consumed by Phase 2b's MERGED-scan branch. Kept
+ * separate from `buildCommentBody` (source-PR audience) because the
+ * tree-repo audience — node owners looking at an unassigned issue in
+ * their own repo — needs different framing: *what source change
+ * happened, which tree nodes might be affected, and why gardener
+ * flagged it*.
+ */
+export interface BuildTreeIssueBodyInput {
+  /** Source repo slug e.g. "alice/cool-thing". */
+  sourceRepo: string;
+  /** Source PR number. */
+  sourcePr: number;
+  /** Source PR title (for human context). */
+  sourcePrTitle: string;
+  /** URL to the source-PR gardener-state comment (for traceability). */
+  sourceCommentUrl: string;
+  verdict: Verdict;
+  severity: Severity;
+  /** One-line summary of the change — from the verdict. */
+  summary: string;
+  /** Tree nodes gardener cited. */
+  treeNodes: { path: string; summary: string }[];
+  /** @-prefixed logins to cc (from CODEOWNERS resolution). May be empty. */
+  codeownersMentions: string[];
+}
+
+export function buildTreeIssueBody(input: BuildTreeIssueBodyInput): string {
+  const {
+    sourceRepo,
+    sourcePr,
+    sourcePrTitle,
+    sourceCommentUrl,
+    verdict,
+    severity,
+    summary,
+    treeNodes,
+    codeownersMentions,
+  } = input;
+  const emoji = VERDICT_EMOJI[verdict];
+  const nodeList =
+    treeNodes.length > 0
+      ? treeNodes.map((n) => `- \`${n.path}\` — ${n.summary}`).join("\n")
+      : "- _(no tree nodes cited)_";
+  const ccLine =
+    codeownersMentions.length > 0
+      ? `cc ${codeownersMentions.join(" ")}`
+      : "_(no CODEOWNERS match for cited nodes — issue is unassigned)_";
+  return [
+    `## Merged source change needs tree review`,
+    "",
+    `${emoji} **verdict:** \`${verdict}\` · **severity:** \`${severity}\``,
+    "",
+    `**Source PR:** [${sourceRepo}#${sourcePr}](https://github.com/${sourceRepo}/pull/${sourcePr}) — ${sourcePrTitle}`,
+    `**Gardener verdict:** ${sourceCommentUrl}`,
+    "",
+    `### What changed`,
+    "",
+    summary,
+    "",
+    `### Tree nodes potentially affected`,
+    "",
+    nodeList,
+    "",
+    `### Action`,
+    "",
+    `A node owner should decide whether the tree needs an update in response to this merged change. This issue is auto-filed by gardener and not auto-assigned — pick it up via CODEOWNERS routing.`,
+    "",
+    ccLine,
+    "",
+    "---",
+    "",
+    `<sub>🌱 Auto-filed by [repo-gardener](https://github.com/agent-team-foundation/repo-gardener) via [First-Tree](https://github.com/agent-team-foundation/first-tree). Close this issue when the tree reflects the source change (or when no change is warranted).</sub>`,
+  ].join("\n");
+}
+
 export function hasPausedMarker(body: string | undefined): boolean {
   if (!body) return false;
   return GARDENER_PAUSED_MARKER_RE.test(body);

--- a/tests/gardener-comment.test.ts
+++ b/tests/gardener-comment.test.ts
@@ -5,6 +5,8 @@ import { runCli } from "../src/cli.js";
 import { GARDENER_USAGE, runGardener } from "#products/gardener/cli.js";
 import {
   buildCommentBody,
+  buildTreeIssueBody,
+  codeownersForPath,
   COMMENT_USAGE,
   commentLogPath,
   defaultClassifier,
@@ -21,6 +23,7 @@ import {
   resolveState,
   runComment,
   shaMatches,
+  withTreeIssueCreatedField,
   type Classifier,
   type ShellResult,
   type ShellRun,
@@ -1095,5 +1098,143 @@ describe("commentLogPath (#159 — log-dir fallback)", () => {
   it("never returns a path inside process.cwd() when HOME is unset (regression for #159)", () => {
     const path = commentLogPath({});
     expect(path.startsWith(process.cwd())).toBe(false);
+    expect(path.endsWith("comment-runs.jsonl")).toBe(true);
+  });
+});
+
+describe("gardener comment -- Phase 2a tree-issue primitives", () => {
+  // ─────────────────── withTreeIssueCreatedField ───────────────────
+  it("withTreeIssueCreatedField appends field to marker that lacks it", () => {
+    const body =
+      "<!-- gardener:state · reviewed=abc · verdict=NEW_TERRITORY · severity=medium · tree_sha=def -->\nhello";
+    const out = withTreeIssueCreatedField(
+      body,
+      "https://github.com/alice/tree/issues/7",
+    );
+    expect(out).toContain(
+      "tree_issue_created=https://github.com/alice/tree/issues/7",
+    );
+    // Existing fields preserved:
+    expect(out).toContain("reviewed=abc");
+    expect(out).toContain("verdict=NEW_TERRITORY");
+    expect(out).toContain("tree_sha=def");
+    expect(out).toContain("\nhello");
+    // Round-trips through parser:
+    expect(parseStateMarker(out!)?.treeIssueCreated).toBe(
+      "https://github.com/alice/tree/issues/7",
+    );
+  });
+
+  it("withTreeIssueCreatedField replaces field when present (idempotent on retry)", () => {
+    const body =
+      "<!-- gardener:state · reviewed=abc · tree_issue_created=https://github.com/alice/tree/issues/1 -->";
+    const out = withTreeIssueCreatedField(
+      body,
+      "https://github.com/alice/tree/issues/2",
+    );
+    expect(out).toContain("tree_issue_created=https://github.com/alice/tree/issues/2");
+    expect(out).not.toContain("tree_issue_created=https://github.com/alice/tree/issues/1");
+  });
+
+  it("withTreeIssueCreatedField returns null for body with no gardener marker", () => {
+    expect(
+      withTreeIssueCreatedField(
+        "random body no marker",
+        "https://github.com/a/b/issues/1",
+      ),
+    ).toBeNull();
+  });
+
+  it("withTreeIssueCreatedField is idempotent — applying twice yields same result", () => {
+    const body =
+      "<!-- gardener:state · reviewed=abc · verdict=ALIGNED · severity=low · tree_sha=d -->";
+    const url = "https://github.com/alice/tree/issues/9";
+    const once = withTreeIssueCreatedField(body, url)!;
+    const twice = withTreeIssueCreatedField(once, url)!;
+    expect(twice).toBe(once);
+  });
+
+  // ─────────────────── codeownersForPath ───────────────────
+  it("codeownersForPath returns owners for longest last-match directory rule", () => {
+    const co = [
+      "* @default",
+      "/pkg-a/ @alice",
+      "/pkg-a/sub/ @bob",
+    ].join("\n");
+    expect(codeownersForPath(co, "pkg-a/sub/foo.ts")).toEqual(["@bob"]);
+    expect(codeownersForPath(co, "pkg-a/foo.ts")).toEqual(["@alice"]);
+    expect(codeownersForPath(co, "pkg-b/foo.ts")).toEqual(["@default"]);
+  });
+
+  it("codeownersForPath returns empty when no rules match and no fallback", () => {
+    const co = "/pkg-a/ @alice\n";
+    expect(codeownersForPath(co, "pkg-b/foo.ts")).toEqual([]);
+  });
+
+  it("codeownersForPath supports multi-owner lines and strips extra @ prefixes", () => {
+    const co = "/pkg-a/ @alice @@bob @team/frontend\n";
+    expect(codeownersForPath(co, "pkg-a/foo.ts")).toEqual([
+      "@alice",
+      "@bob",
+      "@team/frontend",
+    ]);
+  });
+
+  it("codeownersForPath ignores comment and blank lines", () => {
+    const co = [
+      "# header",
+      "",
+      "/pkg-a/ @alice # inline comment",
+      "",
+    ].join("\n");
+    expect(codeownersForPath(co, "pkg-a/foo.ts")).toEqual(["@alice"]);
+  });
+
+  it("codeownersForPath handles exact file patterns", () => {
+    const co = "/README.md @docs\n/pkg-a/ @alice\n";
+    expect(codeownersForPath(co, "README.md")).toEqual(["@docs"]);
+    expect(codeownersForPath(co, "pkg-a/README.md")).toEqual(["@alice"]);
+  });
+
+  // ─────────────────── buildTreeIssueBody ───────────────────
+  it("buildTreeIssueBody composes a tree-repo-audience issue body", () => {
+    const body = buildTreeIssueBody({
+      sourceRepo: "alice/cool",
+      sourcePr: 101,
+      sourcePrTitle: "feat(pkg-a): add thing",
+      sourceCommentUrl: "https://github.com/alice/cool/pull/101#issuecomment-999",
+      verdict: "NEW_TERRITORY",
+      severity: "medium",
+      summary: "Introduces new module pkg-a that isn't covered by any tree node.",
+      treeNodes: [{ path: "pkg-a", summary: "(none cited)" }],
+      codeownersMentions: ["@alice", "@team/frontend"],
+    });
+    expect(body).toContain("Merged source change needs tree review");
+    expect(body).toContain("[alice/cool#101](https://github.com/alice/cool/pull/101)");
+    expect(body).toContain("feat(pkg-a): add thing");
+    expect(body).toContain("#issuecomment-999");
+    expect(body).toContain("`NEW_TERRITORY`");
+    expect(body).toContain("`medium`");
+    expect(body).toContain("Introduces new module pkg-a");
+    expect(body).toContain("`pkg-a`");
+    expect(body).toContain("cc @alice @team/frontend");
+    expect(body).toContain("Auto-filed by [repo-gardener]");
+  });
+
+  it("buildTreeIssueBody handles empty CODEOWNERS mentions gracefully", () => {
+    const body = buildTreeIssueBody({
+      sourceRepo: "alice/cool",
+      sourcePr: 102,
+      sourcePrTitle: "chore: tweak",
+      sourceCommentUrl: "https://github.com/alice/cool/pull/102#issuecomment-1",
+      verdict: "ALIGNED",
+      severity: "low",
+      summary: "Minor tweak.",
+      treeNodes: [],
+      codeownersMentions: [],
+    });
+    expect(body).toContain("no CODEOWNERS match");
+    expect(body).not.toContain("cc @");
+    expect(body).toContain("(no tree nodes cited)");
   });
 });


### PR DESCRIPTION
## Summary

Ships three pure helpers that Phase 2b's MERGED-scan branch will wire into `comment`. Zero behavior change — no I/O, no gh calls, no new command branches, no scan-loop modifications. Small review surface so the wiring PR (Phase 2b, ~200+ lines with orchestration + retry semantics + integration tests) can focus on logic without re-litigating helper shapes.

Fixes #173. Part of #162.

## Depends on #171

This branch contains the Phase 1 parser commit (f2d35c8) as a dependency. **Merge #171 first** — then GitHub will auto-fast-forward this branch's merge base and only the Phase 2a commit (015545d) will land.

## Helpers

1. **`withTreeIssueCreatedField(body, url)`** — append/replace the `tree_issue_created=<url>` sibling field on an existing gardener:state marker. Idempotent on retry: second call with same URL returns the same body byte-for-byte.
2. **`codeownersForPath(codeownersText, path)`** — last-match-wins CODEOWNERS matcher, comment-tolerant, multi-owner, strips duplicate `@` prefixes. Matches the subset `tree generate-codeowners` emits.
3. **`buildTreeIssueBody(input)`** — tree-repo-audience issue body: verdict + severity, source-PR link, cited tree nodes, cc routing (or "no CODEOWNERS match" fallback), traceability sub-footer.

## Phase 2b preview (not in this PR)

- MERGED-PR branch in `reviewOne` at comment.ts:1002, gated on "has gardener:state marker AND lacks tree_issue_created"
- Order: create tree-repo issue → PATCH source-PR marker. On PATCH failure, the next scan re-parses the source marker, sees no `tree_issue_created`, re-runs — and the created-issue step detects duplicate by searching tree repo for a prior auto-filed issue referencing the same source PR URL.
- Token model: single source-repo token today; explicit tree-repo token support deferred until a concrete deploy wants to scope them separately.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run tests/gardener-comment.test.ts` — 62/62 pass (11 new)
- [x] Covers: idempotency on retry, null for bodies without marker, empty CODEOWNERS, multi-owner lines, exact-file patterns, no-fallback paths, empty cc list, node-free bodies
- [x] Marker round-trip: `withTreeIssueCreatedField` output parses back via `parseStateMarker`

🤖 Generated with [Claude Code](https://claude.com/claude-code)