### PR TITLE
fix(sync): housekeeping owns parent NODE.md rollup (closes #189, fixes #188)

### DIFF
--- a/src/products/tree/engine/sync.ts
+++ b/src/products/tree/engine/sync.ts
@@ -982,6 +982,11 @@ interface PreparedProposalGroup {
  * This must be done sequentially because git checkout requires exclusive access.
  * Returns the branch name and PR metadata for the push/create phase.
  */
+interface ParentSubDomainAddition {
+  dirName: string;
+  title: string;
+}
+
 async function prepareProposalGroup(
   shellRun: ShellRun,
   treeRoot: string,
@@ -990,6 +995,7 @@ async function prepareProposalGroup(
   group: ProposalGroup,
   baseRef: string,
   verifyTree: (treeRoot: string) => number | Promise<number>,
+  pendingParentAdditions: Map<string, ParentSubDomainAddition[]>,
 ): Promise<PreparedProposalGroup | null> {
   const shortSha = drift.toSha.slice(0, 7);
   const branchSuffix = group.sourcePrNumber !== null
@@ -1095,31 +1101,20 @@ async function prepareProposalGroup(
         writeFileSync(nodePath, content);
         writtenFiles.push(nodePath);
 
-        // Update parent NODE.md sub-domains list if the new dir isn't listed.
-        // If the parent has no Sub-domains section at all, append one so the
-        // child is discoverable via top-down tree navigation (#122).
+        // Queue the parent NODE.md `## Sub-domains` update for the
+        // housekeeping branch (#188). Per-content branches all fork from
+        // the same baseRef, so writing the parent here would make each
+        // branch's edit conflict with siblings at merge time. The
+        // housekeeping branch runs last and can batch every sibling's
+        // rollup in one idempotent pass.
         const parentNodePath = join(dirname(absDir), "NODE.md");
         if (existsSync(parentNodePath)) {
-          try {
-            const parentContent = readFileSync(parentNodePath, "utf-8");
-            const newDirName = basename(absDir);
-            const alreadyListed = parentContent.includes(`${newDirName}/`) || parentContent.includes(`${newDirName}\\`);
-            if (!alreadyListed) {
-              const newLine = `- \`${newDirName}/\` — ${capitalizedTitle}\n`;
-              const subDomainsMatch = parentContent.match(/(##\s*Sub-?domains?[^\n]*\n)([\s\S]*?)(\n##|\n---|\z)/i);
-              let updated: string | null = null;
-              if (subDomainsMatch) {
-                const insertPoint = parentContent.indexOf(subDomainsMatch[0]) + subDomainsMatch[1].length + subDomainsMatch[2].length;
-                updated = parentContent.slice(0, insertPoint) + newLine + parentContent.slice(insertPoint);
-              } else {
-                const trimmed = parentContent.replace(/\s+$/, "");
-                updated = `${trimmed}\n\n## Sub-domains\n\n${newLine}`;
-              }
-              writeFileSync(parentNodePath, updated);
-              writtenFiles.push(parentNodePath);
-              console.log(`  \u2713 Updated parent: ${relative(treeRoot, parentNodePath)} (added ${newDirName}/)`);
-            }
-          } catch { /* non-fatal */ }
+          const newDirName = basename(absDir);
+          const list = pendingParentAdditions.get(parentNodePath) ?? [];
+          if (!list.some((a) => a.dirName === newDirName)) {
+            list.push({ dirName: newDirName, title: capitalizedTitle });
+          }
+          pendingParentAdditions.set(parentNodePath, list);
         }
       }
     }
@@ -1678,6 +1673,10 @@ export async function runSync(
           `\nPreparing ${applyCount} tree PR(s) (creating branches, committing locally)...`,
         );
         const preparedGroups: PreparedProposalGroup[] = [];
+        // Accumulator for parent NODE.md `## Sub-domains` rollups across all
+        // content groups in this drift (#188). Applied in the housekeeping
+        // branch so sibling content PRs don't collide on the same parent file.
+        const pendingParentAdditions = new Map<string, ParentSubDomainAddition[]>();
         const originalRef = await resolveStableCheckoutRef(shellRun, repo.root);
         if (originalRef === null) {
           return 1;
@@ -1699,6 +1698,7 @@ export async function runSync(
             group,
             originalRef,
             verifyTree,
+            pendingParentAdditions,
           );
           if (prepared === null) {
             // Fatal error during preparation
@@ -1765,11 +1765,60 @@ export async function runSync(
             lastReconciledAt: now().toISOString(),
           });
 
+          // Apply accumulated parent NODE.md `## Sub-domains` rollups here,
+          // on the housekeeping branch (#188). Per-content branches used to
+          // do this in-place and collide at merge time; centralizing here
+          // makes the rollup idempotent (re-reads parent at current main
+          // HEAD, skips already-listed children) and structurally
+          // conflict-free (housekeeping merges last by design).
+          const appliedRollups: string[] = [];
+          for (const [parentPath, additions] of pendingParentAdditions) {
+            if (!existsSync(parentPath)) continue;
+            try {
+              let parentContent = readFileSync(parentPath, "utf-8");
+              let changed = false;
+              for (const { dirName, title } of additions) {
+                const alreadyListed = parentContent.includes(`${dirName}/`)
+                  || parentContent.includes(`${dirName}\\`);
+                if (alreadyListed) continue;
+                const newLine = `- \`${dirName}/\` — ${title}\n`;
+                const subDomainsMatch = parentContent.match(/(##\s*Sub-?domains?[^\n]*\n)([\s\S]*?)(\n##|\n---|\z)/i);
+                if (subDomainsMatch) {
+                  const insertPoint = parentContent.indexOf(subDomainsMatch[0])
+                    + subDomainsMatch[1].length
+                    + subDomainsMatch[2].length;
+                  parentContent = parentContent.slice(0, insertPoint) + newLine + parentContent.slice(insertPoint);
+                } else {
+                  const trimmed = parentContent.replace(/\s+$/, "");
+                  parentContent = `${trimmed}\n\n## Sub-domains\n\n${newLine}`;
+                }
+                changed = true;
+                appliedRollups.push(`${relative(repo.root, parentPath)} ← ${dirName}/`);
+              }
+              if (changed) {
+                writeFileSync(parentPath, parentContent);
+                console.log(`  \u2713 Housekeeping rollup: ${relative(repo.root, parentPath)}`);
+              }
+            } catch { /* non-fatal */ }
+          }
+
           await shellRun("git", ["add", "-A"], { cwd: repo.root });
           const hkDiff = await shellRun("git", ["diff", "--cached", "--quiet"], { cwd: repo.root });
           if (hkDiff.code !== 0) {
             await shellRun("git", ["commit", "-m", `chore(sync): pin ${drift.binding.sourceId} to ${drift.toSha.slice(0, 7)}`], { cwd: repo.root });
             await shellRun("git", ["push", "origin", "HEAD"], { cwd: repo.root });
+            const rollupBody = appliedRollups.length > 0
+              ? [
+                  "",
+                  "## Sub-domains rollup",
+                  "",
+                  "This run introduced new child nodes; parent `NODE.md` navigation",
+                  "sections are updated here (not in per-content branches) to avoid",
+                  "merge conflicts between sibling sync PRs (#188).",
+                  "",
+                  ...appliedRollups.map((r) => `- ${r}`),
+                ].join("\n")
+              : "";
             const hkPr = await shellRun("gh", [
               "pr", "create",
               "--title", `chore(sync): housekeeping for ${drift.binding.sourceId}`,
@@ -1781,6 +1830,7 @@ export async function runSync(
                 `Pins \`lastReconciledSourceCommit\` to \`${drift.toSha.slice(0, 7)}\`.`,
                 "",
                 "CODEOWNERS is regenerated inside each content PR, so no CODEOWNERS diff is expected here.",
+                rollupBody,
               ].join("\n"),
             ], { cwd: repo.root });
             if (hkPr.code === 0) {

--- a/tests/fixtures/sync-golden/two-pr-apply.json
+++ b/tests/fixtures/sync-golden/two-pr-apply.json
@@ -126,14 +126,6 @@
       "command": "git",
       "args": [
         "add",
-        "<TREE_ROOT>/NODE.md"
-      ],
-      "cwdLabel": "<tree-root>"
-    },
-    {
-      "command": "git",
-      "args": [
-        "add",
         "<TREE_ROOT>/.github/CODEOWNERS"
       ],
       "cwdLabel": "<tree-root>"
@@ -185,14 +177,6 @@
       "args": [
         "add",
         "<TREE_ROOT>/pkg-b/NODE.md"
-      ],
-      "cwdLabel": "<tree-root>"
-    },
-    {
-      "command": "git",
-      "args": [
-        "add",
-        "<TREE_ROOT>/NODE.md"
       ],
       "cwdLabel": "<tree-root>"
     },
@@ -379,7 +363,7 @@
         "--title",
         "chore(sync): housekeeping for source-golden",
         "--body",
-        "<BODY_HASH:ad8c287fdfc5d99a>"
+        "<BODY_HASH:fb363870ba1f9505>"
       ],
       "cwdLabel": "<tree-root>"
     },
@@ -398,7 +382,7 @@
     "pr-body::first-tree/sync-source-golden-pr101": "e51af67dddca1c20",
     "pr-body::first-tree/sync-source-golden-pr102": "b0f4343e58e66ccb",
     "commit-msg::2": "6dde9c54721fee28",
-    "pr-body::title:chore(sync): housekeeping for source-golden": "ad8c287fdfc5d99a"
+    "pr-body::title:chore(sync): housekeeping for source-golden": "fb363870ba1f9505"
   },
   "nodeMdFiles": {
     "pkg-a": "d27a7d643355409c",

--- a/tests/tree/sync.test.ts
+++ b/tests/tree/sync.test.ts
@@ -1326,6 +1326,12 @@ describe("sync -- PR labeling", () => {
       if (command === "gh" && args[0] === "pr" && args[1] === "list") {
         return { stdout: "[]", stderr: "", code: 0 };
       }
+      if (command === "gh" && args[0] === "pr" && args[1] === "create") {
+        return { stdout: "https://example/pr/1", stderr: "", code: 0 };
+      }
+      if (command === "gh" && (args[0] === "pr" || args[0] === "label")) {
+        return { stdout: "", stderr: "", code: 0 };
+      }
       if (command === "git") {
         if (args[0] === "symbolic-ref") {
           return { stdout: "main\n", stderr: "", code: 0 };
@@ -1337,9 +1343,11 @@ describe("sync -- PR labeling", () => {
       }
       return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
     };
+    // Parent Sub-domains updates now land in the housekeeping branch (#188),
+    // not per-content-branch, so run with dryRun: false to exercise it.
     const code = await runSync(
       tmp.path,
-      { source: undefined, propose: false, apply: true, dryRun: true },
+      { source: undefined, propose: false, apply: true, dryRun: false },
       { shellRun, verifyTree: () => 0 },
     );
     expect(code).toBe(0);
@@ -1921,6 +1929,188 @@ describe("sync -- PR labeling", () => {
 
     expect(code).toBe(0);
     expect(prCreateCalls).toHaveLength(0);
+  });
+
+  it("does not stage parent NODE.md in per-content-branch git add calls (#188)", async () => {
+    // Regression for #188: two source PRs both add new child dirs under
+    // `engineering/`. Both per-content branches (fork from same baseRef)
+    // were appending to `engineering/NODE.md` Sub-domains — whichever
+    // merged second hit a conflict.
+    //
+    // Fix per #189 / bingran option B: parent Sub-domains edits move to
+    // the housekeeping branch. Per-content branches must only stage
+    // their own child NODE.md (+ regenerated CODEOWNERS).
+    const tmp = useTmpDir();
+    makeTreeShell(tmp.path);
+    mkdirSync(join(tmp.path, "engineering"), { recursive: true });
+    writeFileSync(
+      join(tmp.path, "engineering", "NODE.md"),
+      "---\ntitle: Engineering\nowners: [alice]\n---\n# Engineering\n",
+    );
+    const fromSha = "aa".repeat(20);
+    const toSha = "bb".repeat(20);
+    writeTreeBinding(tmp.path, "source-conflict", {
+      bindingMode: "standalone-source",
+      entrypoint: "/repos/source",
+      lastReconciledSourceCommit: fromSha,
+      remoteUrl: "https://github.com/alice/source.git",
+      rootKind: "git-repo",
+      scope: "repo",
+      sourceId: "source-conflict",
+      sourceName: "source",
+      sourceRootPath: "../source",
+      treeMode: "dedicated",
+      treeRepoName: "tree",
+    });
+
+    // Track which branch is currently checked out so we can bucket
+    // `git add <file>` calls by branch. `git checkout -B <branch> <ref>`
+    // is how sync.ts enters a content branch; we snoop the first arg
+    // after `-B`.
+    let currentBranch: string = "main";
+    const addCallsByBranch: Record<string, string[]> = {};
+
+    const classifyResponses = [
+      JSON.stringify([{
+        path: "engineering/mcp",
+        type: "TREE_MISS",
+        target_node_path: null,
+        rationale: "New MCP area",
+        suggested_node_title: "MCP",
+        suggested_node_body_markdown: "# MCP\n",
+      }]),
+      JSON.stringify([{
+        path: "engineering/router",
+        type: "TREE_MISS",
+        target_node_path: null,
+        rationale: "New router area",
+        suggested_node_title: "Router",
+        suggested_node_body_markdown: "# Router\n",
+      }]),
+    ];
+    let classifyIdx = 0;
+
+    const shellRun: ShellRun = async (command, args) => {
+      if (command === "gh" && args[0] === "auth") return okAuth();
+      if (command === "claude" && args[0] === "--version") return claudeVersionOk();
+      if (command === "gh" && args[0] === "api") {
+        const path = args[1] ?? "";
+        if (path === "/repos/alice/source/commits/HEAD") {
+          return { stdout: `${toSha}\n`, stderr: "", code: 0 };
+        }
+        if (path.startsWith("/repos/alice/source/compare/")) {
+          return {
+            stdout: JSON.stringify({
+              commits: [
+                {
+                  sha: "1".repeat(40),
+                  commit: {
+                    message: "feat(mcp): add (#201)",
+                    author: { name: "a", date: "2026-04-01T00:00:00Z" },
+                  },
+                  files: [{ filename: "engineering/mcp/x.ts" }],
+                },
+                {
+                  sha: "2".repeat(40),
+                  commit: {
+                    message: "feat(router): add (#202)",
+                    author: { name: "b", date: "2026-04-02T00:00:00Z" },
+                  },
+                  files: [{ filename: "engineering/router/y.ts" }],
+                },
+              ],
+            }),
+            stderr: "",
+            code: 0,
+          };
+        }
+        if (path.startsWith("search/issues")) {
+          return {
+            stdout: JSON.stringify({
+              items: [
+                {
+                  number: 201,
+                  title: "feat(mcp): add",
+                  pull_request: { merged_at: "2026-04-01T00:00:00Z", merge_commit_sha: "1".repeat(40) },
+                },
+                {
+                  number: 202,
+                  title: "feat(router): add",
+                  pull_request: { merged_at: "2026-04-02T00:00:00Z", merge_commit_sha: "2".repeat(40) },
+                },
+              ],
+            }),
+            stderr: "",
+            code: 0,
+          };
+        }
+      }
+      if (command === "claude" && args[0] === "-p") {
+        const resp = classifyResponses[classifyIdx] ?? classifyResponses[0];
+        classifyIdx += 1;
+        return { stdout: resp, stderr: "", code: 0 };
+      }
+      if (command === "gh" && args[0] === "pr" && args[1] === "list") {
+        return { stdout: "[]", stderr: "", code: 0 };
+      }
+      if (command === "gh" && args[0] === "pr" && args[1] === "create") {
+        return { stdout: "https://example/pr/1", stderr: "", code: 0 };
+      }
+      if (command === "gh" && (args[0] === "pr" || args[0] === "label")) {
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      if (command === "git") {
+        if (args[0] === "symbolic-ref") return { stdout: "main\n", stderr: "", code: 0 };
+        if (args[0] === "checkout" && args[1] === "-B" && typeof args[2] === "string") {
+          currentBranch = args[2];
+        } else if (args[0] === "checkout" && typeof args[1] === "string" && args[1] !== "-B") {
+          currentBranch = args[1];
+        }
+        if (args[0] === "add" && args[1] !== "-A" && typeof args[1] === "string") {
+          addCallsByBranch[currentBranch] ??= [];
+          addCallsByBranch[currentBranch].push(args[1]);
+        }
+        if (args.includes("diff") && args.includes("--cached") && args.includes("--quiet")) {
+          return { stdout: "", stderr: "", code: 1 };
+        }
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
+    };
+
+    const code = await runSync(
+      tmp.path,
+      { source: undefined, propose: false, apply: true, dryRun: false },
+      { shellRun, verifyTree: () => 0 },
+    );
+    expect(code).toBe(0);
+
+    // Collect per-content-branch `git add <file>` calls (exclude housekeeping).
+    const contentBranches = Object.keys(addCallsByBranch).filter(
+      (b) => b.startsWith("first-tree/sync-") && !b.endsWith("-housekeeping"),
+    );
+    expect(contentBranches.length).toBeGreaterThanOrEqual(2);
+
+    // The fix: no content branch should `git add engineering/NODE.md`.
+    // That parent edit now lives on the housekeeping branch.
+    const parentRel = join("engineering", "NODE.md");
+    for (const branch of contentBranches) {
+      const staged = addCallsByBranch[branch] ?? [];
+      const stagedParent = staged.filter(
+        (p) => p === join(tmp.path, parentRel) || p === parentRel,
+      );
+      expect(
+        stagedParent,
+        `content branch ${branch} must not stage parent ${parentRel}; staged: ${staged.join(", ")}`,
+      ).toEqual([]);
+    }
+
+    // And the parent file on disk (housekeeping branch is the last checkout)
+    // should still reflect BOTH new children — housekeeping did the rollup.
+    const parentText = readFileSync(join(tmp.path, "engineering", "NODE.md"), "utf-8");
+    expect(parentText).toMatch(/## Sub-domains/);
+    expect(parentText).toContain("`mcp/`");
+    expect(parentText).toContain("`router/`");
   });
 });
 


### PR DESCRIPTION
## Summary

- Closes #189 (implementation), fixes #188 (structural conflict)
- Per-content sync branches all fork from the same `baseRef`, so any two sibling PRs that add children under the same parent (e.g. `engineering/mcp/` and `engineering/router/`) both appended to the parent `NODE.md`'s `## Sub-domains` list — a content-vs-content merge conflict, not probabilistic.
- Per bingran's **option B**: accumulate `pendingParentAdditions: Map<parentPath, ParentSubDomainAddition[]>` during prepare; apply rollups in the housekeeping branch, which runs last and already owns binding-pin updates. Idempotent via `alreadyListed` substring check so re-sync doesn't duplicate entries.

## What changes

- `src/products/tree/engine/sync.ts`
  - New `ParentSubDomainAddition` interface.
  - `prepareProposalGroup` gains a `pendingParentAdditions` param; replaces the in-place parent NODE.md write at the old sync.ts:1098-1123 with accumulation.
  - Housekeeping branch applies all queued rollups (after `writeTreeBinding`, before `git add -A`) with idempotent substring check and logs `✓ Housekeeping rollup: <parent>`.
  - Housekeeping PR body now includes a `## Sub-domains rollup` section when rollups apply.

- `tests/tree/sync.test.ts`
  - New failing-first E2E: `does not stage parent NODE.md in per-content-branch git add calls (#188)`. Tracks `git checkout -B <branch>` + `git add <file>` to bucket stages per branch; asserts content branches never stage `engineering/NODE.md` and the housekeeping pass does the rollup.
  - Updated the pre-existing #122 test (`creates a Sub-domains section on parent NODE.md when missing`) to `dryRun: false` so it exercises housekeeping (plus added the `gh pr create` / `gh pr` / `gh label` handlers its shell mock now needs).

- `tests/fixtures/sync-golden/two-pr-apply.json` — **intentional regeneration**, per the README workflow:
  - Removed the two per-content `git add <TREE_ROOT>/NODE.md` entries (no longer happens in per-PR branches).
  - Housekeeping PR body hash: `ad8c287fdfc5d99a` → `fb363870ba1f9505` (now contains the `## Sub-domains rollup` section).
  - `zero-changes.json` and `existing-pr.json` unchanged (neither reaches housekeeping).
  - This was predicted in bingran's #187 review: *"when #188 gets fixed, the two-PR fixture's bodyHashes will shift because the parent `## Sub-domains` edit moves out of per-PR branches into housekeeping. Regenerate via `UPDATE_SYNC_GOLDEN=1` in the #188 fix PR and flag it explicitly in the PR body per the README workflow."*

## Test plan

- [x] `pnpm vitest run tests/tree/sync.test.ts` — 26/26 green (new #188 test passes; #122 still passes after refactor)
- [x] `pnpm typecheck` — clean
- [x] `pnpm vitest run tests/tree/sync-golden-snapshot.test.ts` — 3/3 green after `UPDATE_SYNC_GOLDEN=1` regeneration
- [x] Reviewed fixture diff by hand — exactly two expected shifts

🤖 This PR was authored by a [Claude Code](https://claude.com/claude-code) agent.