### PR TITLE
test(release): add pnpm pack tarball allow/block lists

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,11 +48,12 @@
     "prepack": "pnpm build",
     "test:e2e": "vitest run tests/e2e/cli-e2e.test.ts",
     "test:dist": "FIRST_TREE_DIST_TESTS=1 vitest run tests/dist",
+    "test:release": "FIRST_TREE_RELEASE_TESTS=1 vitest run tests/release",
     "test": "vitest run",
     "eval": "vitest run --config vitest.eval.config.ts",
     "typecheck": "tsc --noEmit",
     "validate:skill": "python3 ./scripts/quick_validate.py ./skills/first-tree && bash ./scripts/check-skill-sync.sh",
-    "release:check": "pnpm version:check && pnpm validate:skill && pnpm typecheck && pnpm test && pnpm build && pnpm test:dist"
+    "release:check": "pnpm version:check && pnpm validate:skill && pnpm typecheck && pnpm test && pnpm build && pnpm test:dist && pnpm test:release"
   },
   "packageManager": "pnpm@10.25.0",
   "license": "Apache-2.0",

--- a/tests/release/pack-contents.test.ts
+++ b/tests/release/pack-contents.test.ts
@@ -1,0 +1,200 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+const RUN = process.env.FIRST_TREE_RELEASE_TESTS === "1";
+const d = RUN ? describe : describe.skip;
+
+interface PackedTarball {
+  tarballPath: string;
+  entries: string[];
+}
+
+function packIntoTempDir(): PackedTarball {
+  const outDir = mkdtempSync(join(tmpdir(), "first-tree-pack-"));
+  const output = execFileSync(
+    "pnpm",
+    ["pack", "--pack-destination", outDir],
+    {
+      cwd: REPO_ROOT,
+      encoding: "utf-8",
+      env: { ...process.env, FIRST_TREE_SKIP_VERSION_CHECK: "1" },
+    },
+  );
+  const match = output.match(/([^\s]+first-tree[^\s]*\.tgz)/);
+  let tarballPath: string | undefined;
+  if (match) {
+    const candidate = match[1];
+    tarballPath = candidate.startsWith("/")
+      ? candidate
+      : join(outDir, candidate.replace(/^.*\//, ""));
+  }
+  if (!tarballPath || !existsSync(tarballPath)) {
+    // Fall back to scanning the output directory.
+    const listing = execFileSync("ls", [outDir], { encoding: "utf-8" })
+      .split("\n")
+      .filter((entry) => entry.endsWith(".tgz"));
+    if (listing.length === 0) {
+      throw new Error("pnpm pack did not produce a tarball");
+    }
+    tarballPath = join(outDir, listing[0]);
+  }
+  const entries = execFileSync("tar", ["tzf", tarballPath], {
+    encoding: "utf-8",
+  })
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return { tarballPath, entries };
+}
+
+let packed: PackedTarball | undefined;
+const CLEANUP: string[] = [];
+
+d("pnpm pack tarball", () => {
+  beforeAll(() => {
+    packed = packIntoTempDir();
+    CLEANUP.push(dirname(packed.tarballPath));
+  }, 120_000);
+
+  afterAll(() => {
+    while (CLEANUP.length > 0) {
+      const dir = CLEANUP.pop();
+      if (dir) rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function entries(): string[] {
+    if (!packed) throw new Error("packed is not initialised");
+    return packed.entries;
+  }
+
+  function has(path: string): boolean {
+    return entries().includes(`package/${path}`);
+  }
+
+  function none(matcher: (entry: string) => boolean): string[] {
+    return entries().filter(matcher);
+  }
+
+  it("includes the CLI entrypoint and statusline bundle", () => {
+    expect(has("dist/cli.js")).toBe(true);
+    expect(has("dist/breeze-statusline.js")).toBe(true);
+    expect(has("package.json")).toBe(true);
+    expect(has("LICENSE")).toBe(true);
+  });
+
+  it("includes every published skill payload", () => {
+    for (const skill of ["first-tree", "tree", "breeze", "gardener"]) {
+      expect(has(`skills/${skill}/SKILL.md`)).toBe(true);
+      expect(has(`skills/${skill}/VERSION`)).toBe(true);
+    }
+  });
+
+  it("includes the first-tree skill references shipped to user repos", () => {
+    for (const ref of [
+      "whitepaper",
+      "onboarding",
+      "principles",
+      "ownership-and-naming",
+      "source-workspace-installation",
+      "upgrade-contract",
+    ]) {
+      expect(has(`skills/first-tree/references/${ref}.md`)).toBe(true);
+    }
+  });
+
+  it("includes tree assets required by the CLI at runtime", () => {
+    expect(has("assets/tree/manifest.json")).toBe(true);
+    expect(has("assets/tree/VERSION")).toBe(true);
+    expect(has("assets/tree/prompts/pr-review.md")).toBe(true);
+    expect(has("assets/tree/templates/root-node.md.template")).toBe(true);
+    expect(has("assets/tree/templates/agents.md.template")).toBe(true);
+    expect(has("assets/tree/templates/members-domain.md.template")).toBe(true);
+    expect(has("assets/tree/templates/member-node.md.template")).toBe(true);
+    expect(has("assets/tree/workflows/validate.yml")).toBe(true);
+    expect(has("assets/tree/workflows/pr-review.yml")).toBe(true);
+    expect(has("assets/tree/workflows/codeowners.yml")).toBe(true);
+    expect(has("assets/tree/helpers/generate-codeowners.ts")).toBe(true);
+    expect(has("assets/tree/helpers/run-review.ts")).toBe(true);
+    expect(has("assets/tree/helpers/summarize-progress.js")).toBe(true);
+  });
+
+  it("includes every product VERSION file", () => {
+    expect(has("src/products/tree/VERSION")).toBe(true);
+    expect(has("src/products/breeze/VERSION")).toBe(true);
+    expect(has("src/products/gardener/VERSION")).toBe(true);
+    expect(has("src/meta/skill-tools/VERSION")).toBe(true);
+  });
+
+  it("does not ship maintainer-only directories", () => {
+    const forbiddenPrefixes = [
+      "package/tests/",
+      "package/docs/",
+      "package/evals/",
+      "package/scripts/",
+      "package/.agents/",
+      "package/.claude/",
+      "package/.github/",
+      "package/first-tree-context/",
+      "package/.first-tree/",
+    ];
+    const leaked = entries().filter((entry) =>
+      forbiddenPrefixes.some((prefix) => entry.startsWith(prefix)),
+    );
+    expect(leaked).toEqual([]);
+  });
+
+  it("does not ship TypeScript sources or sourcemaps from src/", () => {
+    const tsLeaks = none(
+      (entry) => entry.startsWith("package/src/") && entry.endsWith(".ts"),
+    );
+    const mapLeaks = none(
+      (entry) => entry.startsWith("package/dist/") && entry.endsWith(".map"),
+    );
+    expect(tsLeaks).toEqual([]);
+    expect(mapLeaks).toEqual([]);
+  });
+
+  it("ships dist/cli.js with a node shebang", () => {
+    if (!packed) throw new Error("packed is not initialised");
+    const extractDir = mkdtempSync(join(tmpdir(), "first-tree-extract-"));
+    CLEANUP.push(extractDir);
+    execFileSync("tar", [
+      "xzf",
+      packed.tarballPath,
+      "-C",
+      extractDir,
+      "package/dist/cli.js",
+    ]);
+    const content = readFileSync(
+      join(extractDir, "package", "dist", "cli.js"),
+      "utf-8",
+    );
+    expect(content.startsWith("#!/usr/bin/env node")).toBe(true);
+  });
+
+  it("bin entry in package.json matches a shipped file", () => {
+    if (!packed) throw new Error("packed is not initialised");
+    const extractDir = mkdtempSync(join(tmpdir(), "first-tree-extract-"));
+    CLEANUP.push(extractDir);
+    execFileSync("tar", [
+      "xzf",
+      packed.tarballPath,
+      "-C",
+      extractDir,
+      "package/package.json",
+    ]);
+    const pkg = JSON.parse(
+      readFileSync(join(extractDir, "package", "package.json"), "utf-8"),
+    ) as { bin?: Record<string, string> };
+    const binPath = pkg.bin?.["first-tree"];
+    expect(binPath).toBe("dist/cli.js");
+    expect(has(binPath ?? "")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Stage 3 of the release-gate framework. Introduces `tests/release/pack-contents.test.ts`, run via the new `pnpm test:release` (gated by `FIRST_TREE_RELEASE_TESTS=1` so it skips in the default `pnpm test`).
- `release:check` now chains this after `test:dist`, so a single run validates the published tarball shape in addition to the built binary.

## What the suite asserts
- Tarball ships `dist/cli.js`, `dist/breeze-statusline.js`, `LICENSE`, `package.json`.
- All four skills ship their `SKILL.md` + `VERSION`. The `first-tree` entry-point skill ships the six user-facing references (whitepaper, onboarding, principles, ownership-and-naming, source-workspace-installation, upgrade-contract).
- Tree assets (manifest, VERSION, prompts/pr-review.md, four templates, three workflows, three helpers) all present.
- All four product `VERSION` files shipped (tree/breeze/gardener/skill-tools).
- No maintainer-only dir leaks (`tests/`, `docs/`, `evals/`, `scripts/`, `.agents/`, `.claude/`, `.github/`, `.first-tree/`, `first-tree-context/`).
- No `.ts` or `.map` leaks from `src/` (the three asset-side helpers that must ship as TS are explicitly allowlisted above).
- `dist/cli.js` starts with `#!/usr/bin/env node`.
- `package.json.bin["first-tree"]` is `dist/cli.js` and that file is actually in the tarball.

## Test plan
- [x] `pnpm test:release` — 9 tests pass locally.
- [x] `pnpm test` leaves the release suite skipped.

https://claude.ai/code/session_01U5uJVMRpnQfr9C8mSV3s6a