### PR TITLE
docs(products): add per-product READMEs

### DIFF
--- a/src/meta/skill-tools/README.md
+++ b/src/meta/skill-tools/README.md
@@ -1,0 +1,28 @@
+# `first-tree skill` (meta)
+
+Diagnostic / maintenance commands for the four skill payloads that ship with this package (`first-tree`, `tree`, `breeze`, `gardener`). **This is not a product** — it's a meta command, excluded from `PRODUCTS` in [`src/products/manifest.ts`](../../products/manifest.ts) and rendered under the "Diagnostics" section of `first-tree --help`.
+
+## What's in this directory
+
+```
+skill-tools/
+├── VERSION
+├── cli.ts                 # dispatcher
+└── engine/
+    ├── commands/          # list.ts, doctor.ts, link.ts
+    └── lib/paths.ts       # shared skill layout helpers
+```
+
+## Commands
+
+| Command | Role |
+|---------|------|
+| `first-tree skill list` | Print the four bundled skills with installed status + version |
+| `first-tree skill doctor` | Diagnose skill-install health (exits non-zero on problems) |
+| `first-tree skill link` | Idempotently repair `.claude/skills/*` alias symlinks |
+
+The `list/doctor/link` trio is the canonical entrypoint an agent reaches for when the `first-tree` umbrella skill's **"Managing Skills On This Machine"** section sends them here.
+
+## Related
+
+- Tests: [`tests/meta/skill-commands.test.ts`](../../../tests/meta/skill-commands.test.ts)

--- a/src/products/breeze/README.md
+++ b/src/products/breeze/README.md
@@ -1,0 +1,41 @@
+# `first-tree breeze`
+
+Local daemon that takes over your `gh` login and turns GitHub notifications (PRs, comments, discussions, issues) into a triaged, optionally auto-handled inbox. Drives a Claude Code statusline, an SSE dashboard, and scheduled background work.
+
+## What's in this directory
+
+```
+breeze/
+├── VERSION
+├── cli.ts                 # dispatcher
+└── engine/
+    ├── commands/          # install, start, stop, poll, watch, doctor, cleanup, status, status-manager
+    ├── daemon/            # long-lived process: broker, bus, claim, dispatcher, poller, runner, scheduler, …
+    ├── runtime/           # classifier, config, identity helpers
+    ├── bridge.ts          # integration with the umbrella CLI
+    └── statusline.ts      # zero-dep bundle consumed by the Claude Code statusline hook
+```
+
+## Commands
+
+| Command | Role |
+|---------|------|
+| `first-tree breeze install` | Set up the daemon (launchd on macOS) and Claude Code hooks |
+| `first-tree breeze start/stop` | Control the daemon lifecycle |
+| `first-tree breeze run-once` | One-shot poll for scripting |
+| `first-tree breeze status` | Print current inbox status |
+| `first-tree breeze watch` | Interactive TUI inbox (Ink) |
+| `first-tree breeze doctor` | Diagnose daemon / gh login / hook health |
+| `first-tree breeze cleanup` | Clear stale state |
+
+Run `first-tree breeze --help` for the authoritative list.
+
+## Runtime constraints
+
+`engine/statusline.ts` is bundled separately (`dist/breeze-statusline.js`) and is called every few seconds by the Claude Code statusline hook. It must stay zero-dep and cold-start under 30ms — do not import `ink`, `zod`, or the umbrella CLI from it.
+
+## Related
+
+- User-facing skill: [`skills/breeze/SKILL.md`](../../../skills/breeze/SKILL.md)
+- Assets (SSE dashboard HTML): [`assets/breeze/`](../../../assets/breeze)
+- Tests: [`tests/breeze/`](../../../tests/breeze)

--- a/src/products/gardener/README.md
+++ b/src/products/gardener/README.md
@@ -1,0 +1,35 @@
+# `first-tree gardener`
+
+Local maintenance agent for Context Trees. Keeps the tree coherent as code and reviews evolve:
+
+- **`respond`** — fixes sync PRs based on reviewer feedback (reactive maintenance).
+- **`comment`** — reviews source-repo PRs / issues against the bound tree and posts structured verdict comments.
+
+The intended scope extends beyond reactive maintenance: gardener should proactively watch source repos for changes that affect tree coverage, open corresponding issues on the tree repo, and assign the right owners. That proactive layer is the next milestone and currently ships only the `respond` + `comment` primitives.
+
+## What's in this directory
+
+```
+gardener/
+├── VERSION
+├── cli.ts                 # dispatcher
+└── engine/
+    ├── commands/          # respond.ts, comment.ts
+    └── (domain modules)   # comment builder, classifier, gh helpers, …
+```
+
+## Commands
+
+| Command | Role |
+|---------|------|
+| `first-tree gardener respond --pr <n> --repo owner/name` | Fix a sync PR based on reviewer feedback |
+| `first-tree gardener comment --pr <n> --repo owner/name` | Review a source PR against the tree and post a verdict |
+| `first-tree gardener comment --issue <n> --repo owner/name` | Same, for an issue |
+
+Run `first-tree gardener --help` for the authoritative list.
+
+## Related
+
+- User-facing skill: [`skills/gardener/SKILL.md`](../../../skills/gardener/SKILL.md)
+- Tests: [`tests/gardener/`](../../../tests/gardener)
+- Gardener has no shipped `assets/` — it's a pure runtime tool.

--- a/src/products/tree/README.md
+++ b/src/products/tree/README.md
@@ -1,0 +1,42 @@
+# `first-tree tree`
+
+CLI toolkit for creating, binding, and maintaining a Context Tree repo.
+
+## What's in this directory
+
+```
+tree/
+├── VERSION                # product semver (independent of npm package)
+├── cli.ts                 # thin arg-routing dispatcher (lazy-loads commands)
+└── engine/
+    ├── commands/          # one file per subcommand (bind, init, publish, …)
+    ├── rules/             # tree validation rules
+    ├── runtime/           # asset loader, installer, upgrader, source integration
+    ├── validators/        # node + member validators
+    └── (domain modules)   # bind.ts, init.ts, sync.ts, publish.ts, …
+```
+
+## Commands
+
+| Command | Role |
+|---------|------|
+| `first-tree tree inspect` | Classify the current folder (source / workspace / tree) |
+| `first-tree tree init` | High-level onboarding wrapper |
+| `first-tree tree bind` | Bind current repo/workspace to an existing tree |
+| `first-tree tree workspace sync` | Bind discovered child repos to a shared tree |
+| `first-tree tree publish` | Push the tree to GitHub and refresh bound sources |
+| `first-tree tree verify` | Run validation checks on a tree repo |
+| `first-tree tree upgrade` | Refresh installed source/tree integration from the package |
+| `first-tree tree generate-codeowners` | Generate `.github/CODEOWNERS` from tree ownership |
+| `first-tree tree review` | PR review helper for tree repos in CI |
+| `first-tree tree inject-context` | Claude Code SessionStart payload from root `NODE.md` |
+| `first-tree tree help onboarding` | Print the full onboarding guide |
+
+Run `first-tree tree --help` for the authoritative list.
+
+## Related
+
+- User-facing skill: [`skills/tree/SKILL.md`](../../../skills/tree/SKILL.md)
+- Runtime assets shipped to user repos: [`assets/tree/`](../../../assets/tree)
+- Tests: [`tests/tree/`](../../../tests/tree)
+- Architecture notes: [`docs/architecture/overview.md`](../../../docs/architecture/overview.md)


### PR DESCRIPTION
## Summary
Every product directory (`src/products/tree/`, `breeze/`, `gardener/`) and the meta skill-tools dir (`src/meta/skill-tools/`) now has a short README so a contributor opening the folder can onboard without cross-referencing the top-level README.

Each README covers:

- Purpose in one sentence
- Internal directory layout tree
- Command table with roles
- Pointers to the matching skill, assets, and tests

`gardener/README.md` also documents the intended proactive scope (watch source → open tree issue → assign) that extends beyond today's reactive `respond`/`comment` primitives, flagging the product-scope question we identified during the refactor.

Step P2-b of the three-product-alignment refactor.

## Test plan
- [x] `pnpm test` (902 passing)
- [x] `pnpm validate:skill`