### PR TITLE
refactor(sync): factor openTreePr primitive (closes #191, Phase 3 of #162)

### DIFF
--- a/src/products/tree/engine/open-tree-pr.ts
+++ b/src/products/tree/engine/open-tree-pr.ts
@@ -1,0 +1,69 @@
+import type { ShellRun } from "#products/tree/engine/sync.js";
+
+export interface OpenTreePrOpts {
+  branch: string;
+  title: string;
+  body: string;
+  labels?: string[];
+}
+
+export interface OpenTreePrResult {
+  success: boolean;
+  prUrl?: string;
+  error?: string;
+}
+
+/**
+ * Push a branch to origin and open a tree PR against the default base.
+ *
+ * Shared by `sync` (per-content and housekeeping PRs) and `respond`
+ * (rescued-from-merged-source flow). The shell-call envelope produced
+ * here is parsed by repo-gardener — see
+ * `tests/fixtures/sync-golden/README.md`. Changing the sequence or
+ * argv shape of git/gh invocations is a coordinated change.
+ */
+export async function openTreePr(
+  shellRun: ShellRun,
+  treeRoot: string,
+  opts: OpenTreePrOpts,
+): Promise<OpenTreePrResult> {
+  const { branch, title, body, labels } = opts;
+
+  const pushResult = await shellRun("git", ["push", "origin", branch], {
+    cwd: treeRoot,
+  });
+  if (pushResult.code !== 0) {
+    return { success: false, error: `git push failed: ${pushResult.stderr.trim()}` };
+  }
+
+  const prCreate = await shellRun(
+    "gh",
+    ["pr", "create", "--head", branch, "--title", title, "--body", body],
+    { cwd: treeRoot },
+  );
+  if (prCreate.code !== 0) {
+    const stderr = prCreate.stderr.trim();
+    if (
+      stderr.toLowerCase().includes("already exists")
+      || stderr.toLowerCase().includes("a pull request for branch")
+    ) {
+      return { success: true, prUrl: `(existing PR for ${branch})` };
+    }
+    return { success: false, error: `gh pr create failed: ${stderr}` };
+  }
+  const prUrl = prCreate.stdout.trim();
+
+  if (labels && labels.length > 0) {
+    for (const label of labels) {
+      await shellRun(
+        "gh",
+        ["label", "create", label, "--color", "2ea44f", "--description", `Created by first-tree sync`, "--force"],
+        { cwd: treeRoot },
+      );
+    }
+    const labelArgs = labels.flatMap((l) => ["--add-label", l]);
+    await shellRun("gh", ["pr", "edit", prUrl, ...labelArgs], { cwd: treeRoot });
+  }
+
+  return { success: true, prUrl };
+}

--- a/src/products/tree/engine/sync.ts
+++ b/src/products/tree/engine/sync.ts
@@ -21,6 +21,7 @@ import {
   type TreeBindingState,
 } from "#products/tree/engine/runtime/binding-state.js";
 import { resolveNodeOwners } from "../../../../assets/tree/helpers/generate-codeowners.js";
+import { openTreePr } from "#products/tree/engine/open-tree-pr.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -1229,53 +1230,21 @@ async function prepareProposalGroup(
 /**
  * Phase 2: Push branches and create PRs.
  * This can be parallelized because each branch is independent.
+ *
+ * Thin adapter over `openTreePr` that maps sync's `PreparedProposalGroup`
+ * to the primitive's option shape and applies the sync-specific label set.
  */
 async function pushAndCreatePr(
   shellRun: ShellRun,
   treeRoot: string,
   prepared: PreparedProposalGroup,
 ): Promise<{ success: boolean; prUrl?: string; error?: string }> {
-  const { branch, prTitle, prBody } = prepared;
-
-  // Push the branch
-  const pushResult = await shellRun("git", ["push", "origin", branch], {
-    cwd: treeRoot,
+  return openTreePr(shellRun, treeRoot, {
+    branch: prepared.branch,
+    title: prepared.prTitle,
+    body: prepared.prBody,
+    labels: ["first-tree:sync"],
   });
-  if (pushResult.code !== 0) {
-    return { success: false, error: `git push failed: ${pushResult.stderr.trim()}` };
-  }
-
-  // Create the PR
-  const prCreate = await shellRun(
-    "gh",
-    ["pr", "create", "--head", branch, "--title", prTitle, "--body", prBody],
-    { cwd: treeRoot },
-  );
-  if (prCreate.code !== 0) {
-    const stderr = prCreate.stderr.trim();
-    if (
-      stderr.toLowerCase().includes("already exists")
-      || stderr.toLowerCase().includes("a pull request for branch")
-    ) {
-      return { success: true, prUrl: `(existing PR for ${branch})` };
-    }
-    return { success: false, error: `gh pr create failed: ${stderr}` };
-  }
-  const prUrl = prCreate.stdout.trim();
-
-  // Add labels (best effort, don't fail if this doesn't work)
-  const labels = ["first-tree:sync"];
-  for (const label of labels) {
-    await shellRun(
-      "gh",
-      ["label", "create", label, "--color", "2ea44f", "--description", `Created by first-tree sync`, "--force"],
-      { cwd: treeRoot },
-    );
-  }
-  const labelArgs = labels.flatMap((l) => ["--add-label", l]);
-  await shellRun("gh", ["pr", "edit", prUrl, ...labelArgs], { cwd: treeRoot });
-
-  return { success: true, prUrl };
 }
 
 /**

--- a/tests/tree/open-tree-pr.test.ts
+++ b/tests/tree/open-tree-pr.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import { openTreePr } from "#products/tree/engine/open-tree-pr.js";
+import type { ShellResult, ShellRun } from "#products/tree/engine/sync.js";
+
+type Call = { command: string; args: string[] };
+
+function recordingShell(
+  handler: (c: Call) => ShellResult,
+): { shell: ShellRun; calls: Call[] } {
+  const calls: Call[] = [];
+  const shell: ShellRun = async (command, args) => {
+    calls.push({ command, args });
+    return handler({ command, args });
+  };
+  return { shell, calls };
+}
+
+describe("openTreePr", () => {
+  it("pushes, creates PR, and applies labels on happy path", async () => {
+    const { shell, calls } = recordingShell((c) => {
+      if (c.command === "git" && c.args[0] === "push") {
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      if (c.command === "gh" && c.args[0] === "pr" && c.args[1] === "create") {
+        return { stdout: "https://github.com/o/r/pull/42\n", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    });
+
+    const result = await openTreePr(shell, "/tree", {
+      branch: "first-tree/sync-abc",
+      title: "sync: abc",
+      body: "body",
+      labels: ["first-tree:sync"],
+    });
+
+    expect(result).toEqual({ success: true, prUrl: "https://github.com/o/r/pull/42" });
+
+    const kinds = calls.map((c) => `${c.command} ${c.args.slice(0, 2).join(" ")}`);
+    expect(kinds).toEqual([
+      "git push origin",
+      "gh pr create",
+      "gh label create",
+      "gh pr edit",
+    ]);
+
+    const prCreate = calls.find((c) => c.command === "gh" && c.args[1] === "create")!;
+    expect(prCreate.args).toEqual([
+      "pr", "create",
+      "--head", "first-tree/sync-abc",
+      "--title", "sync: abc",
+      "--body", "body",
+    ]);
+
+    const labelCreate = calls.find((c) => c.command === "gh" && c.args[0] === "label")!;
+    expect(labelCreate.args).toEqual([
+      "label", "create", "first-tree:sync",
+      "--color", "2ea44f",
+      "--description", "Created by first-tree sync",
+      "--force",
+    ]);
+
+    const prEdit = calls.find((c) => c.command === "gh" && c.args[1] === "edit")!;
+    expect(prEdit.args).toEqual([
+      "pr", "edit", "https://github.com/o/r/pull/42",
+      "--add-label", "first-tree:sync",
+    ]);
+  });
+
+  it("returns failure when git push fails", async () => {
+    const { shell, calls } = recordingShell((c) => {
+      if (c.command === "git" && c.args[0] === "push") {
+        return { stdout: "", stderr: "remote rejected\n", code: 1 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    });
+
+    const result = await openTreePr(shell, "/tree", {
+      branch: "b", title: "t", body: "y", labels: ["first-tree:sync"],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("git push failed");
+    expect(result.error).toContain("remote rejected");
+    expect(calls).toHaveLength(1);
+  });
+
+  it("treats 'already exists' as success and skips labels", async () => {
+    const { shell, calls } = recordingShell((c) => {
+      if (c.command === "git") return { stdout: "", stderr: "", code: 0 };
+      if (c.args[1] === "create") {
+        return { stdout: "", stderr: "a pull request for branch already exists", code: 1 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    });
+
+    const result = await openTreePr(shell, "/tree", {
+      branch: "b", title: "t", body: "y", labels: ["first-tree:sync"],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.prUrl).toBe("(existing PR for b)");
+    expect(calls.some((c) => c.command === "gh" && c.args[0] === "label")).toBe(false);
+    expect(calls.some((c) => c.command === "gh" && c.args[1] === "edit")).toBe(false);
+  });
+
+  it("skips label calls entirely when labels is omitted or empty", async () => {
+    const { shell, calls } = recordingShell((c) => {
+      if (c.command === "git") return { stdout: "", stderr: "", code: 0 };
+      if (c.args[1] === "create") return { stdout: "https://x/pr/1", stderr: "", code: 0 };
+      return { stdout: "", stderr: "", code: 0 };
+    });
+
+    const result = await openTreePr(shell, "/tree", {
+      branch: "b", title: "t", body: "y",
+    });
+
+    expect(result).toEqual({ success: true, prUrl: "https://x/pr/1" });
+    expect(calls.map((c) => c.command + " " + c.args[0] + " " + c.args[1])).toEqual([
+      "git push origin",
+      "gh pr create",
+    ]);
+  });
+
+  it("supports multiple custom labels", async () => {
+    const { shell, calls } = recordingShell((c) => {
+      if (c.command === "git") return { stdout: "", stderr: "", code: 0 };
+      if (c.args[1] === "create") return { stdout: "https://x/pr/1", stderr: "", code: 0 };
+      return { stdout: "", stderr: "", code: 0 };
+    });
+
+    await openTreePr(shell, "/tree", {
+      branch: "b", title: "t", body: "y",
+      labels: ["label-a", "label-b"],
+    });
+
+    const labelCreates = calls.filter((c) => c.command === "gh" && c.args[0] === "label");
+    expect(labelCreates.map((c) => c.args[2])).toEqual(["label-a", "label-b"]);
+
+    const prEdit = calls.find((c) => c.command === "gh" && c.args[1] === "edit")!;
+    expect(prEdit.args).toEqual([
+      "pr", "edit", "https://x/pr/1",
+      "--add-label", "label-a",
+      "--add-label", "label-b",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #191 — Phase 3 of the gardener↔sync integration per #162 (already signed off by bingran).
- Extracts the push/create/label dance from `pushAndCreatePr` into a caller-agnostic primitive, so Phase 5 `respond` wiring (#160) doesn't duplicate error handling or drift from the shell envelope repo-gardener parses.
- Zero behavior change for `sync --apply`. Golden fixtures unchanged.

## Shape

```ts
// src/products/tree/engine/open-tree-pr.ts
openTreePr(shellRun, treeRoot, { branch, title, body, labels? })
  → { success, prUrl?, error? }
```

- Existing-PR detection (`already exists` / `a pull request for branch`) lives in the primitive.
- Labels are optional — zero `gh label` calls when omitted. Sync passes `["first-tree:sync"]`; respond will pass its own set in Phase 5.
- Sync's `pushAndCreatePr` is now a thin adapter mapping `PreparedProposalGroup` → opts.
- Parallel runner and rate-limit retry wrapper untouched.

## Test plan

- [x] **Golden fixtures unchanged** — `pnpm vitest run tests/tree/sync-golden-snapshot.test.ts` 3/3 green with **no fixture regeneration**. Verified repo-gardener-visible envelope is byte-identical.
- [x] `pnpm vitest run tests/tree/sync.test.ts` — 25/25 green (this branch is off main; the 26th test lands with #190).
- [x] New `tests/tree/open-tree-pr.test.ts` — 5/5 green. Covers: happy path with exact argv, push failure, existing-PR short-circuit skipping labels, empty-labels skip, multiple custom labels.
- [x] `pnpm typecheck` clean.

## Why this is safe

The primitive preserves the exact call order and argv shape that repo-gardener parses: `git push origin <branch>` → `gh pr create --head --title --body` → (for each label) `gh label create ... --force` → `gh pr edit <url> --add-label <l> ...`. The golden fixture test is the safety net — it fails if anything shifts. It didn't fail.

🤖 This PR was authored by a [Claude Code](https://claude.com/claude-code) agent.