### PR TITLE
refactor(shared): extract VERSION reader into src/shared/version.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "imports": {
     "#products/*": "./src/products/*",
     "#meta/*": "./src/meta/*",
+    "#shared/*": "./src/shared/*",
     "#skill/*": "./skills/first-tree/*",
     "#evals/*": "./evals/*",
     "#src/*": "./src/*"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
-import { readFileSync, realpathSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 import {
@@ -10,6 +9,7 @@ import {
   getCommand,
   readProductVersion,
 } from "./products/manifest.js";
+import { readPackageVersion } from "./shared/version.js";
 
 export const USAGE = buildUsage();
 
@@ -110,32 +110,8 @@ async function runAutoUpgradeCheck(): Promise<void> {
   }
 }
 
-function readFirstTreeVersion(): string {
-  // Walk up from this module until we find the package.json that owns the CLI.
-  let dir = dirname(fileURLToPath(import.meta.url));
-  while (true) {
-    const candidate = join(dir, "package.json");
-    try {
-      const pkg = JSON.parse(readFileSync(candidate, "utf-8")) as {
-        name?: string;
-        version?: string;
-      };
-      if (pkg.name === "first-tree" && typeof pkg.version === "string") {
-        return pkg.version;
-      }
-    } catch {
-      // keep walking
-    }
-    const parent = dirname(dir);
-    if (parent === dir) {
-      return "unknown";
-    }
-    dir = parent;
-  }
-}
-
 function formatVersionLine(): string {
-  const cliVersion = readFirstTreeVersion();
+  const cliVersion = readPackageVersion(import.meta.url, "first-tree");
   const parts = [`first-tree=${cliVersion}`];
   for (const product of PRODUCTS) {
     parts.push(`${product.name}=${readProductVersion(product.name)}`);

--- a/src/meta/skill-tools/cli.ts
+++ b/src/meta/skill-tools/cli.ts
@@ -12,9 +12,7 @@
  * "Managing Skills On This Machine" section sends them here.
  */
 
-import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { readOwnVersion } from "#shared/version.js";
 
 export const SKILL_USAGE = `usage: first-tree skill <command>
 
@@ -39,20 +37,7 @@ Examples:
 type Output = (text: string) => void;
 
 function readSkillVersion(): string {
-  const here = dirname(fileURLToPath(import.meta.url));
-  const candidates = [
-    join(here, "VERSION"),
-    join(here, "..", "..", "..", "src", "meta", "skill-tools", "VERSION"),
-    join(here, "..", "src", "meta", "skill-tools", "VERSION"),
-  ];
-  for (const candidate of candidates) {
-    try {
-      return readFileSync(candidate, "utf-8").trim();
-    } catch {
-      // try next
-    }
-  }
-  return "unknown";
+  return readOwnVersion(import.meta.url, "src/meta/skill-tools");
 }
 
 export async function runSkill(

--- a/src/products/gardener/cli.ts
+++ b/src/products/gardener/cli.ts
@@ -16,9 +16,7 @@
  * comments.
  */
 
-import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { readOwnVersion } from "#shared/version.js";
 
 export const GARDENER_USAGE = `usage: first-tree gardener <command>
 
@@ -45,20 +43,7 @@ Examples:
 type Output = (text: string) => void;
 
 function readGardenerVersion(): string {
-  const here = dirname(fileURLToPath(import.meta.url));
-  const candidates = [
-    join(here, "VERSION"),
-    join(here, "..", "..", "..", "src", "products", "gardener", "VERSION"),
-    join(here, "..", "src", "products", "gardener", "VERSION"),
-  ];
-  for (const candidate of candidates) {
-    try {
-      return readFileSync(candidate, "utf-8").trim();
-    } catch {
-      // try next
-    }
-  }
-  return "unknown";
+  return readOwnVersion(import.meta.url, "src/products/gardener");
 }
 
 export async function runGardener(

--- a/src/products/manifest.ts
+++ b/src/products/manifest.ts
@@ -19,9 +19,7 @@
  * surface. `ALL_COMMANDS` is the concatenation for lookup.
  */
 
-import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { readOwnVersion } from "#shared/version.js";
 
 type Output = (text: string) => void;
 type CommandRunner = (args: string[], output: Output) => Promise<number>;
@@ -131,24 +129,11 @@ export function listProductNames(): readonly string[] {
 }
 
 /**
- * Read a product's VERSION file. VERSION files live as siblings of the
- * bundled product cli.ts. When the CLI runs from the published package
- * they are under `dist/products/<name>/`; in the source tree they are
- * under `src/products/<name>/`. We probe both.
+ * Read a product's VERSION file via the shared version reader.
  */
 export function readProductVersion(productName: string): string {
-  const here = dirname(fileURLToPath(import.meta.url));
-  const candidates = [
-    join(here, productName, "VERSION"),
-    join(here, "..", "..", "src", "products", productName, "VERSION"),
-    join(here, "..", "products", productName, "VERSION"),
-  ];
-  for (const candidate of candidates) {
-    try {
-      return readFileSync(candidate, "utf-8").trim();
-    } catch {
-      // try next
-    }
-  }
-  return "unknown";
+  return readOwnVersion(
+    import.meta.url,
+    `src/products/${productName}`,
+  );
 }

--- a/src/shared/version.ts
+++ b/src/shared/version.ts
@@ -1,0 +1,89 @@
+/**
+ * Shared helper for reading VERSION files owned by a module.
+ *
+ * Every product and meta command carries its own VERSION file next to
+ * its source `cli.ts`. These files are not bundled into `dist/` — so
+ * when the CLI runs from the published package we still resolve back
+ * into the source tree to read them. This helper consolidates the
+ * per-module probing logic that would otherwise be copy-pasted across
+ * every product dispatcher.
+ *
+ * Usage from a product CLI:
+ *
+ *     import { readOwnVersion } from "#shared/version.js";
+ *     const version = readOwnVersion(import.meta.url, "src/products/gardener");
+ *
+ * The second argument is the repo-root-relative directory that owns
+ * the VERSION file. We first try `here/VERSION` (useful if VERSION ever
+ * ships alongside the dist output), then walk upward looking for a
+ * directory that contains `sourceRelativeDir/VERSION`. That handles
+ * both source (`tsx`, tests) and bundled (`dist/cli.js`) execution.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Walk up from the caller module looking for the named npm package's
+ * package.json and return its `version` field. Returns `"unknown"` if
+ * no matching package.json is found.
+ */
+export function readPackageVersion(
+  importMetaUrl: string,
+  packageName: string,
+): string {
+  let dir = dirname(fileURLToPath(importMetaUrl));
+  while (true) {
+    const candidate = join(dir, "package.json");
+    try {
+      const pkg = JSON.parse(readFileSync(candidate, "utf-8")) as {
+        name?: string;
+        version?: string;
+      };
+      if (pkg.name === packageName && typeof pkg.version === "string") {
+        return pkg.version;
+      }
+    } catch {
+      // keep walking
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      return "unknown";
+    }
+    dir = parent;
+  }
+}
+
+export function readOwnVersion(
+  importMetaUrl: string,
+  sourceRelativeDir: string,
+): string {
+  const here = dirname(fileURLToPath(importMetaUrl));
+
+  const sibling = join(here, "VERSION");
+  if (existsSync(sibling)) {
+    try {
+      return readFileSync(sibling, "utf-8").trim();
+    } catch {
+      // fall through to walk-up probe
+    }
+  }
+
+  let dir = here;
+  while (true) {
+    const candidate = join(dir, sourceRelativeDir, "VERSION");
+    if (existsSync(candidate)) {
+      try {
+        return readFileSync(candidate, "utf-8").trim();
+      } catch {
+        // fall through to keep walking
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      return "unknown";
+    }
+    dir = parent;
+  }
+}


### PR DESCRIPTION
## Summary
The same ~15-line VERSION-probing loop was copy-pasted across `src/cli.ts`, `src/products/manifest.ts`, `src/products/gardener/cli.ts`, and `src/meta/skill-tools/cli.ts` — three of them also hard-coded their own source-relative directory. This lifts the logic into one helper so future product additions get version reading for free.

- New `src/shared/version.ts` with `readOwnVersion(metaUrl, sourceDir)` and `readPackageVersion(metaUrl, pkgName)`.
- Adds `#shared/*` package-imports alias.
- Rewrites all four call sites to use the shared helpers.
- `readOwnVersion` now walks upward from the caller to find the source tree instead of probing three hand-coded fallback paths — more robust for future layout changes.

Step P1-a of the three-product-alignment refactor.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (902 passing)
- [x] `pnpm validate:skill`
- [x] `pnpm build`