### PR TITLE
refactor(gardener/respond): drop scan-loop; require --pr/--repo (closes #160)

### DIFF
--- a/src/products/gardener/engine/respond.ts
+++ b/src/products/gardener/engine/respond.ts
@@ -40,25 +40,25 @@ import {
 
 const execFileAsync = promisify(execFile);
 
-export const RESPOND_USAGE = `usage: first-tree gardener respond [--pr <n> --repo <owner/name>] [--tree-path PATH]
+export const RESPOND_USAGE = `usage: first-tree gardener respond --pr <n> --repo <owner/name> [--tree-path PATH]
 
-Fix sync PRs based on reviewer feedback. Ports the
+Fix a single sync PR based on reviewer feedback. Ports the
 gardener-respond-manual.md runbook into a deterministic CLI.
 
 Only acts on PRs whose branch starts with \`first-tree/sync-\` or whose
 label set contains \`first-tree:sync\`. Never force-pushes, never creates
 new PRs, never merges (that is the reviewer agent's job).
 
-Modes:
-  (default)             Scan all open sync PRs on the tree repo in cwd
-                        and fix each CHANGES_REQUESTED PR.
-  --pr <n> --repo <o/r> Single-PR mode. Fix one PR. Used by breeze-runner
-                        when dispatched from a review notification.
+Invocation is single-PR only. The trigger is breeze-runner dispatching
+on a \`review_requested\`/reviewer-feedback notification, which supplies
+the target \`--pr\` and \`--repo\`. There is no scan mode — the scheduled
+"find all PRs that need fixing" loop was removed; discovery now lives
+in breeze's notification poller.
 
 Options:
   --tree-path PATH      Tree repo directory (default: cwd)
-  --pr <n>              PR number (requires --repo)
-  --repo <owner/name>   Target repository (requires --pr)
+  --pr <n>              PR number (required; must be paired with --repo)
+  --repo <owner/name>   Target repository (required; must be paired with --pr)
   --dry-run             Print planned actions; do not push or comment
   --help, -h            Show this help message
 
@@ -694,102 +694,6 @@ async function respondSinglePr(
   };
 }
 
-async function respondScanMode(
-  opts: {
-    treeRoot: string;
-    dryRun: boolean;
-    shell: ShellRun;
-    env: NodeJS.ProcessEnv;
-    write: (line: string) => void;
-    now: () => Date;
-    gardenerLogin: string;
-  },
-): Promise<{ status: RespondStatus; summary: string }> {
-  const { shell, write, env, gardenerLogin } = opts;
-  // Best-effort: detect tree repo slug from `gh repo view`.
-  const repoRes = await shell("gh", [
-    "repo",
-    "view",
-    "--json",
-    "nameWithOwner",
-    "-q",
-    ".nameWithOwner",
-  ], { cwd: opts.treeRoot });
-  if (repoRes.code !== 0) {
-    const msg = `Could not determine tree repo slug (is this a git repo with gh set up?)`;
-    write(msg);
-    logEvent(env, { kind: "error", message: msg });
-    return { status: "failed", summary: msg };
-  }
-  const treeRepo = repoRes.stdout.trim();
-
-  const listRes = await shell("gh", [
-    "pr",
-    "list",
-    "--repo",
-    treeRepo,
-    "--state",
-    "open",
-    "--json",
-    "number,title,headRefName,reviewDecision,updatedAt,labels",
-  ]);
-  if (listRes.code !== 0) {
-    const msg = `gh pr list failed: ${listRes.stderr.trim()}`;
-    write(msg);
-    logEvent(env, { kind: "error", message: msg });
-    return { status: "failed", summary: msg };
-  }
-  const prs = jsonTryParse<PrView[]>(listRes.stdout) ?? [];
-  const syncPrs = prs.filter(isSyncPr);
-
-  logEvent(env, {
-    kind: "scan",
-    tree_repo: treeRepo,
-    total_prs: prs.length,
-    needs_fix: syncPrs.length,
-  });
-
-  if (syncPrs.length === 0) {
-    write(`No open sync PRs on ${treeRepo}`);
-    return { status: "skipped", summary: `no sync PRs on ${treeRepo}` };
-  }
-
-  let handled = 0;
-  let skipped = 0;
-  let failed = 0;
-  for (const pr of syncPrs) {
-    const result = await respondSinglePr({
-      repo: treeRepo,
-      pr: pr.number,
-      dryRun: opts.dryRun,
-      shell,
-      env,
-      write,
-      now: opts.now,
-      gardenerLogin,
-    });
-    if (result.status === "handled") handled += 1;
-    else if (result.status === "failed") failed += 1;
-    else skipped += 1;
-  }
-
-  const summary = `scanned=${syncPrs.length} handled=${handled} skipped=${skipped} failed=${failed}`;
-  write(
-    `gardener-respond run complete (scan)\n  Tree repo: ${treeRepo}\n  ${summary}`,
-  );
-  logEvent(env, {
-    kind: "run",
-    prs_scanned: syncPrs.length,
-    prs_fixed: handled,
-    learnings: 0,
-    duration_s: 0,
-  });
-  return {
-    status: failed > 0 ? "failed" : handled > 0 ? "handled" : "skipped",
-    summary,
-  };
-}
-
 export async function runRespond(
   args: string[],
   deps: RespondDeps = {},
@@ -840,28 +744,18 @@ export async function runRespond(
   }
 
   try {
-    if (flags.pr !== undefined || flags.repo !== undefined) {
-      if (flags.pr === undefined || !flags.repo) {
-        write(`--pr and --repo must be used together`);
-        emitBreezeResult(write, "failed", "pr/repo flag pair incomplete");
-        return 1;
-      }
-      const result = await respondSinglePr({
-        repo: flags.repo,
-        pr: flags.pr,
-        dryRun: flags.dryRun,
-        shell,
-        env,
-        write,
-        now,
-        gardenerLogin,
-      });
-      emitBreezeResult(write, result.status, result.summary);
-      return result.status === "failed" ? 1 : 0;
+    if (flags.pr === undefined || !flags.repo) {
+      write(
+        `--pr and --repo are required: gardener-respond is single-PR only.\n`
+          + `Breeze dispatches this command with both flags set when a\n`
+          + `review_requested notification fires. See --help.`,
+      );
+      emitBreezeResult(write, "failed", "pr/repo flags required");
+      return 1;
     }
-
-    const result = await respondScanMode({
-      treeRoot,
+    const result = await respondSinglePr({
+      repo: flags.repo,
+      pr: flags.pr,
       dryRun: flags.dryRun,
       shell,
       env,

--- a/tests/gardener/gardener-respond.test.ts
+++ b/tests/gardener/gardener-respond.test.ts
@@ -198,6 +198,90 @@ describe("gardener respond -- BREEZE_RESULT trailer", () => {
   });
 });
 
+describe("gardener respond -- single-PR only (scan mode removed, #160/#162 step 5)", () => {
+  it("exits 1 with a clear error when invoked with no --pr/--repo", async () => {
+    const tmp = useTmpDir();
+    const calls: ShellCall[] = [];
+    const shell = makeShell([], calls);
+    const { write, lines } = captureWrite();
+    const code = await runRespond(
+      ["--tree-path", tmp.path],
+      {
+        shellRun: shell,
+        write,
+        // Pre-set GARDENER_LOGIN so resolveGardenerLogin doesn't make a
+        // `gh api /user` call — this test only cares about dispatch, not
+        // login resolution.
+        env: { GARDENER_LOGIN: "gardener-bot" },
+        now: () => new Date("2026-04-17T00:00:00Z"),
+      },
+    );
+    expect(code).toBe(1);
+    // No gh calls should happen — we reject before any scan/fetch I/O.
+    expect(calls.filter((c) => c.command === "gh")).toHaveLength(0);
+    const joined = lines.join("\n");
+    expect(joined).toContain("--pr and --repo are required");
+    expect(lines[lines.length - 1]).toMatch(
+      /^BREEZE_RESULT: status=failed summary=pr\/repo flags required/,
+    );
+  });
+
+  it("exits 1 when only --pr is supplied (no --repo)", async () => {
+    const tmp = useTmpDir();
+    const { write, lines } = captureWrite();
+    const shell = makeShell([]);
+    const code = await runRespond(
+      ["--pr", "42", "--tree-path", tmp.path],
+      { shellRun: shell, write, env: { GARDENER_LOGIN: "gardener-bot" } },
+    );
+    expect(code).toBe(1);
+    expect(lines[lines.length - 1]).toMatch(/^BREEZE_RESULT: status=failed /);
+  });
+
+  it("exits 1 when only --repo is supplied (no --pr)", async () => {
+    const tmp = useTmpDir();
+    const { write, lines } = captureWrite();
+    const shell = makeShell([]);
+    const code = await runRespond(
+      ["--repo", "alice/tree", "--tree-path", tmp.path],
+      { shellRun: shell, write, env: { GARDENER_LOGIN: "gardener-bot" } },
+    );
+    expect(code).toBe(1);
+    expect(lines[lines.length - 1]).toMatch(/^BREEZE_RESULT: status=failed /);
+  });
+
+  it("does not invoke `gh pr list` (scan mode is removed)", async () => {
+    const tmp = useTmpDir();
+    const calls: ShellCall[] = [];
+    const shell = makeShell([], calls);
+    const { write } = captureWrite();
+    // Invoke with no flags — would have triggered scan-mode on main, now rejects.
+    await runRespond(
+      ["--tree-path", tmp.path],
+      { shellRun: shell, write, env: { GARDENER_LOGIN: "gardener-bot" } },
+    );
+    // Assert no gh pr list call happened. (Under the old scan-mode path, this
+    // was the first gh call after `gh repo view`.)
+    const prListCalls = calls.filter(
+      (c) => c.command === "gh" && c.args[0] === "pr" && c.args[1] === "list",
+    );
+    expect(prListCalls).toHaveLength(0);
+  });
+
+  it("help text documents single-PR-only invocation", () => {
+    // The pre-refactor "Modes: (default) Scan ..." section is gone.
+    expect(RESPOND_USAGE).not.toMatch(/^\s*Modes:/m);
+    expect(RESPOND_USAGE).not.toMatch(/\(default\)\s+Scan/);
+    // The required single-PR flags are documented.
+    expect(RESPOND_USAGE).toContain("--pr <n>");
+    expect(RESPOND_USAGE).toContain("--repo <owner/name>");
+    expect(RESPOND_USAGE).toContain("required");
+    // The synopsis line no longer wraps --pr/--repo in brackets
+    // (they're not optional anymore).
+    expect(RESPOND_USAGE).toMatch(/respond --pr <n> --repo <owner\/name>/);
+  });
+});
+
 describe("gardener respond -- snapshot mode", () => {
   it("reads from BREEZE_SNAPSHOT_DIR when set and does not call gh api", async () => {
     const tmp = useTmpDir();


### PR DESCRIPTION
## Summary

- Deletes `respondScanMode` — breeze-runner's notification poller now owns PR discovery and dispatches `first-tree gardener respond --pr <n> --repo <r>` on a `review_requested`/reviewer-feedback event.
- Makes `--pr` and `--repo` required; missing flags exit 1 with a clear error pointing at breeze as the canonical trigger.
- Rewrites `RESPOND_USAGE` to document single-PR-only invocation (removes the "Modes:" section).
- Adds 5 tests under a new `single-PR only (scan mode removed, #160/#162 step 5)` describe block covering all four flag-validation paths and the help text.

This is step 5 of bingran's 6-step plan on #162 (signed off 2026-04-17T23:16:54Z) and unblocks Phase 5 (wire real edit orchestrator into respond).

## Context

Before this PR, `respond` had two modes:
1. Single-PR (`--pr`/`--repo`) — called by breeze-runner
2. Scan mode (default, no flags) — called by a scheduled cron that enumerated all open sync PRs with `breeze:in_progress`

Mode 2 is dead weight now that breeze dispatches on notifications; keeping it invites double-dispatch races and a stale assumption that respond owns discovery. Removing it makes the respond contract match how it's actually triggered.

## Test plan

- [x] Unit: 39/39 respond tests, 109/109 gardener tests pass
- [x] Typecheck clean
- [x] Full suite: 905 pass / 2 pre-existing unrelated failures (launchd plist, skill artifacts — verified via `git stash` on main)
- [x] E2E (built CLI):
  - `node dist/cli.js gardener respond` → exit 1 + "--pr and --repo are required" error + `BREEZE_RESULT: status=failed`
  - `node dist/cli.js gardener respond --pr 42` → same error
  - `node dist/cli.js gardener respond --repo foo/bar` → same error
  - `node dist/cli.js gardener respond --help` → single-PR-only usage text, no "Modes:" section

Closes #160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)