### PR TITLE
test: wire release:check into CI, prepublishOnly, and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,4 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: pnpm version:check
-
-      - run: pnpm validate:skill
-
-      - run: pnpm typecheck
-
-      - run: pnpm test
-
-      - run: pnpm build
+      - run: pnpm release:check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,13 +73,25 @@ Maintaining this repo is different from using it — see the user-facing
 
 ## Validation
 
+Single release gate — CI runs this exact command and `prepublishOnly`
+reruns it before `npm publish`:
+
+```bash
+pnpm release:check
+```
+
+Individual steps if you want to iterate on one layer:
+
 ```bash
 pnpm validate:skill
 pnpm typecheck
 pnpm test
 pnpm build
-pnpm pack
+pnpm test:dist     # post-build binary smoke (requires a prior pnpm build)
+pnpm test:release  # pack + npm install <tarball> smoke
 ```
+
+See `docs/testing/overview.md` for the layered gate contract.
 
 Maintainer-only eval tooling lives in `evals/`. See `evals/README.md` before
 running `EVALS=1 pnpm eval`.

--- a/docs/testing/overview.md
+++ b/docs/testing/overview.md
@@ -6,14 +6,58 @@ the bound Context Tree.
 Use this local reference when you need the concrete commands and file
 entrypoints for validating work in this source repo.
 
-## Core Checks
+## Release Gate
+
+A single command — `pnpm release:check` — is the "green means shippable"
+gate. CI runs exactly this command, and `prepublishOnly` reruns it before
+`npm publish` so a local mistake cannot accidentally publish a broken
+tarball. The gate chains seven steps in order; any one failure aborts.
+
+```bash
+pnpm release:check
+```
+
+It composes:
+
+1. `pnpm version:check` — `package.json`, `assets/tree/VERSION`,
+   `src/products/tree/VERSION`, and `skills/first-tree/VERSION` agree.
+2. `pnpm validate:skill` — canonical skill layout + alias symlinks + no
+   legacy artifacts in any of the four skill payloads.
+3. `pnpm typecheck` — `tsc --noEmit` across the TypeScript graph.
+4. `pnpm test` — all unit + e2e suites (vitest). Release-only suites
+   (`tests/dist/`, `tests/release/`) are env-gated and skip here.
+5. `pnpm build` — `tsdown` produces `dist/cli.js` and
+   `dist/breeze-statusline.js`.
+6. `pnpm test:dist` — runs the real built binary: `--version`, per-namespace
+   `--help`, statusline latency, bundle does not reference `src/`.
+7. `pnpm test:release` — `pnpm pack` + `npm install <tarball>` in a clean
+   temp dir; asserts the published files list (allowlist + blocklist), the
+   bin shebang, the installed CLI's version and namespace help, the four
+   bundled skills + references on disk, and absence of maintainer-only
+   directories.
+
+### Env-gated release suites
+
+The heavy release-only suites are gated so the default `pnpm test` stays
+fast:
+
+- `FIRST_TREE_DIST_TESTS=1` enables `tests/dist/*` (used by `test:dist`).
+- `FIRST_TREE_RELEASE_TESTS=1` enables `tests/release/*` (used by
+  `test:release`).
+
+You rarely need to set them by hand — `pnpm test:dist` and
+`pnpm test:release` wire the flags for you.
+
+## Individual Checks
 
 ```bash
 pnpm validate:skill
 pnpm typecheck
-pnpm test:e2e
 pnpm test
+pnpm test:e2e
 pnpm build
+pnpm test:dist         # requires a prior `pnpm build`
+pnpm test:release      # packs + installs the tarball in a temp dir
 ```
 
 ### What Each Check Covers
@@ -25,7 +69,10 @@ pnpm build
   publish/review flows.
 - `pnpm test` runs unit tests plus repo-local helper tests that support
   maintainer tooling.
-- `pnpm build` checks the thin CLI bundle.
+- `pnpm build` emits the thin CLI bundle and the statusline bundle.
+- `pnpm test:dist` smoke-tests the built binary against real `node` invocations.
+- `pnpm test:release` publishes the repo into a tarball, installs it clean,
+  and drives the installed CLI end-to-end.
 
 ## Targeted Unit Tests
 
@@ -48,9 +95,10 @@ coverage expectations aligned with the tree node.
 pnpm pack
 ```
 
-Inspect the tarball when package contents or install/upgrade behavior changes.
-The published package should include the thin CLI shell and canonical skill, but
-not repo-only developer tooling such as root `evals/`.
+Useful for manual tarball inspection. For automated coverage,
+`pnpm test:release` already runs `pnpm pack` + `npm install` and asserts
+the package contents; you shouldn't need to run `pnpm pack` by hand unless
+you're diagnosing a specific packaging regression.
 
 ## Repo-Only Evals
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "eval": "vitest run --config vitest.eval.config.ts",
     "typecheck": "tsc --noEmit",
     "validate:skill": "python3 ./scripts/quick_validate.py ./skills/first-tree && bash ./scripts/check-skill-sync.sh",
-    "release:check": "pnpm version:check && pnpm validate:skill && pnpm typecheck && pnpm test && pnpm build && pnpm test:dist && pnpm test:release"
+    "release:check": "pnpm version:check && pnpm validate:skill && pnpm typecheck && pnpm test && pnpm build && pnpm test:dist && pnpm test:release",
+    "prepublishOnly": "pnpm release:check"
   },
   "packageManager": "pnpm@10.25.0",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
- Stage 5 — the final wiring that makes "green = shippable" real.
- CI replaces its five individual steps with a single `pnpm release:check`, so the same seven-step gate runs on every PR.
- `prepublishOnly` reruns `pnpm release:check` before `npm publish`, so a local mistake cannot accidentally publish.
- `docs/testing/overview.md` now documents the full gate (what each step covers, the env flags that gate the release-only suites, and how `pnpm test` relates to the gate).
- `AGENTS.md` points maintainers at `pnpm release:check` first and lists the per-layer commands for iteration.

## Test plan
- [x] CI will now run `pnpm release:check` (all seven layers). The previous five-step sequence was equivalent but didn't include dist/release smoke.
- [x] Local `pnpm test`, `pnpm test:dist`, `pnpm test:release` all green (see #197–#200).
- [ ] Full `pnpm release:check` run pending (tracked in the final stage of this series).

https://claude.ai/code/session_01U5uJVMRpnQfr9C8mSV3s6a