### PR TITLE
test: add release:check aggregator script

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "test": "vitest run",
     "eval": "vitest run --config vitest.eval.config.ts",
     "typecheck": "tsc --noEmit",
-    "validate:skill": "python3 ./scripts/quick_validate.py ./skills/first-tree && bash ./scripts/check-skill-sync.sh"
+    "validate:skill": "python3 ./scripts/quick_validate.py ./skills/first-tree && bash ./scripts/check-skill-sync.sh",
+    "release:check": "pnpm version:check && pnpm validate:skill && pnpm typecheck && pnpm test && pnpm build"
   },
   "packageManager": "pnpm@10.25.0",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
- Stage 1 of a six-stage "green = shippable" release-gate framework.
- Adds a single `pnpm release:check` that chains the five existing gates (`version:check`, `validate:skill`, `typecheck`, `test`, `build`) so any one failure aborts the whole run.
- No new tests yet — those arrive in later stages (dist smoke, tarball contents, clean-install smoke). `prepublishOnly` is deliberately deferred until stages 2–4 land.

## Test plan
- [x] `pnpm release:check` — runs each step in order; CI already runs the identical commands.
- [ ] Extended in later stages with `test:dist` and `test:release`.

https://claude.ai/code/session_01U5uJVMRpnQfr9C8mSV3s6a