### PR TITLE
test(dist): add post-build CLI smoke tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ Thumbs.db
 
 # Node.js
 node_modules/
-dist/
+/dist/
 *.tsbuildinfo
 .first-tree/local-tree.json
 .first-tree/tmp/

--- a/package.json
+++ b/package.json
@@ -47,11 +47,12 @@
     "build": "tsdown",
     "prepack": "pnpm build",
     "test:e2e": "vitest run tests/e2e/cli-e2e.test.ts",
+    "test:dist": "FIRST_TREE_DIST_TESTS=1 vitest run tests/dist",
     "test": "vitest run",
     "eval": "vitest run --config vitest.eval.config.ts",
     "typecheck": "tsc --noEmit",
     "validate:skill": "python3 ./scripts/quick_validate.py ./skills/first-tree && bash ./scripts/check-skill-sync.sh",
-    "release:check": "pnpm version:check && pnpm validate:skill && pnpm typecheck && pnpm test && pnpm build"
+    "release:check": "pnpm version:check && pnpm validate:skill && pnpm typecheck && pnpm test && pnpm build && pnpm test:dist"
   },
   "packageManager": "pnpm@10.25.0",
   "license": "Apache-2.0",

--- a/tests/dist/cli-binary.test.ts
+++ b/tests/dist/cli-binary.test.ts
@@ -1,0 +1,136 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const RUN = process.env.FIRST_TREE_DIST_TESTS === "1";
+const d = RUN ? describe : describe.skip;
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const DIST = join(REPO_ROOT, "dist");
+const CLI = join(DIST, "cli.js");
+const STATUSLINE = join(DIST, "breeze-statusline.js");
+
+function readPkgVersion(): string {
+  const pkg = JSON.parse(
+    readFileSync(join(REPO_ROOT, "package.json"), "utf-8"),
+  ) as { version: string; bin?: Record<string, string> };
+  return pkg.version;
+}
+
+function runNode(
+  args: string[],
+  opts: { env?: NodeJS.ProcessEnv } = {},
+): { code: number; stdout: string; stderr: string } {
+  const result = spawnSync(process.execPath, args, {
+    cwd: REPO_ROOT,
+    encoding: "utf-8",
+    env: { ...process.env, ...opts.env, FIRST_TREE_SKIP_VERSION_CHECK: "1" },
+  });
+  return {
+    code: result.status ?? 1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+d("dist/cli.js", () => {
+  beforeAll(() => {
+    if (!existsSync(CLI)) {
+      throw new Error(
+        `dist/cli.js missing. Run 'pnpm build' before 'pnpm test:dist'.`,
+      );
+    }
+  });
+
+  it("declares the expected bin entry in package.json", () => {
+    const pkg = JSON.parse(
+      readFileSync(join(REPO_ROOT, "package.json"), "utf-8"),
+    ) as { bin?: Record<string, string> };
+    expect(pkg.bin).toBeDefined();
+    expect(pkg.bin?.["first-tree"]).toBe("dist/cli.js");
+    expect(existsSync(join(REPO_ROOT, pkg.bin?.["first-tree"] ?? ""))).toBe(
+      true,
+    );
+  });
+
+  it("reports a version string that contains the package.json version", () => {
+    const { code, stdout } = runNode([CLI, "--version"]);
+    expect(code).toBe(0);
+    expect(stdout).toContain(`first-tree=${readPkgVersion()}`);
+  });
+
+  it("shows the top-level usage with all four namespaces", () => {
+    const { code, stdout } = runNode([CLI, "--help"]);
+    expect(code).toBe(0);
+    expect(stdout).toContain("first-tree <namespace>");
+    for (const ns of ["tree", "breeze", "gardener", "skill"]) {
+      expect(stdout).toContain(ns);
+    }
+  });
+
+  it.each(["tree", "breeze", "gardener", "skill"])(
+    "boots the %s namespace help without error",
+    (ns) => {
+      const { code, stdout } = runNode([CLI, ns, "--help"]);
+      expect(code).toBe(0);
+      expect(stdout).toContain(`first-tree ${ns}`);
+    },
+  );
+
+  it("exits non-zero on an unknown namespace", () => {
+    const { code } = runNode([CLI, "not-a-namespace"]);
+    expect(code).not.toBe(0);
+  });
+});
+
+d("dist/breeze-statusline.js", () => {
+  beforeAll(() => {
+    if (!existsSync(STATUSLINE)) {
+      throw new Error(
+        `dist/breeze-statusline.js missing. Run 'pnpm build' first.`,
+      );
+    }
+  });
+
+  it("is emitted as an independent bundle", () => {
+    const size = statSync(STATUSLINE).size;
+    expect(size).toBeGreaterThan(0);
+  });
+
+  it("executes and exits within the statusline latency budget", () => {
+    const started = Date.now();
+    const result = spawnSync(process.execPath, [STATUSLINE], {
+      cwd: REPO_ROOT,
+      encoding: "utf-8",
+      input: JSON.stringify({ cwd: REPO_ROOT }),
+      env: { ...process.env, FIRST_TREE_SKIP_VERSION_CHECK: "1" },
+      timeout: 5_000,
+    });
+    const duration = Date.now() - started;
+    expect(result.status ?? 1).toBe(0);
+    expect(duration).toBeLessThan(2_000);
+  });
+});
+
+d("dist bundle integrity", () => {
+  it("does not reference the TypeScript sources", () => {
+    const entries = readdirSync(DIST);
+    for (const entry of entries) {
+      if (!entry.endsWith(".js")) continue;
+      const content = readFileSync(join(DIST, entry), "utf-8");
+      expect(
+        content.includes("../src/") || content.includes("/src/products/"),
+        `${entry} still references the src/ tree`,
+      ).toBe(false);
+    }
+  });
+
+  it("package.json files allowlist includes the dist folder", () => {
+    const pkg = JSON.parse(
+      readFileSync(join(REPO_ROOT, "package.json"), "utf-8"),
+    ) as { files?: string[] };
+    expect(pkg.files).toContain("dist");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,5 +19,12 @@ export default defineConfig({
       "tests/**/*.test.tsx",
       "evals/tests/**/*.test.ts",
     ],
+    exclude: [
+      "**/node_modules/**",
+      "dist/**",
+      "**/cypress/**",
+      "**/.{idea,git,cache,output,temp}/**",
+      "**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,eslint,prettier}.config.*",
+    ],
   },
 });


### PR DESCRIPTION
## Summary
- Stage 2 of the release-gate framework. Adds `tests/dist/cli-binary.test.ts` executed via `pnpm test:dist` (and now chained into `pnpm release:check` after `pnpm build`).
- The suite is gated by `FIRST_TREE_DIST_TESTS=1`, so `pnpm test` still runs fast and does not require a prior build. Once built, `test:dist` runs the real `dist/cli.js` binary end-to-end.
- Narrowed the root `dist/` ignore to `/dist/` so `tests/dist/` can be tracked; added vitest's default exclude list explicitly (otherwise `**/dist/**` silently drops the new suite).

## What the suite asserts
- `dist/cli.js --version` contains the `package.json` version.
- Top-level `--help` lists all four namespaces.
- `first-tree <ns> --help` exits 0 for `tree`, `breeze`, `gardener`, `skill`.
- Unknown namespace exits non-zero.
- `dist/breeze-statusline.js` exists and returns within a 2s budget (real perf budget is <30ms; 2s is a CI-safe ceiling).
- No dist file references `src/`.
- `package.json.bin["first-tree"]` points at an existing file, and `dist` is in `files`.

## Test plan
- [x] `pnpm build && pnpm test:dist` — 12 tests pass locally.
- [x] `pnpm test` leaves the dist suite skipped (env var off).

https://claude.ai/code/session_01U5uJVMRpnQfr9C8mSV3s6a