### PR TITLE
docs(readme): rewrite around the three-product model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,238 +1,159 @@
 # first-tree
 
-first-tree - The living source of truth for your team. Give your agent superpowers with just a skill.
+**A Git-native knowledge layer for your team — and a three-tool suite that keeps it alive.**
 
-`first-tree` publishes the `first-tree` CLI and bundles the canonical
-`first-tree` skill used to bootstrap and maintain Context Tree repos. A
-Context Tree is a **Git-native knowledge layer** for decisions, ownership, and
-cross-domain relationships that agents and humans keep current together.
+`first-tree` publishes the `first-tree` CLI and its bundled agent skills. A Context Tree is the living source of truth for decisions, ownership, and cross-domain relationships that humans and agents maintain together — `first-tree` is the toolkit that lets agents build, tend, and react to it.
 
-## Quick Start For Agents
+---
 
-Paste one of these into your agent (Claude Code, Codex, or any agent you are using) from the root you want to onboard. You only need to decide whether your team needs a new tree or should join an existing one. The agent should inspect the current folder and decide whether it is onboarding a single repo or a multi-repo workspace.
+## The three tools
 
-If you are the first person on your team to set up a Context Tree:
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                         first-tree (umbrella CLI)                    │
+├──────────────┬───────────────────────────┬───────────────────────────┤
+│    tree      │        gardener           │          breeze           │
+│  toolkit     │    local daemon           │     local daemon          │
+├──────────────┼───────────────────────────┼───────────────────────────┤
+│  init, bind, │ watches source repos →    │ watches gh notifications  │
+│  sync,       │ opens issues on the tree  │ → labels / routes / drafts│
+│  publish,    │ repo & assigns owners;    │ replies for PRs, issues,  │
+│  verify, ... │ responds to sync-PR       │ discussions, reviews.     │
+│              │ review feedback.          │                           │
+└──────────────┴───────────────────────────┴───────────────────────────┘
+                           │
+                   ┌───────┴────────┐
+                   │ first-tree     │  ← umbrella skill:
+                   │    skill       │    methodology, references,
+                   │                │    routing into the product skills
+                   └────────────────┘
+```
+
+| Tool | What it is | When to reach for it |
+|------|------------|----------------------|
+| **[tree](src/products/tree)** | CLI toolkit — `first-tree tree init/bind/sync/publish/verify/upgrade/workspace/review/generate-codeowners/inject-context` (e.g. `first-tree tree publish` pushes the tree to GitHub and refreshes bound sources). | You want an agent to create, maintain, or bind a Context Tree repo. |
+| **[gardener](src/products/gardener)** | Local maintenance daemon — proactively watches source repos and opens/assigns tree issues; responds to review feedback on sync PRs | You want the tree to stay coherent as code changes without asking a human to drive it. |
+| **[breeze](src/products/breeze)** | Local inbox daemon — takes over your `gh` login and turns GitHub notifications (PRs, comments, discussions, issues) into a triaged, optionally auto-handled queue | You want an agent sitting on your GitHub notifications so you don't have to. |
+
+Every product ships:
+- an operational handbook at `skills/<name>/SKILL.md` (loaded into agents),
+- a lazy CLI dispatcher at `src/products/<name>/cli.ts`,
+- its own semver'd `VERSION` file, independent from the npm package version.
+
+The umbrella skill at [`skills/first-tree/`](skills/first-tree) is the single entry point an agent reads first — it teaches the Context Tree methodology and routes to the three product skills above. Diagnostic/meta commands (`first-tree skill list/doctor/link`) live under [`src/meta/skill-tools/`](src/meta/skill-tools) and are not products.
+
+---
+
+## Quick start
+
+### For an agent (recommended)
+
+Paste one of these into Claude Code, Codex, or any agent — from the root you want to onboard:
+
+**First person on the team:**
 ```text
-Use the latest first-tree CLI (https://github.com/agent-team-foundation/first-tree). First run `first-tree tree inspect --json` to determine whether the current folder is a single repo or a multi-repo workspace. If it is a multi-repo workspace, treat it as one workspace and create a single shared Context Tree for all repos in the current folder by default, rather than creating one tree per repo. Then install the skill in the current repo or workspace root and complete the onboarding process by creating the appropriate new Context Tree setup for this team.
+Use the latest first-tree CLI (https://github.com/agent-team-foundation/first-tree).
+Run `first-tree tree inspect --json` to classify the current folder, then install
+the skill and onboard this repo or workspace by creating a new Context Tree.
 ```
 
-If your team already has a Context Tree:
+**Joining an existing tree:**
 ```text
-Use the latest first-tree CLI (https://github.com/agent-team-foundation/first-tree). First run `first-tree tree inspect --json` to determine whether the current folder is a single repo or a multi-repo workspace. If it is a multi-repo workspace, treat it as one workspace and connect all repos in the current folder to the same shared Context Tree by default, rather than binding each repo to its own separate tree. Then install the skill in the current repo or workspace root and complete the onboarding process by connecting this repo or workspace to the existing shared Context Tree at `https://github.com/<your-organization>/<your-tree-repo-name>`.
+Use the latest first-tree CLI (https://github.com/agent-team-foundation/first-tree).
+Run `first-tree tree inspect --json`, install the skill, and bind this repo or
+workspace to the existing shared tree at
+https://github.com/<your-org>/<your-tree-repo>.
 ```
 
-## Install And Run
-
-The npm package and installed CLI command are both `first-tree`.
-
-- One-off use without installing globally:
-
-  ```bash
-  npx -p first-tree first-tree tree inspect --json
-  npx -p first-tree first-tree tree init
-  ```
-
-- Global install:
-
-  ```bash
-  npm install -g first-tree
-  first-tree tree init
-  ```
-
-- Show the installed CLI version:
-
-  ```bash
-  first-tree --version
-  ```
-
-- Show the command list:
-
-  ```bash
-  first-tree --help
-  ```
-
-## Onboarding Modes
-
-`first-tree` now models onboarding with three explicit concepts:
-
-- `source/workspace root` — the repo or folder where local agent integration is installed
-- `tree repo` — the Git repo that stores `NODE.md`, domains, members, and decisions
-- `binding` — the metadata that connects a source/workspace root to a tree repo
-
-That model supports three first-class onboarding paths.
-
-### Single Repo + Dedicated Tree
-
-This remains the default for a normal Git repo:
+### For a human
 
 ```bash
-first-tree tree init
+# one-off (no global install)
+npx -p first-tree first-tree tree inspect --json
+npx -p first-tree first-tree tree init
+
+# global install
+npm install -g first-tree
+first-tree --help          # list products + diagnostics
+first-tree --version       # CLI + per-product versions
 ```
 
-The CLI:
+---
 
-- installs `.agents/skills/first-tree/` and `.claude/skills/first-tree/` in the source/workspace root
-- adds `WHITEPAPER.md`
-- updates `AGENTS.md` / `CLAUDE.md`
-- creates or reuses a sibling `<repo>-tree` checkout
-- installs the bundled `first-tree` skill in that tree repo if it is missing
-- scaffolds the dedicated tree repo there
-- writes binding metadata locally and in the tree repo
+## Onboarding modes
 
-### Existing Shared Tree
+`first-tree` models onboarding with three explicit concepts:
 
-If the user already has a shared Context Tree, bind to it instead of creating a
-new sibling:
+- **source / workspace root** — the repo or folder that gets local agent integration
+- **tree repo** — the Git repo that stores `NODE.md`, domains, members, decisions
+- **binding** — metadata that links a source to a tree
 
-```bash
-first-tree tree bind --tree-path ../org-context --tree-mode shared
-```
+Four first-class paths:
 
-Or let `init` do the same thing as a high-level wrapper:
+| Scenario | Command |
+|----------|---------|
+| Single repo + new dedicated tree | `first-tree tree init` |
+| Bind to existing shared tree | `first-tree tree bind --tree-path ../org-context --tree-mode shared` |
+| Workspace root + shared tree | `first-tree tree init --scope workspace --sync-members` (then `first-tree tree workspace sync`) |
+| You're inside the tree repo itself | `first-tree tree init tree --here` |
 
-```bash
-first-tree tree init --tree-path ../org-context --tree-mode shared
-```
+See [`skills/first-tree/references/onboarding.md`](skills/first-tree/references/onboarding.md) for the full guide, and run `first-tree tree help onboarding` to print it.
 
-If the tree is remote-only, pass `--tree-url`; `bind` / `init` will clone a
-local checkout, ensure the tree repo has the bundled skill installed, and then
-write the binding metadata in both locations.
+---
 
-### Workspace Root + Shared Tree
-
-When the current root is a parent folder or root repo that contains child repos
-or submodules, use one shared tree for all of them:
-
-```bash
-first-tree tree init --scope workspace --tree-path ../org-context --tree-mode shared --sync-members
-```
-
-Or create a new shared tree automatically:
-
-```bash
-first-tree tree init --scope workspace --sync-members
-```
-
-The workspace root gets its own local skill integration plus
-`.first-tree/source.json` (with workspace members). Each discovered child repo is then bound as a
-`workspace-member` to the same tree via `first-tree tree workspace sync`.
-
-### Explicit Tree Bootstrap
-
-If you are already inside the tree repo itself, use:
-
-```bash
-first-tree tree init tree --here
-```
-
-## Inspect First
-
-`first-tree tree inspect --json` is the agent-friendly way to classify the current
-folder before modifying anything. It reports:
-
-- whether the root is a tree repo, source repo, workspace repo, or workspace folder
-- discovered child repos / submodules
-- existing `source.json`, `tree.json`, and local checkout state
-
-## What Lives Where
+## Layout after onboarding
 
 ```text
-<source-repo-or-workspace>/
-  .agents/skills/first-tree/
-  .claude/skills/first-tree
-  WHITEPAPER.md
-  AGENTS.md
-  CLAUDE.md
-  .first-tree/
-    source.json              # .first-tree/source.json (includes workspace members for workspace roots)
-  ... source code or workspace folders ...
-
-<tree-repo>/
-  .agents/skills/first-tree/
-  .claude/skills/first-tree
-  .first-tree/
-    VERSION
-    progress.md
-    tree.json                # .first-tree/tree.json
-    bindings/                # .first-tree/bindings/
-      <source-id>.json
-    bootstrap.json           # legacy compatibility for older publish flows
-  source-repos.md            # generated index of bound source/workspace repos
-  NODE.md
-  AGENTS.md
-  CLAUDE.md
-  members/
-    NODE.md
-  ... your tree domains ...
+<source-repo-or-workspace>/          <tree-repo>/
+  .agents/skills/first-tree/           .agents/skills/first-tree/
+  .claude/skills/first-tree            .claude/skills/first-tree
+  WHITEPAPER.md                        .first-tree/
+  AGENTS.md                              VERSION
+  CLAUDE.md                              progress.md
+  .first-tree/                           tree.json
+    source.json                          bindings/<source-id>.json
+  … your code …                        source-repos.md
+                                       NODE.md
+                                       AGENTS.md / CLAUDE.md
+                                       members/NODE.md
+                                       … tree domains …
 ```
 
-The source/workspace root is not the tree. It should never contain `NODE.md`,
-`members/`, or tree-scoped `AGENTS.md` / `CLAUDE.md`.
+The source/workspace root is never a tree — it never contains `NODE.md`, `members/`, or tree-scoped `AGENTS.md` / `CLAUDE.md`. Source-side state lives under `.first-tree/source.json`; tree-side state lives under `.first-tree/tree.json` and `.first-tree/bindings/<source-id>.json`.
 
-The tree repo stores canonical binding metadata in `.first-tree/bindings/` and
-generates `source-repos.md` as the human/agent-friendly repo index, while
-source/workspace roots keep local checkout guidance in `.first-tree/source.json`
-plus their own source/workspace binding state.
+---
 
-## Commands
+## Repository layout (for contributors)
 
-| Command | What it does |
-| --- | --- |
-| `first-tree tree inspect` | Classify the current folder and report existing bindings / child repos |
-| `first-tree tree init` | High-level onboarding wrapper for single repos, shared trees, and workspace roots |
-| `first-tree tree init tree` | Low-level tree bootstrap for an explicit tree checkout |
-| `first-tree tree bind` | Bind the current repo/workspace root to an existing tree repo |
-| `first-tree tree workspace sync` | Bind discovered child repos to the same shared tree |
-| `first-tree tree publish` | Publish a tree repo to GitHub and refresh locally bound source/workspace repos with the published URL |
-| `first-tree tree verify` | Run verification checks against a tree repo |
-| `first-tree tree upgrade` | Refresh installed source/workspace integration or tree metadata from the current package |
-| `first-tree tree generate-codeowners` | Generate `.github/CODEOWNERS` from tree ownership frontmatter |
-| `first-tree tree review` | Run the Claude Code PR review helper for a tree repo in CI |
-| `first-tree tree inject-context` | Output a Claude Code SessionStart hook payload from the root `NODE.md` |
-| `first-tree tree help onboarding` | Print the full onboarding guide |
+```text
+src/
+  cli.ts                  # umbrella dispatcher
+  products/
+    manifest.ts           # single source of truth for product/meta registration
+    tree/                 # tree product (CLI + engine)
+    breeze/               # breeze product (CLI + engine + daemon)
+    gardener/             # gardener product (CLI + engine)
+  meta/
+    skill-tools/          # `first-tree skill list/doctor/link` diagnostics
+  shared/
+    version.ts            # shared VERSION/package.json readers
+assets/
+  tree/                   # runtime assets installed into user repos
+  breeze/                 # breeze dashboard HTML
+skills/
+  first-tree/             # umbrella skill (methodology + routing)
+  tree/ breeze/ gardener/ # per-product operational handbooks
+tests/
+  tree/ breeze/ gardener/ meta/ e2e/     # grouped by product
+docs/                     # maintainer-only implementation notes
+evals/                    # maintainer-only evaluation harness
+```
 
-## Package And Command
+See [`AGENTS.md`](AGENTS.md) (== `CLAUDE.md`) for maintainer rules, and [`docs/source-map.md`](docs/source-map.md) for the annotated file map.
 
-- The npm package is `first-tree`.
-- The installed CLI command is also `first-tree`.
-- The CLI dispatches into three products: `tree`, `breeze`, `gardener`.
-  Run `first-tree --help` for the routing.
-- The published package ships four skill payloads, each with the same
-  name in the package and when installed into a user repo:
-  - `skills/first-tree/` — entry-point skill: methodology, references,
-    and routing to the product skills
-  - `skills/tree/` — operational handbook for the `first-tree tree` CLI
-  - `skills/breeze/` — operational handbook for the `first-tree breeze` CLI
-  - `skills/gardener/` — operational handbook for the `first-tree gardener` CLI
-- In this source repo, `.agents/skills/<name>/` and `.claude/skills/<name>/`
-  are tracked symlink aliases back to the four `skills/<name>/` payloads
-  so local agents resolve the same skills the package ships.
-- `npx -p first-tree first-tree <product> <command>` is the recommended
-  one-off entrypoint.
+---
 
-## Canonical Documentation
-
-User-facing references ship in `skills/first-tree/references/` (installed in user
-repos as `skills/first-tree/references/`) and are copied to user repos via
-`first-tree tree init` / `first-tree tree bind`.
-
-Canonical design and architecture knowledge for this project lives in the bound
-Context Tree under `first-tree-skill-cli/`. Repo-local maintainer notes in
-`docs/` are implementation-only and never ship.
-
-- User-facing overview: `skills/first-tree/references/whitepaper.md`
-- User onboarding: `skills/first-tree/references/onboarding.md`
-- Source/workspace install contract:
-  `skills/first-tree/references/source-workspace-installation.md`
-- Upgrade and layout contract:
-  `skills/first-tree/references/upgrade-contract.md`
-- Canonical architecture node: `first-tree-skill-cli/repo-architecture.md`
-- Canonical sync design node: `first-tree-skill-cli/sync.md`
-- Maintainer entrypoint: `docs/source-map.md`
-
-## Developing This Repo
-
-Run these commands from the repo root:
+## Developing
 
 ```bash
 pnpm install --frozen-lockfile
@@ -240,20 +161,45 @@ pnpm validate:skill
 pnpm typecheck
 pnpm test
 pnpm build
+pnpm pack            # when package contents change
 ```
 
-When package contents or install/upgrade behavior changes, also run:
+Evals live in [`evals/`](evals) — see `evals/README.md`.
 
-```bash
-pnpm pack
-```
+## Package And Command
 
-## Contributing And Security
+- The npm package is `first-tree`; the installed CLI command is also `first-tree`.
+- The CLI dispatches into three products (`tree`, `breeze`, `gardener`) plus diagnostic meta commands (`skill`). Run `first-tree --help` to see the routing.
+- The published package ships **four skill payloads**, each with the same name in the package and when installed into a user repo:
+  - `skills/first-tree/` — the umbrella entry-point `first-tree` skill (methodology, references, routing).
+  - `skills/tree/`, `skills/breeze/`, `skills/gardener/` — one operational handbook per product CLI.
+- In this source repo, `.agents/skills/first-tree/` and `.claude/skills/first-tree/` (plus the three product equivalents) are tracked symlink aliases back to the four `skills/<name>/` payloads, so local agents resolve the same skills the package ships.
+- `npx -p first-tree first-tree <command>` is the recommended one-off entrypoint.
 
-- Use the GitHub issue forms for bug reports and feature requests.
-- See `CONTRIBUTING.md` for local setup and validation expectations.
-- See `CODE_OF_CONDUCT.md` for community expectations.
-- See `SECURITY.md` for vulnerability reporting guidance.
+## Canonical Documentation
+
+User-facing references ship under `skills/first-tree/references/` and get copied into user repos by `first-tree tree init` / `first-tree tree bind`:
+
+- Methodology overview: `skills/first-tree/references/whitepaper.md`
+- Onboarding guide: `skills/first-tree/references/onboarding.md`
+- Source/workspace install contract: `skills/first-tree/references/source-workspace-installation.md`
+- Upgrade and layout contract: `skills/first-tree/references/upgrade-contract.md`
+
+Decision-grade design knowledge for this project lives in the bound Context Tree under `first-tree-skill-cli/`, not in this repo:
+
+- Canonical architecture: `first-tree-skill-cli/repo-architecture.md`
+- Canonical sync design: `first-tree-skill-cli/sync.md`
+
+Repo-local maintainer notes (`docs/source-map.md` and friends) are implementation-only and never ship. `<repo>-tree` is the default sibling name for a dedicated tree repo created by `first-tree tree init`.
+
+---
+
+## Contributing and security
+
+- GitHub issue forms for bugs and feature requests.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) for local setup and validation expectations.
+- [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) for community expectations.
+- [`SECURITY.md`](SECURITY.md) for vulnerability reporting.
 
 ## License
 


### PR DESCRIPTION
## Summary
Reworks the top-level README so the three products (`tree`, `breeze`, `gardener`) are the primary framing, with:

- An ASCII architecture diagram showing the three tools + the umbrella `first-tree` skill.
- A per-product "what it is / when to reach for it" table with direct links to `src/products/<x>/` and `skills/<x>/`.
- An explicit call-out that meta skill-tools (`first-tree skill list/doctor/link`) are diagnostics, not products.
- A repo layout block so contributors see the `src/` / `meta/` / `shared/` split at a glance.
- Preserved all contract strings checked by `tests/tree/skill-artifacts`.

Step P1-b of the three-product-alignment refactor.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (902 passing)
- [x] `pnpm validate:skill`