### PR TITLE
refactor: align first-tree CLI and skill contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,17 +1,17 @@
 # Agent Instructions for first-tree
 
-This repo distributes the `first-tree` npm package: a thin umbrella CLI that
-dispatches into three product namespaces (`tree`, `breeze`, `gardener`) plus
-four lightweight skill payloads (`first-tree` entry point + one per product).
-It is not a user context tree. Maintaining this repo is different from using
-it — see the user-facing `skills/first-tree/SKILL.md` for what gets shipped
-as the entry-point skill.
+This repo distributes the `first-tree` npm package: a thin umbrella CLI with
+three primary product namespaces (`tree`, `breeze`, `gardener`), one
+maintenance namespace (`skill`), and four lightweight skill payloads
+(`first-tree` entry point + one per product). It is not a user context tree.
+Maintaining this repo is different from using it — see the user-facing
+`skills/first-tree/SKILL.md` for what gets shipped as the entry-point skill.
 
 ## Start Here
 
 1. `docs/source-map.md` — maintainer entrypoint; it points to canonical Context Tree nodes first, then local implementation notes
-2. `src/products/manifest.ts` — the single source of truth for the three
-   products; all dispatch, version reporting, and skill management reads from
+2. `src/products/manifest.ts` — the single source of truth for the CLI
+   namespaces; all dispatch, version reporting, and skill management reads from
    here
 3. `skills/first-tree/SKILL.md` — the user-facing entry-point skill (read
    this so you understand what ships to user repos and how it routes to the
@@ -25,9 +25,9 @@ as the entry-point skill.
 
 - Treat the source repo as a TypeScript project, not a tree repo.
 - Canonical layout:
-  - `src/cli.ts` — top-level umbrella dispatcher (`first-tree <product> <command>`); delegates to the manifest
-  - `src/products/manifest.ts` — the product manifest (name, description,
-    lazy entrypoint, auto-upgrade, assets/skill flags)
+  - `src/cli.ts` — top-level umbrella dispatcher (`first-tree <namespace> <command>`); delegates to the manifest
+  - `src/products/manifest.ts` — the CLI namespace manifest (kind, name,
+    description, lazy entrypoint, auto-upgrade, assets/skill flags)
   - `src/products/<name>/` — one folder per product (`tree`, `breeze`,
     `gardener`). Each has the same shape:
     - `VERSION` — product version (separate from npm package version)
@@ -39,6 +39,9 @@ as the entry-point skill.
     - `engine/` root — business-logic modules (domain specific)
     - Product-specific extras: `engine/daemon/` (breeze), `engine/rules/`
       and `engine/validators/` (tree)
+  - `src/meta/skill-tools/` — maintenance namespace for skill inspection and
+    repair (`list`, `doctor`, `link`); it ships no product skill payload of
+    its own
   - `assets/<name>/` — runtime payloads read by the CLI at runtime. Only
     `tree` ships real assets today; `breeze` ships just the SSE dashboard
     HTML; `gardener` ships none.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 **A Git-native knowledge layer for your team — and a three-tool suite that keeps it alive.**
 
-`first-tree` publishes the `first-tree` CLI and its bundled agent skills. A Context Tree is the living source of truth for decisions, ownership, and cross-domain relationships that humans and agents maintain together — `first-tree` is the toolkit that lets agents build, tend, and react to it.
+`first-tree` publishes the `first-tree` CLI and its bundled agent skills. A
+Context Tree is the living source of truth for decisions, ownership, and
+cross-domain relationships that humans and agents maintain together —
+`first-tree` is the toolkit that lets agents build, tend, and react to it.
 
 ---
 
-## The three tools
+## The Three Tools
 
 ```
 ┌──────────────────────────────────────────────────────────────────────┐
@@ -31,26 +34,68 @@
 
 | Tool | What it is | When to reach for it |
 |------|------------|----------------------|
-| **[tree](src/products/tree)** | CLI toolkit — `first-tree tree init/bind/sync/publish/verify/upgrade/workspace/review/generate-codeowners/inject-context` (e.g. `first-tree tree publish` pushes the tree to GitHub and refreshes bound sources). | You want an agent to create, maintain, or bind a Context Tree repo. |
-| **[gardener](src/products/gardener)** | Local maintenance daemon — proactively watches source repos and opens/assigns tree issues; responds to review feedback on sync PRs | You want the tree to stay coherent as code changes without asking a human to drive it. |
-| **[breeze](src/products/breeze)** | Local inbox daemon — takes over your `gh` login and turns GitHub notifications (PRs, comments, discussions, issues) into a triaged, optionally auto-handled queue | You want an agent sitting on your GitHub notifications so you don't have to. |
+| **[tree](src/products/tree)** | CLI toolkit for `first-tree tree init/bind/sync/publish/verify/upgrade/workspace/review/generate-codeowners/inject-context/bootstrap` | You want an agent to create, maintain, or bind a Context Tree repo. |
+| **[gardener](src/products/gardener)** | Local maintenance daemon that watches source repos, opens/assigns tree issues, and responds to sync-PR review feedback | You want the tree to stay coherent as code changes without asking a human to drive it. |
+| **[breeze](src/products/breeze)** | Local inbox daemon that takes over your `gh` login and turns GitHub notifications into a triaged, optionally auto-handled queue | You want an agent sitting on your GitHub notifications so you don't have to. |
 
 Every product ships:
 - an operational handbook at `skills/<name>/SKILL.md` (loaded into agents),
 - a lazy CLI dispatcher at `src/products/<name>/cli.ts`,
 - its own semver'd `VERSION` file, independent from the npm package version (see [docs/architecture/versioning.md](docs/architecture/versioning.md)).
 
-The umbrella skill at [`skills/first-tree/`](skills/first-tree) is the single entry point an agent reads first — it teaches the Context Tree methodology and routes to the three product skills above. Diagnostic/meta commands (`first-tree skill list/doctor/link`) live under [`src/meta/skill-tools/`](src/meta/skill-tools) and are not products.
+The umbrella `first-tree` skill at [`skills/first-tree/`](skills/first-tree/) is
+the single entry point an agent reads first — it teaches the Context Tree
+methodology and routes to the three product skills above. The CLI also exposes
+one **maintenance namespace** — `first-tree skill ...` — for skill
+installation, diagnosis, and repair. It is not a fourth product.
 
 ---
 
-## Quick start
+## Install And Run
 
-### For an agent (recommended)
+The npm package and installed CLI command are both `first-tree`.
 
-Paste one of these into Claude Code, Codex, or any agent — from the root you want to onboard:
+- One-off use without installing globally:
+
+  ```bash
+  npx first-tree tree inspect --json
+  npx first-tree tree init
+  ```
+
+  For automation, hooks, or CI templates, prefer the more explicit form:
+
+  ```bash
+  npx -p first-tree first-tree tree inspect --json
+  ```
+
+- Global install:
+
+  ```bash
+  npm install -g first-tree
+  first-tree tree init
+  ```
+
+- Show the installed CLI version:
+
+  ```bash
+  first-tree --version
+  ```
+
+- Show the command list:
+
+  ```bash
+  first-tree --help
+  ```
+
+---
+
+## Quick Start For Agents
+
+Paste one of these into Claude Code, Codex, or any agent — from the root you
+want to onboard:
 
 **First person on the team:**
+
 ```text
 Use the latest first-tree CLI (https://github.com/agent-team-foundation/first-tree).
 Run `first-tree tree inspect --json` to classify the current folder, then install
@@ -58,6 +103,7 @@ the skill and onboard this repo or workspace by creating a new Context Tree.
 ```
 
 **Joining an existing tree:**
+
 ```text
 Use the latest first-tree CLI (https://github.com/agent-team-foundation/first-tree).
 Run `first-tree tree inspect --json`, install the skill, and bind this repo or
@@ -65,22 +111,9 @@ workspace to the existing shared tree at
 https://github.com/<your-org>/<your-tree-repo>.
 ```
 
-### For a human
-
-```bash
-# one-off (no global install)
-npx -p first-tree first-tree tree inspect --json
-npx -p first-tree first-tree tree init
-
-# global install
-npm install -g first-tree
-first-tree --help          # list products + diagnostics
-first-tree --version       # CLI + per-product versions
-```
-
 ---
 
-## Onboarding modes
+## Onboarding Modes
 
 `first-tree` models onboarding with three explicit concepts:
 
@@ -95,35 +128,132 @@ Four first-class paths:
 | Single repo + new dedicated tree | `first-tree tree init` |
 | Bind to existing shared tree | `first-tree tree bind --tree-path ../org-context --tree-mode shared` |
 | Workspace root + shared tree | `first-tree tree init --scope workspace --sync-members` (then `first-tree tree workspace sync`) |
-| You're inside the tree repo itself | `first-tree tree init tree --here` |
+| You're inside the tree repo itself | `first-tree tree bootstrap --here` |
 
-See [`skills/first-tree/references/onboarding.md`](skills/first-tree/references/onboarding.md) for the full guide, and run `first-tree tree help onboarding` to print it.
+When the current root is a workspace, the workspace root gets local integration
+plus `.first-tree/source.json` (with workspace members), and discovered child
+repos become `workspace-member`s bound to the same shared tree.
+
+See [`skills/first-tree/references/onboarding.md`](skills/first-tree/references/onboarding.md)
+for the full guide, and run `first-tree tree help onboarding` to print it.
 
 ---
 
-## Layout after onboarding
+## What Lives Where
 
 ```text
-<source-repo-or-workspace>/          <tree-repo>/
-  .agents/skills/first-tree/           .agents/skills/first-tree/
-  .claude/skills/first-tree            .claude/skills/first-tree
-  WHITEPAPER.md                        .first-tree/
-  AGENTS.md                              VERSION
-  CLAUDE.md                              progress.md
-  .first-tree/                           tree.json
-    source.json                          bindings/<source-id>.json
-  … your code …                        source-repos.md
-                                       NODE.md
-                                       AGENTS.md / CLAUDE.md
-                                       members/NODE.md
-                                       … tree domains …
+<source-repo-or-workspace>/
+  .agents/skills/first-tree/
+  .claude/skills/first-tree
+  WHITEPAPER.md
+  AGENTS.md
+  CLAUDE.md
+  .first-tree/
+    source.json              # includes workspace members for workspace roots
+  … your code …
+
+<tree-repo>/
+  .agents/skills/first-tree/
+  .claude/skills/first-tree
+  .first-tree/
+    VERSION
+    progress.md
+    tree.json
+    bindings/<source-id>.json
+    bootstrap.json
+  source-repos.md
+  NODE.md
+  AGENTS.md
+  CLAUDE.md
+  members/NODE.md
+  … tree domains …
 ```
 
-The source/workspace root is never a tree — it never contains `NODE.md`, `members/`, or tree-scoped `AGENTS.md` / `CLAUDE.md`. Source-side state lives under `.first-tree/source.json`; tree-side state lives under `.first-tree/tree.json` and `.first-tree/bindings/<source-id>.json`.
+The source/workspace root is never a tree — it never contains `NODE.md`,
+`members/`, or tree-scoped `AGENTS.md` / `CLAUDE.md`. Source-side state lives
+under `.first-tree/source.json`; tree-side state lives under `.first-tree/tree.json`
+and `.first-tree/bindings/<source-id>.json`. The default dedicated tree repo
+name is `<repo>-tree`, while shared tree setups continue to work cleanly for
+multi-repo workspaces.
 
 ---
 
-## Repository layout (for contributors)
+## Commands
+
+| Command | What it does |
+| --- | --- |
+| `first-tree tree inspect` | Classify the current folder and report existing bindings / child repos |
+| `first-tree tree init` | High-level onboarding wrapper for single repos, shared trees, and workspace roots |
+| `first-tree tree bootstrap` | Canonical low-level tree bootstrap for an explicit tree checkout |
+| `first-tree tree bind` | Bind the current repo/workspace root to an existing tree repo |
+| `first-tree tree workspace sync` | Bind discovered child repos to the same shared tree |
+| `first-tree tree publish` | Publish a dedicated tree repo or shared tree repo to GitHub and refresh locally bound source/workspace repos |
+| `first-tree tree verify` | Run verification checks against a tree repo |
+| `first-tree tree upgrade` | Refresh installed source/workspace integration or tree metadata from the current package |
+| `first-tree tree generate-codeowners` | Generate `.github/CODEOWNERS` from tree ownership frontmatter |
+| `first-tree tree review` | Run the Claude Code PR review helper for a tree repo in CI |
+| `first-tree tree inject-context` | Output a Claude Code SessionStart hook payload from the root `NODE.md` |
+| `first-tree tree help onboarding` | Print the full onboarding guide |
+| `first-tree skill install` | Install the four shipped skills under `.agents/skills/*` and `.claude/skills/*` |
+| `first-tree skill upgrade` | Wipe and reinstall the four shipped skills from the current package |
+| `first-tree skill doctor` | Diagnose whether the four shipped skills are installed and healthy |
+
+---
+
+## Package And Command
+
+- The npm package is `first-tree`.
+- The installed CLI command is also `first-tree`.
+- The CLI dispatches into three products: `tree`, `breeze`, `gardener`.
+- The CLI also exposes one maintenance namespace: `skill`.
+  Run `first-tree --help` for the routing.
+- The published package ships **four skill payloads**, each with the same
+  name in the package and when installed into a user repo:
+  - `skills/first-tree/` — the umbrella entry-point `first-tree` skill (methodology, references, routing).
+  - `skills/tree/`, `skills/breeze/`, `skills/gardener/` — one operational handbook per product CLI.
+- In this source repo, `.agents/skills/first-tree/` and `.claude/skills/first-tree/`
+  (plus the three product equivalents) are tracked symlink aliases back to the
+  four `skills/<name>/` payloads, so local agents resolve the same skills the
+  package ships.
+- `npx first-tree <namespace> <command>` is the recommended human-facing
+  one-off entrypoint.
+- For automation, hooks, and CI templates, prefer the more explicit
+  `npx -p first-tree first-tree <namespace> <command>` form.
+
+---
+
+## Canonical Documentation
+
+User-facing references ship under `skills/first-tree/references/` and get
+copied into user repos by `first-tree tree init` / `first-tree tree bind`:
+
+- Methodology overview: `skills/first-tree/references/whitepaper.md`
+- Onboarding guide: `skills/first-tree/references/onboarding.md`
+- Source/workspace install contract:
+  `skills/first-tree/references/source-workspace-installation.md`
+- Upgrade and layout contract:
+  `skills/first-tree/references/upgrade-contract.md`
+
+Decision-grade design knowledge for this project lives in the bound Context Tree
+under `first-tree-skill-cli/`, not in this repo:
+
+- Canonical architecture: `first-tree-skill-cli/repo-architecture.md`
+- Canonical sync design: `first-tree-skill-cli/sync.md`
+
+Repo-local maintainer notes live in:
+
+- `docs/source-map.md`
+- `docs/architecture/overview.md`
+- `docs/architecture/thin-cli.md`
+- `docs/build/distribution.md`
+- `docs/testing/overview.md`
+- `docs/design/sync.md`
+
+These are implementation-only and never ship.
+
+---
+
+## Repository Layout (For Contributors)
 
 ```text
 src/
@@ -134,9 +264,9 @@ src/
     breeze/               # breeze product (CLI + engine + daemon)
     gardener/             # gardener product (CLI + engine)
   meta/
-    skill-tools/          # `first-tree skill list/doctor/link` diagnostics
+    skill-tools/          # `first-tree skill ...` maintenance commands
   shared/
-    version.ts            # shared VERSION/package.json readers
+    version.ts            # shared VERSION/package readers
 assets/
   tree/                   # runtime assets installed into user repos
   breeze/                 # breeze dashboard HTML
@@ -149,7 +279,8 @@ docs/                     # maintainer-only implementation notes
 evals/                    # maintainer-only evaluation harness
 ```
 
-See [`AGENTS.md`](AGENTS.md) (== `CLAUDE.md`) for maintainer rules, and [`docs/source-map.md`](docs/source-map.md) for the annotated file map.
+See [`AGENTS.md`](AGENTS.md) (== `CLAUDE.md`) for maintainer rules, and
+[`docs/source-map.md`](docs/source-map.md) for the annotated file map.
 
 ---
 
@@ -166,35 +297,7 @@ pnpm pack            # when package contents change
 
 Evals live in [`evals/`](evals) — see `evals/README.md`.
 
-## Package And Command
-
-- The npm package is `first-tree`; the installed CLI command is also `first-tree`.
-- The CLI dispatches into three products (`tree`, `breeze`, `gardener`) plus diagnostic meta commands (`skill`). Run `first-tree --help` to see the routing.
-- The published package ships **four skill payloads**, each with the same name in the package and when installed into a user repo:
-  - `skills/first-tree/` — the umbrella entry-point `first-tree` skill (methodology, references, routing).
-  - `skills/tree/`, `skills/breeze/`, `skills/gardener/` — one operational handbook per product CLI.
-- In this source repo, `.agents/skills/first-tree/` and `.claude/skills/first-tree/` (plus the three product equivalents) are tracked symlink aliases back to the four `skills/<name>/` payloads, so local agents resolve the same skills the package ships.
-- `npx -p first-tree first-tree <command>` is the recommended one-off entrypoint.
-
-## Canonical Documentation
-
-User-facing references ship under `skills/first-tree/references/` and get copied into user repos by `first-tree tree init` / `first-tree tree bind`:
-
-- Methodology overview: `skills/first-tree/references/whitepaper.md`
-- Onboarding guide: `skills/first-tree/references/onboarding.md`
-- Source/workspace install contract: `skills/first-tree/references/source-workspace-installation.md`
-- Upgrade and layout contract: `skills/first-tree/references/upgrade-contract.md`
-
-Decision-grade design knowledge for this project lives in the bound Context Tree under `first-tree-skill-cli/`, not in this repo:
-
-- Canonical architecture: `first-tree-skill-cli/repo-architecture.md`
-- Canonical sync design: `first-tree-skill-cli/sync.md`
-
-Repo-local maintainer notes (`docs/source-map.md` and friends) are implementation-only and never ship. `<repo>-tree` is the default sibling name for a dedicated tree repo created by `first-tree tree init`.
-
----
-
-## Contributing and security
+## Contributing And Security
 
 - GitHub issue forms for bugs and feature requests.
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) for local setup and validation expectations.

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ cross-domain relationships that humans and agents maintain together —
 Every product ships:
 - an operational handbook at `skills/<name>/SKILL.md` (loaded into agents),
 - a lazy CLI dispatcher at `src/products/<name>/cli.ts`,
-- its own semver'd `VERSION` file, independent from the npm package version (see [docs/architecture/versioning.md](docs/architecture/versioning.md)).
+- its own semver'd `VERSION` file, independent from the npm package version.
 
-The umbrella `first-tree` skill at [`skills/first-tree/`](skills/first-tree/) is
-the single entry point an agent reads first — it teaches the Context Tree
+The umbrella `first-tree` skill at [`skills/first-tree/`](skills/first-tree/)
+is the single entry point an agent reads first — it teaches the Context Tree
 methodology and routes to the three product skills above. The CLI also exposes
 one **maintenance namespace** — `first-tree skill ...` — for skill
 installation, diagnosis, and repair. It is not a fourth product.
@@ -171,10 +171,10 @@ for the full guide, and run `first-tree tree help onboarding` to print it.
 
 The source/workspace root is never a tree — it never contains `NODE.md`,
 `members/`, or tree-scoped `AGENTS.md` / `CLAUDE.md`. Source-side state lives
-under `.first-tree/source.json`; tree-side state lives under `.first-tree/tree.json`
-and `.first-tree/bindings/<source-id>.json`. The default dedicated tree repo
-name is `<repo>-tree`, while shared tree setups continue to work cleanly for
-multi-repo workspaces.
+under `.first-tree/source.json`; tree-side state lives under
+`.first-tree/tree.json` and `.first-tree/bindings/<source-id>.json`. The
+default dedicated tree repo name is `<repo>-tree`, while shared tree setups
+continue to work cleanly for multi-repo workspaces.
 
 ---
 
@@ -245,6 +245,7 @@ Repo-local maintainer notes live in:
 - `docs/source-map.md`
 - `docs/architecture/overview.md`
 - `docs/architecture/thin-cli.md`
+- `docs/architecture/versioning.md`
 - `docs/build/distribution.md`
 - `docs/testing/overview.md`
 - `docs/design/sync.md`

--- a/assets/tree/claude-commands/first-tree-sync-schedule.md
+++ b/assets/tree/claude-commands/first-tree-sync-schedule.md
@@ -5,7 +5,7 @@
 ## What this does
 
 Runs two maintenance steps in sequence:
-1. `first-tree sync` -- detect source drift and open tree-update PRs
+1. `first-tree tree sync` -- detect source drift and open tree-update PRs
 2. `gardener` review -- review open PRs on the tree repo for context fit
 
 ## Step 1: Run sync

--- a/assets/tree/claude-commands/first-tree-sync-start.md
+++ b/assets/tree/claude-commands/first-tree-sync-start.md
@@ -9,7 +9,7 @@ those PRs for context fit.
 Check that `.claude/commands/first-tree-sync.md` exists locally.
 
 - If missing → output:
-  "❌ first-tree sync is not installed. Run `first-tree upgrade` to
+  "❌ first-tree sync is not installed. Run `first-tree tree upgrade` to
   install the sync runbook, then retry."
   STOP.
 
@@ -20,7 +20,7 @@ Check that `.first-tree/bindings/` exists and contains at least one
 
 - If empty or missing → output:
   "❌ No bound sources found in `.first-tree/bindings/`.
-  Bind a source repo first with `first-tree bind`, then retry."
+  Bind a source repo first with `first-tree tree bind`, then retry."
   STOP.
 
 ## 3. Verify bindings have remoteUrl

--- a/assets/tree/claude-commands/first-tree-sync.md
+++ b/assets/tree/claude-commands/first-tree-sync.md
@@ -40,7 +40,7 @@ Check the calling context:
 `RUN_MODE` determines which GitHub access mechanism is required:
 
 - `manual` / `loop` -> runs locally on the user's machine. Use the
-  `gh` CLI and the bundled `first-tree sync` command. Verify
+  `gh` CLI and the bundled `first-tree tree sync` command. Verify
   `gh auth status` succeeds; if not, exit with:
 
   > ❌ `gh` is not authenticated. Run `gh auth login` and retry.
@@ -79,7 +79,7 @@ server naming. If the connected connector uses different names (e.g.
 `mcp__claude_ai_github__list_commits`), use the equivalent tool.
 
 **Local execution advantage**: in `manual` / `loop` mode the bundled
-`first-tree sync` CLI handles Steps 1-3 as a single command,
+`first-tree tree sync` CLI handles Steps 1-3 as a single command,
 including LLM-backed classification via the local `claude` CLI. Cloud
 `schedule` mode must reimplement the same logic step-by-step using MCP
 tools because the container cannot shell out to `claude`.
@@ -105,7 +105,7 @@ done
 If `.first-tree/bindings/` is empty, exit with:
 
 > ⏭ No bindings recorded under `.first-tree/bindings/`. Nothing to
-> sync. Run `first-tree bind` from a source repo first.
+> sync. Run `first-tree tree bind` from a source repo first.
 
 ### Cloud (`schedule`)
 
@@ -146,7 +146,7 @@ stderr and surface it to the user.
 If you do not have a built `dist/`, fall back to:
 
 ```bash
-npx -p first-tree first-tree sync --tree-path "$PWD" --propose
+npx -p first-tree first-tree tree sync --tree-path "$PWD" --propose
 ```
 
 ✓ If the CLI succeeded, proposals are written under
@@ -320,7 +320,7 @@ with the GitHub connector wired. A reasonable cadence:
 
 ## Recap
 
-- Local mode is a thin wrapper around `first-tree sync`. The CLI
+- Local mode is a thin wrapper around `first-tree tree sync`. The CLI
   does the heavy lifting, including LLM-backed classification via the
   local `claude` CLI (required).
 - Cloud mode reimplements detection + classification using MCP

--- a/assets/tree/examples/claude-code/README.md
+++ b/assets/tree/examples/claude-code/README.md
@@ -11,4 +11,4 @@ cp .claude/skills/first-tree/assets/framework/examples/claude-code/settings.json
 
 ## What It Does
 
-The `SessionStart` hook runs `npx -p first-tree first-tree inject-context --skip-version-check` when a Claude Code session begins. This invokes the bundled CLI to read the root `NODE.md` and inject it as additional session context, giving the agent an overview of the tree structure before any task. The `--skip-version-check` flag avoids the npm registry check on every session start.
+The `SessionStart` hook runs `npx -p first-tree first-tree tree inject-context --skip-version-check` when a Claude Code session begins. This invokes the bundled CLI to read the root `NODE.md` and inject it as additional session context, giving the agent an overview of the tree structure before any task. The `--skip-version-check` flag avoids the npm registry check on every session start.

--- a/assets/tree/examples/claude-code/settings.json
+++ b/assets/tree/examples/claude-code/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -p first-tree first-tree inject-context --skip-version-check"
+            "command": "npx -p first-tree first-tree tree inject-context --skip-version-check"
           }
         ]
       }

--- a/assets/tree/examples/codex/hooks.json
+++ b/assets/tree/examples/codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -p first-tree first-tree inject-context --skip-version-check",
+            "command": "npx -p first-tree first-tree tree inject-context --skip-version-check",
             "statusMessage": "Loading First Tree context"
           }
         ]

--- a/assets/tree/helpers/generate-codeowners.ts
+++ b/assets/tree/helpers/generate-codeowners.ts
@@ -207,7 +207,7 @@ export function generate(
       return 0;
     }
     console.log(
-      "CODEOWNERS is out-of-date. Run: npx first-tree generate-codeowners",
+      "CODEOWNERS is out-of-date. Run: npx -p first-tree first-tree tree generate-codeowners",
     );
     return 1;
   }

--- a/assets/tree/workflows/codeowners.yml
+++ b/assets/tree/workflows/codeowners.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: "22"
 
-      - run: npx -p first-tree first-tree generate-codeowners
+      - run: npx -p first-tree first-tree tree generate-codeowners
 
       - name: Commit if changed
         run: |

--- a/assets/tree/workflows/pr-review.yml
+++ b/assets/tree/workflows/pr-review.yml
@@ -46,7 +46,7 @@ jobs:
           gh pr view "$PR_NUMBER" --json headRefOid -q .headRefOid > /tmp/pr-head-sha.txt
 
       - name: Run Claude review
-        run: npx -p first-tree first-tree review
+        run: npx -p first-tree first-tree tree review
 
       - name: Parse and post review
         run: |

--- a/assets/tree/workflows/validate.yml
+++ b/assets/tree/workflows/validate.yml
@@ -16,4 +16,4 @@ jobs:
           node-version: "22"
 
       - name: Validate tree
-        run: npx -p first-tree first-tree verify
+        run: npx -p first-tree first-tree tree verify

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -6,7 +6,7 @@ the bound Context Tree.
 This file is source-repo-local. It maps the tree's architectural decisions onto
 the files maintainers edit in this repo.
 
-## Three Products, One Umbrella CLI
+## Three Products, One Maintenance Namespace
 
 `first-tree` is an umbrella CLI that dispatches into three products:
 
@@ -14,9 +14,14 @@ the files maintainers edit in this repo.
 - **`breeze`** — Proposal / inbox daemon with a GitHub notifications statusline
 - **`gardener`** — Automated maintenance agent for tree sync PRs and source-repo review comments
 
-All three live under `src/products/<name>/` and share the same shape. The
-single source of truth for the product set is `src/products/manifest.ts` —
-the umbrella CLI, version reporting, and skill tooling read from there.
+It also exposes one maintenance namespace:
+
+- **`skill`** — inspect, diagnose, and repair the four shipped skill payloads
+
+The three products live under `src/products/<name>/` and share the same shape.
+The single source of truth for the CLI namespace set is
+`src/products/manifest.ts` — the umbrella CLI, version reporting, and skill
+tooling read from there.
 
 ## Four Skills
 
@@ -37,12 +42,13 @@ ships.
 
 | Path | Local responsibility |
 | --- | --- |
-| `src/cli.ts` | Top-level umbrella dispatcher for `first-tree <product> <command>`; iterates the product manifest |
-| `src/products/manifest.ts` | Single source of truth for the three products; add a new product by adding one entry here |
+| `src/cli.ts` | Top-level umbrella dispatcher for `first-tree <namespace> <command>`; iterates the namespace manifest |
+| `src/products/manifest.ts` | Single source of truth for the CLI namespace set; add a new namespace by adding one entry here |
 | `src/products/tree/` | Tree product root (CLI dispatcher + `VERSION`) |
 | `src/products/tree/engine/` | Tree business logic: `commands/`, `runtime/`, `rules/`, `validators/`, plus `bind.ts`, `init.ts`, `verify.ts`, `publish.ts`, `sync.ts`, `workspace.ts`, `upgrade.ts`, `inspect.ts`, etc. |
 | `src/products/breeze/` | Breeze product: CLI dispatcher + `engine/` (commands, runtime, daemon, bridge, statusline) |
 | `src/products/gardener/` | Gardener product: CLI dispatcher + `engine/` (commands, runtime, comment, respond) |
+| `src/meta/skill-tools/` | Maintenance namespace: skill inventory, diagnosis, installation, and symlink repair |
 | `skills/first-tree/` | Entry-point skill payload that ships verbatim to user repos |
 | `skills/tree/`, `skills/breeze/`, `skills/gardener/` | Per-product operational skill payloads |
 | `assets/tree/` | Runtime assets for the tree product, installed or refreshed by the CLI (templates, workflows, prompts, helpers, examples) |
@@ -59,9 +65,9 @@ ships.
   subdirectories). Breeze uses `engine/daemon/`; tree uses `engine/rules/`
   and `engine/validators/`. Do not place business logic at the product root
   alongside `cli.ts`.
-- Every product must be listed in `src/products/manifest.ts` — `src/cli.ts`
-  iterates the manifest, so a missing entry means the product is invisible
-  to the umbrella.
+- Every CLI namespace must be listed in `src/products/manifest.ts` —
+  `src/cli.ts` iterates the manifest, so a missing entry means the namespace is
+  invisible to the umbrella.
 - Keep source/workspace repos free of tree content; tree nodes belong in the
   bound Context Tree repo.
 - Treat `source-repos.md` as generated output; tree-side truth still lives in

--- a/docs/architecture/thin-cli.md
+++ b/docs/architecture/thin-cli.md
@@ -3,7 +3,7 @@
 Authoritative decision node: `first-tree-skill-cli/thin-cli-shell.md` in the
 bound Context Tree.
 
-Use this local reference when changing `src/cli.ts`, the product dispatchers in
+Use this local reference when changing `src/cli.ts`, the namespace dispatchers in
 `src/products/*/cli.ts`, or the tree command adapters in
 `src/products/tree/engine/commands/`.
 
@@ -11,49 +11,35 @@ Use this local reference when changing `src/cli.ts`, the product dispatchers in
 
 The top-level shell (`src/cli.ts`) should:
 
-- parse `first-tree <product> <command>`
-- expose help and version (CLI + per-product VERSION)
+- parse `first-tree <namespace> <command>`
+- expose help and version (CLI + per-namespace VERSION)
 - handle `--skip-version-check`
-- lazy-load and dispatch into `src/products/<product>/cli.js`
-- stay thin — never statically import another product
+- lazy-load and dispatch into `src/products/<namespace>/cli.js`
+- stay thin — never statically import another namespace
 
-Each product dispatcher (currently `tree/cli.ts`; `breeze/cli.ts` is a stub)
-owns its own USAGE and dispatches into its engine's command adapters.
+Each namespace dispatcher owns its own USAGE and dispatches into its engine's
+command adapters. The primary products are `tree`, `breeze`, and `gardener`;
+`skill` is the maintenance namespace for shipped skill health and repair.
 
 ## Current CLI Surface
 
-```
-first-tree tree <command>
-```
+Primary product namespaces:
 
-Tree commands:
+- `first-tree tree <command>`
+- `first-tree breeze <command>`
+- `first-tree gardener <command>`
 
-- `inspect`
-- `init`
-- `bind`
-- `workspace`
-- `publish`
-- `verify`
-- `upgrade`
-- `sync`
-- `review`
-- `generate-codeowners`
-- `invite`
-- `join`
-- `inject-context`
-- `help`
+Maintenance namespace:
 
-```
-first-tree breeze <command>
-```
-
-Breeze is a Phase 0 stub and exits with a not-implemented error.
+- `first-tree skill <command>`
 
 ## Local Touchpoints
 
-- `src/cli.ts` — umbrella usage text, global flags, and product dispatch
+- `src/cli.ts` — umbrella usage text, global flags, and namespace dispatch
 - `src/products/tree/cli.ts` — tree product USAGE and command dispatch
-- `src/products/breeze/cli.ts` — breeze stub dispatcher
+- `src/products/breeze/cli.ts` — breeze product dispatcher
+- `src/products/gardener/cli.ts` — gardener product dispatcher
+- `src/meta/skill-tools/cli.ts` — maintenance-namespace dispatcher for shipped skill health
 - `src/products/tree/engine/commands/*.ts` — thin tree command adapters
 - `tests/e2e/thin-cli.test.ts` — direct CLI smoke coverage
 - `tests/e2e/cli-e2e.test.ts` — end-to-end command workflow coverage

--- a/docs/architecture/versioning.md
+++ b/docs/architecture/versioning.md
@@ -1,53 +1,60 @@
 # Versioning
 
-`first-tree` ships several things that are independently versioned on purpose. This doc explains what each version means, when to bump which one, and why we don't try to collapse them into a single SemVer stream.
+`first-tree` ships several things that are independently versioned on purpose.
+This doc explains what each version means, when to bump which one, and why we
+do not try to collapse them into a single SemVer stream.
 
-## The four version families
+## The Version Families
 
 | Family | Files | Example | What it represents |
 |--------|-------|---------|--------------------|
-| **npm package** | `package.json` `version` field | `first-tree@0.2.6` | Released artifact. What `npm install -g first-tree` pins. Consumer-facing. |
-| **Product** | `src/products/<name>/VERSION` | `tree=0.2.6`, `breeze=0.1.0`, `gardener=0.1.0` | The public surface of a single product CLI. Bumps on command-shape or behavior changes users may depend on. |
-| **Skill payload** | `skills/<name>/VERSION` | `skills/tree/VERSION = 0.2` | The operational handbook an agent reads. Bumps when the user-facing guidance changes in a way existing installations should pick up. |
-| **Runtime asset** | `assets/<name>/VERSION` | `assets/tree/VERSION = 0.2.6` | The asset bundle installed into user repos (templates, workflows, helpers). Bumps whenever installed content changes — this is what `first-tree tree upgrade` diffs against. |
+| **npm package** | `package.json#version` | `first-tree@0.2.6` | Released artifact. What `npm install -g first-tree` pins. |
+| **Product** | `src/products/<name>/VERSION` | `tree=0.2.6`, `breeze=0.1.0`, `gardener=0.1.0` | The public surface of a single product CLI. |
+| **Meta command** | `src/meta/skill-tools/VERSION` | `skill=0.2.6` | The public surface of the maintenance namespace. |
+| **Skill payload** | `skills/<name>/VERSION` | `skills/tree/VERSION = 0.2` | The operational handbook an agent reads. |
+| **Runtime asset** | `assets/<name>/VERSION` | `assets/tree/VERSION = 0.2.6` | Installed templates/workflows/helpers for user repos. |
 
-Meta (non-product) commands also carry their own VERSION (e.g. `src/meta/skill-tools/VERSION = 0.2.6`). It follows the same rules as a product VERSION but isn't reported by `first-tree --version` (which iterates `PRODUCTS`, not meta).
+## Why They Are Independent
 
-## Why they are independent
+Each family has a different audience and a different breaking-change trigger:
 
-Each family has a different audience and a different "breaking change" trigger:
+- **npm package** changes when we cut a release.
+- **Product / meta command** changes when a single CLI surface changes.
+- **Skill payload** changes when the agent-facing handbook changes.
+- **Runtime asset** changes when the files we install into user repos change.
 
-- **npm package** changes when we cut a release — it encodes the whole bundle.
-- **Product** changes when a single CLI's surface changes. Bumping gardener should not force a breeze release note.
-- **Skill payload** changes when the agent-facing handbook changes. Users re-install skills via `first-tree tree upgrade`; the VERSION is how that upgrade knows something moved.
-- **Runtime asset** changes when the files we install into user repos change. This version is the contract for in-place upgrades of user checkouts.
+Collapsing these would either over-trigger upgrades or hide meaningful install
+contract changes from `upgrade`.
 
-Collapsing these would either over-trigger upgrades (a breeze-only fix bumping every user's tree assets) or under-trigger them (a silent asset change invisible to `upgrade`).
-
-## When to bump what
+## When To Bump What
 
 | Change type | Bump |
 |-------------|------|
-| Release a new npm version | `package.json` `version` |
+| Release a new npm version | `package.json#version` |
 | Add / change a `first-tree tree` subcommand | `src/products/tree/VERSION` |
 | Add / change a `first-tree breeze` subcommand | `src/products/breeze/VERSION` |
 | Add / change a `first-tree gardener` subcommand | `src/products/gardener/VERSION` |
+| Change `first-tree skill install/upgrade/list/doctor/link` behavior | `src/meta/skill-tools/VERSION` |
 | Edit `skills/first-tree/SKILL.md` or any shared reference | `skills/first-tree/VERSION` |
 | Edit `skills/tree/SKILL.md` | `skills/tree/VERSION` |
 | Edit a runtime template / workflow under `assets/tree/` | `assets/tree/VERSION` |
-| Change the SSE dashboard HTML under `assets/breeze/` | *(none today — breeze assets are unversioned; bump if introducing VERSION)* |
-| Change `first-tree skill list/doctor/link` behavior | `src/meta/skill-tools/VERSION` |
 
-## How versions are read
+## How Versions Are Read
 
-- `first-tree --version` iterates `PRODUCTS` in [`src/products/manifest.ts`](../../src/products/manifest.ts) and prints one line per product via `readProductVersion`.
-- Each dispatcher's `--version` reads its own VERSION via [`src/shared/version.ts`](../../src/shared/version.ts) (`readOwnVersion(import.meta.url, sourceRelativeDir)`).
-- The umbrella CLI version comes from `package.json` via `readPackageVersion(import.meta.url, "first-tree")`.
-- The installer reads `skills/<name>/VERSION` and `assets/<name>/VERSION` to decide whether to overwrite files during `first-tree tree init/upgrade`.
+- `first-tree --version` iterates `ALL_COMMANDS` in
+  [`src/products/manifest.ts`](../../src/products/manifest.ts) and prints one
+  line per product/meta command via `readCommandVersion`.
+- The umbrella CLI version comes from `package.json` via
+  `readPackageVersion(import.meta.url, "first-tree")`.
+- `readCommandVersion` delegates to [`src/shared/version.ts`](../../src/shared/version.ts)
+  so built `dist/` entrypoints can still resolve shipped `VERSION` files.
+- The installer reads `skills/<name>/VERSION` and `assets/<name>/VERSION` to
+  decide whether to overwrite files during `first-tree tree init/upgrade`.
 
-## Practical rules
+## Practical Rules
 
-- Never bump a version "just to be consistent". Each family changes on its own cadence.
-- Bumping a skill VERSION without bumping its product VERSION is common — handbook edits rarely imply CLI behavior changes.
-- Bumping an asset VERSION without bumping a skill or product is also common — a template-only change.
-- The npm package version should be bumped last, after all other files that changed in the release are bumped, so release notes can refer to them.
+- Never bump a version “just to be consistent.” Each family changes on its own cadence.
+- Bumping a skill `VERSION` without bumping its product `VERSION` is common.
+- Bumping an asset `VERSION` without bumping a skill or product is also common.
+- Namespace `VERSION` files must ship in the published package so built
+  `dist/cli.js --version` does not print `unknown`.

--- a/docs/build/distribution.md
+++ b/docs/build/distribution.md
@@ -38,13 +38,19 @@ Inspect the tarball contents before merging packaging changes.
 - `.github/workflows/ci.yml` is the thin CI shell for repo validation.
 - `assets/tree/VERSION` marks the shipped tree product payload version.
 - `src/products/tree/VERSION` mirrors the tree product version for `--version`.
-- `src/products/breeze/VERSION` marks the breeze product version (Phase 0 stub).
+- `src/products/breeze/VERSION`, `src/products/gardener/VERSION`, and
+  `src/meta/skill-tools/VERSION` mirror the other namespace versions for
+  `first-tree --version`.
 
 ## Release Checklist
 
 - If package contents or install/upgrade behavior changed, run `pnpm pack`.
 - Inspect the tarball to confirm it includes `dist/`, `skills/first-tree/`,
-  `skills/breeze/`, and `assets/`, while excluding repo-only sources such as
-  `docs/`, `tests/`, `src/`, and `evals/`.
+  `skills/breeze/`, `assets/`, and the shipped
+  `src/products/{tree,breeze,gardener}/VERSION` plus
+  `src/meta/skill-tools/VERSION`
+  runtime metadata files used by `first-tree --version`, while excluding
+  repo-only sources such as `docs/`, `tests/`, the rest of `src/`, and
+  `evals/`.
 - If you changed anything copied into user repos, bump
   `assets/tree/VERSION` and sync the upgrade docs/tests in the same change.

--- a/docs/design/sync.md
+++ b/docs/design/sync.md
@@ -1,4 +1,4 @@
-# `first-tree sync`
+# `first-tree tree sync`
 
 Authoritative decision node: `first-tree-skill-cli/sync.md` in the bound
 Context Tree.

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -13,8 +13,8 @@ docs below only for source-repo implementation details.
 | `first-tree-skill-cli/thin-cli-shell.md` | Command-surface contract for the thin CLI shell |
 | `first-tree-skill-cli/build-and-distribution.md` | Packaging and release invariants |
 | `first-tree-skill-cli/validation-surface.md` | Validation philosophy and coverage expectations |
-| `first-tree-skill-cli/sync.md` | Authoritative product/architecture context for `first-tree sync` |
-| `src/products/manifest.ts` | Single source of truth for the three products (tree, breeze, gardener) |
+| `first-tree-skill-cli/sync.md` | Authoritative product/architecture context for `first-tree tree sync` |
+| `src/products/manifest.ts` | Single source of truth for the CLI namespace set: products (`tree`, `breeze`, `gardener`) plus maintenance (`skill`) |
 | `skills/first-tree/SKILL.md` | User-facing entry-point skill: methodology + routing to product skills |
 | `skills/tree/SKILL.md` | Operational handbook for the `first-tree tree` CLI |
 | `skills/breeze/SKILL.md` | Operational handbook for the `first-tree breeze` CLI |
@@ -46,11 +46,12 @@ docs below only for source-repo implementation details.
 
 | Path | Purpose |
 | --- | --- |
-| `src/cli.ts` | Top-level umbrella dispatcher for `first-tree <product> <command>`; reads from the product manifest |
-| `src/products/manifest.ts` | Product manifest (name, description, lazy entrypoint, auto-upgrade, asset/skill flags) |
+| `src/cli.ts` | Top-level umbrella dispatcher for `first-tree <namespace> <command>`; reads from the namespace manifest |
+| `src/products/manifest.ts` | Namespace manifest (kind, name, description, lazy entrypoint, auto-upgrade, asset/skill flags) |
 | `src/products/tree/cli.ts` | Tree product dispatcher (lazy-loaded) |
 | `src/products/breeze/cli.ts` | Breeze product dispatcher (lazy-loaded) |
 | `src/products/gardener/cli.ts` | Gardener product dispatcher (lazy-loaded) |
+| `src/meta/skill-tools/cli.ts` | Skill maintenance-namespace dispatcher (lazy-loaded) |
 | `src/products/breeze/engine/` | Breeze business logic: `commands/`, `runtime/`, `daemon/`, `bridge.ts`, `statusline.ts` |
 | `src/products/gardener/engine/` | Gardener business logic: `commands/`, `runtime/`, `comment.ts`, `respond.ts` |
 | `src/products/tree/engine/init.ts` | High-level onboarding wrapper plus low-level tree bootstrap |

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -24,10 +24,10 @@ docs below only for source-repo implementation details.
 | `skills/first-tree/references/upgrade-contract.md` | Installed layout and upgrade invariants |
 | `docs/architecture/overview.md` | Local file-level architecture map for this source repo |
 | `docs/architecture/thin-cli.md` | Implementation touchpoints for `src/cli.ts` and command adapters |
+| `docs/architecture/versioning.md` | Local contract for VERSION files, package version reporting, and release-layer boundaries |
 | `docs/build/distribution.md` | Packaging surfaces and release checklist in this repo |
 | `docs/testing/overview.md` | Concrete validation commands and targeted test entrypoints |
 | `docs/design/sync.md` | Local implementation touchpoints for the sync feature |
-| `docs/architecture/versioning.md` | Policy for the four independent VERSION files (npm, product, skill, asset) |
 
 ## Runtime Payload
 
@@ -49,9 +49,13 @@ docs below only for source-repo implementation details.
 | `src/cli.ts` | Top-level umbrella dispatcher for `first-tree <namespace> <command>`; reads from the namespace manifest |
 | `src/products/manifest.ts` | Namespace manifest (kind, name, description, lazy entrypoint, auto-upgrade, asset/skill flags) |
 | `src/products/tree/cli.ts` | Tree product dispatcher (lazy-loaded) |
+| `src/products/tree/README.md` | Maintainer/product-local overview for the tree product |
 | `src/products/breeze/cli.ts` | Breeze product dispatcher (lazy-loaded) |
+| `src/products/breeze/README.md` | Maintainer/product-local overview for the breeze product |
 | `src/products/gardener/cli.ts` | Gardener product dispatcher (lazy-loaded) |
+| `src/products/gardener/README.md` | Maintainer/product-local overview for the gardener product |
 | `src/meta/skill-tools/cli.ts` | Skill maintenance-namespace dispatcher (lazy-loaded) |
+| `src/meta/skill-tools/README.md` | Maintainer/meta overview for the skill maintenance namespace |
 | `src/products/breeze/engine/` | Breeze business logic: `commands/`, `runtime/`, `daemon/`, `bridge.ts`, `statusline.ts` |
 | `src/products/gardener/engine/` | Gardener business logic: `commands/`, `runtime/`, `comment.ts`, `respond.ts` |
 | `src/products/tree/engine/init.ts` | High-level onboarding wrapper plus low-level tree bootstrap |

--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
   },
   "files": [
     "dist",
+    "src/products/tree/VERSION",
+    "src/products/breeze/VERSION",
+    "src/products/gardener/VERSION",
+    "src/meta/skill-tools/VERSION",
     "skills/first-tree",
     "skills/tree",
     "skills/breeze",

--- a/scripts/check-skill-sync.sh
+++ b/scripts/check-skill-sync.sh
@@ -84,7 +84,7 @@ require_file "$ENGINE_DIR/runtime/adapters.ts"
 require_file "$ENGINE_DIR/validators/members.ts"
 require_file "$ENGINE_DIR/validators/nodes.ts"
 
-# Tree product has its own VERSION + cli entrypoint; breeze is a stub.
+# Primary product namespaces keep their own VERSION + cli entrypoint.
 require_file "$REPO_ROOT/src/products/tree/VERSION"
 require_file "$REPO_ROOT/src/products/tree/cli.ts"
 require_file "$REPO_ROOT/src/products/breeze/VERSION"
@@ -109,9 +109,35 @@ require_file "$ASSETS_DIR/workflows/pr-review.yml"
 require_file "$ASSETS_DIR/workflows/codeowners.yml"
 require_file "$ASSETS_DIR/examples/claude-code/README.md"
 require_file "$ASSETS_DIR/examples/claude-code/settings.json"
+require_file "$ASSETS_DIR/examples/codex/hooks.json"
 require_file "$ASSETS_DIR/helpers/generate-codeowners.ts"
 require_file "$ASSETS_DIR/helpers/run-review.ts"
 require_file "$ASSETS_DIR/helpers/summarize-progress.js"
+
+if ! grep -q 'first-tree tree verify' "$ASSETS_DIR/workflows/validate.yml"; then
+  echo "validate.yml is not using the namespaced tree verify command." >&2
+  exit 1
+fi
+
+if ! grep -q 'first-tree tree review' "$ASSETS_DIR/workflows/pr-review.yml"; then
+  echo "pr-review.yml is not using the namespaced tree review command." >&2
+  exit 1
+fi
+
+if ! grep -q 'first-tree tree generate-codeowners' "$ASSETS_DIR/workflows/codeowners.yml"; then
+  echo "codeowners.yml is not using the namespaced tree generate-codeowners command." >&2
+  exit 1
+fi
+
+if ! grep -q 'first-tree tree inject-context' "$ASSETS_DIR/examples/claude-code/settings.json"; then
+  echo "Claude Code example settings are not using the namespaced tree inject-context command." >&2
+  exit 1
+fi
+
+if ! grep -q 'first-tree tree inject-context' "$ASSETS_DIR/examples/codex/hooks.json"; then
+  echo "Codex example hooks are not using the namespaced tree inject-context command." >&2
+  exit 1
+fi
 
 require_file "$REPO_ROOT/evals/first-tree-eval.test.ts"
 require_file "$REPO_ROOT/evals/README.md"
@@ -212,6 +238,18 @@ if ! grep -q '"assets"' "$REPO_ROOT/package.json"; then
   echo "package.json is missing assets in the published files list." >&2
   exit 1
 fi
+
+for version_path in \
+  '"src/products/tree/VERSION"' \
+  '"src/products/breeze/VERSION"' \
+  '"src/products/gardener/VERSION"' \
+  '"src/meta/skill-tools/VERSION"'
+do
+  if ! grep -q "$version_path" "$REPO_ROOT/package.json"; then
+    echo "package.json is missing $version_path in the published files list." >&2
+    exit 1
+  fi
+done
 
 MANIFEST_PATH="$REPO_ROOT/src/products/manifest.ts"
 require_file "$MANIFEST_PATH"

--- a/skills/first-tree/SKILL.md
+++ b/skills/first-tree/SKILL.md
@@ -58,6 +58,10 @@ If you do not know which product you need, start here, skim the table above,
 and load whichever skill looks like the closest match. Loading more than one
 is fine.
 
+The CLI also exposes one maintenance namespace: `first-tree skill ...`. That
+namespace is not a fourth product — it is the toolkit surface for inspecting
+and repairing the four shipped skills.
+
 ## Before Every Task
 
 1. Read the root `NODE.md`.
@@ -87,7 +91,13 @@ Recommended invocation — no install step needed, always runs the latest
 published version:
 
 ```bash
-npx -p first-tree first-tree <product> <command>
+npx first-tree <namespace> <command>
+```
+
+For automation, hooks, and CI templates, prefer the more explicit form:
+
+```bash
+npx -p first-tree first-tree <namespace> <command>
 ```
 
 The CLI auto-checks for updates on every invocation. Pass
@@ -109,21 +119,25 @@ per product (`tree`, `breeze`, `gardener`). They live at:
 Each is also mirrored at `.claude/skills/<name>/` via a symlink so both
 Claude Code and other agent runtimes discover them.
 
-To refresh the installed skill payloads from the current `first-tree` package:
+To install or refresh the shipped skill payloads in the current repo:
 
 ```bash
-npx -p first-tree first-tree tree upgrade
+npx first-tree skill install
+npx first-tree skill upgrade
 ```
 
-This rewrites the installed skill copies to match the skills bundled inside
-the package. Safe to re-run; idempotent.
+These commands rewrite the installed skill copies to match the skills bundled
+inside the package. Safe to re-run; idempotent.
+
+Use `npx first-tree tree upgrade` when you want the broader
+source/workspace integration or tree metadata refreshed too.
 
 To inspect or repair the installed skills directly:
 
 ```bash
-npx -p first-tree first-tree skill list     # show all four skills + versions
-npx -p first-tree first-tree skill doctor   # diagnose install health; exits non-zero on problems
-npx -p first-tree first-tree skill link     # repair .claude/skills/* symlinks
+npx first-tree skill list     # show all four skills + versions
+npx first-tree skill doctor   # diagnose install health; exits non-zero on problems
+npx first-tree skill link     # repair .claude/skills/* symlinks
 ```
 
 ## Ownership And Editing

--- a/skills/first-tree/references/onboarding.md
+++ b/skills/first-tree/references/onboarding.md
@@ -126,13 +126,13 @@ Then `first-tree tree workspace sync` binds every discovered child repo as a
 If you have already switched into the tree repo itself:
 
 ```bash
-first-tree tree init tree --here
+first-tree tree bootstrap --here
 ```
 
 Or from elsewhere:
 
 ```bash
-first-tree tree init tree --tree-path ../org-context
+first-tree tree bootstrap --tree-path ../org-context
 ```
 
 Use this only for the tree repo. Do not use `--here` inside a source/workspace

--- a/skills/first-tree/references/source-workspace-installation.md
+++ b/skills/first-tree/references/source-workspace-installation.md
@@ -66,11 +66,11 @@ workspace repo, or non-git workspace folder.
 
 When an agent is asked to install `first-tree`:
 
-1. Run `first-tree inspect --json`.
+1. Run `first-tree tree inspect --json`.
 2. Ask whether an existing Context Tree already exists.
-3. If yes, prefer `first-tree bind`.
-4. If no, use `first-tree init`.
-5. If the current root is a workspace, follow with `first-tree workspace sync`.
+3. If yes, prefer `first-tree tree bind`.
+4. If no, use `first-tree tree init`.
+5. If the current root is a workspace, follow with `first-tree tree workspace sync`.
 
 Do not recreate a new sibling tree repo when the user already has a shared tree
 they want to keep using.
@@ -95,15 +95,17 @@ package folders that are not repos do not get repo-level binding metadata.
 
 ## Verification And Upgrade
 
-- Verify the tree repo with `first-tree verify`.
-- Use `first-tree upgrade` in a source/workspace root to refresh local
+- Verify the tree repo with `first-tree tree verify`.
+- Use `first-tree skill upgrade` when you only need the four local skill
+  payloads refreshed under `.agents/skills/*` and `.claude/skills/*`.
+- Use `first-tree tree upgrade` in a source/workspace root to refresh local
   integration.
-- Use `first-tree upgrade --tree-path ...` to refresh the tree repo metadata
+- Use `first-tree tree upgrade --tree-path ...` to refresh the tree repo metadata
   plus its installed tree-repo skill.
 
 ## Publish Rule
 
-`first-tree publish` is tree-centric:
+`first-tree tree publish` is tree-centric:
 
 - it publishes the tree repo
 - it refreshes locally bound source/workspace repos with the published tree URL

--- a/skills/first-tree/references/upgrade-contract.md
+++ b/skills/first-tree/references/upgrade-contract.md
@@ -1,7 +1,7 @@
 # Upgrade Contract
 
-This file describes the installed layout in user repos and how `first-tree
-upgrade` refreshes it.
+This file describes the installed layout in user repos and how
+`first-tree skill upgrade` and `first-tree tree upgrade` refresh it.
 
 ## Two Distribution Channels
 
@@ -10,7 +10,7 @@ The `first-tree` npm package ships two things:
 1. **CLI tools** — engine, runtime, validators, helpers, templates, and
    workflows. Users invoke them with `npx -p first-tree first-tree <command>`.
 2. **Skill payload** — `SKILL.md`, `references/`, and `VERSION`. This is copied
-   into user repos and refreshed by `first-tree upgrade`.
+   into user repos and refreshed by `first-tree tree upgrade`.
 
 The skill payload contains knowledge only. Executable behavior stays in the CLI.
 
@@ -26,7 +26,7 @@ The installed skill `VERSION` tracks `major.minor`.
 
 ## Installed Layout
 
-In a source/workspace root, `first-tree init` / `first-tree bind` produce:
+In a source/workspace root, `first-tree tree init` / `first-tree tree bind` produce:
 
 ```text
 .agents/skills/first-tree/
@@ -38,7 +38,7 @@ CLAUDE.md
   source.json             # includes workspace members for workspace roots
 ```
 
-In a tree repo, `first-tree init tree` produces:
+In a tree repo, `first-tree tree bootstrap` produces:
 
 ```text
 .agents/skills/first-tree/
@@ -59,16 +59,19 @@ members/
 
 ## Wipe-And-Replace Upgrade
 
-`first-tree upgrade` in a source/workspace root:
+`first-tree skill upgrade` in any repo/workspace root:
 
 1. wipes previous installed skill locations
 2. reinstalls `.agents/skills/first-tree/`
 3. recreates the `.claude/skills/first-tree` symlink
-4. refreshes `WHITEPAPER.md`
-5. refreshes the managed `FIRST-TREE-SOURCE-INTEGRATION:` block
-6. preserves `.first-tree/source.json`
+4. also installs the product skills under `.agents/skills/{tree,breeze,gardener}/`
+5. preserves everything outside the skill directories
 
-`first-tree upgrade --tree-path ...` in a tree repo refreshes tree-side
+`first-tree tree upgrade` in a source/workspace root additionally refreshes
+`WHITEPAPER.md`, the managed `FIRST-TREE-SOURCE-INTEGRATION:` block, and other
+source/workspace integration files while preserving `.first-tree/source.json`.
+
+`first-tree tree upgrade --tree-path ...` in a tree repo refreshes tree-side
 metadata such as `.first-tree/VERSION` plus the installed tree-repo skill.
 
 ## What Gets Preserved
@@ -80,25 +83,29 @@ metadata such as `.first-tree/VERSION` plus the installed tree-repo skill.
 
 ## Command Intent
 
-- `first-tree inspect`
+- `first-tree tree inspect`
   - classify the current root before onboarding
-- `first-tree init`
+- `first-tree tree init`
   - high-level onboarding wrapper
   - creates a dedicated tree by default for a single repo
   - prefers a shared tree for workspace roots
-- `first-tree init tree`
+- `first-tree tree bootstrap`
   - low-level tree bootstrap for an explicit tree checkout
-- `first-tree bind`
+- `first-tree tree bind`
   - connect a source/workspace root to an existing tree repo
-- `first-tree workspace sync`
+- `first-tree tree workspace sync`
   - bind child repos to the same shared tree
-- `first-tree publish`
+- `first-tree tree publish`
   - publish the tree repo
   - refresh locally bound source/workspace repos with the published URL
-- `first-tree verify`
+- `first-tree tree verify`
   - validate the tree repo
-- `first-tree upgrade`
+- `first-tree tree upgrade`
   - refresh local integration or tree metadata
+- `first-tree skill install`
+  - install the four shipped skills only
+- `first-tree skill upgrade`
+  - wipe and reinstall the four shipped skills only
 
 ## Invariants
 

--- a/skills/tree/SKILL.md
+++ b/skills/tree/SKILL.md
@@ -50,7 +50,7 @@ During `bind` / `init`, the CLI also ensures the tree repo has the bundled
 |---|---|
 | `first-tree tree inspect` | Classify the current folder and report bindings / child repos |
 | `first-tree tree init` | High-level onboarding wrapper for single repos, shared trees, and workspace roots |
-| `first-tree tree init tree` | Low-level tree bootstrap for an explicit tree checkout |
+| `first-tree tree bootstrap` | Low-level tree bootstrap for an explicit tree checkout |
 | `first-tree tree bind` | Bind the current repo/workspace root to an existing tree repo |
 | `first-tree tree workspace sync` | Bind child repos to the same shared tree |
 | `first-tree tree verify` | Validate a tree repo: frontmatter, owners, soft_links, members, progress |
@@ -66,18 +66,23 @@ For full options on any command, run `first-tree tree <command> --help`.
 ## Recommended Invocation
 
 ```bash
-npx -p first-tree first-tree tree <command>
+npx first-tree tree <command>
 ```
 
-This always runs the latest published version. The CLI auto-checks for
+This is the recommended human-facing one-off invocation. The CLI auto-checks for
 updates on every invocation; pass `--skip-version-check` to suppress the
 check for latency-sensitive callers like SessionStart hooks.
 
-To refresh the installed skill payload when a new minor version is released:
+To refresh source/workspace integration or tree metadata from the current
+package:
 
 ```bash
-npx -p first-tree first-tree tree upgrade
+npx first-tree tree upgrade
 ```
+
+If you only need to wipe and reinstall the four shipped skill payloads under
+`.agents/skills/*` and `.claude/skills/*`, use `npx first-tree skill upgrade`
+instead.
 
 ## Ownership
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,10 +4,11 @@ import { realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 import {
+  ALL_COMMANDS,
   META_COMMANDS,
   PRODUCTS,
   getCommand,
-  readProductVersion,
+  readCommandVersion,
 } from "./products/manifest.js";
 import { readPackageVersion } from "./shared/version.js";
 
@@ -18,29 +19,34 @@ function buildUsage(): string {
     `  ${name.padEnd(20)}  ${description}`;
   const productLines = PRODUCTS.map((p) => formatRow(p.name, p.description))
     .join("\n");
-  const metaLines = META_COMMANDS.map((m) => formatRow(m.name, m.description))
-    .join("\n");
+  const maintenanceLines = META_COMMANDS.map((m) =>
+    formatRow(m.name, m.description)
+  ).join("\n");
+  const primaryProducts = PRODUCTS.map((p) => p.name).join(", ");
+  const maintenanceNamespaces = META_COMMANDS.map((m) => m.name).join(", ");
   const gettingStarted = [
     "  first-tree tree --help",
     "  first-tree tree inspect --json",
     "  first-tree tree init",
     "  first-tree breeze --help",
     "  first-tree breeze status",
+    "  first-tree skill doctor",
   ].join("\n");
-  return `usage: first-tree <command> [...]
+  return `usage: first-tree <namespace> <command>
 
-  first-tree is an umbrella CLI that dispatches into product namespaces.
+  first-tree is an umbrella CLI with three primary products (${primaryProducts})
+  plus a maintenance namespace (${maintenanceNamespaces}).
   This CLI is designed for agents, not humans. Let your agent handle it.
 
 Products:
 ${productLines}
 
-Diagnostics:
-${metaLines}
+Maintenance:
+${maintenanceLines}
 
 Global options:
   --help, -h            Show this help message
-  --version, -v         Show version numbers for the CLI and each product
+  --version, -v         Show version numbers for the CLI and each namespace
   --skip-version-check  Skip the auto-upgrade check (for latency-sensitive callers)
 
 Getting started:
@@ -59,7 +65,6 @@ export function isDirectExecution(
   }
 
   try {
-    // npm commonly invokes bins through a symlink or shim path.
     return realpathSync(argv1) === realpathSync(fileURLToPath(metaUrl));
   } catch {
     return false;
@@ -83,8 +88,6 @@ export function stripGlobalFlags(args: string[]): {
 }
 
 async function runAutoUpgradeCheck(): Promise<void> {
-  // Best-effort silent auto-upgrade. Any failure is swallowed so the user's
-  // command always runs.
   try {
     const {
       checkAndAutoUpgrade,
@@ -113,8 +116,8 @@ async function runAutoUpgradeCheck(): Promise<void> {
 function formatVersionLine(): string {
   const cliVersion = readPackageVersion(import.meta.url, "first-tree");
   const parts = [`first-tree=${cliVersion}`];
-  for (const product of PRODUCTS) {
-    parts.push(`${product.name}=${readProductVersion(product.name)}`);
+  for (const command of ALL_COMMANDS) {
+    parts.push(`${command.name}=${readCommandVersion(command.name)}`);
   }
   return parts.join(" ");
 }
@@ -136,13 +139,13 @@ export async function runCli(
     return 0;
   }
 
-  const commandName = args[0];
-  const command = getCommand(commandName);
+  const namespaceName = args[0];
+  const command = getCommand(namespaceName);
 
   if (!command) {
-    write(`Unknown command: ${commandName}`);
+    write(`Unknown first-tree namespace: ${namespaceName}`);
     write(
-      `Did you mean \`first-tree tree ${commandName}\`? Run \`first-tree --help\` for the list of commands.`,
+      `Did you mean \`first-tree tree ${namespaceName}\`? Run \`first-tree --help\` for the list of products and maintenance commands.`,
     );
     return 1;
   }

--- a/src/meta/skill-tools/README.md
+++ b/src/meta/skill-tools/README.md
@@ -1,15 +1,20 @@
 # `first-tree skill` (meta)
 
-Diagnostic / maintenance commands for the four skill payloads that ship with this package (`first-tree`, `tree`, `breeze`, `gardener`). **This is not a product** — it's a meta command, excluded from `PRODUCTS` in [`src/products/manifest.ts`](../../products/manifest.ts) and rendered under the "Diagnostics" section of `first-tree --help`.
+Diagnostic / maintenance commands for the four skill payloads that ship with
+this package (`first-tree`, `tree`, `breeze`, `gardener`). **This is not a
+product** — it is a meta command, excluded from `PRODUCTS` in
+[`src/products/manifest.ts`](../../products/manifest.ts) and rendered under the
+"Maintenance" section of `first-tree --help`.
 
-## What's in this directory
+## What's In This Directory
 
-```
+```text
 skill-tools/
 ├── VERSION
+├── README.md              # meta-command overview
 ├── cli.ts                 # dispatcher
 └── engine/
-    ├── commands/          # list.ts, doctor.ts, link.ts
+    ├── commands/          # install.ts, upgrade.ts, list.ts, doctor.ts, link.ts
     └── lib/paths.ts       # shared skill layout helpers
 ```
 
@@ -17,11 +22,15 @@ skill-tools/
 
 | Command | Role |
 |---------|------|
+| `first-tree skill install` | Install the four bundled skills into `.agents/skills/*` and `.claude/skills/*` |
+| `first-tree skill upgrade` | Wipe and reinstall the four bundled skills from the current package |
 | `first-tree skill list` | Print the four bundled skills with installed status + version |
 | `first-tree skill doctor` | Diagnose skill-install health (exits non-zero on problems) |
 | `first-tree skill link` | Idempotently repair `.claude/skills/*` alias symlinks |
 
-The `list/doctor/link` trio is the canonical entrypoint an agent reaches for when the `first-tree` umbrella skill's **"Managing Skills On This Machine"** section sends them here.
+The `install/upgrade/list/doctor/link` surface is the canonical entrypoint an
+agent reaches for when the `first-tree` umbrella skill's **"Managing Skills On
+This Machine"** section sends them here.
 
 ## Related
 

--- a/src/meta/skill-tools/cli.ts
+++ b/src/meta/skill-tools/cli.ts
@@ -1,15 +1,10 @@
 /**
- * Skill-tools meta dispatcher.
+ * Skill maintenance-namespace dispatcher.
  *
  * Routes `first-tree skill <command>` into cross-cutting skill tooling:
- * listing installed skills, diagnosing their health, and repairing the
- * .claude/ alias symlinks that point into .agents/.
- *
- * This is a META command, not a product — it manages the four skill
- * payloads (first-tree + tree/breeze/gardener) rather than shipping one
- * of its own. The `first-tree skill` command family is the user-facing
- * entry point an agent reaches for when the first-tree skill's
- * "Managing Skills On This Machine" section sends them here.
+ * listing installed skills, diagnosing their health, repairing the
+ * .claude/ alias symlinks that point into .agents/, and reinstalling the
+ * shipped skill payloads.
  */
 
 import { readOwnVersion } from "#shared/version.js";
@@ -20,15 +15,19 @@ export const SKILL_USAGE = `usage: first-tree skill <command>
   (first-tree, tree, breeze, gardener).
 
 Commands:
+  install               Install the four skills into .agents/ and .claude/
+  upgrade               Wipe and reinstall the four skills from this package
   list                  Print the four skills with installed status + version
   doctor                Diagnose skill-install health (exits non-zero on problems)
   link                  Idempotently repair .claude/skills/* symlinks
 
 Options:
   --help, -h            Show this help message
-  --version, -v         Show skill product version
+  --version, -v         Show the skill maintenance-namespace version
 
 Examples:
+  first-tree skill install
+  first-tree skill upgrade
   first-tree skill list
   first-tree skill doctor
   first-tree skill link --root /path/to/repo
@@ -68,6 +67,14 @@ export async function runSkill(
     case "list": {
       const { runList } = await import("./engine/commands/list.js");
       return runList(rest, { write });
+    }
+    case "install": {
+      const { runInstall } = await import("./engine/commands/install.js");
+      return runInstall(rest, { write });
+    }
+    case "upgrade": {
+      const { runUpgrade } = await import("./engine/commands/upgrade.js");
+      return runUpgrade(rest, { write });
     }
     case "doctor": {
       const { runDoctor } = await import("./engine/commands/doctor.js");

--- a/src/meta/skill-tools/engine/commands/doctor.ts
+++ b/src/meta/skill-tools/engine/commands/doctor.ts
@@ -1,15 +1,13 @@
 /**
  * `first-tree skill doctor` — diagnose skill install health.
- *
- * Reports per-skill: presence of the .agents/ entry, presence of the
- * .claude/ symlink, whether the symlinks point at the expected targets,
- * and whether the SKILL.md frontmatter is readable. Exits non-zero if
- * anything is wrong so CI can gate on it.
  */
 
 import { existsSync, lstatSync, readlinkSync } from "node:fs";
 import { join } from "node:path";
-import { allSkillLayouts } from "#meta/skill-tools/engine/lib/paths.js";
+import {
+  allSkillLayouts,
+  requiredFilesForSkill,
+} from "#meta/skill-tools/engine/lib/paths.js";
 
 export interface DoctorDeps {
   targetRoot?: string;
@@ -23,38 +21,40 @@ interface Diagnosis {
 
 function inspect(targetRoot: string, name: string): Diagnosis {
   const problems: string[] = [];
-  const layouts = allSkillLayouts().find((l) => l.name === name)!;
-  const agentsFull = join(targetRoot, layouts.agentsPath);
-  const claudeFull = join(targetRoot, layouts.claudePath);
+  const layout = allSkillLayouts().find((l) => l.name === name)!;
+  const agentsFull = join(targetRoot, layout.agentsPath);
+  const claudeFull = join(targetRoot, layout.claudePath);
 
   if (!existsSync(agentsFull)) {
-    problems.push(`missing: ${layouts.agentsPath}`);
+    problems.push(`missing: ${layout.agentsPath}`);
   } else {
-    const skillMd = join(agentsFull, "SKILL.md");
-    if (!existsSync(skillMd)) {
-      problems.push(`${layouts.agentsPath}/SKILL.md does not exist`);
+    for (const relPath of requiredFilesForSkill(name)) {
+      const fullPath = join(agentsFull, relPath);
+      if (!existsSync(fullPath)) {
+        problems.push(`${layout.agentsPath}/${relPath} does not exist`);
+      }
     }
   }
 
   if (!existsSync(claudeFull)) {
-    problems.push(`missing: ${layouts.claudePath}`);
+    problems.push(`missing: ${layout.claudePath}`);
   } else {
     try {
       const stat = lstatSync(claudeFull);
       if (!stat.isSymbolicLink()) {
         problems.push(
-          `${layouts.claudePath} should be a symlink to ${layouts.claudeSymlinkTarget}`,
+          `${layout.claudePath} should be a symlink to ${layout.claudeSymlinkTarget}`,
         );
       } else {
         const actual = readlinkSync(claudeFull);
-        if (actual !== layouts.claudeSymlinkTarget) {
+        if (actual !== layout.claudeSymlinkTarget) {
           problems.push(
-            `${layouts.claudePath} -> ${actual}, expected ${layouts.claudeSymlinkTarget}`,
+            `${layout.claudePath} -> ${actual}, expected ${layout.claudeSymlinkTarget}`,
           );
         }
       }
     } catch {
-      problems.push(`${layouts.claudePath} is unreadable`);
+      problems.push(`${layout.claudePath} is unreadable`);
     }
   }
 
@@ -70,7 +70,7 @@ export function runDoctor(
 
   Diagnoses the health of the four first-tree skill installs in the
   current working directory (or --root <path>). Reports per-skill
-  presence, SKILL.md readability, and symlink target correctness.
+  presence, required-file completeness, and symlink target correctness.
 
   Exits 0 if all four skills are healthy, 1 otherwise.
 
@@ -112,7 +112,7 @@ Options:
   write(`${bad} of 4 skills have problems.`);
   write("");
   write("Fix with:");
-  write("  first-tree skill link    # repair symlinks");
-  write("  first-tree tree upgrade  # reinstall all four skills");
+  write("  first-tree skill link     # repair symlinks");
+  write("  first-tree skill upgrade  # reinstall all four skills");
   return 1;
 }

--- a/src/meta/skill-tools/engine/commands/install.ts
+++ b/src/meta/skill-tools/engine/commands/install.ts
@@ -1,0 +1,72 @@
+import {
+  copyCanonicalSkill,
+  resolveBundledPackageRoot,
+} from "#products/tree/engine/runtime/installer.js";
+
+export interface InstallDeps {
+  targetRoot?: string;
+  write?: (text: string) => void;
+}
+
+export const INSTALL_USAGE = `usage: first-tree skill install
+
+  Install the four shipped first-tree skills into the current working
+  directory (or --root <path>). This manages only the local skill payloads
+  under .agents/skills/* and .claude/skills/*; it does not write tree/source
+  binding metadata.
+
+Options:
+  --root <path>         Install into a different directory (default: cwd)
+  --help, -h            Show this help message
+`;
+
+function parseTargetRoot(
+  args: readonly string[],
+): string | { error: string } {
+  let targetRoot = process.cwd();
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--root") {
+      const value = args[i + 1];
+      if (!value) {
+        return { error: "Missing value for --root" };
+      }
+      targetRoot = value;
+      i += 1;
+      continue;
+    }
+    return { error: `Unknown install option: ${arg}` };
+  }
+  return targetRoot;
+}
+
+export function runInstall(
+  args: readonly string[],
+  deps: InstallDeps = {},
+): number {
+  if (args[0] === "--help" || args[0] === "-h") {
+    (deps.write ?? console.log)(INSTALL_USAGE);
+    return 0;
+  }
+
+  const parsedRoot = deps.targetRoot ?? parseTargetRoot(args);
+  if (typeof parsedRoot !== "string") {
+    console.error(parsedRoot.error);
+    console.log(INSTALL_USAGE);
+    return 1;
+  }
+
+  const write = deps.write ?? ((text: string) => process.stdout.write(text + "\n"));
+  try {
+    const sourceRoot = resolveBundledPackageRoot();
+    copyCanonicalSkill(sourceRoot, parsedRoot);
+    write(
+      "Installed the four shipped first-tree skills under `.agents/skills/*` and `.claude/skills/*`.",
+    );
+    return 0;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`first-tree skill install: ${message}`);
+    return 1;
+  }
+}

--- a/src/meta/skill-tools/engine/commands/upgrade.ts
+++ b/src/meta/skill-tools/engine/commands/upgrade.ts
@@ -1,0 +1,72 @@
+import {
+  copyCanonicalSkill,
+  resolveBundledPackageRoot,
+} from "#products/tree/engine/runtime/installer.js";
+
+export interface UpgradeDeps {
+  targetRoot?: string;
+  write?: (text: string) => void;
+}
+
+export const UPGRADE_USAGE = `usage: first-tree skill upgrade
+
+  Wipe and reinstall the four shipped first-tree skills in the current
+  working directory (or --root <path>) from the currently installed
+  first-tree package. This refreshes only the local skill payloads under
+  .agents/skills/* and .claude/skills/*.
+
+Options:
+  --root <path>         Upgrade a different directory (default: cwd)
+  --help, -h            Show this help message
+`;
+
+function parseTargetRoot(
+  args: readonly string[],
+): string | { error: string } {
+  let targetRoot = process.cwd();
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--root") {
+      const value = args[i + 1];
+      if (!value) {
+        return { error: "Missing value for --root" };
+      }
+      targetRoot = value;
+      i += 1;
+      continue;
+    }
+    return { error: `Unknown upgrade option: ${arg}` };
+  }
+  return targetRoot;
+}
+
+export function runUpgrade(
+  args: readonly string[],
+  deps: UpgradeDeps = {},
+): number {
+  if (args[0] === "--help" || args[0] === "-h") {
+    (deps.write ?? console.log)(UPGRADE_USAGE);
+    return 0;
+  }
+
+  const parsedRoot = deps.targetRoot ?? parseTargetRoot(args);
+  if (typeof parsedRoot !== "string") {
+    console.error(parsedRoot.error);
+    console.log(UPGRADE_USAGE);
+    return 1;
+  }
+
+  const write = deps.write ?? ((text: string) => process.stdout.write(text + "\n"));
+  try {
+    const sourceRoot = resolveBundledPackageRoot();
+    copyCanonicalSkill(sourceRoot, parsedRoot);
+    write(
+      "Upgraded the four shipped first-tree skills under `.agents/skills/*` and `.claude/skills/*`.",
+    );
+    return 0;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`first-tree skill upgrade: ${message}`);
+    return 1;
+  }
+}

--- a/src/meta/skill-tools/engine/lib/paths.ts
+++ b/src/meta/skill-tools/engine/lib/paths.ts
@@ -6,9 +6,14 @@
  */
 
 import { join } from "node:path";
-import { ALL_SKILL_NAMES } from "#products/tree/engine/runtime/asset-loader.js";
+import {
+  ALL_SKILL_NAMES,
+  INSTALLED_SKILL_REQUIRED_FILES,
+} from "#products/tree/engine/runtime/asset-loader.js";
 
 export { ALL_SKILL_NAMES };
+
+const PRODUCT_SKILL_REQUIRED_FILES = ["SKILL.md", "VERSION"] as const;
 
 export interface SkillLayout {
   readonly name: string;
@@ -37,4 +42,10 @@ export function layoutForSkill(name: string): SkillLayout {
 
 export function allSkillLayouts(): readonly SkillLayout[] {
   return ALL_SKILL_NAMES.map(layoutForSkill);
+}
+
+export function requiredFilesForSkill(name: string): readonly string[] {
+  return name === "first-tree"
+    ? INSTALLED_SKILL_REQUIRED_FILES
+    : PRODUCT_SKILL_REQUIRED_FILES;
 }

--- a/src/products/breeze/README.md
+++ b/src/products/breeze/README.md
@@ -1,12 +1,16 @@
 # `first-tree breeze`
 
-Local daemon that takes over your `gh` login and turns GitHub notifications (PRs, comments, discussions, issues) into a triaged, optionally auto-handled inbox. Drives a Claude Code statusline, an SSE dashboard, and scheduled background work.
+Local daemon that takes over your `gh` login and turns GitHub notifications
+(PRs, comments, discussions, issues) into a triaged, optionally auto-handled
+inbox. Drives a Claude Code statusline, an SSE dashboard, and scheduled
+background work.
 
-## What's in this directory
+## What's In This Directory
 
-```
+```text
 breeze/
 ├── VERSION
+├── README.md              # product overview
 ├── cli.ts                 # dispatcher
 └── engine/
     ├── commands/          # install, start, stop, poll, watch, doctor, cleanup, status, status-manager
@@ -30,9 +34,12 @@ breeze/
 
 Run `first-tree breeze --help` for the authoritative list.
 
-## Runtime constraints
+## Runtime Constraints
 
-`engine/statusline.ts` is bundled separately (`dist/breeze-statusline.js`) and is called every few seconds by the Claude Code statusline hook. It must stay zero-dep and cold-start under 30ms — do not import `ink`, `zod`, or the umbrella CLI from it.
+`engine/statusline.ts` is bundled separately (`dist/breeze-statusline.js`) and
+is called every few seconds by the Claude Code statusline hook. It must stay
+zero-dep and cold-start under 30ms — do not import `ink`, `zod`, or the
+umbrella CLI from it.
 
 ## Related
 

--- a/src/products/gardener/README.md
+++ b/src/products/gardener/README.md
@@ -1,17 +1,23 @@
 # `first-tree gardener`
 
-Local maintenance agent for Context Trees. Keeps the tree coherent as code and reviews evolve:
+Local maintenance agent for Context Trees. Keeps the tree coherent as code and
+reviews evolve:
 
 - **`respond`** — fixes sync PRs based on reviewer feedback (reactive maintenance).
 - **`comment`** — reviews source-repo PRs / issues against the bound tree and posts structured verdict comments.
 
-The intended scope extends beyond reactive maintenance: gardener should proactively watch source repos for changes that affect tree coverage, open corresponding issues on the tree repo, and assign the right owners. That proactive layer is the next milestone and currently ships only the `respond` + `comment` primitives.
+The intended scope extends beyond reactive maintenance: gardener should
+proactively watch source repos for changes that affect tree coverage, open
+corresponding issues on the tree repo, and assign the right owners. That
+proactive layer is the next milestone and currently ships only the `respond` +
+`comment` primitives.
 
-## What's in this directory
+## What's In This Directory
 
-```
+```text
 gardener/
 ├── VERSION
+├── README.md              # product overview
 ├── cli.ts                 # dispatcher
 └── engine/
     ├── commands/          # respond.ts, comment.ts

--- a/src/products/manifest.ts
+++ b/src/products/manifest.ts
@@ -4,19 +4,12 @@
  * The surface splits into two kinds of commands:
  *
  *   - Products: `tree`, `breeze`, `gardener`. Each is a real tool with its
- *     own CLI, its own skill payload under `skills/<name>/`, and optional
- *     runtime assets under `assets/<name>/`. These are what users mean
- *     when they say "a first-tree product".
+ *     own CLI, its own skill payload under `skills/<name>`, and optional
+ *     runtime assets under `assets/<name>`.
  *
- *   - Meta commands: `skill`. These are maintenance/diagnostic tools that
- *     operate on the product suite itself. They don't ship skills or
- *     assets, aren't subject to auto-upgrade, and shouldn't be treated as
- *     products by callers that iterate the product set.
- *
- * The umbrella CLI (src/cli.ts) and maintainer scripts should iterate
- * `PRODUCTS` for product-level logic (help listing, version reporting,
- * auto-upgrade) and `META_COMMANDS` when they want the full dispatch
- * surface. `ALL_COMMANDS` is the concatenation for lookup.
+ *   - Meta commands: `skill`. These are maintenance tools that operate on the
+ *     product suite itself. They don't ship skills or assets, and shouldn't be
+ *     treated as products by callers that iterate only the product set.
  */
 
 import { readOwnVersion } from "#shared/version.js";
@@ -27,23 +20,17 @@ type CommandRunner = (args: string[], output: Output) => Promise<number>;
 export type CommandKind = "product" | "meta";
 
 export interface CommandDefinition {
-  /** Subcommand name as typed on the CLI (`first-tree <name> ...`). */
   readonly name: string;
-  /** `product` = real tool; `meta` = maintenance/diagnostic command. */
   readonly kind: CommandKind;
-  /** One-line description shown in the umbrella `--help` usage block. */
   readonly description: string;
-  /** Lazy loader for the command's CLI entrypoint. */
   readonly load: () => Promise<{ run: CommandRunner }>;
-  /** Whether invoking this command should trigger the auto-upgrade check. */
   readonly autoUpgradeOnInvoke: boolean;
+  readonly versionDir: string;
 }
 
 export interface ProductDefinition extends CommandDefinition {
   readonly kind: "product";
-  /** Whether this product ships runtime assets under `assets/<name>/`. */
   readonly hasAssets: boolean;
-  /** Whether this product ships a skill under `skills/<name>/`. */
   readonly hasSkill: boolean;
 }
 
@@ -55,13 +42,13 @@ export const PRODUCTS: readonly ProductDefinition[] = [
   {
     name: "tree",
     kind: "product",
-    description:
-      "Context Tree tooling (init, bind, sync, publish, ...)",
+    description: "Context Tree tooling (init, bind, sync, publish, ...)",
     load: async () => {
       const mod = await import("./tree/cli.js");
       return { run: (args, output) => mod.runTree(args, output) };
     },
     autoUpgradeOnInvoke: true,
+    versionDir: "src/products/tree",
     hasAssets: true,
     hasSkill: true,
   },
@@ -75,19 +62,20 @@ export const PRODUCTS: readonly ProductDefinition[] = [
       return { run: (args, output) => mod.runBreeze(args, output) };
     },
     autoUpgradeOnInvoke: false,
+    versionDir: "src/products/breeze",
     hasAssets: true,
     hasSkill: true,
   },
   {
     name: "gardener",
     kind: "product",
-    description:
-      "Context Tree maintenance agent (respond, comment, ...)",
+    description: "Context Tree maintenance agent (respond, comment, ...)",
     load: async () => {
       const mod = await import("./gardener/cli.js");
       return { run: (args, output) => mod.runGardener(args, output) };
     },
     autoUpgradeOnInvoke: false,
+    versionDir: "src/products/gardener",
     hasAssets: false,
     hasSkill: true,
   },
@@ -98,12 +86,13 @@ export const META_COMMANDS: readonly MetaDefinition[] = [
     name: "skill",
     kind: "meta",
     description:
-      "Inspect and repair the four bundled first-tree skills (list, doctor, link)",
+      "Manage the four bundled first-tree skills (install, upgrade, list, doctor, link)",
     load: async () => {
       const mod = await import("#meta/skill-tools/cli.js");
       return { run: (args, output) => mod.runSkill(args, output) };
     },
     autoUpgradeOnInvoke: false,
+    versionDir: "src/meta/skill-tools",
   },
 ];
 
@@ -128,12 +117,14 @@ export function listProductNames(): readonly string[] {
   return PRODUCTS.map((p) => p.name);
 }
 
-/**
- * Read a product's VERSION file via the shared version reader.
- */
-export function readProductVersion(productName: string): string {
-  return readOwnVersion(
-    import.meta.url,
-    `src/products/${productName}`,
-  );
+export function listMetaCommandNames(): readonly string[] {
+  return META_COMMANDS.map((m) => m.name);
+}
+
+export function readCommandVersion(commandName: string): string {
+  const command = getCommand(commandName);
+  if (!command) {
+    return "unknown";
+  }
+  return readOwnVersion(import.meta.url, command.versionDir);
 }

--- a/src/products/tree/README.md
+++ b/src/products/tree/README.md
@@ -2,14 +2,15 @@
 
 CLI toolkit for creating, binding, and maintaining a Context Tree repo.
 
-## What's in this directory
+## What's In This Directory
 
-```
+```text
 tree/
 ├── VERSION                # product semver (independent of npm package)
+├── README.md              # product overview
 ├── cli.ts                 # thin arg-routing dispatcher (lazy-loads commands)
 └── engine/
-    ├── commands/          # one file per subcommand (bind, init, publish, …)
+    ├── commands/          # one file per subcommand (bind, init, bootstrap, publish, …)
     ├── rules/             # tree validation rules
     ├── runtime/           # asset loader, installer, upgrader, source integration
     ├── validators/        # node + member validators
@@ -22,6 +23,7 @@ tree/
 |---------|------|
 | `first-tree tree inspect` | Classify the current folder (source / workspace / tree) |
 | `first-tree tree init` | High-level onboarding wrapper |
+| `first-tree tree bootstrap` | Canonical low-level tree bootstrap for an explicit tree checkout |
 | `first-tree tree bind` | Bind current repo/workspace to an existing tree |
 | `first-tree tree workspace sync` | Bind discovered child repos to a shared tree |
 | `first-tree tree publish` | Push the tree to GitHub and refresh bound sources |

--- a/src/products/tree/cli.ts
+++ b/src/products/tree/cli.ts
@@ -14,11 +14,12 @@ export const TREE_USAGE = `usage: first-tree tree <command>
 Commands:
   inspect               Classify the current folder before onboarding
   init                  High-level onboarding wrapper for repo/workspace roots
+  bootstrap             Low-level tree-repo bootstrap for an explicit tree checkout
   bind                  Bind the current repo/workspace root to an existing tree repo
   workspace             Workspace helpers (currently: sync child repos to a shared tree)
   publish               Publish a tree repo to GitHub
   verify                Run verification checks against a tree repo
-  upgrade               Refresh the installed skill in a tree repo
+  upgrade               Refresh source/workspace integration or tree metadata
   sync                  Detect drift between a tree repo and its bound sources
   review                Run Claude Code PR review (CI helper)
   generate-codeowners   Generate .github/CODEOWNERS from tree ownership
@@ -35,14 +36,16 @@ Common examples:
   first-tree tree init
   first-tree tree init --tree-path ../org-context --tree-mode shared
   first-tree tree init --scope workspace --tree-path ../org-context --tree-mode shared --sync-members
+  first-tree tree bootstrap --here
   first-tree tree bind --tree-path ../org-context --tree-mode shared
   first-tree tree publish --tree-path ../org-context
-  mkdir my-org-tree && cd my-org-tree && git init && first-tree tree init tree --here
+  mkdir my-org-tree && cd my-org-tree && git init && first-tree tree bootstrap --here
   first-tree tree verify --tree-path ../my-org-tree
   first-tree tree upgrade --tree-path ../my-org-tree
 
 Note:
-  \`first-tree tree init tree --here\` is for when the current repo is already the tree repo.
+  \`first-tree tree bootstrap --here\` is for when the current repo is already the tree repo.
+  Legacy alias: \`first-tree tree init tree ...\`
 `;
 
 type Output = (text: string) => void;
@@ -66,6 +69,12 @@ export async function runTree(
         "#products/tree/engine/commands/init.js"
       );
       return runInit(args.slice(1));
+    }
+    case "bootstrap": {
+      const { runBootstrap } = await import(
+        "#products/tree/engine/commands/bootstrap.js"
+      );
+      return runBootstrap(args.slice(1), write);
     }
     case "inspect": {
       const { runInspect } = await import(

--- a/src/products/tree/engine/bind.ts
+++ b/src/products/tree/engine/bind.ts
@@ -34,7 +34,7 @@ import {
 import { upsertFirstTreeIndexFile, upsertSourceIntegrationFiles } from "#products/tree/engine/runtime/source-integration.js";
 import { relativeRepoPath } from "#products/tree/engine/dedicated-tree.js";
 
-export const BIND_USAGE = `usage: first-tree bind [--tree-path PATH | --tree-url URL] [--tree-mode dedicated|shared] [--mode standalone-source|shared-source|workspace-root|workspace-member] [--workspace-id ID] [--workspace-root PATH] [--entrypoint PATH]
+export const BIND_USAGE = `usage: first-tree tree bind [--tree-path PATH | --tree-url URL] [--tree-mode dedicated|shared] [--mode standalone-source|shared-source|workspace-root|workspace-member] [--workspace-id ID] [--workspace-root PATH] [--entrypoint PATH]
 
 Bind the current source/workspace root to an existing Context Tree repo.
 
@@ -48,9 +48,9 @@ What it does:
   6. Syncs the bound codebase repo into the tree repo under .first-tree/submodules/
 
 Typical examples:
-  first-tree bind --tree-path ../org-context --tree-mode shared
-  first-tree bind --tree-path ../org-context --tree-mode shared --mode workspace-root --workspace-id my-workspace
-  first-tree bind --tree-path ../org-context --tree-mode shared --mode workspace-member --workspace-id my-workspace --workspace-root ..
+  first-tree tree bind --tree-path ../org-context --tree-mode shared
+  first-tree tree bind --tree-path ../org-context --tree-mode shared --mode workspace-root --workspace-id my-workspace
+  first-tree tree bind --tree-path ../org-context --tree-mode shared --mode workspace-member --workspace-id my-workspace --workspace-root ..
 
 Options:
   --tree-path PATH      Local checkout of the tree repo to bind
@@ -234,12 +234,12 @@ function ensureTreeCheckout(
   const treeRepo = new Repo(resolvedTreeRoot);
   if (!treeRepo.isGitRepo()) {
     throw new Error(
-      `Tree checkout is not a git repository: ${resolvedTreeRoot}. Run \`first-tree init tree\` first or point bind at an existing tree checkout.`,
+      `Tree checkout is not a git repository: ${resolvedTreeRoot}. Run \`first-tree tree bootstrap\` first or point bind at an existing tree checkout.`,
     );
   }
   if (treeRepo.root === sourceRepo.root) {
     throw new Error(
-      "The source/workspace root and tree repo resolved to the same path. Use `first-tree init --here` only when the current repo itself should become the tree.",
+      "The source/workspace root and tree repo resolved to the same path. Use `first-tree tree bootstrap --here` only when the current repo itself should become the tree.",
     );
   }
 

--- a/src/products/tree/engine/commands/bootstrap.ts
+++ b/src/products/tree/engine/commands/bootstrap.ts
@@ -1,0 +1,5 @@
+export {
+  BOOTSTRAP_USAGE,
+  parseBootstrapArgs,
+  runBootstrapCli as runBootstrap,
+} from "#products/tree/engine/init.js";

--- a/src/products/tree/engine/commands/generate-codeowners.ts
+++ b/src/products/tree/engine/commands/generate-codeowners.ts
@@ -1,6 +1,6 @@
 import { generate } from "../../../../../assets/tree/helpers/generate-codeowners.js";
 
-export const GENERATE_CODEOWNERS_USAGE = `usage: first-tree generate-codeowners [--check]
+export const GENERATE_CODEOWNERS_USAGE = `usage: first-tree tree generate-codeowners [--check]
 
 Generate \`.github/CODEOWNERS\` from the Context Tree's NODE.md ownership
 frontmatter. Walks the tree, resolves owners (with parent inheritance), and

--- a/src/products/tree/engine/commands/help.ts
+++ b/src/products/tree/engine/commands/help.ts
@@ -1,4 +1,4 @@
-const HELP_USAGE = `usage: first-tree help <topic>
+const HELP_USAGE = `usage: first-tree tree help <topic>
 
 Topics:
   onboarding   How to set up a context tree from scratch

--- a/src/products/tree/engine/commands/init.ts
+++ b/src/products/tree/engine/commands/init.ts
@@ -1,1 +1,5 @@
-export { INIT_USAGE, parseInitArgs, runInitCli as runInit } from "#products/tree/engine/init.js";
+export {
+  INIT_USAGE,
+  parseInitArgs,
+  runInitCli as runInit,
+} from "#products/tree/engine/init.js";

--- a/src/products/tree/engine/commands/inject-context.ts
+++ b/src/products/tree/engine/commands/inject-context.ts
@@ -1,6 +1,6 @@
 import { buildTreeFirstContextBundle } from "#products/tree/engine/runtime/tree-first-context.js";
 
-export const INJECT_CONTEXT_USAGE = `usage: first-tree inject-context
+export const INJECT_CONTEXT_USAGE = `usage: first-tree tree inject-context
 
 Output a SessionStart hook payload that injects tree-first cross-repo context.
 When the current working directory is a bound source/workspace root, the

--- a/src/products/tree/engine/commands/review.ts
+++ b/src/products/tree/engine/commands/review.ts
@@ -2,7 +2,7 @@ import { join } from "node:path";
 import { resolveBundledAssetRoot, resolveBundledPackageRoot } from "#products/tree/engine/runtime/installer.js";
 import { runReview as runReviewImpl } from "../../../../../assets/tree/helpers/run-review.js";
 
-export const REVIEW_USAGE = `usage: first-tree review [--diff PATH] [--output PATH]
+export const REVIEW_USAGE = `usage: first-tree tree review [--diff PATH] [--output PATH]
 
 Run Claude Code PR review against a Context Tree repo. Reads the PR diff,
 loads the bundled review prompt and the repo's AGENTS.md/NODE.md, invokes

--- a/src/products/tree/engine/init.ts
+++ b/src/products/tree/engine/init.ts
@@ -66,9 +66,30 @@ import { runWorkspaceSync } from "#products/tree/engine/workspace-sync.js";
  * Different agents may name this differently — change it here to update
  * all generated task text at once.
  */
-export const INTERACTIVE_TOOL = "AskUserQuestion";
-export const INIT_USAGE = `usage: first-tree init [--tree-path PATH | --tree-url URL] [--tree-mode dedicated|shared] [--scope repo|workspace] [--workspace-id ID] [--sync-members] [--seed-members contributors]
-       first-tree init tree [--here] [--tree-path PATH] [--seed-members contributors]
+export const INTERACTIVE_TOOL = "structured user-input tool";
+export const BOOTSTRAP_USAGE = `usage: first-tree tree bootstrap [--here] [--tree-path PATH] [--seed-members contributors]
+
+Low-level tree-repo bootstrap for an explicit tree checkout.
+
+Use this only when the current repo itself should become the tree repo, or
+when you are intentionally creating / refreshing a dedicated tree checkout.
+
+Examples:
+  first-tree tree bootstrap --here
+  first-tree tree bootstrap --tree-path ../my-org-tree
+
+Legacy alias:
+  first-tree tree init tree ...
+
+Options:
+  --here                     Initialize the current repo in place as a tree repo
+  --seed-members contributors
+                             Seed initial \`members/*/NODE.md\` files from contributor history
+  --tree-path PATH           Use an explicit local tree repo path
+  --help                     Show this help message
+`;
+
+export const INIT_USAGE = `usage: first-tree tree init [--tree-path PATH | --tree-url URL] [--tree-mode dedicated|shared] [--scope repo|workspace] [--workspace-id ID] [--sync-members] [--seed-members contributors]
 
 High-level onboarding wrapper for source repos, workspace roots, and shared trees.
 
@@ -84,19 +105,18 @@ Default behavior:
     the provided tree instead of creating a new sibling tree repo.
 
 Low-level tree bootstrap:
-  - \`first-tree init tree --here\` initializes the current repo in place as a
+  - Use \`first-tree tree bootstrap --here\` when the current repo should become the
     tree repo.
-  - \`first-tree init tree --tree-path ../my-tree\` creates or refreshes a tree
-    checkout at an explicit path.
+  - Use \`first-tree tree bootstrap --tree-path ../my-tree\` to create or refresh a
+    tree checkout at an explicit path.
 
 Recommended examples:
-  first-tree init
-  first-tree init --tree-path ../org-context --tree-mode shared
-  first-tree init --scope workspace --tree-path ../org-context --tree-mode shared --sync-members
-  mkdir my-org-tree && cd my-org-tree && git init && first-tree init tree --here
+  first-tree tree init
+  first-tree tree init --tree-path ../org-context --tree-mode shared
+  first-tree tree init --scope workspace --tree-path ../org-context --tree-mode shared --sync-members
+  mkdir my-org-tree && cd my-org-tree && git init && first-tree tree bootstrap --here
 
 Options:
-  --here                     Initialize the current repo in place as a tree repo
   --seed-members contributors
                              Seed initial \`members/*/NODE.md\` files from contributor history
   --tree-name NAME           Override the default sibling repo name (\`<repo>-tree\`)
@@ -191,7 +211,7 @@ export function formatTaskList(
       );
       lines.push("## Source Workspace Workflow");
       lines.push(
-        `- [ ] When this initial tree version is ready, run \`first-tree publish --open-pr\` from this dedicated tree repo. It will create or reuse the GitHub \`*-tree\` repo, continue supporting older \`*-context\` repos, record the published tree GitHub URL back in \`${context.sourceRepoName}\`, refresh the local tree checkout config, and open the source/workspace PR.`,
+        `- [ ] When this initial tree version is ready, run \`first-tree tree publish --open-pr\` from this dedicated tree repo. It will create or reuse the GitHub \`*-tree\` repo, continue supporting older \`*-context\` repos, record the published tree GitHub URL back in \`${context.sourceRepoName}\`, refresh the local tree checkout config, and open the source/workspace PR.`,
       );
       lines.push(
         `- [ ] After publish succeeds, treat the checkout recorded in \`${SOURCE_STATE}\` as the canonical local working copy for this tree. The bootstrap repo can be deleted when you no longer need it.`,
@@ -210,10 +230,10 @@ export function formatTaskList(
       " identify all information you need from the user. Ask the user for their code" +
       " repositories or project directories so you can analyze the source yourself —" +
       " derive project descriptions, domains, and members from the code instead of" +
-      " asking the user to describe them. Collect everything upfront using the" +
-      ` **${INTERACTIVE_TOOL}** tool with structured options — present selectable choices` +
+      " asking the user to describe them. Collect everything upfront using your" +
+      ` agent's **${INTERACTIVE_TOOL}** when available — present selectable choices` +
       " (with label and description) so the user can pick instead of typing free-form" +
-      ` answers. You may batch up to 4 questions per ${INTERACTIVE_TOOL} call.\n`,
+      " answers.\n",
   );
   for (const group of groups) {
     lines.push(`## ${group.group}`);
@@ -224,7 +244,7 @@ export function formatTaskList(
   }
   lines.push("## Verification");
   lines.push(
-    "After completing the tasks above, run `first-tree verify` to confirm:",
+    "After completing the tasks above, run `first-tree tree verify` to confirm:",
   );
   lines.push(
     `- [ ] \`${context?.frameworkVersionPath ?? FRAMEWORK_VERSION}\` exists`,
@@ -233,7 +253,7 @@ export function formatTaskList(
   lines.push(
     `- [ ] \`${AGENT_INSTRUCTIONS_FILE}\` has framework markers and \`${CLAUDE_INSTRUCTIONS_FILE}\` mirrors the same workflow guidance`,
   );
-  lines.push("- [ ] `first-tree verify` passes with no errors");
+  lines.push("- [ ] `first-tree tree verify` passes with no errors");
   lines.push("- [ ] At least one member node exists");
   lines.push("");
   lines.push("---");
@@ -241,7 +261,7 @@ export function formatTaskList(
   lines.push(
     "**Important:** As you complete each task, check it off in" +
       ` \`${context?.progressPath ?? INSTALLED_PROGRESS}\` by changing \`- [ ]\` to \`- [x]\`.` +
-      " Run `first-tree verify` when done — it will fail if any" +
+      " Run `first-tree tree verify` when done — it will fail if any" +
       " items remain unchecked.",
   );
   lines.push("");
@@ -298,9 +318,9 @@ export function runInit(repo?: Repo, options?: InitOptions): number {
   const r = initTarget.repo;
   if (options?.here && sourceRepo.isLikelySourceRepo() && !sourceRepo.looksLikeTreeRepo()) {
     console.log(
-      "Warning: `first-tree init --here` is initializing this source/workspace" +
+      "Warning: `first-tree tree bootstrap --here` is initializing this source/workspace" +
         " repo in place. This will create `NODE.md`, `members/`, and tree-scoped" +
-        ` ${AGENT_INSTRUCTIONS_FILE}/${CLAUDE_INSTRUCTIONS_FILE} here. Use plain \`first-tree init\` to create` +
+        ` ${AGENT_INSTRUCTIONS_FILE}/${CLAUDE_INSTRUCTIONS_FILE} here. Use \`first-tree tree init\` to create` +
         " a sibling dedicated tree repo instead.",
     );
     console.log();
@@ -529,7 +549,6 @@ export interface ParsedInitArgs {
 
 export interface ParsedInitCliArgs extends ParsedInitArgs {
   scope?: "repo" | "workspace";
-  subcommand?: "tree";
   syncMembers?: boolean;
   treeMode?: "dedicated" | "shared";
   treeUrl?: string;
@@ -595,7 +614,16 @@ export function parseInitArgs(
   return parsed;
 }
 
+export function parseBootstrapArgs(
+  args: string[],
+): ParsedInitArgs | { error: string } {
+  return parseInitArgs(args);
+}
+
 export function runInitCli(args: string[] = []): number {
+  if (args[0] === "tree") {
+    return runBootstrapCli(args.slice(1));
+  }
   if (args.includes("--help") || args.includes("-h")) {
     console.log(INIT_USAGE);
     return 0;
@@ -611,16 +639,30 @@ export function runInitCli(args: string[] = []): number {
   return runInitWorkflow(parsed);
 }
 
+export function runBootstrapCli(
+  args: string[] = [],
+  output: (text: string) => void = console.log,
+): number {
+  if (args.includes("--help") || args.includes("-h")) {
+    output(BOOTSTRAP_USAGE);
+    return 0;
+  }
+
+  const parsed = parseBootstrapArgs(args);
+  if ("error" in parsed) {
+    console.error(parsed.error);
+    output(BOOTSTRAP_USAGE);
+    return 1;
+  }
+
+  return runExplicitTreeInit(parsed);
+}
+
 export function parseInitCliArgs(
   args: string[],
 ): ParsedInitCliArgs | { error: string } {
   const parsed: ParsedInitCliArgs = {};
   let index = 0;
-
-  if (args[0] === "tree") {
-    parsed.subcommand = "tree";
-    index = 1;
-  }
 
   for (; index < args.length; index += 1) {
     const arg = args[index];
@@ -714,7 +756,7 @@ export function parseInitCliArgs(
   if (parsed.here && parsed.treeName) {
     return { error: "Cannot combine --here with --tree-name" };
   }
-  if (parsed.here && parsed.treePath && parsed.subcommand !== "tree") {
+  if (parsed.here && parsed.treePath) {
     return { error: "Cannot combine --here with --tree-path" };
   }
   if (parsed.treeName && parsed.treePath) {
@@ -804,7 +846,7 @@ function runExplicitTreeInit(parsed: ParsedInitCliArgs): number {
 }
 
 function runInitWorkflow(parsed: ParsedInitCliArgs): number {
-  if (parsed.subcommand === "tree" || parsed.here) {
+  if (parsed.here) {
     return runExplicitTreeInit(parsed);
   }
 
@@ -885,7 +927,7 @@ function resolveInitTarget(
     return {
       ok: false,
       message:
-        "not a git repository. Run this from your source/workspace repo, or create a dedicated tree repo first:\n  git init\n  first-tree init --here",
+        "not a git repository. Run this from your source/workspace repo, or create a dedicated tree repo first:\n  git init\n  first-tree tree bootstrap --here",
     };
   }
 

--- a/src/products/tree/engine/inspect.ts
+++ b/src/products/tree/engine/inspect.ts
@@ -13,7 +13,7 @@ import {
 import { readLocalTreeConfig } from "#products/tree/engine/runtime/local-tree-config.js";
 import { discoverWorkspaceRepos } from "#products/tree/engine/workspace.js";
 
-export const INSPECT_USAGE = `usage: first-tree inspect [--json]
+export const INSPECT_USAGE = `usage: first-tree tree inspect [--json]
 
 Inspect the current folder and report how first-tree would classify it.
 
@@ -92,7 +92,7 @@ export function runInspect(repo?: Repo, json = false): number {
     return 0;
   }
 
-  console.log("first-tree inspect\n");
+  console.log("first-tree tree inspect\n");
   console.log(`  Root:           ${inspection.root}`);
   console.log(`  Root kind:      ${inspection.rootKind}`);
   console.log(`  Classification: ${inspection.classification}`);

--- a/src/products/tree/engine/invite.ts
+++ b/src/products/tree/engine/invite.ts
@@ -10,7 +10,7 @@ import {
 import { listTreeBindings } from "#products/tree/engine/runtime/binding-state.js";
 import { resolveBundledPackageRoot } from "#products/tree/engine/runtime/installer.js";
 
-export const INVITE_USAGE = `usage: first-tree invite --github-id <id> --type <type>
+export const INVITE_USAGE = `usage: first-tree tree invite --github-id <id> --type <type>
        [--title <name>] [--role <role>] [--domains <d1,d2>]
        [--delegate-mention <id>]
        [--tree-path <path>]
@@ -310,7 +310,7 @@ export function composeMagicWord(
   );
   lines.push("");
   lines.push(
-    `  npx first-tree join --tree-url ${treeUrl} --invite ${githubId} --branch ${branchName}`,
+    `  npx -p first-tree first-tree tree join --tree-url ${treeUrl} --invite ${githubId} --branch ${branchName}`,
   );
   lines.push("");
   lines.push("--- End Invite ---");

--- a/src/products/tree/engine/join.ts
+++ b/src/products/tree/engine/join.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 
-export const JOIN_USAGE = `usage: first-tree join --tree-url <url> --invite <github-id>
+export const JOIN_USAGE = `usage: first-tree tree join --tree-url <url> --invite <github-id>
        [--branch <name>] [--tree-path <path>] [--skip-install]
 
 Accept a pending invite to a Context Tree.

--- a/src/products/tree/engine/member-seeding.ts
+++ b/src/products/tree/engine/member-seeding.ts
@@ -437,7 +437,7 @@ function renderMemberNode(
     ? "GitHub"
     : "git";
   const aboutText =
-    `Seeded from ${sourceLabel} contributor history during \`first-tree init\`. ` +
+    `Seeded from ${sourceLabel} contributor history during \`first-tree tree init\`. ` +
     "Review this node, remove stale contributors, and replace the placeholder role and domains with current ownership.";
   const focusText = contributor.type === "autonomous_agent"
     ? "Review the automation scope and current ownership before relying on this node."

--- a/src/products/tree/engine/publish.ts
+++ b/src/products/tree/engine/publish.ts
@@ -36,11 +36,11 @@ import {
   SKILL_ROOT,
 } from "#products/tree/engine/runtime/asset-loader.js";
 
-export const PUBLISH_USAGE = `usage: first-tree publish [--open-pr] [--tree-path PATH] [--source-repo PATH] [--source-remote NAME]
+export const PUBLISH_USAGE = `usage: first-tree tree publish [--open-pr] [--tree-path PATH] [--source-repo PATH] [--source-remote NAME]
 
 Publish a Context Tree repo to GitHub and refresh any bound source/workspace
 repos with the published tree URL. This is the networked second-stage command
-after \`first-tree init\` / \`first-tree bind\`, run from the tree repo (or
+after \`first-tree tree init\` / \`first-tree tree bind\`, run from the tree repo (or
 pointed at one with --tree-path).
 
 What it does:
@@ -748,14 +748,14 @@ export function runPublish(repo?: Repo, options?: PublishOptions): number {
 
   if (treeRepo.hasSourceWorkspaceIntegration() && !treeRepo.looksLikeTreeRepo()) {
     console.error(
-      `Error: this repo only has the first-tree source/workspace integration installed. Run ${formatDedicatedTreePathExample("first-tree publish", treeRepo)} or switch into the dedicated tree repo first.`,
+      `Error: this repo only has the first-tree source/workspace integration installed. Run ${formatDedicatedTreePathExample("first-tree tree publish", treeRepo)} or switch into the dedicated tree repo first.`,
     );
     return 1;
   }
 
   if (!treeRepo.hasFramework() || !treeRepo.looksLikeTreeRepo()) {
     console.error(
-      "Error: `first-tree publish` must run from a dedicated tree repo (or use `--tree-path` to point at one). Run `first-tree init` first.",
+      "Error: `first-tree tree publish` must run from a dedicated tree repo (or use `--tree-path` to point at one). Run `first-tree tree init` first.",
     );
     return 1;
   }
@@ -763,7 +763,7 @@ export function runPublish(repo?: Repo, options?: PublishOptions): number {
   const sourceRepoRoots = resolveBoundSourceRepoRoots(treeRepo, options);
   if (sourceRepoRoots.length === 0) {
     console.error(
-      "Error: could not determine any bound source/workspace repo for this tree. Re-run `first-tree bind` or `first-tree init` first, or pass `--source-repo PATH`.",
+      "Error: could not determine any bound source/workspace repo for this tree. Re-run `first-tree tree bind` or `first-tree tree init` first, or pass `--source-repo PATH`.",
     );
     return 1;
   }
@@ -786,14 +786,14 @@ export function runPublish(repo?: Repo, options?: PublishOptions): number {
 
   if (sourceRepo.root === treeRepo.root) {
     console.error(
-      "Error: the source/workspace repo and dedicated tree repo resolved to the same path. `first-tree publish` expects two separate repos.",
+      "Error: the source/workspace repo and dedicated tree repo resolved to the same path. `first-tree tree publish` expects two separate repos.",
     );
     return 1;
   }
 
   if (!sourceRepo.hasCurrentInstalledSkill() || !sourceRepo.hasSourceWorkspaceIntegration()) {
     console.error(
-      "Error: the source/workspace repo does not have the first-tree source integration installed. Run `first-tree init` from the source/workspace repo first.",
+      "Error: the source/workspace repo does not have the first-tree source integration installed. Run `first-tree tree init` from the source/workspace repo first.",
     );
     return 1;
   }

--- a/src/products/tree/engine/rules/framework.ts
+++ b/src/products/tree/engine/rules/framework.ts
@@ -9,7 +9,7 @@ export function evaluate(repo: Repo): RuleResult {
   const tasks: string[] = [];
   if (!repo.hasFramework()) {
     tasks.push(
-      `Framework metadata not found — run \`first-tree init\` to install ${installedSkillRootsDisplay()} plus \`${FIRST_TREE_INDEX_FILE}\` in a source/workspace repo, or bootstrap a dedicated tree repo with \`.first-tree/\` metadata`,
+      `Framework metadata not found — run \`first-tree tree init\` to install ${installedSkillRootsDisplay()} plus \`${FIRST_TREE_INDEX_FILE}\` in a source/workspace repo, or bootstrap a dedicated tree repo with \`.first-tree/\` metadata`,
     );
   }
   return { group: "Framework", order: 1, tasks };

--- a/src/products/tree/engine/rules/populate-tree.ts
+++ b/src/products/tree/engine/rules/populate-tree.ts
@@ -13,10 +13,10 @@ export function evaluate(repo: Repo): RuleResult {
   );
 
   tasks.push(
-    `Ask the user whether they want to continue building the first-pass full tree now using the **${INTERACTIVE_TOOL}** tool. ` +
+    `Ask the user whether they want to continue building the first-pass full tree now using your agent's **${INTERACTIVE_TOOL}** when available. ` +
       "Present two options: (1) **Yes — continue baseline tree expansion**: explain the expected scope first, " +
       "including how many top-level domains you plan to cover, how many waves of parallel work you expect, " +
-      "and that you will finish with root-node reconciliation plus `first-tree verify`; " +
+      "and that you will finish with root-node reconciliation plus `first-tree tree verify`; " +
       "(2) **No — keep the initial scaffold only**: skip deep population and finish init with the current top-level structure. " +
       "If the user selects No, check off all remaining items in this section and move on.",
   );
@@ -32,14 +32,14 @@ export function evaluate(repo: Repo): RuleResult {
     "Use parallel **sub-tasks / subagents** (for example, TaskCreate where available) in waves, not as unbounded fan-out. " +
       "The default split is one sub-task per top-level domain so each domain can be populated concurrently. " +
       "Keep the main agent responsible for the root `NODE.md`, cross-domain `soft_links`, overlap cleanup between domains, " +
-      "and the final `first-tree verify` pass. Each domain sub-task should: read the relevant source code, identify " +
+      "and the final `first-tree tree verify` pass. Each domain sub-task should: read the relevant source code, identify " +
       "sub-domains, create NODE.md files, and establish soft_links between related domains.",
   );
 
   tasks.push(
     "Continue launching additional waves until every top-level domain has first-pass baseline coverage. " +
       "After the domain waves finish, update the root NODE.md to list every top-level domain with a one-line " +
-      "description, reconcile any cross-domain soft_links, and ensure all NODE.md files pass `first-tree verify` — valid frontmatter, no placeholders, " +
+      "description, reconcile any cross-domain soft_links, and ensure all NODE.md files pass `first-tree tree verify` — valid frontmatter, no placeholders, " +
       "and soft_links that resolve correctly.",
   );
 

--- a/src/products/tree/engine/runtime/adapters.ts
+++ b/src/products/tree/engine/runtime/adapters.ts
@@ -17,7 +17,7 @@ export const CLAUDE_SETTINGS_PATH = ".claude/settings.json";
 export const CODEX_CONFIG_PATH = ".codex/config.toml";
 export const CODEX_HOOKS_PATH = ".codex/hooks.json";
 export const INJECT_CONTEXT_COMMAND =
-  "npx -p first-tree first-tree inject-context --skip-version-check";
+  "npx -p first-tree first-tree tree inject-context --skip-version-check";
 
 const CODEX_SESSION_START_MATCHER = "startup|resume";
 const CODEX_SESSION_START_STATUS = "Loading First Tree context";
@@ -61,7 +61,7 @@ export interface AgentContextHookReport {
 }
 
 const AGENT_CONTEXT_REPAIR_HINT =
-  "Repair with a mutating first-tree command such as `first-tree upgrade`, `first-tree bind`, `first-tree init`, `first-tree workspace sync`, or `first-tree publish`.";
+  "Repair with a mutating first-tree command such as `first-tree tree upgrade`, `first-tree tree bind`, `first-tree tree init`, `first-tree tree workspace sync`, or `first-tree tree publish`.";
 
 export function formatAgentContextHookMessages(
   result: AgentContextHookSyncResult,
@@ -193,7 +193,7 @@ export function refreshInjectContextHook(
     `$1${INJECT_CONTEXT_COMMAND}$2`,
   );
   updated = updated.replace(
-    /\.\/(npx -p first-tree first-tree inject-context --skip-version-check)/g,
+    /\.\/(npx -p first-tree first-tree tree inject-context --skip-version-check)/g,
     "$1",
   );
 
@@ -469,6 +469,12 @@ function isCodexManagedHook(hook: Record<string, unknown>): boolean {
 
 function matchesLegacyHookPattern(command: string): boolean {
   if (command === INJECT_CONTEXT_COMMAND || command === `./${INJECT_CONTEXT_COMMAND}`) {
+    return true;
+  }
+  if (
+    command === "npx -p first-tree first-tree inject-context --skip-version-check"
+    || command === "./npx -p first-tree first-tree inject-context --skip-version-check"
+  ) {
     return true;
   }
   return STALE_INJECT_CONTEXT_PATTERNS.some((pattern) => {

--- a/src/products/tree/engine/runtime/source-integration.ts
+++ b/src/products/tree/engine/runtime/source-integration.ts
@@ -77,7 +77,7 @@ export function buildSourceIntegrationBlock(
   const description = describeBinding(bindingMode, treeMode, treeRepoName);
   const scopeText = describeScope(bindingMode, treeMode, treeRepoName, workspaceId);
   const fallbackInstruction = treeRepoUrl === null
-    ? `- If the tree has not been published yet, work from the local checkout recorded in \`${sourceStatePathValue}\` or the tree path you just bound until \`first-tree publish\` records the GitHub repo URL.`
+    ? `- If the tree has not been published yet, work from the local checkout recorded in \`${sourceStatePathValue}\` or the tree path you just bound until \`first-tree tree publish\` records the GitHub repo URL.`
     : `- If the configured checkout is missing, clone a temporary working copy from \`${treeRepoUrl}\` into \`${temporaryCheckoutPath}/\`, use it for the current task, and delete it before you finish.`;
 
   return [

--- a/src/products/tree/engine/sync.ts
+++ b/src/products/tree/engine/sync.ts
@@ -24,7 +24,7 @@ import { resolveNodeOwners } from "../../../../assets/tree/helpers/generate-code
 
 const execFileAsync = promisify(execFile);
 
-export const SYNC_USAGE = `usage: first-tree sync [--tree-path PATH] [--source ID] [--propose] [--apply] [--dry-run]
+export const SYNC_USAGE = `usage: first-tree tree sync [--tree-path PATH] [--source ID] [--propose] [--apply] [--dry-run]
 
 Detect drift between a Context Tree and the source repo(s) it describes.
 Runs in three phases controlled by flags:
@@ -813,7 +813,7 @@ Return a JSON array only, no prose.`;
       "  npm install -g @anthropic-ai/claude-code\n\n" +
       "Then authenticate:\n" +
       "  claude login\n\n" +
-      "Once installed, re-run: first-tree sync --tree-path <path>",
+      "Once installed, re-run: first-tree tree sync --tree-path <path>",
     );
     process.exit(1);
   }
@@ -1184,7 +1184,7 @@ async function prepareProposalGroup(
       prBody: "",
       group,
       skipped: true,
-      skipReason: "first-tree verify failed",
+      skipReason: "first-tree tree verify failed",
     };
   }
 
@@ -1344,7 +1344,7 @@ export async function runSync(
 
   if (!repo.looksLikeTreeRepo()) {
     console.error(
-      `\u274C ${treeRoot} does not look like a Context Tree repo. Run first-tree sync inside a tree repo, or pass --tree-path.`,
+      `\u274C ${treeRoot} does not look like a Context Tree repo. Run first-tree tree sync inside a tree repo, or pass --tree-path.`,
     );
     return 1;
   }
@@ -1364,7 +1364,7 @@ export async function runSync(
       "  npm install -g @anthropic-ai/claude-code\n\n" +
       "Then authenticate:\n" +
       "  claude login\n\n" +
-      "Once installed, re-run: first-tree sync --tree-path <path>",
+      "Once installed, re-run: first-tree tree sync --tree-path <path>",
     );
     return 1;
   }
@@ -1393,7 +1393,7 @@ export async function runSync(
         `   Sync needs a GitHub URL to fetch commits and merged PRs.\n` +
         `   Fix: edit .first-tree/bindings/${binding.sourceId}.json and add:\n` +
         `     "remoteUrl": "https://github.com/<owner>/<repo>"\n` +
-        `   Then re-run first-tree sync.`,
+        `   Then re-run first-tree tree sync.`,
       );
       hasConfigErrors = true;
       continue;

--- a/src/products/tree/engine/upgrade.ts
+++ b/src/products/tree/engine/upgrade.ts
@@ -45,7 +45,7 @@ import {
   readBundledSkillVersion,
 } from "#products/tree/engine/runtime/upgrader.js";
 
-export const UPGRADE_USAGE = `usage: first-tree upgrade [--tree-path PATH]
+export const UPGRADE_USAGE = `usage: first-tree tree upgrade [--tree-path PATH]
 
 Refresh the installed skill payload from the bundled \`first-tree\` package.
 
@@ -108,7 +108,7 @@ export function ensureSyncRunbook(
       "\n\u26A0\uFE0F  repo-gardener is required for sync to review tree-update PRs before merge.\n" +
       "   Install it by running this in Claude Code:\n\n" +
       '   Fetch the latest release of repo-gardener and execute its onboarding script: https://github.com/agent-team-foundation/repo-gardener/releases/latest\n\n' +
-      "   After installing gardener, run `first-tree upgrade` again.\n",
+      "   After installing gardener, run `first-tree tree upgrade` again.\n",
     );
   }
 
@@ -281,7 +281,7 @@ function formatUpgradeTaskList(
   if (repo.hasAgentInstructionsMarkers()) {
     lines.push(
       "## Agent Instructions",
-      `- [ ] Compare the framework section in \`${AGENT_INSTRUCTIONS_FILE}\` with the bundled template (run \`first-tree init --help\` to see what templates ship) and update the text between the markers if needed`,
+      `- [ ] Compare the framework section in \`${AGENT_INSTRUCTIONS_FILE}\` with the bundled template (run \`first-tree tree init --help\` to see what templates ship) and update the text between the markers if needed`,
       `- [ ] Compare the framework section in \`${CLAUDE_INSTRUCTIONS_FILE}\` with the bundled template and update the text between the markers if needed`,
       "",
     );
@@ -290,13 +290,13 @@ function formatUpgradeTaskList(
   lines.push(
     "## Verification",
     `- [ ] \`${repo.frameworkVersionPath()}\` reads \`${packagedVersion}\``,
-    "- [ ] `first-tree verify` passes",
+    "- [ ] `first-tree tree verify` passes",
     "",
     "---",
     "",
     "**Important:** As you complete each task, check it off in" +
       ` \`${repo.preferredProgressPath()}\` by changing \`- [ ]\` to \`- [x]\`.` +
-      " Run `first-tree verify` when done — it will fail if any" +
+      " Run `first-tree tree verify` when done — it will fail if any" +
       " items remain unchecked.",
     "",
   );
@@ -315,14 +315,14 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
 
   if (workingRepo.isLikelySourceRepo() && !workingRepo.looksLikeTreeRepo() && !workspaceOnlyIntegration) {
     console.error(
-      "Error: no installed framework skill found here. This looks like a source/workspace repo. Run `first-tree init` to create a dedicated tree repo, or pass `--tree-path` to upgrade an existing tree repo.",
+      "Error: no installed framework skill found here. This looks like a source/workspace repo. Run `first-tree tree init` to create a dedicated tree repo, or pass `--tree-path` to upgrade an existing tree repo.",
     );
     return 1;
   }
 
   if (!workingRepo.hasFramework()) {
     console.error(
-      "Error: no first-tree framework metadata found. Run `first-tree init` first.",
+      "Error: no first-tree framework metadata found. Run `first-tree tree init` first.",
     );
     return 1;
   }
@@ -330,7 +330,7 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
   const layout = workingRepo.frameworkLayout();
   if (layout === null) {
     console.error(
-      "Error: no first-tree framework metadata found. Run `first-tree init` first.",
+      "Error: no first-tree framework metadata found. Run `first-tree tree init` first.",
     );
     return 1;
   }
@@ -363,7 +363,7 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
     compareSkillVersions(localVersion, packagedVersion) > 0
   ) {
     console.log(
-      "The installed skill is newer than the skill bundled with this `first-tree` package. Install a newer package version before running `first-tree upgrade`.",
+      "The installed skill is newer than the skill bundled with this `first-tree` package. Install a newer package version before running `first-tree tree upgrade`.",
     );
     return 1;
   }
@@ -377,7 +377,7 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
     ? treeResolution.value.root
     : join(dirname(workingRepo.root), treeRepoName);
   const sourceRepoTreePathHint = formatDedicatedTreePathExample(
-    "first-tree upgrade",
+    "first-tree tree upgrade",
     workingRepo,
   );
 
@@ -522,7 +522,7 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
       && compareSkillVersions(installedTreeSkillVersion, packagedVersion) > 0
     ) {
       console.log(
-        "The installed tree-repo skill is newer than the skill bundled with this `first-tree` package. Install a newer package version before running `first-tree upgrade`.",
+        "The installed tree-repo skill is newer than the skill bundled with this `first-tree` package. Install a newer package version before running `first-tree tree upgrade`.",
       );
       return 1;
     }

--- a/src/products/tree/engine/verify.ts
+++ b/src/products/tree/engine/verify.ts
@@ -18,7 +18,7 @@ import { runValidateMembers } from "#products/tree/engine/validators/members.js"
 import { runValidateNodes } from "#products/tree/engine/validators/nodes.js";
 
 const UNCHECKED_RE = /^- \[ \] (.+)$/gm;
-export const VERIFY_USAGE = `usage: first-tree verify [--tree-path PATH]
+export const VERIFY_USAGE = `usage: first-tree tree verify [--tree-path PATH]
 
 Run validation checks against a Context Tree repo. Reads the tree from the
 current working directory unless \`--tree-path\` is provided.
@@ -120,14 +120,14 @@ export function runVerify(
 
   if (r.hasSourceWorkspaceIntegration() && !r.looksLikeTreeRepo()) {
     console.error(
-      `Error: this repo only has the first-tree source/workspace integration installed. Verify the dedicated tree repo instead, for example ${formatDedicatedTreePathExample("first-tree verify", r)}.`,
+      `Error: this repo only has the first-tree source/workspace integration installed. Verify the dedicated tree repo instead, for example ${formatDedicatedTreePathExample("first-tree tree verify", r)}.`,
     );
     return 1;
   }
 
   if (r.isLikelySourceRepo() && !r.looksLikeTreeRepo()) {
     console.error(
-      "Error: no first-tree framework metadata found here. This looks like a source/workspace repo. Run `first-tree init` to create a dedicated tree repo, or pass `--tree-path` to verify an existing tree repo.",
+      "Error: no first-tree framework metadata found here. This looks like a source/workspace repo. Run `first-tree tree init` to create a dedicated tree repo, or pass `--tree-path` to verify an existing tree repo.",
     );
     return 1;
   }

--- a/src/products/tree/engine/workspace-sync.ts
+++ b/src/products/tree/engine/workspace-sync.ts
@@ -7,7 +7,7 @@ import {
 } from "#products/tree/engine/runtime/binding-state.js";
 import { discoverWorkspaceRepos } from "#products/tree/engine/workspace.js";
 
-export const WORKSPACE_SYNC_USAGE = `usage: first-tree workspace sync [--tree-path PATH | --tree-url URL] [--workspace-id ID] [--dry-run]
+export const WORKSPACE_SYNC_USAGE = `usage: first-tree tree workspace sync [--tree-path PATH | --tree-url URL] [--workspace-id ID] [--dry-run]
 
 Bind every discovered child repo / submodule under the current workspace root
 to the same shared Context Tree.
@@ -137,7 +137,7 @@ export function runWorkspaceSync(repo?: Repo, options?: WorkspaceSyncOptions): n
 export function runWorkspaceCli(args: string[] = []): number {
   const subcommand = args[0];
   if (!subcommand || subcommand === "--help" || subcommand === "-h") {
-    console.log(`usage: first-tree workspace <subcommand>\n\nSubcommands:\n  sync   Bind all discovered child repos to the same shared tree\n`);
+    console.log(`usage: first-tree tree workspace <subcommand>\n\nSubcommands:\n  sync   Bind all discovered child repos to the same shared tree\n`);
     return 0;
   }
 

--- a/tests/e2e/thin-cli.test.ts
+++ b/tests/e2e/thin-cli.test.ts
@@ -40,10 +40,10 @@ afterEach(() => {
 });
 
 describe("thin CLI shell", () => {
-  it("exposes both product namespaces in the top-level USAGE", () => {
-    expect(USAGE).toContain("first-tree <command>");
+  it("exposes the product and maintenance namespaces in the top-level USAGE", () => {
+    expect(USAGE).toContain("first-tree <namespace>");
     expect(USAGE).toContain("Products:");
-    expect(USAGE).toContain("Diagnostics:");
+    expect(USAGE).toContain("Maintenance:");
     expect(USAGE).toContain("tree");
     expect(USAGE).toContain("breeze");
     expect(USAGE).toContain("gardener");
@@ -53,15 +53,16 @@ describe("thin CLI shell", () => {
   });
 
   it("documents tree commands in the tree USAGE", () => {
-    expect(TREE_USAGE).toContain("first-tree tree init tree --here");
+    expect(TREE_USAGE).toContain("first-tree tree bootstrap --here");
     expect(TREE_USAGE).toContain(
       "first-tree tree init --tree-path ../org-context --tree-mode shared",
     );
     expect(TREE_USAGE).toContain("first-tree tree publish --tree-path ../org-context");
     expect(TREE_USAGE).toContain("my-org-tree");
     expect(TREE_USAGE).toContain(
-      "`first-tree tree init tree --here` is for when the current repo is already the tree repo.",
+      "`first-tree tree bootstrap --here` is for when the current repo is already the tree repo.",
     );
+    expect(TREE_USAGE).toContain("Legacy alias");
     expect(TREE_USAGE).toContain("review");
     expect(TREE_USAGE).toContain("generate-codeowners");
     expect(TREE_USAGE).toContain("inject-context");
@@ -99,14 +100,15 @@ describe("thin CLI shell", () => {
     expect(output.lines).toEqual([USAGE]);
   });
 
-  it("prints the CLI version plus one version per product in the manifest", async () => {
+  it("prints the CLI version plus one version per command in the manifest", async () => {
     const output = captureOutput();
     const pkgPath = fileURLToPath(new URL("../../package.json", import.meta.url));
     const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as { version: string };
-    const productVersion = (name: string): string => {
-      const versionPath = fileURLToPath(
-        new URL(`../../src/products/${name}/VERSION`, import.meta.url),
-      );
+    const commandVersion = (name: string): string => {
+      const relPath = name === "skill"
+        ? "../../src/meta/skill-tools/VERSION"
+        : `../../src/products/${name}/VERSION`;
+      const versionPath = fileURLToPath(new URL(relPath, import.meta.url));
       return readFileSync(versionPath, "utf-8").trim();
     };
 
@@ -116,9 +118,10 @@ describe("thin CLI shell", () => {
     expect(output.lines).toEqual([
       [
         `first-tree=${pkg.version}`,
-        `tree=${productVersion("tree")}`,
-        `breeze=${productVersion("breeze")}`,
-        `gardener=${productVersion("gardener")}`,
+        `tree=${commandVersion("tree")}`,
+        `breeze=${commandVersion("breeze")}`,
+        `gardener=${commandVersion("gardener")}`,
+        `skill=${commandVersion("skill")}`,
       ].join(" "),
     ]);
   });
@@ -136,7 +139,7 @@ describe("thin CLI shell", () => {
     expect(output.lines.join("\n")).toContain("Node.js 18+");
   });
 
-  it("fails with hint for an unknown command", async () => {
+  it("fails with hint for an unknown namespace", async () => {
     const output = captureOutput();
 
     const code = await runCli(
@@ -145,7 +148,7 @@ describe("thin CLI shell", () => {
     );
 
     expect(code).toBe(1);
-    expect(output.lines[0]).toBe("Unknown command: wat");
+    expect(output.lines[0]).toBe("Unknown first-tree namespace: wat");
     expect(output.lines[1]).toContain("first-tree tree wat");
   });
 
@@ -215,6 +218,16 @@ describe("thin CLI shell", () => {
       output.write,
     );
     expect(code).toBe(0);
+  });
+
+  it("routes tree bootstrap command", async () => {
+    const output = captureOutput();
+    const code = await runCli(
+      ["--skip-version-check", "tree", "bootstrap", "--help"],
+      output.write,
+    );
+    expect(code).toBe(0);
+    expect(output.lines.join("\n")).toContain("usage: first-tree tree bootstrap");
   });
 
   it("breeze product prints breeze USAGE for --help", async () => {

--- a/tests/meta/skill-commands.test.ts
+++ b/tests/meta/skill-commands.test.ts
@@ -1,9 +1,11 @@
-import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { runInstall } from "../../src/meta/skill-tools/engine/commands/install.js";
 import { runDoctor } from "../../src/meta/skill-tools/engine/commands/doctor.js";
 import { runLink } from "../../src/meta/skill-tools/engine/commands/link.js";
 import { runList } from "../../src/meta/skill-tools/engine/commands/list.js";
+import { runUpgrade } from "../../src/meta/skill-tools/engine/commands/upgrade.js";
 import { useTmpDir } from "../helpers.js";
 
 function seedAgentsSkill(root: string, name: string, version = "0.2"): void {
@@ -14,6 +16,20 @@ function seedAgentsSkill(root: string, name: string, version = "0.2"): void {
     `---\nname: ${name}\ndescription: test\n---\n`,
   );
   writeFileSync(join(dir, "VERSION"), `${version}\n`);
+  if (name === "first-tree") {
+    const refs = join(dir, "references");
+    mkdirSync(refs, { recursive: true });
+    for (const filename of [
+      "whitepaper.md",
+      "onboarding.md",
+      "source-workspace-installation.md",
+      "principles.md",
+      "ownership-and-naming.md",
+      "upgrade-contract.md",
+    ]) {
+      writeFileSync(join(refs, filename), `# ${filename}\n`);
+    }
+  }
 }
 
 function seedClaudeSymlink(root: string, name: string): void {
@@ -47,6 +63,39 @@ describe("first-tree skill list", () => {
   });
 });
 
+describe("first-tree skill install / upgrade", () => {
+  it("installs all four skills into an empty target root", () => {
+    const tmp = useTmpDir();
+    const lines: string[] = [];
+
+    const code = runInstall([], {
+      targetRoot: tmp.path,
+      write: (t) => lines.push(t),
+    });
+
+    expect(code).toBe(0);
+    expect(lines.join("\n")).toContain("Installed the four shipped first-tree skills");
+    for (const name of ["first-tree", "tree", "breeze", "gardener"]) {
+      expect(existsSync(join(tmp.path, ".agents", "skills", name, "SKILL.md"))).toBe(true);
+    }
+  });
+
+  it("upgrades an existing install in place", () => {
+    const tmp = useTmpDir();
+    seedAgentsSkill(tmp.path, "first-tree", "0.1");
+    seedClaudeSymlink(tmp.path, "first-tree");
+
+    const lines: string[] = [];
+    const code = runUpgrade([], {
+      targetRoot: tmp.path,
+      write: (t) => lines.push(t),
+    });
+
+    expect(code).toBe(0);
+    expect(lines.join("\n")).toContain("Upgraded the four shipped first-tree skills");
+  });
+});
+
 describe("first-tree skill doctor", () => {
   it("exits 1 when a skill is missing", () => {
     const tmp = useTmpDir();
@@ -76,6 +125,30 @@ describe("first-tree skill doctor", () => {
     expect(code).toBe(0);
     expect(lines.join("\n")).toContain("All four skills are installed and healthy.");
   });
+
+  it("exits 1 when the entry-point skill is missing required reference files", () => {
+    const tmp = useTmpDir();
+    for (const name of ["first-tree", "tree", "breeze", "gardener"]) {
+      seedAgentsSkill(tmp.path, name);
+      seedClaudeSymlink(tmp.path, name);
+    }
+
+    rmSync(
+      join(tmp.path, ".agents", "skills", "first-tree", "references", "upgrade-contract.md"),
+      { force: true },
+    );
+
+    const lines: string[] = [];
+    const code = runDoctor([], {
+      targetRoot: tmp.path,
+      write: (t) => lines.push(t),
+    });
+
+    expect(code).toBe(1);
+    expect(lines.join("\n")).toContain(
+      ".agents/skills/first-tree/references/upgrade-contract.md does not exist",
+    );
+  });
 });
 
 describe("first-tree skill link", () => {
@@ -83,7 +156,6 @@ describe("first-tree skill link", () => {
     const tmp = useTmpDir();
     seedAgentsSkill(tmp.path, "first-tree");
     seedAgentsSkill(tmp.path, "tree");
-    // Deliberately do NOT create the .claude/ symlinks.
 
     const lines: string[] = [];
     const code = runLink([], {
@@ -95,7 +167,6 @@ describe("first-tree skill link", () => {
     const body = lines.join("\n");
     expect(body).toContain("linked .claude/skills/first-tree");
     expect(body).toContain("linked .claude/skills/tree");
-    // breeze + gardener skipped because no .agents/ install
     expect(body).toContain("skipped 2 skill(s)");
   });
 
@@ -111,7 +182,6 @@ describe("first-tree skill link", () => {
     });
 
     expect(code).toBe(0);
-    // "Linked 0 symlink(s)" — the correct symlink was left alone.
     expect(lines.join("\n")).toContain("Linked 0 symlink(s)");
   });
 });

--- a/tests/tree/init.test.ts
+++ b/tests/tree/init.test.ts
@@ -9,6 +9,7 @@ import {
 import { basename, dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  BOOTSTRAP_USAGE,
   formatTaskList,
   INIT_USAGE,
   parseInitArgs,
@@ -85,7 +86,7 @@ describe("formatTaskList", () => {
     const groups = [{ group: "G", order: 1, tasks: ["t"] }];
     const output = formatTaskList(groups);
     expect(output).toContain("## Verification");
-    expect(output).toContain("first-tree verify");
+    expect(output).toContain("first-tree tree verify");
   });
 
   it("handles empty groups", () => {
@@ -101,7 +102,7 @@ describe("formatTaskList", () => {
       sourceRepoPath: "../ADHD",
     });
 
-    expect(output).toContain("first-tree publish --open-pr");
+    expect(output).toContain("first-tree tree publish --open-pr");
     expect(output).toContain("canonical local working copy");
   });
 });
@@ -540,8 +541,8 @@ describe("runInit", () => {
 
 describe("parseInitArgs", () => {
   it("documents that --here is only for dedicated tree repos", () => {
-    expect(INIT_USAGE).toContain("first-tree init tree --here");
-    expect(INIT_USAGE).toContain("Initialize the current repo in place as a tree repo");
+    expect(BOOTSTRAP_USAGE).toContain("first-tree tree bootstrap --here");
+    expect(BOOTSTRAP_USAGE).toContain("Initialize the current repo in place as a tree repo");
   });
 
   it("parses dedicated repo options", () => {

--- a/tests/tree/inject-context.test.ts
+++ b/tests/tree/inject-context.test.ts
@@ -129,6 +129,6 @@ describe("runInjectContext", () => {
   it("prints help with --help", () => {
     const code = runInjectContext(["--help"]);
     expect(code).toBe(0);
-    expect(logged.join("\n")).toContain("first-tree inject-context");
+    expect(logged.join("\n")).toContain("first-tree tree inject-context");
   });
 });

--- a/tests/tree/inspect.test.ts
+++ b/tests/tree/inspect.test.ts
@@ -68,7 +68,7 @@ describe("inspectRepo", () => {
 
     expect(inspection.agentContextHookReport.overall).toBe("drifted");
     expect(inspection.agentContextHookReport.repairHint).toContain(
-      "first-tree upgrade",
+      "first-tree tree upgrade",
     );
     expect(inspection.agentContextHookReport.files).toEqual(
       expect.arrayContaining([

--- a/tests/tree/invite.test.ts
+++ b/tests/tree/invite.test.ts
@@ -233,7 +233,7 @@ describe("composeMagicWord", () => {
     expect(result).toContain("- frontend-app");
     expect(result).toContain("- infra");
     expect(result).toContain(
-      "npx first-tree join --tree-url https://github.com/org/my-org-context.git --invite bob --branch invite/bob",
+      "npx -p first-tree first-tree tree join --tree-url https://github.com/org/my-org-context.git --invite bob --branch invite/bob",
     );
   });
 
@@ -252,7 +252,7 @@ describe("composeMagicWord", () => {
     );
 
     expect(result).not.toContain("## What repositories does it cover?");
-    expect(result).toContain("npx first-tree join");
+    expect(result).toContain("npx -p first-tree first-tree tree join");
   });
 });
 

--- a/tests/tree/publish.test.ts
+++ b/tests/tree/publish.test.ts
@@ -181,7 +181,7 @@ function createRunner(
 
 describe("parsePublishArgs", () => {
   it("documents the publish command", () => {
-    expect(PUBLISH_USAGE).toContain("first-tree publish");
+    expect(PUBLISH_USAGE).toContain("first-tree tree publish");
     expect(PUBLISH_USAGE).toContain("--open-pr");
     expect(PUBLISH_USAGE).toContain("--source-repo PATH");
   });

--- a/tests/tree/rules.test.ts
+++ b/tests/tree/rules.test.ts
@@ -284,7 +284,7 @@ describe("agentIntegration rule", () => {
     mkdirSync(join(tmp.path, ".claude"));
     writeFileSync(
       join(tmp.path, ".claude", "settings.json"),
-      '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"npx -p first-tree first-tree inject-context --skip-version-check"}]}]}}',
+      '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"npx -p first-tree first-tree tree inject-context --skip-version-check"}]}]}}',
     );
     const repo = new Repo(tmp.path);
     const result = agentIntegration.evaluate(repo);
@@ -450,7 +450,7 @@ describe("evaluateAll", () => {
     mkdirSync(join(tmp.path, ".claude"), { recursive: true });
     writeFileSync(
       join(tmp.path, ".claude", "settings.json"),
-      '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"npx -p first-tree first-tree inject-context --skip-version-check"}]}]}}',
+      '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"npx -p first-tree first-tree tree inject-context --skip-version-check"}]}]}}',
     );
     const wfDir = join(tmp.path, ".github", "workflows");
     mkdirSync(wfDir, { recursive: true });

--- a/tests/tree/skill-artifacts.test.ts
+++ b/tests/tree/skill-artifacts.test.ts
@@ -156,7 +156,7 @@ describe("skill artifacts", () => {
     });
   });
 
-  it("ships the canonical skill in the published tarball", () => {
+  it("ships the canonical skill in the published tarball", { timeout: 15000 }, () => {
     const packDir = mkdtempSync(join(tmpdir(), "first-tree-pack-"));
     try {
       const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf-8")) as {
@@ -177,6 +177,10 @@ describe("skill artifacts", () => {
       });
 
       expect(listing).toContain("package/dist/cli.js");
+      expect(listing).toContain("package/src/products/tree/VERSION");
+      expect(listing).toContain("package/src/products/breeze/VERSION");
+      expect(listing).toContain("package/src/products/gardener/VERSION");
+      expect(listing).toContain("package/src/meta/skill-tools/VERSION");
       expect(listing).toContain("package/skills/first-tree/SKILL.md");
       expect(listing).toContain("package/skills/first-tree/VERSION");
       expect(listing).toContain(
@@ -207,6 +211,26 @@ describe("skill artifacts", () => {
     }
   });
 
+  it("prints namespace versions from the built CLI without unknown placeholders", () => {
+    execFileSync("pnpm", ["build"], {
+      cwd: ROOT,
+      stdio: "pipe",
+      encoding: "utf-8",
+    });
+    const versionLine = execFileSync("node", ["dist/cli.js", "--version"], {
+      cwd: ROOT,
+      stdio: "pipe",
+      encoding: "utf-8",
+    }).trim();
+
+    expect(versionLine).toContain("first-tree=");
+    expect(versionLine).toContain("tree=");
+    expect(versionLine).toContain("breeze=");
+    expect(versionLine).toContain("gardener=");
+    expect(versionLine).toContain("skill=");
+    expect(versionLine).not.toContain("unknown");
+  });
+
   it("keeps naming and installation guidance aligned", () => {
     const read = (path: string) => readFileSync(join(ROOT, path), "utf-8");
 
@@ -222,6 +246,7 @@ describe("skill artifacts", () => {
     expect(read("README.md")).toContain(".agents/skills/first-tree/");
     expect(read("README.md")).toContain(".claude/skills/first-tree/");
     expect(read("README.md")).toContain("four skill payloads");
+    expect(read("README.md")).toContain("maintenance namespace");
     expect(read("README.md")).toContain("dedicated tree repo");
     expect(read("README.md")).toContain("first-tree tree inspect");
     expect(read("README.md")).toContain("first-tree tree bind");
@@ -235,8 +260,11 @@ describe("skill artifacts", () => {
     expect(read("README.md")).toContain("first-tree tree publish");
     expect(read("README.md")).toContain("<repo>-tree");
     expect(read("README.md")).toContain("shared tree");
-    expect(read("README.md")).toContain("first-tree tree init tree --here");
+    expect(read("README.md")).toContain("first-tree tree bootstrap --here");
+    expect(read("README.md")).toContain("npx first-tree tree init");
+    expect(read("README.md")).toContain("npx first-tree <namespace> <command>");
     expect(read("AGENTS.md")).toContain("docs/source-map.md");
+    expect(read("AGENTS.md")).toContain("maintenance namespace");
     expect(read("AGENTS.md")).toContain("source-workspace-installation.md");
     expect(read("AGENTS.md")).toContain("first-tree-skill-cli/");
     expect(read("AGENTS.md")).toContain("entry-point skill payload");
@@ -259,7 +287,7 @@ describe("skill artifacts", () => {
     expect(onboarding).toContain("source-repos.md");
     expect(onboarding).not.toContain(".first-tree/submodules/");
     expect(onboarding).toContain("<repo>-tree");
-    expect(onboarding).toContain("first-tree tree init tree --here");
+    expect(onboarding).toContain("first-tree tree bootstrap --here");
     expect(onboarding).toContain("shared tree");
     expect(onboarding).not.toContain("This clones the framework into `.context-tree/`");
     expect(onboarding).not.toContain("from upstream");
@@ -288,13 +316,17 @@ describe("skill artifacts", () => {
     expect(firstTreeSkillMd).toContain("Context Tree");
     expect(firstTreeSkillMd).toContain("Before Every Task");
     expect(firstTreeSkillMd).toContain("After Every Task");
-    expect(firstTreeSkillMd).toContain("npx -p first-tree first-tree");
+    expect(firstTreeSkillMd).toContain("npx first-tree <namespace> <command>");
+    expect(firstTreeSkillMd).toContain("npx -p first-tree first-tree <namespace> <command>");
+    expect(firstTreeSkillMd).toContain("first-tree skill install");
+    expect(firstTreeSkillMd).toContain("first-tree skill upgrade");
     expect(firstTreeSkillMd).toContain("--skip-version-check");
     expect(firstTreeSkillMd).toContain("references/principles.md");
     expect(firstTreeSkillMd).toContain("references/ownership-and-naming.md");
     // tree is the operational handbook for `first-tree tree` commands.
     expect(treeSkillMd).toContain("first-tree tree inspect");
     expect(treeSkillMd).toContain("first-tree tree init");
+    expect(treeSkillMd).toContain("first-tree tree bootstrap");
     expect(treeSkillMd).toContain("first-tree tree bind");
     expect(treeSkillMd).toContain("first-tree tree workspace sync");
     expect(treeSkillMd).toContain("first-tree tree verify");
@@ -305,6 +337,7 @@ describe("skill artifacts", () => {
     expect(sourceMap).not.toContain("repo-snapshot");
     expect(sourceMap).not.toContain("sync-skill-artifacts.sh");
     expect(sourceMap).toContain("first-tree-skill-cli/repo-architecture.md");
+    expect(sourceMap).toContain("products (`tree`, `breeze`, `gardener`) plus maintenance (`skill`)");
     expect(sourceMap).toContain("first-tree-skill-cli/thin-cli-shell.md");
     expect(sourceMap).toContain("first-tree-skill-cli/build-and-distribution.md");
     expect(sourceMap).toContain("first-tree-skill-cli/validation-surface.md");
@@ -339,8 +372,9 @@ describe("skill artifacts", () => {
     expect(sourceWorkspaceInstall).toContain("source-repos.md");
     expect(sourceWorkspaceInstall).not.toContain(".first-tree/submodules/");
     expect(sourceWorkspaceInstall).toContain("workspace-member");
-    expect(sourceWorkspaceInstall).toContain("first-tree workspace sync");
-    expect(sourceWorkspaceInstall).toContain("first-tree publish");
+    expect(sourceWorkspaceInstall).toContain("first-tree tree workspace sync");
+    expect(sourceWorkspaceInstall).toContain("first-tree skill upgrade");
+    expect(sourceWorkspaceInstall).toContain("first-tree tree publish");
     expect(sourceWorkspaceInstall).toContain("<repo>-tree");
     expect(sourceWorkspaceInstall).toContain("Do not recreate a new sibling tree repo");
 

--- a/tests/tree/summarize-progress.test.ts
+++ b/tests/tree/summarize-progress.test.ts
@@ -24,7 +24,7 @@ const SAMPLE_PROGRESS = `# Context Tree Init
 - [ ] Launch wave-based domain population
 
 ## Verification
-- [ ] Run first-tree verify
+- [ ] Run first-tree tree verify
 `;
 
 describe("summarize-progress helper", () => {

--- a/tests/tree/sync.test.ts
+++ b/tests/tree/sync.test.ts
@@ -1818,7 +1818,7 @@ describe("sync -- PR labeling", () => {
     );
   });
 
-  it("skips pushing PR branches that fail first-tree verify", async () => {
+  it("skips pushing PR branches that fail first-tree tree verify", async () => {
     const tmp = useTmpDir();
     makeTreeShell(tmp.path);
     const fromSha = "11".repeat(20);

--- a/tests/tree/upgrade.test.ts
+++ b/tests/tree/upgrade.test.ts
@@ -138,7 +138,7 @@ describe("runUpgrade", () => {
     expect(
       readFileSync(join(repoDir.path, ".claude", "settings.json"), "utf-8"),
     ).toContain(
-      "npx -p first-tree first-tree inject-context --skip-version-check",
+      "npx -p first-tree first-tree tree inject-context --skip-version-check",
     );
   });
 
@@ -342,7 +342,7 @@ describe("runUpgrade", () => {
     expect(
       readFileSync(join(repoDir.path, ".claude", "settings.json"), "utf-8"),
     ).toContain(
-      "npx -p first-tree first-tree inject-context --skip-version-check",
+      "npx -p first-tree first-tree tree inject-context --skip-version-check",
     );
   });
 
@@ -423,7 +423,7 @@ describe("runUpgrade", () => {
     expect(
       readFileSync(join(repoDir.path, ".claude", "settings.json"), "utf-8"),
     ).toContain(
-      "npx -p first-tree first-tree inject-context --skip-version-check",
+      "npx -p first-tree first-tree tree inject-context --skip-version-check",
     );
   });
 

--- a/tests/tree/wipe-and-refresh.test.ts
+++ b/tests/tree/wipe-and-refresh.test.ts
@@ -96,7 +96,7 @@ describe("refreshInjectContextHook", () => {
       "utf-8",
     );
     expect(updated).toContain(
-      "npx -p first-tree first-tree inject-context --skip-version-check",
+      "npx -p first-tree first-tree tree inject-context --skip-version-check",
     );
     expect(updated).not.toContain("inject-tree-context.sh");
   });
@@ -133,7 +133,7 @@ describe("refreshInjectContextHook", () => {
       "utf-8",
     );
     expect(updated).toContain(
-      "npx -p first-tree first-tree inject-context --skip-version-check",
+      "npx -p first-tree first-tree tree inject-context --skip-version-check",
     );
     expect(updated).not.toContain(".context-tree/scripts/inject-tree-context.sh");
   });
@@ -167,7 +167,7 @@ describe("refreshInjectContextHook", () => {
       "utf-8",
     );
     expect(updated).toContain(
-      `"command":"npx -p first-tree first-tree inject-context --skip-version-check"`,
+      `"command":"npx -p first-tree first-tree tree inject-context --skip-version-check"`,
     );
     expect(updated).not.toContain("./npx");
   });
@@ -200,7 +200,7 @@ describe("refreshInjectContextHook", () => {
       "utf-8",
     );
     expect(updated).toContain(
-      `"command":"npx -p first-tree first-tree inject-context --skip-version-check"`,
+      `"command":"npx -p first-tree first-tree tree inject-context --skip-version-check"`,
     );
   });
 
@@ -217,7 +217,7 @@ describe("refreshInjectContextHook", () => {
                 {
                   type: "command",
                   command:
-                    "npx -p first-tree first-tree inject-context --skip-version-check",
+                    "npx -p first-tree first-tree tree inject-context --skip-version-check",
                 },
               ],
             },
@@ -247,7 +247,7 @@ describe("ensureAgentContextHooks", () => {
     });
     expect(
       readFileSync(join(tmp.path, ".claude", "settings.json"), "utf-8"),
-    ).toContain("first-tree inject-context");
+    ).toContain("first-tree tree inject-context");
     expect(
       readFileSync(join(tmp.path, ".codex", "config.toml"), "utf-8"),
     ).toContain("codex_hooks = true");


### PR DESCRIPTION
## Summary
- align the first-tree CLI around three product namespaces plus one `skill` maintenance namespace
- add `first-tree skill install` and `first-tree skill upgrade` for local skill lifecycle management
- make `first-tree tree bootstrap` the canonical low-level tree-repo bootstrap surface while keeping `first-tree tree init tree` as a compatibility alias
- shorten human-facing one-off docs to `npx first-tree ...` while keeping explicit `npx -p first-tree first-tree ...` forms for hooks and CI
- ship per-namespace VERSION metadata so `first-tree --version` works correctly from the published package
- update hooks, workflows, skills, README, maintainer docs, and tests to the new contract

## Validation
- `pnpm validate:skill`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- verified `node dist/cli.js --version`

## Tree PR
- depends on / accompanies https://github.com/agent-team-foundation/first-tree-context/pull/142