### PR TITLE
test(agent-e2e): add harness + LLM-judge skill quality gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "test:e2e": "vitest run tests/e2e/cli-e2e.test.ts",
     "test:dist": "FIRST_TREE_DIST_TESTS=1 vitest run tests/dist",
     "test:release": "FIRST_TREE_RELEASE_TESTS=1 vitest run tests/release",
+    "test:agent": "FIRST_TREE_AGENT_TESTS=1 vitest run tests/agent-e2e",
     "test": "vitest run",
     "eval": "vitest run --config vitest.eval.config.ts",
     "typecheck": "tsc --noEmit",
@@ -59,6 +60,7 @@
   "packageManager": "pnpm@10.25.0",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@anthropic-ai/sdk": "^0.90.0",
     "@types/node": "^25.5.0",
     "@types/proper-lockfile": "^4.1.4",
     "@types/react": "^19.2.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.90.0
+        version: 0.90.0(zod@4.3.6)
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
@@ -52,6 +55,15 @@ packages:
     resolution: {integrity: sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==}
     engines: {node: '>=18'}
 
+  '@anthropic-ai/sdk@0.90.0':
+    resolution: {integrity: sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   '@babel/generator@7.29.1':
     resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
@@ -68,6 +80,10 @@ packages:
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
@@ -737,6 +753,10 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
@@ -915,6 +935,9 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   tsdown@0.12.9:
     resolution: {integrity: sha512-MfrXm9PIlT3saovtWKf/gCJJ/NQCdE0SiREkdNC+9Qy6UHhdeDPxnkFaBD7xttVUmgp0yUHtGirpoLB+OVLuLA==}
     engines: {node: '>=18.0.0'}
@@ -1074,6 +1097,12 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
+  '@anthropic-ai/sdk@0.90.0(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
+
   '@babel/generator@7.29.1':
     dependencies:
       '@babel/parser': 7.29.2
@@ -1089,6 +1118,8 @@ snapshots:
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/runtime@7.29.2': {}
 
   '@babel/types@7.29.0':
     dependencies:
@@ -1594,6 +1625,11 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
+
   loupe@3.2.1: {}
 
   magic-string@0.30.21:
@@ -1777,6 +1813,8 @@ snapshots:
   tinyrainbow@2.0.0: {}
 
   tinyspy@4.0.4: {}
+
+  ts-algebra@2.0.0: {}
 
   tsdown@0.12.9(typescript@5.9.3):
     dependencies:

--- a/tests/agent-e2e/baselines/skill-quality.json
+++ b/tests/agent-e2e/baselines/skill-quality.json
@@ -1,0 +1,4 @@
+{
+  "tolerance": 0.5,
+  "skills": {}
+}

--- a/tests/agent-e2e/helpers/baselines.ts
+++ b/tests/agent-e2e/helpers/baselines.ts
@@ -1,0 +1,92 @@
+/**
+ * Baseline pinning for LLM-judge scores.
+ *
+ * LLM-based evals wobble. We accept some variance but refuse regressions
+ * past a fixed tolerance. Baselines live in
+ * tests/agent-e2e/baselines/*.json and are hand-bumped by maintainers
+ * after reviewing why a score drifted (same pattern as gstack's
+ * test/fixtures baselines).
+ */
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const BASELINE_DIR = resolve(HERE, "..", "baselines");
+
+export interface SkillQualityBaseline {
+  clarity: number;
+  completeness: number;
+  actionability: number;
+}
+
+export interface SkillQualityBaselines {
+  /** How far a per-axis score may drop below baseline before we fail. */
+  tolerance: number;
+  skills: Record<string, SkillQualityBaseline>;
+}
+
+function baselinePath(name: string): string {
+  return join(BASELINE_DIR, `${name}.json`);
+}
+
+export function loadSkillQualityBaselines(): SkillQualityBaselines {
+  const file = baselinePath("skill-quality");
+  if (!existsSync(file)) {
+    return { tolerance: 0.5, skills: {} };
+  }
+  return JSON.parse(readFileSync(file, "utf-8")) as SkillQualityBaselines;
+}
+
+export interface Regression {
+  axis: keyof SkillQualityBaseline;
+  baseline: number;
+  observed: number;
+  tolerance: number;
+}
+
+/**
+ * Returns the list of axes that regressed past tolerance. Empty = OK.
+ * If no baseline exists for a skill, this is a no-op (baselines get
+ * seeded by running the test once and committing the output).
+ */
+export function findSkillRegressions(args: {
+  skill: string;
+  observed: SkillQualityBaseline;
+  baselines: SkillQualityBaselines;
+}): Regression[] {
+  const baseline = args.baselines.skills[args.skill];
+  if (!baseline) return [];
+  const regressions: Regression[] = [];
+  for (const axis of ["clarity", "completeness", "actionability"] as const) {
+    const delta = baseline[axis] - args.observed[axis];
+    if (delta > args.baselines.tolerance) {
+      regressions.push({
+        axis,
+        baseline: baseline[axis],
+        observed: args.observed[axis],
+        tolerance: args.baselines.tolerance,
+      });
+    }
+  }
+  return regressions;
+}
+
+/**
+ * Write (or overwrite) the baseline for a skill. Used by the
+ * `--update` flag in the harness; never called automatically from a
+ * passing test run.
+ */
+export function writeSkillBaseline(
+  skill: string,
+  observed: SkillQualityBaseline,
+): void {
+  const current = loadSkillQualityBaselines();
+  current.skills[skill] = {
+    clarity: observed.clarity,
+    completeness: observed.completeness,
+    actionability: observed.actionability,
+  };
+  writeFileSync(baselinePath("skill-quality"), JSON.stringify(current, null, 2) + "\n");
+}

--- a/tests/agent-e2e/helpers/llm-judge.ts
+++ b/tests/agent-e2e/helpers/llm-judge.ts
@@ -1,0 +1,176 @@
+/**
+ * LLM-as-judge helper for agent-e2e tests.
+ *
+ * Pattern adapted from gstack's test/helpers/llm-judge.ts: a strict-JSON
+ * judge that scores an input against named axes (1–5), with automatic
+ * retry on malformed output and on rate limits.
+ *
+ * Only runs when `FIRST_TREE_AGENT_TESTS=1` and `ANTHROPIC_API_KEY` are
+ * both set. The judge model is fixed (sonnet); bumping it is a
+ * decision-grade change because baselines are pinned against it.
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+
+const JUDGE_MODEL = "claude-sonnet-4-5";
+const MAX_RETRIES = 3;
+
+export interface JudgeScore {
+  clarity: number;
+  completeness: number;
+  actionability: number;
+  reasoning: string;
+}
+
+export interface JudgeAxis {
+  name: string;
+  description: string;
+  /** Inclusive, 1–5. */
+  min: number;
+}
+
+export interface JudgeVerdict<Axes extends string> {
+  scores: Record<Axes, number>;
+  reasoning: string;
+  raw: string;
+}
+
+function extractJson(text: string): string | null {
+  const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (fence) return fence[1].trim();
+  const first = text.indexOf("{");
+  const last = text.lastIndexOf("}");
+  if (first === -1 || last === -1 || last < first) return null;
+  return text.slice(first, last + 1);
+}
+
+async function callAnthropic(prompt: string): Promise<string> {
+  const client = new Anthropic();
+  let lastError: unknown;
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    try {
+      const response = await client.messages.create({
+        model: JUDGE_MODEL,
+        max_tokens: 1024,
+        messages: [{ role: "user", content: prompt }],
+      });
+      const block = response.content.find((b) => b.type === "text");
+      if (block && block.type === "text") return block.text;
+      throw new Error("judge response had no text block");
+    } catch (err) {
+      lastError = err;
+      const delay = 500 * 2 ** attempt;
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+  throw lastError;
+}
+
+/**
+ * Score an arbitrary string against a set of named axes.
+ *
+ * The judge is instructed to return strict JSON with integer scores and
+ * a single reasoning field. Missing or non-numeric scores raise.
+ */
+export async function judgeAgainstAxes<Axes extends string>(args: {
+  subject: string;
+  content: string;
+  axes: Array<{ key: Axes; description: string }>;
+}): Promise<JudgeVerdict<Axes>> {
+  const axesDoc = args.axes
+    .map(
+      (a, i) =>
+        `  ${i + 1}. ${a.key} (1–5): ${a.description}`,
+    )
+    .join("\n");
+
+  const prompt = `You are an impartial judge evaluating the quality of ${args.subject}.
+
+Score the content below on each axis from 1 (bad) to 5 (excellent).
+Axes:
+${axesDoc}
+
+Respond with STRICT JSON only, matching this schema:
+{
+${args.axes.map((a) => `  "${a.key}": <integer 1-5>,`).join("\n")}
+  "reasoning": "<one short paragraph explaining the scores>"
+}
+
+No prose outside the JSON. No markdown fences. No commentary.
+
+--- BEGIN CONTENT ---
+${args.content}
+--- END CONTENT ---`;
+
+  const raw = await callAnthropic(prompt);
+  const json = extractJson(raw);
+  if (!json) {
+    throw new Error(`judge returned non-JSON output:\n${raw.slice(0, 400)}`);
+  }
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(json) as Record<string, unknown>;
+  } catch (err) {
+    throw new Error(
+      `judge JSON parse failed: ${(err as Error).message}\n--- raw ---\n${raw.slice(0, 400)}`,
+    );
+  }
+
+  const scores = {} as Record<Axes, number>;
+  for (const axis of args.axes) {
+    const value = parsed[axis.key];
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      throw new Error(
+        `judge did not return numeric score for "${axis.key}": ${JSON.stringify(value)}`,
+      );
+    }
+    const clamped = Math.max(1, Math.min(5, Math.round(value)));
+    scores[axis.key] = clamped;
+  }
+  const reasoning =
+    typeof parsed.reasoning === "string" ? parsed.reasoning : "";
+  return { scores, reasoning, raw };
+}
+
+/**
+ * Convenience wrapper for the three canonical SKILL.md quality axes.
+ * The axes mirror gstack/test/helpers/llm-judge.ts::judge().
+ */
+export async function judgeSkillQuality(args: {
+  skillName: string;
+  content: string;
+}): Promise<JudgeScore> {
+  const verdict = await judgeAgainstAxes({
+    subject: `the SKILL.md file for "${args.skillName}"`,
+    content: args.content,
+    axes: [
+      {
+        key: "clarity" as const,
+        description:
+          "Can a coding agent unambiguously understand what each step does without guessing?",
+      },
+      {
+        key: "completeness" as const,
+        description:
+          "Are all inputs, outputs, commands, arguments, valid values, and edge cases covered?",
+      },
+      {
+        key: "actionability" as const,
+        description:
+          "Can the agent take concrete action (construct correct CLI invocations, pick the right flow) using only this file?",
+      },
+    ],
+  });
+  return {
+    clarity: verdict.scores.clarity,
+    completeness: verdict.scores.completeness,
+    actionability: verdict.scores.actionability,
+    reasoning: verdict.reasoning,
+  };
+}
+
+export function judgeAvailable(): boolean {
+  if (process.env.FIRST_TREE_AGENT_TESTS !== "1") return false;
+  if (!process.env.ANTHROPIC_API_KEY) return false;
+  return true;
+}

--- a/tests/agent-e2e/skill-quality.test.ts
+++ b/tests/agent-e2e/skill-quality.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Stage A: static SKILL.md quality gates.
+ *
+ * Each of the four published skills must score ≥4/5 on clarity,
+ * completeness, and actionability, and must not regress past tolerance
+ * against its pinned baseline (baselines/skill-quality.json).
+ *
+ * Gated by FIRST_TREE_AGENT_TESTS=1 and ANTHROPIC_API_KEY so the
+ * default test run never calls the API. Invoked via `pnpm test:agent`.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  findSkillRegressions,
+  loadSkillQualityBaselines,
+} from "./helpers/baselines.js";
+import {
+  judgeAvailable,
+  judgeSkillQuality,
+} from "./helpers/llm-judge.js";
+
+const REPO_ROOT = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+);
+
+const SKILLS = [
+  { name: "first-tree", path: "skills/first-tree/SKILL.md" },
+  { name: "tree", path: "skills/tree/SKILL.md" },
+  { name: "breeze", path: "skills/breeze/SKILL.md" },
+  { name: "gardener", path: "skills/gardener/SKILL.md" },
+];
+
+const MIN_SCORE = 4;
+const d = judgeAvailable() ? describe : describe.skip;
+
+d("SKILL.md quality (LLM judge)", () => {
+  const baselines = loadSkillQualityBaselines();
+
+  it.each(SKILLS)(
+    "$name skill scores ≥$expected on every axis and does not regress",
+    async ({ name, path }) => {
+      const content = readFileSync(join(REPO_ROOT, path), "utf-8");
+      const score = await judgeSkillQuality({ skillName: name, content });
+
+      expect(
+        score.clarity,
+        `${name}: clarity=${score.clarity}\n${score.reasoning}`,
+      ).toBeGreaterThanOrEqual(MIN_SCORE);
+      expect(
+        score.completeness,
+        `${name}: completeness=${score.completeness}\n${score.reasoning}`,
+      ).toBeGreaterThanOrEqual(MIN_SCORE);
+      expect(
+        score.actionability,
+        `${name}: actionability=${score.actionability}\n${score.reasoning}`,
+      ).toBeGreaterThanOrEqual(MIN_SCORE);
+
+      const regressions = findSkillRegressions({
+        skill: name,
+        observed: score,
+        baselines,
+      });
+      expect(
+        regressions,
+        `${name} regressed past tolerance (${baselines.tolerance}):\n` +
+          regressions
+            .map(
+              (r) =>
+                `  ${r.axis}: baseline=${r.baseline} observed=${r.observed}`,
+            )
+            .join("\n"),
+      ).toEqual([]);
+    },
+    120_000,
+  );
+});


### PR DESCRIPTION
## Summary
- First of a new **agent-e2e** test tier, separate from `release:check`. Covers what Claude Code / Codex agents see when routing through our `SKILL.md` files.
- Stage A: test harness + LLM-judge + four static quality tests (one per published skill).
- Gated by `FIRST_TREE_AGENT_TESTS=1` + `ANTHROPIC_API_KEY`, so the default `pnpm test` never calls the API. New script: `pnpm test:agent`.
- Not wired into `release:check`: this tier targets periodic CI and pre-release gating (Stage F), not every PR, to keep per-commit cost + model-flake risk low.

## What it gates
For each of the four shipped skills (`first-tree`, `tree`, `breeze`, `gardener`):
- **Clarity** ≥ 4/5 — agent can unambiguously follow each step
- **Completeness** ≥ 4/5 — inputs/outputs/flags/edge cases all covered
- **Actionability** ≥ 4/5 — agent can act with only this file
- **No regression** past `tolerance` (default 0.5) vs pinned `baselines/skill-quality.json`

Scores come from a strict-JSON judge (sonnet-4-5) modelled on gstack's `test/helpers/llm-judge.ts`. JSON extractor tolerates markdown fences; retries on transient failures.

## Baselines
Seeded empty. Maintainers run `pnpm test:agent` once against a known-good commit, review the scores, and commit the numbers — same hand-pinned flow gstack uses. Until then the regression check is a no-op but the hard ≥4 floor still applies.

## Test plan
- [x] `pnpm typecheck` — clean.
- [x] `pnpm test` — 927/927 pass; the four new tests skip (env flag off).
- [x] `pnpm test:agent` (no `ANTHROPIC_API_KEY`) — skips cleanly.
- [x] `pnpm release:check` — still green end-to-end; new tier is out-of-band by design.

## Follow-ups (same PR series)
- Stage B: command-discovery tests (6) — spawn real Claude CLI, assert it calls the right `first-tree <ns>` command
- Stage C: path-disambiguation tests (3)
- Stage D: anti-hallucination tests (3)
- Stage E: help self-sufficiency tests (4)
- Stage F: CI cron wiring + `docs/testing/overview.md` update

https://claude.ai/code/session_01U5uJVMRpnQfr9C8mSV3s6a