### PR TITLE
test(sync-golden): add zero-changes and existing-PR fixtures (closes #167)

### DIFF
--- a/tests/fixtures/sync-golden/README.md
+++ b/tests/fixtures/sync-golden/README.md
@@ -1,0 +1,34 @@
+# sync-golden fixtures
+
+**Changing any file in this directory requires coordination with
+[`repo-gardener`](https://github.com/agent-team-foundation/repo-gardener)
+maintainers.**
+
+These fixtures lock down the external-effects shape of
+`first-tree sync --apply` — the commit message, PR title, PR body,
+labels, branch name pattern, and order of `git`/`gh` calls. Repo-gardener
+shells out to `first-tree sync --apply` on a schedule and parses these
+surfaces. Any drift here silently changes what repo-gardener produces
+in production.
+
+## Fixtures
+
+- `two-pr-apply.json` — happy path: two merged source PRs, two tree
+  PRs created end-to-end.
+- `zero-changes.json` — source HEAD already matches
+  `lastReconciledSourceCommit`; sync short-circuits with "up to date"
+  and creates nothing.
+- `existing-pr.json` — a tree PR already exists for both source PRs
+  (matched via `gh pr list --search`); sync skips push/create for both
+  groups. Idempotency path.
+
+## Updating
+
+To regenerate after an **intentional**, coordinated change:
+
+```
+UPDATE_SYNC_GOLDEN=1 pnpm vitest run tests/tree/sync-golden-snapshot.test.ts
+```
+
+Review the fixture diff by hand in the same PR as the code change.
+Never auto-regenerate in CI.

--- a/tests/fixtures/sync-golden/existing-pr.json
+++ b/tests/fixtures/sync-golden/existing-pr.json
@@ -1,0 +1,135 @@
+{
+  "exitCode": 0,
+  "calls": [
+    {
+      "command": "gh",
+      "args": [
+        "auth",
+        "status"
+      ],
+      "cwdLabel": null
+    },
+    {
+      "command": "claude",
+      "args": [
+        "--version"
+      ],
+      "cwdLabel": null
+    },
+    {
+      "command": "gh",
+      "args": [
+        "api",
+        "/repos/alice/source/commits/HEAD",
+        "--jq",
+        ".sha"
+      ],
+      "cwdLabel": null
+    },
+    {
+      "command": "gh",
+      "args": [
+        "api",
+        "/repos/alice/source/compare/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      ],
+      "cwdLabel": null
+    },
+    {
+      "command": "gh",
+      "args": [
+        "api",
+        "search/issues?q=repo:alice/source+is:pr+is:merged+merged:>=2026-04-01&per_page=100"
+      ],
+      "cwdLabel": null
+    },
+    {
+      "command": "gh",
+      "args": [
+        "api",
+        "/repos/alice/source/pulls/101/files",
+        "--paginate"
+      ],
+      "cwdLabel": null
+    },
+    {
+      "command": "gh",
+      "args": [
+        "api",
+        "/repos/alice/source/pulls/102/files",
+        "--paginate"
+      ],
+      "cwdLabel": null
+    },
+    {
+      "command": "claude",
+      "args": [
+        "-p",
+        "--output-format",
+        "json",
+        "You are a Context Tree maintenance agent. A Context Tree is a structured knowledge base (markdown NODE.md files) that captures product decisions, architecture, conventions, and domain knowledge for a codebase.\n\nYour job: given the tree's current nodes and a recently merged PR, determine whether the tree is MISSING knowledge that this PR introduced.\n\nContext: this PR has already been reviewed and approved (including context-fit review by gardener). It does not conflict with the tree. The only question is: did it introduce NEW knowledge that the tree doesn't yet capture?\n\nIMPORTANT:\n- For nodes marked with CONTENT below, read the content carefully. A node might exist for an area but NOT cover the specific feature this PR added.\n- If \"Changed files\" are listed below, use them to verify what the PR actually modified. Do NOT describe features not reflected in the changed file paths.\n- Be factually precise: only describe capabilities the source PR actually introduced. Do not extrapolate or generalize beyond what the diff shows.\n- For example, if an \"Authentication\" node only mentions JWT but the PR adds OAuth support, that is a TREE_MISS — the tree needs a new node (or the existing node needs supplementing, which counts as TREE_MISS for sync purposes).\n\nAsk yourself:\n- Did this PR add a new feature, module, convention, or architectural pattern that NO existing node covers in its content? → TREE_MISS\n- Do the existing nodes (including their content) already adequately describe what this PR introduced? → TREE_OK\n\nBias toward TREE_MISS. If in doubt, classify as TREE_MISS.\n\n## Current tree nodes (1 total, 0 with content shown)\n- NODE.md title=\"Example Tree\" owners=alice\n\n## Merged PR\ncommit 1111111 [pkg-a] feat(pkg-a): add thing (#101)\npr feat(pkg-a): add thing\n\n## Output format\nReturn a JSON array. Each element represents one area that needs a NEW tree node (NOT one per commit — group related changes):\n{\n  \"path\": \"suggested/node/path\",\n  \"type\": \"TREE_MISS\" | \"TREE_OK\",\n  \"rationale\": \"one sentence explaining why the tree needs this node\",\n  \"suggested_node_title\": \"Human-readable title for the node\",\n  \"suggested_node_body_markdown\": \"Draft NODE.md body content ONLY (2-5 paragraphs, no YAML frontmatter)\",\n  \"suggested_soft_links\": [\"other/tree/path\", \"another/one\"]\n}\n\nFor TREE_OK items, only path, type, and rationale are required (other fields can be empty strings or omitted).\n\nIMPORTANT:\n- Only return TREE_MISS or TREE_OK. Sync does not support in-place edits to existing NODE.md files, so do not propose supplement-style updates — if an existing node needs more content, classify as TREE_MISS with a new path and leave the existing node alone.\n- `suggested_node_body_markdown` must contain body content only. Do NOT include YAML frontmatter or code fences.\n- `suggested_soft_links` must list every tree path the body cross-references (other domains, governance, backend, etc.) so the new node shows up in the tree graph. Use paths from the \"Current tree nodes\" list above. Omit or use [] when the body does not reference other domains.\n\nReturn a JSON array only, no prose."
+      ],
+      "cwdLabel": null
+    },
+    {
+      "command": "claude",
+      "args": [
+        "-p",
+        "--output-format",
+        "json",
+        "You are a Context Tree maintenance agent. A Context Tree is a structured knowledge base (markdown NODE.md files) that captures product decisions, architecture, conventions, and domain knowledge for a codebase.\n\nYour job: given the tree's current nodes and a recently merged PR, determine whether the tree is MISSING knowledge that this PR introduced.\n\nContext: this PR has already been reviewed and approved (including context-fit review by gardener). It does not conflict with the tree. The only question is: did it introduce NEW knowledge that the tree doesn't yet capture?\n\nIMPORTANT:\n- For nodes marked with CONTENT below, read the content carefully. A node might exist for an area but NOT cover the specific feature this PR added.\n- If \"Changed files\" are listed below, use them to verify what the PR actually modified. Do NOT describe features not reflected in the changed file paths.\n- Be factually precise: only describe capabilities the source PR actually introduced. Do not extrapolate or generalize beyond what the diff shows.\n- For example, if an \"Authentication\" node only mentions JWT but the PR adds OAuth support, that is a TREE_MISS — the tree needs a new node (or the existing node needs supplementing, which counts as TREE_MISS for sync purposes).\n\nAsk yourself:\n- Did this PR add a new feature, module, convention, or architectural pattern that NO existing node covers in its content? → TREE_MISS\n- Do the existing nodes (including their content) already adequately describe what this PR introduced? → TREE_OK\n\nBias toward TREE_MISS. If in doubt, classify as TREE_MISS.\n\n## Current tree nodes (1 total, 0 with content shown)\n- NODE.md title=\"Example Tree\" owners=alice\n\n## Merged PR\ncommit 2222222 [pkg-b] feat(pkg-b): add thing (#102)\npr feat(pkg-b): add thing\n\n## Output format\nReturn a JSON array. Each element represents one area that needs a NEW tree node (NOT one per commit — group related changes):\n{\n  \"path\": \"suggested/node/path\",\n  \"type\": \"TREE_MISS\" | \"TREE_OK\",\n  \"rationale\": \"one sentence explaining why the tree needs this node\",\n  \"suggested_node_title\": \"Human-readable title for the node\",\n  \"suggested_node_body_markdown\": \"Draft NODE.md body content ONLY (2-5 paragraphs, no YAML frontmatter)\",\n  \"suggested_soft_links\": [\"other/tree/path\", \"another/one\"]\n}\n\nFor TREE_OK items, only path, type, and rationale are required (other fields can be empty strings or omitted).\n\nIMPORTANT:\n- Only return TREE_MISS or TREE_OK. Sync does not support in-place edits to existing NODE.md files, so do not propose supplement-style updates — if an existing node needs more content, classify as TREE_MISS with a new path and leave the existing node alone.\n- `suggested_node_body_markdown` must contain body content only. Do NOT include YAML frontmatter or code fences.\n- `suggested_soft_links` must list every tree path the body cross-references (other domains, governance, backend, etc.) so the new node shows up in the tree graph. Use paths from the \"Current tree nodes\" list above. Omit or use [] when the body does not reference other domains.\n\nReturn a JSON array only, no prose."
+      ],
+      "cwdLabel": null
+    },
+    {
+      "command": "git",
+      "args": [
+        "symbolic-ref",
+        "--quiet",
+        "--short",
+        "HEAD"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "gh",
+      "args": [
+        "pr",
+        "list",
+        "--search",
+        "sync(source-golden): from alice/source#101",
+        "--json",
+        "number",
+        "--limit",
+        "1"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "gh",
+      "args": [
+        "pr",
+        "list",
+        "--search",
+        "sync(source-golden): from alice/source#102",
+        "--json",
+        "number",
+        "--limit",
+        "1"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "git",
+      "args": [
+        "checkout",
+        "main"
+      ],
+      "cwdLabel": "<tree-root>"
+    }
+  ],
+  "bodyHashes": {},
+  "nodeMdFiles": {
+    "pkg-a": "<absent>",
+    "pkg-b": "<absent>"
+  }
+}

--- a/tests/fixtures/sync-golden/zero-changes.json
+++ b/tests/fixtures/sync-golden/zero-changes.json
@@ -1,0 +1,32 @@
+{
+  "exitCode": 0,
+  "calls": [
+    {
+      "command": "gh",
+      "args": [
+        "auth",
+        "status"
+      ],
+      "cwdLabel": null
+    },
+    {
+      "command": "claude",
+      "args": [
+        "--version"
+      ],
+      "cwdLabel": null
+    },
+    {
+      "command": "gh",
+      "args": [
+        "api",
+        "/repos/alice/source/commits/HEAD",
+        "--jq",
+        ".sha"
+      ],
+      "cwdLabel": null
+    }
+  ],
+  "bodyHashes": {},
+  "nodeMdFiles": {}
+}

--- a/tests/tree/sync-golden-snapshot.test.ts
+++ b/tests/tree/sync-golden-snapshot.test.ts
@@ -32,13 +32,10 @@ import {
 import { writeTreeBinding } from "#products/tree/engine/runtime/binding-state.js";
 import { makeTreeMetadata, useTmpDir } from "../helpers.js";
 
-const FIXTURE_PATH = join(
-  __dirname,
-  "..",
-  "fixtures",
-  "sync-golden",
-  "two-pr-apply.json",
-);
+const FIXTURE_DIR = join(__dirname, "..", "fixtures", "sync-golden");
+const FIXTURE_PATH = join(FIXTURE_DIR, "two-pr-apply.json");
+const FIXTURE_PATH_ZERO = join(FIXTURE_DIR, "zero-changes.json");
+const FIXTURE_PATH_EXISTING = join(FIXTURE_DIR, "existing-pr.json");
 
 interface Captured {
   command: string;
@@ -78,9 +75,21 @@ function makeTreeShell(root: string): void {
   );
 }
 
+interface ShellOverrides {
+  /** Replaces the `/repos/alice/source/compare/<...>` response. Pass null for zero commits. */
+  compareCommits?: Array<{ sha: string; message: string; files: string[] }> | null;
+  /** Replaces the `search/issues` response for merged PRs. */
+  mergedPrItems?: Array<{ number: number; title: string; mergedSha: string; mergedAt: string }>;
+  /** Returned when sync.ts calls `gh pr list --search` to check for an existing tree PR. */
+  existingTreePrsBySearch?: Array<{ number: number }>;
+  /** Overrides the `/repos/alice/source/commits/HEAD` SHA (40 hex chars). Default: "bb"*20. */
+  headSha?: string;
+}
+
 function makeRecordingShell(
   tmpPath: string,
   classifyResponses: string[],
+  overrides: ShellOverrides = {},
 ): { shellRun: ShellRun; captured: Captured[]; bodies: string[] } {
   const captured: Captured[] = [];
   const bodies: string[] = [];
@@ -104,56 +113,77 @@ function makeRecordingShell(
     if (command === "gh" && args[0] === "api") {
       const path = args[1] ?? "";
       if (path === "/repos/alice/source/commits/HEAD") {
-        return { stdout: "bb".repeat(20) + "\n", stderr: "", code: 0 };
+        const sha = overrides.headSha ?? "bb".repeat(20);
+        return { stdout: sha + "\n", stderr: "", code: 0 };
       }
       if (path.startsWith("/repos/alice/source/compare/")) {
-        return {
-          stdout: JSON.stringify({
-            commits: [
-              {
-                sha: "1".repeat(40),
+        const defaultCommits = [
+          {
+            sha: "1".repeat(40),
+            commit: {
+              message: "feat(pkg-a): add thing (#101)",
+              author: { name: "a", date: "2026-04-01T00:00:00Z" },
+            },
+            files: [{ filename: "pkg-a/x.ts" }],
+          },
+          {
+            sha: "2".repeat(40),
+            commit: {
+              message: "feat(pkg-b): add thing (#102)",
+              author: { name: "b", date: "2026-04-02T00:00:00Z" },
+            },
+            files: [{ filename: "pkg-b/y.ts" }],
+          },
+        ];
+        const commits = overrides.compareCommits === undefined
+          ? defaultCommits
+          : overrides.compareCommits === null
+            ? []
+            : overrides.compareCommits.map((c) => ({
+                sha: c.sha,
                 commit: {
-                  message: "feat(pkg-a): add thing (#101)",
+                  message: c.message,
                   author: { name: "a", date: "2026-04-01T00:00:00Z" },
                 },
-                files: [{ filename: "pkg-a/x.ts" }],
-              },
-              {
-                sha: "2".repeat(40),
-                commit: {
-                  message: "feat(pkg-b): add thing (#102)",
-                  author: { name: "b", date: "2026-04-02T00:00:00Z" },
-                },
-                files: [{ filename: "pkg-b/y.ts" }],
-              },
-            ],
-          }),
+                files: c.files.map((filename) => ({ filename })),
+              }));
+        return {
+          stdout: JSON.stringify({ commits }),
           stderr: "",
           code: 0,
         };
       }
       if (path.startsWith("search/issues")) {
+        const defaultItems = [
+          {
+            number: 101,
+            title: "feat(pkg-a): add thing",
+            pull_request: {
+              merged_at: "2026-04-01T00:00:00Z",
+              merge_commit_sha: "1".repeat(40),
+            },
+          },
+          {
+            number: 102,
+            title: "feat(pkg-b): add thing",
+            pull_request: {
+              merged_at: "2026-04-02T00:00:00Z",
+              merge_commit_sha: "2".repeat(40),
+            },
+          },
+        ];
+        const items = overrides.mergedPrItems
+          ? overrides.mergedPrItems.map((i) => ({
+              number: i.number,
+              title: i.title,
+              pull_request: {
+                merged_at: i.mergedAt,
+                merge_commit_sha: i.mergedSha,
+              },
+            }))
+          : defaultItems;
         return {
-          stdout: JSON.stringify({
-            items: [
-              {
-                number: 101,
-                title: "feat(pkg-a): add thing",
-                pull_request: {
-                  merged_at: "2026-04-01T00:00:00Z",
-                  merge_commit_sha: "1".repeat(40),
-                },
-              },
-              {
-                number: 102,
-                title: "feat(pkg-b): add thing",
-                pull_request: {
-                  merged_at: "2026-04-02T00:00:00Z",
-                  merge_commit_sha: "2".repeat(40),
-                },
-              },
-            ],
-          }),
+          stdout: JSON.stringify({ items }),
           stderr: "",
           code: 0,
         };
@@ -165,6 +195,16 @@ function makeRecordingShell(
       return { stdout: response, stderr: "", code: 0 };
     }
     if (command === "gh" && args[0] === "pr" && args[1] === "list") {
+      if (
+        overrides.existingTreePrsBySearch
+        && args.includes("--search")
+      ) {
+        return {
+          stdout: JSON.stringify(overrides.existingTreePrsBySearch),
+          stderr: "",
+          code: 0,
+        };
+      }
       return { stdout: "[]", stderr: "", code: 0 };
     }
     if (command === "gh" && args[0] === "pr" && args[1] === "create") {
@@ -251,6 +291,71 @@ function extractBodies(calls: Captured[]): Record<string, string> {
   return out;
 }
 
+function makeBoundTree(tmpPath: string) {
+  makeTreeShell(tmpPath);
+  writeTreeBinding(tmpPath, "source-golden", {
+    bindingMode: "standalone-source",
+    entrypoint: "/repos/source",
+    lastReconciledSourceCommit: "aa".repeat(20),
+    remoteUrl: "https://github.com/alice/source.git",
+    rootKind: "git-repo",
+    scope: "repo",
+    sourceId: "source-golden",
+    sourceName: "source",
+    sourceRootPath: "../source",
+    treeMode: "dedicated",
+    treeRepoName: "tree",
+  });
+}
+
+async function runAndCapture(
+  tmpPath: string,
+  classifyResponses: string[],
+  overrides: ShellOverrides,
+  nodeDirs: string[],
+): Promise<Snapshot> {
+  const { shellRun, captured } = makeRecordingShell(
+    tmpPath,
+    classifyResponses,
+    overrides,
+  );
+  const exitCode = await runSync(
+    tmpPath,
+    { source: undefined, propose: false, apply: true, dryRun: false },
+    { shellRun, verifyTree: () => 0 },
+  );
+  const bodies = extractBodies(captured);
+  const bodyHashes: Record<string, string> = {};
+  for (const [k, v] of Object.entries(bodies)) bodyHashes[k] = hash(v);
+  const nodeMdFiles: Record<string, string> = {};
+  for (const dir of nodeDirs) {
+    try {
+      const p = join(tmpPath, dir, "NODE.md");
+      nodeMdFiles[dir] = hash(readFileSync(p, "utf-8"));
+    } catch {
+      nodeMdFiles[dir] = "<absent>";
+    }
+  }
+  return {
+    exitCode,
+    calls: redact(captured, tmpPath),
+    bodyHashes,
+    nodeMdFiles,
+  };
+}
+
+function assertOrUpdate(snapshot: Snapshot, fixturePath: string): void {
+  if (process.env.UPDATE_SYNC_GOLDEN === "1") {
+    mkdirSync(FIXTURE_DIR, { recursive: true });
+    writeFileSync(fixturePath, JSON.stringify(snapshot, null, 2) + "\n");
+    // eslint-disable-next-line no-console
+    console.log(`[golden] wrote fixture: ${fixturePath}`);
+    return;
+  }
+  const expected: Snapshot = JSON.parse(readFileSync(fixturePath, "utf-8"));
+  expect(snapshot).toEqual(expected);
+}
+
 describe("sync --apply golden snapshot (Phase 0.a)", () => {
   it("produces byte-identical git/gh call shape for two-PR scheduled sync", async () => {
     const tmp = useTmpDir();
@@ -332,5 +437,58 @@ describe("sync --apply golden snapshot (Phase 0.a)", () => {
 
     const expected: Snapshot = JSON.parse(readFileSync(FIXTURE_PATH, "utf-8"));
     expect(snapshot).toEqual(expected);
+  });
+
+  it("captures the zero-changes path: head == lastReconciledSourceCommit, no PR created", async () => {
+    // Scenario: sync runs but source HEAD already matches lastReconciledSourceCommit.
+    // sync.ts short-circuits at `binding.lastReconciledSourceCommit === head` and
+    // emits "up to date" without calling compareCommits, classify, push, or pr create.
+    // Repo-gardener relies on this being a clean no-op (no PR, no branch, exit 0).
+    const tmp = useTmpDir();
+    makeBoundTree(tmp.path);
+    const snapshot = await runAndCapture(
+      tmp.path,
+      [],
+      { headSha: "aa".repeat(20) },
+      [],
+    );
+    assertOrUpdate(snapshot, FIXTURE_PATH_ZERO);
+  });
+
+  it("captures the existing-PR short-circuit: skipReason set, no push/create for matched group", async () => {
+    // Scenario: one source PR has commits to sync, but a tree PR for that source
+    // PR already exists (matched via `gh pr list --search`). sync.ts must skip
+    // the push/create path for that group. Repo-gardener depends on this
+    // idempotency — rerunning sync must not open duplicate tree PRs.
+    const tmp = useTmpDir();
+    makeBoundTree(tmp.path);
+    const snapshot = await runAndCapture(
+      tmp.path,
+      [
+        JSON.stringify([
+          {
+            path: "pkg-a",
+            type: "TREE_MISS",
+            target_node_path: null,
+            rationale: "No node for pkg-a",
+            suggested_node_title: "pkg-a",
+            suggested_node_body_markdown: "# pkg-a",
+          },
+        ]),
+        JSON.stringify([
+          {
+            path: "pkg-b",
+            type: "TREE_MISS",
+            target_node_path: null,
+            rationale: "No node for pkg-b",
+            suggested_node_title: "pkg-b",
+            suggested_node_body_markdown: "# pkg-b",
+          },
+        ]),
+      ],
+      { existingTreePrsBySearch: [{ number: 777 }] },
+      ["pkg-a", "pkg-b"],
+    );
+    assertOrUpdate(snapshot, FIXTURE_PATH_EXISTING);
   });
 });


### PR DESCRIPTION
## Summary

Extends the sync golden-snapshot harness with the two remaining fixture scenarios bingran named on #167 (2026-04-17T23:18:08Z signoff with calibrations):

- **`zero-changes.json`** — source HEAD already matches `lastReconciledSourceCommit`; sync short-circuits with \"up to date\", creates nothing.
- **`existing-pr.json`** — a tree PR already exists for each source PR (via `gh pr list --search`); sync sets `skipReason`, no push/create happens for the matched groups.

Happy two-PR fixture already landed under #167's Phase 0.a.

Both scenarios are **idempotency paths** repo-gardener relies on. Drift in either during the Phase 3 `openTreePr` refactor would silently cause repo-gardener's scheduled runs to either skip real work or open duplicate tree PRs.

## Implementation notes

- `makeRecordingShell` now accepts a `ShellOverrides` object (`compareCommits`, `mergedPrItems`, `existingTreePrsBySearch`, `headSha`) so all three scenarios compose from the same mock without forking.
- Added `tests/fixtures/sync-golden/README.md` with the \"changing these files requires repo-gardener coordination\" header per bingran's update-workflow calibration.

## Tripwire verification

Renamed `housekeeping` → `HOUSEKEEP` in `sync.ts:1754`. The two-PR fixture trips, as expected. (zero-changes and existing-PR don't reach the housekeeping branch, so they only flag on changes to the code paths they exercise — each fixture is a focused tripwire.)

## Test plan

- [x] `pnpm vitest run tests/tree/sync-golden-snapshot.test.ts` → 3/3 pass
- [x] Replay mode (no `UPDATE_SYNC_GOLDEN`) passes deterministically
- [x] Typecheck clean
- [x] Tripwire verified (see above)

Closes #167. Unblocks the Phase 3 refactor of `sync.ts` (#162 step 4 / task #30) — factoring `openTreePr` out of `pushAndCreatePr` can now land with the snapshot suite as a safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)