### PR TITLE
feat(gardener/comment): MERGED-PR → tree-repo issue (closes #193, Phase 2b of #162)

### DIFF
--- a/src/products/gardener/engine/comment.ts
+++ b/src/products/gardener/engine/comment.ts
@@ -102,7 +102,12 @@ export interface ShellResult {
 export type ShellRun = (
   command: string,
   args: string[],
-  options?: { cwd?: string; input?: string; timeout?: number },
+  options?: {
+    cwd?: string;
+    input?: string;
+    timeout?: number;
+    env?: NodeJS.ProcessEnv;
+  },
 ) => Promise<ShellResult>;
 
 export interface CommentDeps {
@@ -115,7 +120,12 @@ export interface CommentDeps {
 async function defaultShellRun(
   command: string,
   args: string[],
-  options: { cwd?: string; input?: string; timeout?: number } = {},
+  options: {
+    cwd?: string;
+    input?: string;
+    timeout?: number;
+    env?: NodeJS.ProcessEnv;
+  } = {},
 ): Promise<ShellResult> {
   try {
     const { stdout, stderr } = await execFileAsync(command, args, {
@@ -123,6 +133,7 @@ async function defaultShellRun(
       encoding: "utf-8",
       maxBuffer: 32 * 1024 * 1024,
       timeout: options.timeout,
+      env: options.env,
     });
     return { stdout: String(stdout), stderr: String(stderr), code: 0 };
   } catch (err) {
@@ -1062,9 +1073,308 @@ function emitBreezeResult(
   write: (line: string) => void,
   status: CommentStatus,
   summary: string,
+  extras?: Record<string, string>,
 ): void {
   const compact = summary.replace(/\s+/g, " ").trim() || "no-op";
-  write(`BREEZE_RESULT: status=${status} summary=${compact}`);
+  const extraPairs = extras
+    ? Object.entries(extras)
+        .map(([k, v]) => ` ${k}=${v.replace(/\s+/g, "_")}`)
+        .join("")
+    : "";
+  write(`BREEZE_RESULT: status=${status} summary=${compact}${extraPairs}`);
+}
+
+// ───────────────────────── MERGED → tree-repo issue ────────────────
+
+export interface HandleMergedIssueInput {
+  sourceRepo: string;
+  sourcePr: number;
+  sourcePrTitle: string;
+  /** The existing gardener-state comment on the source PR. */
+  gardenerCommentId: number;
+  gardenerCommentBody: string;
+  /** Tree repo slug `owner/name`. */
+  treeSlug: string;
+  /** Classifier output from the merged SHA (verdict + severity + nodes). */
+  verdict: Verdict;
+  severity: Severity;
+  summary: string;
+  treeNodes: { path: string; summary: string }[];
+  /** Resolved CODEOWNERS cc list, already @-prefixed. */
+  codeownersMentions: string[];
+  shell: ShellRun;
+  env: NodeJS.ProcessEnv;
+  write: (line: string) => void;
+  dryRun: boolean;
+}
+
+export type HandleMergedIssueOutcome =
+  | { kind: "created"; issueUrl: string; markerPatched: boolean }
+  | { kind: "skipped"; reason: string }
+  | { kind: "failed"; reason: string; issueUrl?: string };
+
+/**
+ * Creates a tree-repo issue for a merged source PR and PATCHes the
+ * source-PR gardener comment to mark the link. Called exactly once
+ * per merged source PR per scan from `reviewOne`.
+ *
+ * Contract (spec: #166, signed off on 2026-04-17):
+ *   - `TREE_REPO_TOKEN` is required on both tree-repo calls. No fallback
+ *     to ambient `gh` auth — unset → `skipped`.
+ *   - Marker is the sole source of truth for idempotency; caller must
+ *     already have checked `tree_issue_created` is absent from the
+ *     existing marker before invoking this function.
+ *   - No in-process retry. 401/403/404 on tree-repo calls → `skipped`
+ *     (treat as config error). 5xx/network → `failed`.
+ *   - On issue-create success + marker-PATCH failure, returns
+ *     `failed` but with `issueUrl` set so the caller logs it for
+ *     manual recovery.
+ */
+export async function handleMergedIssue(
+  input: HandleMergedIssueInput,
+): Promise<HandleMergedIssueOutcome> {
+  const {
+    sourceRepo,
+    sourcePr,
+    sourcePrTitle,
+    gardenerCommentId,
+    gardenerCommentBody,
+    treeSlug,
+    verdict,
+    severity,
+    summary,
+    treeNodes,
+    codeownersMentions,
+    shell,
+    env,
+    write,
+    dryRun,
+  } = input;
+
+  const treeRepoToken = env.TREE_REPO_TOKEN;
+  if (!treeRepoToken) {
+    return { kind: "skipped", reason: "TREE_REPO_TOKEN unset" };
+  }
+
+  const sourceCommentUrl =
+    `https://github.com/${sourceRepo}/pull/${sourcePr}#issuecomment-${gardenerCommentId}`;
+
+  const body = buildTreeIssueBody({
+    sourceRepo,
+    sourcePr,
+    sourcePrTitle,
+    sourceCommentUrl,
+    verdict,
+    severity,
+    summary,
+    treeNodes,
+    codeownersMentions,
+  });
+  const title = `[gardener] tree update needed for ${sourceRepo}#${sourcePr}`;
+
+  write(
+    `\u2712 merged ${sourceRepo}#${sourcePr}: creating tree issue on ${treeSlug}`,
+  );
+
+  if (dryRun) {
+    return { kind: "created", issueUrl: "(dry-run)", markerPatched: true };
+  }
+
+  const tokenEnv: NodeJS.ProcessEnv = { ...env, GH_TOKEN: treeRepoToken };
+
+  const createRes = await shell(
+    "gh",
+    ["issue", "create", "--repo", treeSlug, "--title", title, "--body", body],
+    { env: tokenEnv },
+  );
+  if (createRes.code !== 0) {
+    const stderr = createRes.stderr || "";
+    const isConfigError = /\b(401|403|404)\b/.test(stderr);
+    const reason = isConfigError
+      ? `tree-repo auth/access error (${stderr.split("\n")[0] || "401/403/404"})`
+      : `gh issue create failed: ${stderr.split("\n")[0] || "unknown"}`;
+    return isConfigError
+      ? { kind: "skipped", reason }
+      : { kind: "failed", reason };
+  }
+  const issueUrl = createRes.stdout.trim().split("\n").pop()?.trim() ?? "";
+
+  const newBody = withTreeIssueCreatedField(gardenerCommentBody, issueUrl);
+  if (!newBody) {
+    return {
+      kind: "failed",
+      reason: "marker not found on gardener comment — cannot PATCH",
+      issueUrl,
+    };
+  }
+
+  const patchRes = await shell(
+    "gh",
+    [
+      "api",
+      "-X",
+      "PATCH",
+      `/repos/${sourceRepo}/issues/comments/${gardenerCommentId}`,
+      "-f",
+      `body=${newBody}`,
+    ],
+    { env: tokenEnv },
+  );
+  if (patchRes.code !== 0) {
+    write(
+      `\u26A0 tree issue created at ${issueUrl} but marker PATCH failed — ` +
+        `record manually: ${patchRes.stderr.split("\n")[0] || "unknown error"}`,
+    );
+    return { kind: "failed", reason: "marker PATCH failed", issueUrl };
+  }
+
+  return { kind: "created", issueUrl, markerPatched: true };
+}
+
+/**
+ * Decide whether a MERGED source PR requires a tree-repo issue, and
+ * if so, run the create + marker-PATCH dance via `handleMergedIssue`.
+ *
+ * Returns:
+ *   - `null`  — fall through to the existing stale-skip (no gardener
+ *               marker, or marker already has `tree_issue_created`).
+ *   - a `{ status, summary }` shape when the merged branch took
+ *               responsibility for this PR (handled | skipped | failed).
+ */
+async function tryHandleMergedPr(input: {
+  sourceRepo: string;
+  sourcePr: number;
+  sourcePrTitle: string;
+  sourcePrDiff?: string;
+  sourcePrView?: PrView;
+  comments: IssueComment[];
+  gardenerUser: string;
+  treeRoot: string;
+  treeSlug?: string;
+  treeSha?: string;
+  classifier: Classifier;
+  shell: ShellRun;
+  env: NodeJS.ProcessEnv;
+  write: (line: string) => void;
+  dryRun: boolean;
+}): Promise<{ status: CommentStatus; summary: string } | null> {
+  const {
+    sourceRepo,
+    sourcePr,
+    sourcePrTitle,
+    sourcePrDiff,
+    sourcePrView,
+    comments,
+    gardenerUser,
+    treeRoot,
+    treeSlug,
+    treeSha,
+    classifier,
+    shell,
+    env,
+    write,
+    dryRun,
+  } = input;
+
+  const hasGardenerMarker = (b: string | undefined): boolean =>
+    typeof b === "string" && /<!--\s*gardener:/.test(b);
+  const gardenerComments = comments.filter(
+    (c) =>
+      (c.user?.login === gardenerUser || hasGardenerMarker(c.body)) &&
+      c.body && c.body.length > 0,
+  );
+  const latestState = gardenerComments
+    .filter((c) => extractStateMarker(c.body) !== null)
+    .sort((a, b) => (a.created_at ?? "").localeCompare(b.created_at ?? ""))
+    .pop();
+
+  if (!latestState || latestState.id === undefined) return null;
+  const parsed = parseStateMarker(latestState.body);
+  if (!parsed) return null;
+  if (parsed.treeIssueCreated) {
+    // Already linked — idempotent skip, but count it as handled so the
+    // trailer reflects that this PR was considered by the branch.
+    return {
+      status: "skipped",
+      summary: `merged #${sourcePr}: already linked to ${parsed.treeIssueCreated}`,
+    };
+  }
+
+  if (!treeSlug) {
+    return {
+      status: "skipped",
+      summary: `merged #${sourcePr}: tree_repo not configured`,
+    };
+  }
+
+  // Token gate — load-bearing. No fallback to ambient gh auth.
+  const treeRepoToken = env.TREE_REPO_TOKEN;
+  if (!treeRepoToken) {
+    return {
+      status: "skipped",
+      summary: `merged #${sourcePr}: TREE_REPO_TOKEN unset`,
+    };
+  }
+
+  const classification = await classifier({
+    type: "pr",
+    prView: sourcePrView,
+    diff: sourcePrDiff,
+    treeRoot,
+    treeSha,
+  });
+
+  const codeownersPath = join(treeRoot, ".github", "CODEOWNERS");
+  const codeownersText = existsSync(codeownersPath)
+    ? readFileSync(codeownersPath, "utf-8")
+    : "";
+  const mentions = new Set<string>();
+  for (const node of classification.treeNodes) {
+    for (const m of codeownersForPath(codeownersText, node.path)) {
+      mentions.add(m);
+    }
+  }
+
+  const outcome = await handleMergedIssue({
+    sourceRepo,
+    sourcePr,
+    sourcePrTitle,
+    gardenerCommentId: latestState.id,
+    gardenerCommentBody: latestState.body ?? "",
+    treeSlug,
+    verdict: classification.verdict,
+    severity: classification.severity,
+    summary: classification.summary,
+    treeNodes: classification.treeNodes,
+    codeownersMentions: Array.from(mentions),
+    shell,
+    env,
+    write,
+    dryRun,
+  });
+
+  if (outcome.kind === "created") {
+    write(
+      `\u2713 merged ${sourceRepo}#${sourcePr}: tree issue ${outcome.issueUrl}`,
+    );
+    return {
+      status: "handled",
+      summary: `merged #${sourcePr}: opened ${outcome.issueUrl}`,
+    };
+  }
+  if (outcome.kind === "skipped") {
+    write(`\u23ed merged ${sourceRepo}#${sourcePr}: ${outcome.reason}`);
+    return {
+      status: "skipped",
+      summary: `merged #${sourcePr}: ${outcome.reason}`,
+    };
+  }
+  const tail = outcome.issueUrl ? ` (issue: ${outcome.issueUrl})` : "";
+  write(`\u274c merged ${sourceRepo}#${sourcePr}: ${outcome.reason}${tail}`);
+  return {
+    status: "failed",
+    summary: `merged #${sourcePr}: ${outcome.reason}${tail}`,
+  };
 }
 
 // ───────────────────────── Single-item review ─────────────────────
@@ -1148,10 +1458,46 @@ async function reviewOne(
     return { status: "failed", summary: msg };
   }
 
-  // Freshness guard — skip merged/closed items (Step 4-pre).
+  // Freshness guard — handle merged/closed items.
+  //
+  // MERGED-PR branch (Phase 2b, #162/#166): if the source PR was
+  // merged with a `gardener:state` marker that has not yet been
+  // linked to a tree-repo issue, create the tree issue (gated on
+  // `TREE_REPO_TOKEN`) and PATCH the marker. Other MERGED paths —
+  // no marker, or marker already linked — fall through to the
+  // existing stale skip.
   const itemState = type === "pr"
     ? bundle.prView?.state
     : bundle.issueView?.state;
+  if (type === "pr" && itemState === "MERGED") {
+    const mergedOutcome = await tryHandleMergedPr({
+      sourceRepo: repo,
+      sourcePr: number,
+      sourcePrTitle: bundle.prView?.title ?? `#${number}`,
+      sourcePrDiff: bundle.diff,
+      sourcePrView: bundle.prView,
+      comments: bundle.issueComments,
+      gardenerUser,
+      treeRoot,
+      treeSlug: opts.treeSlug,
+      treeSha: opts.treeSha ?? bundle.subject.treeSha,
+      classifier,
+      shell,
+      env,
+      write,
+      dryRun,
+    });
+    if (mergedOutcome) {
+      logEvent(env, {
+        kind: "merged_issue",
+        number,
+        status: mergedOutcome.status,
+        summary: mergedOutcome.summary,
+      });
+      return mergedOutcome;
+    }
+    // Otherwise fall through to stale skip.
+  }
   if (type === "pr" && (itemState === "MERGED" || itemState === "CLOSED")) {
     const msg = `#${number}: ${itemState} since scan, skipping`;
     write(`\u23ed ${msg}`);
@@ -1498,7 +1844,9 @@ export async function runComment(
         treeRepoUrl,
         treeSlug,
       });
-      emitBreezeResult(write, result.status, result.summary);
+      emitBreezeResult(write, result.status, result.summary, {
+        tree_repo_token: env.TREE_REPO_TOKEN ? "present" : "absent",
+      });
       return result.status === "failed" ? 1 : 0;
     }
 
@@ -1526,7 +1874,9 @@ export async function runComment(
       treeRepoUrl,
       treeSlug,
     });
-    emitBreezeResult(write, result.status, result.summary);
+    emitBreezeResult(write, result.status, result.summary, {
+      tree_repo_token: env.TREE_REPO_TOKEN ? "present" : "absent",
+    });
     return result.status === "failed" ? 1 : 0;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/tests/gardener/gardener-comment.test.ts
+++ b/tests/gardener/gardener-comment.test.ts
@@ -1238,3 +1238,377 @@ describe("gardener comment -- Phase 2a tree-issue primitives", () => {
     expect(body).toContain("(no tree nodes cited)");
   });
 });
+
+// ─────────────────── Phase 2b: MERGED → tree-repo issue ───────────────────
+
+describe("gardener comment -- MERGED-PR scan branch (#193, Phase 2b of #162)", () => {
+  // Shared fixture: a merged source PR with an existing gardener:state
+  // marker comment that has no `tree_issue_created` field yet.
+  function writeMergedSnapshot(
+    snapshotDir: string,
+    opts: { markerExtras?: string } = {},
+  ): void {
+    mkdirSync(snapshotDir, { recursive: true });
+    writeFileSync(
+      join(snapshotDir, "pr-view.json"),
+      JSON.stringify({
+        number: 42,
+        title: "feat: add thing",
+        headRefOid: "dead1234",
+        state: "MERGED",
+        author: { login: "someone" },
+        additions: 10,
+        deletions: 0,
+        updatedAt: "2026-04-16T00:00:00Z",
+      }),
+    );
+    const markerSuffix = opts.markerExtras ? ` · ${opts.markerExtras}` : "";
+    writeFileSync(
+      join(snapshotDir, "issue-comments.json"),
+      JSON.stringify([
+        {
+          id: 9001,
+          user: { login: "repo-gardener" },
+          created_at: "2026-04-15T00:00:00Z",
+          body:
+            `<!-- gardener:state · reviewed=dead1234 · verdict=NEW_TERRITORY ` +
+            `· severity=medium · tree_sha=tsha1234${markerSuffix} -->\n\n` +
+            `🌱 **gardener** · NEW_TERRITORY\n`,
+        },
+      ]),
+    );
+    writeFileSync(
+      join(snapshotDir, "subject.json"),
+      JSON.stringify({ gardenerUser: "repo-gardener", treeSha: "tsha1234" }),
+    );
+    writeFileSync(join(snapshotDir, "pr.diff"), "");
+  }
+
+  const mergedClassifier: Classifier = async () => ({
+    verdict: "NEW_TERRITORY",
+    severity: "medium",
+    summary: "Introduces a new area not covered by the tree.",
+    treeNodes: [{ path: "product/NODE.md", summary: "product scope" }],
+  });
+
+  it("TREE_REPO_TOKEN unset → skipped with tree_repo_token=absent trailer", async () => {
+    const tmp = useTmpDir();
+    const snapshotDir = join(tmp.path, "snap");
+    writeMergedSnapshot(snapshotDir);
+    writeConfig(tmp.path, "tree_repo: o/tree\ntarget_repo: o/src\n");
+
+    const calls: ShellCall[] = [];
+    const shell = makeShell(
+      [() => ({ stdout: "", stderr: "", code: 0 })],
+      calls,
+    );
+    const { write, lines } = captureWrite();
+
+    const code = await runComment(
+      ["--pr", "42", "--repo", "o/src", "--tree-path", tmp.path],
+      {
+        shellRun: shell,
+        write,
+        env: { BREEZE_SNAPSHOT_DIR: snapshotDir },
+        classifier: mergedClassifier,
+      },
+    );
+
+    expect(code).toBe(0);
+    const trailer = lines[lines.length - 1];
+    expect(trailer).toMatch(/^BREEZE_RESULT: status=skipped /);
+    expect(trailer).toContain("tree_repo_token=absent");
+    expect(trailer).toContain("TREE_REPO_TOKEN");
+    expect(calls.some((c) => c.args.includes("create"))).toBe(false);
+  });
+
+  it("marker already has tree_issue_created → skipped, no issue-create call", async () => {
+    const tmp = useTmpDir();
+    const snapshotDir = join(tmp.path, "snap");
+    writeMergedSnapshot(snapshotDir, {
+      markerExtras: "tree_issue_created=https://github.com/o/tree/issues/7",
+    });
+    writeConfig(tmp.path, "tree_repo: o/tree\ntarget_repo: o/src\n");
+
+    const calls: ShellCall[] = [];
+    const shell = makeShell(
+      [() => ({ stdout: "", stderr: "", code: 0 })],
+      calls,
+    );
+    const { write, lines } = captureWrite();
+
+    const code = await runComment(
+      ["--pr", "42", "--repo", "o/src", "--tree-path", tmp.path],
+      {
+        shellRun: shell,
+        write,
+        env: {
+          BREEZE_SNAPSHOT_DIR: snapshotDir,
+          TREE_REPO_TOKEN: "tok-xyz",
+        },
+        classifier: mergedClassifier,
+      },
+    );
+
+    expect(code).toBe(0);
+    expect(lines[lines.length - 1]).toContain("already linked");
+    expect(calls.some((c) => c.args[0] === "issue")).toBe(false);
+    expect(calls.some((c) => c.args[1] === "PATCH")).toBe(false);
+  });
+
+  it("happy path: creates tree issue and PATCHes the source-PR marker", async () => {
+    const tmp = useTmpDir();
+    const snapshotDir = join(tmp.path, "snap");
+    writeMergedSnapshot(snapshotDir);
+    writeConfig(tmp.path, "tree_repo: o/tree\ntarget_repo: o/src\n");
+
+    const calls: ShellCall[] = [];
+    const shell = makeShell(
+      [
+        (call) => {
+          if (call.args[0] === "issue" && call.args[1] === "create") {
+            return {
+              stdout: "https://github.com/o/tree/issues/123\n",
+              stderr: "",
+              code: 0,
+            };
+          }
+          return null;
+        },
+        () => ({ stdout: "", stderr: "", code: 0 }),
+      ],
+      calls,
+    );
+    const { write, lines } = captureWrite();
+
+    const code = await runComment(
+      ["--pr", "42", "--repo", "o/src", "--tree-path", tmp.path],
+      {
+        shellRun: shell,
+        write,
+        env: {
+          BREEZE_SNAPSHOT_DIR: snapshotDir,
+          TREE_REPO_TOKEN: "tok-xyz",
+        },
+        classifier: mergedClassifier,
+      },
+    );
+
+    expect(code).toBe(0);
+
+    const issueCreate = calls.find(
+      (c) => c.args[0] === "issue" && c.args[1] === "create",
+    );
+    expect(issueCreate).toBeDefined();
+    expect(issueCreate!.args).toContain("--repo");
+    expect(issueCreate!.args).toContain("o/tree");
+    expect(issueCreate!.args).toContain("--title");
+    const titleIdx = issueCreate!.args.indexOf("--title");
+    expect(issueCreate!.args[titleIdx + 1]).toBe(
+      "[gardener] tree update needed for o/src#42",
+    );
+
+    const patch = calls.find(
+      (c) => c.args[0] === "api" && c.args[1] === "-X" && c.args[2] === "PATCH",
+    );
+    expect(patch).toBeDefined();
+    expect(patch!.args[3]).toBe("/repos/o/src/issues/comments/9001");
+    const bodyArg = patch!.args[5];
+    expect(bodyArg).toContain("body=");
+    expect(bodyArg).toContain(
+      "tree_issue_created=https://github.com/o/tree/issues/123",
+    );
+
+    const trailer = lines[lines.length - 1];
+    expect(trailer).toMatch(/^BREEZE_RESULT: status=handled /);
+    expect(trailer).toContain("tree_repo_token=present");
+    expect(trailer).toContain("https://github.com/o/tree/issues/123");
+  });
+
+  it("issue-create 404 → skipped (config error), no PATCH", async () => {
+    const tmp = useTmpDir();
+    const snapshotDir = join(tmp.path, "snap");
+    writeMergedSnapshot(snapshotDir);
+    writeConfig(tmp.path, "tree_repo: o/tree\ntarget_repo: o/src\n");
+
+    const calls: ShellCall[] = [];
+    const shell = makeShell(
+      [
+        (call) => {
+          if (call.args[0] === "issue" && call.args[1] === "create") {
+            return {
+              stdout: "",
+              stderr: "HTTP 404: Not Found (o/tree)",
+              code: 1,
+            };
+          }
+          return null;
+        },
+        () => ({ stdout: "", stderr: "", code: 0 }),
+      ],
+      calls,
+    );
+    const { write, lines } = captureWrite();
+
+    const code = await runComment(
+      ["--pr", "42", "--repo", "o/src", "--tree-path", tmp.path],
+      {
+        shellRun: shell,
+        write,
+        env: {
+          BREEZE_SNAPSHOT_DIR: snapshotDir,
+          TREE_REPO_TOKEN: "tok-xyz",
+        },
+        classifier: mergedClassifier,
+      },
+    );
+
+    expect(code).toBe(0);
+    expect(lines[lines.length - 1]).toMatch(/^BREEZE_RESULT: status=skipped /);
+    expect(lines[lines.length - 1]).toContain("tree_repo_token=present");
+    expect(calls.some((c) => c.args[1] === "PATCH")).toBe(false);
+  });
+
+  it("issue-create 503 → failed with issue URL absent", async () => {
+    const tmp = useTmpDir();
+    const snapshotDir = join(tmp.path, "snap");
+    writeMergedSnapshot(snapshotDir);
+    writeConfig(tmp.path, "tree_repo: o/tree\ntarget_repo: o/src\n");
+
+    const calls: ShellCall[] = [];
+    const shell = makeShell(
+      [
+        (call) => {
+          if (call.args[0] === "issue" && call.args[1] === "create") {
+            return {
+              stdout: "",
+              stderr: "HTTP 503: Service Unavailable",
+              code: 1,
+            };
+          }
+          return null;
+        },
+        () => ({ stdout: "", stderr: "", code: 0 }),
+      ],
+      calls,
+    );
+    const { write, lines } = captureWrite();
+
+    const code = await runComment(
+      ["--pr", "42", "--repo", "o/src", "--tree-path", tmp.path],
+      {
+        shellRun: shell,
+        write,
+        env: {
+          BREEZE_SNAPSHOT_DIR: snapshotDir,
+          TREE_REPO_TOKEN: "tok-xyz",
+        },
+        classifier: mergedClassifier,
+      },
+    );
+
+    expect(code).toBe(1);
+    expect(lines[lines.length - 1]).toMatch(/^BREEZE_RESULT: status=failed /);
+    expect(calls.some((c) => c.args[1] === "PATCH")).toBe(false);
+  });
+
+  it("create succeeds, PATCH fails → failed but logs issue URL for manual recovery", async () => {
+    const tmp = useTmpDir();
+    const snapshotDir = join(tmp.path, "snap");
+    writeMergedSnapshot(snapshotDir);
+    writeConfig(tmp.path, "tree_repo: o/tree\ntarget_repo: o/src\n");
+
+    const calls: ShellCall[] = [];
+    const shell = makeShell(
+      [
+        (call) => {
+          if (call.args[0] === "issue" && call.args[1] === "create") {
+            return {
+              stdout: "https://github.com/o/tree/issues/124\n",
+              stderr: "",
+              code: 0,
+            };
+          }
+          if (call.args[0] === "api" && call.args[1] === "-X" && call.args[2] === "PATCH") {
+            return { stdout: "", stderr: "HTTP 500", code: 1 };
+          }
+          return null;
+        },
+        () => ({ stdout: "", stderr: "", code: 0 }),
+      ],
+      calls,
+    );
+    const { write, lines } = captureWrite();
+
+    const code = await runComment(
+      ["--pr", "42", "--repo", "o/src", "--tree-path", tmp.path],
+      {
+        shellRun: shell,
+        write,
+        env: {
+          BREEZE_SNAPSHOT_DIR: snapshotDir,
+          TREE_REPO_TOKEN: "tok-xyz",
+        },
+        classifier: mergedClassifier,
+      },
+    );
+
+    expect(code).toBe(1);
+    expect(lines[lines.length - 1]).toMatch(/^BREEZE_RESULT: status=failed /);
+    // Issue URL must appear in log output so operators can recover.
+    expect(lines.some((l) => l.includes("https://github.com/o/tree/issues/124")))
+      .toBe(true);
+  });
+
+  it("MERGED PR without a gardener marker → falls through to existing stale skip", async () => {
+    const tmp = useTmpDir();
+    const snapshotDir = join(tmp.path, "snap");
+    mkdirSync(snapshotDir, { recursive: true });
+    writeFileSync(
+      join(snapshotDir, "pr-view.json"),
+      JSON.stringify({
+        number: 42,
+        title: "random merged PR",
+        headRefOid: "beef0000",
+        state: "MERGED",
+        author: { login: "someone" },
+        additions: 1,
+        deletions: 0,
+        updatedAt: "2026-04-16T00:00:00Z",
+      }),
+    );
+    writeFileSync(join(snapshotDir, "issue-comments.json"), JSON.stringify([]));
+    writeFileSync(
+      join(snapshotDir, "subject.json"),
+      JSON.stringify({ gardenerUser: "repo-gardener" }),
+    );
+    writeFileSync(join(snapshotDir, "pr.diff"), "");
+    writeConfig(tmp.path, "tree_repo: o/tree\ntarget_repo: o/src\n");
+
+    const calls: ShellCall[] = [];
+    const shell = makeShell(
+      [() => ({ stdout: "", stderr: "", code: 0 })],
+      calls,
+    );
+    const { write, lines } = captureWrite();
+
+    const code = await runComment(
+      ["--pr", "42", "--repo", "o/src", "--tree-path", tmp.path],
+      {
+        shellRun: shell,
+        write,
+        env: {
+          BREEZE_SNAPSHOT_DIR: snapshotDir,
+          TREE_REPO_TOKEN: "tok-xyz",
+        },
+        classifier: mergedClassifier,
+      },
+    );
+
+    expect(code).toBe(0);
+    expect(lines[lines.length - 1]).toMatch(/^BREEZE_RESULT: status=skipped /);
+    expect(lines.some((l) => l.includes("MERGED since scan"))).toBe(true);
+    expect(calls.some((c) => c.args[0] === "issue" && c.args[1] === "create"))
+      .toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #193 — Phase 2b of the gardener↔sync integration per #162. Spec of record: #166 (bingran-you signed off 2026-04-17).
- When \`reviewOne\` encounters a MERGED source PR that has a \`gardener:state\` marker but no \`tree_issue_created=\`, instead of skipping as stale: create a tree-repo issue via the already-landed \`buildTreeIssueBody\`, then PATCH the source-PR marker.
- Primitives from #174 (\`buildTreeIssueBody\`, \`withTreeIssueCreatedField\`, \`parseStateMarker\`, \`codeownersForPath\`) do the real work. This PR is the orchestration.

## Contract (locked in #166)

- **Token:** \`TREE_REPO_TOKEN\` required. **No fallback** to ambient \`gh\` auth. Unset → \`status=skipped\`.
- **Idempotency:** marker is the sole source of truth. No \`gh issue list --search\` pre-check. If marker already has \`tree_issue_created\`, skip with "already linked". Duplicate-issue edge accepted; URL is logged on marker-PATCH failure for manual recovery.
- **Retry:** none in-process. 401/403/404 → \`skipped\` (config error). 5xx/network → \`failed\`. Scan cadence is the retry loop.
- **Self-loop guard:** MERGED branch runs AFTER the \`first-tree:sync\` label check, so tree PRs never create tree issues about themselves.
- **BREEZE_RESULT trailer:** gains \`tree_repo_token=present|absent\` per bingran's ask.

## What changes

- \`src/products/gardener/engine/comment.ts\`:
  - \`ShellRun\` options gain an optional \`env\`, threaded through \`defaultShellRun\` so \`TREE_REPO_TOKEN\` can scope to tree-repo calls only.
  - \`emitBreezeResult\` accepts extra k/v pairs appended to the trailer; \`runComment\`'s two emit sites pass \`tree_repo_token=present|absent\`.
  - New exported \`handleMergedIssue\` primitive — narrow seam that does create + PATCH given classifier output and CODEOWNERS cc; caller has already done the marker-presence check.
  - New internal \`tryHandleMergedPr\` — glue that looks up the gardener comment, parses its marker, runs the classifier on the merged SHA, resolves CODEOWNERS from \`.github/CODEOWNERS\`, and calls \`handleMergedIssue\`. Returns \`null\` to fall through to the existing stale-skip.
  - MERGED branch in \`reviewOne\` runs \`tryHandleMergedPr\`, falling through on \`null\`.

- \`tests/gardener/gardener-comment.test.ts\` (+7 tests, total 74/74):
  - \`TREE_REPO_TOKEN\` unset → \`status=skipped\`, \`tree_repo_token=absent\`, no shell calls for issue-create.
  - marker already has \`tree_issue_created\` → \`skipped\` with "already linked", no create/PATCH calls.
  - happy path: \`gh issue create --repo tree/slug --title "[gardener] tree update needed for o/src#42" --body …\` → \`gh api -X PATCH /repos/o/src/issues/comments/9001\` with \`tree_issue_created=<url>\` appended; trailer \`status=handled tree_repo_token=present\`.
  - issue-create 404 → \`skipped\`, no PATCH.
  - issue-create 503 → \`failed\`.
  - create OK + PATCH fails → \`failed\`, issue URL printed to log for manual recovery.
  - MERGED PR with no gardener marker → existing stale-skip path untouched.

## Out of scope

- Sync-path \`openTreePr\` factoring (that's #191 / #192, landing separately).
- Tree-PR \`review_requested\` → \`respond\` wiring (that's Phase 5 / #160).
- Schedule / MCP dispatch.

## Test plan

- [x] \`pnpm typecheck\` clean.
- [x] \`pnpm vitest run tests/gardener/gardener-comment.test.ts\` — 74/74 green.
- [x] Full suite: 918/921 (3 pre-existing failures in \`skill-artifacts\` / \`breeze-daemon-launchd\` unrelated to this change; verified by running the same tests on stashed main).
- [ ] E2E smoke on a real MERGED source PR with a gardener marker — blocked on a live test environment with \`TREE_REPO_TOKEN\` available; recommend validating before merge.

🤖 This PR was authored by a [Claude Code](https://claude.com/claude-code) agent.