### PR TITLE
test(agent-e2e): add command-discovery tests (6)

### DIFF
--- a/tests/agent-e2e/command-discovery.test.ts
+++ b/tests/agent-e2e/command-discovery.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Stage B: command-discovery tests.
+ *
+ * Given an intent prompt, the agent (armed with our SKILL.md files)
+ * must invoke the correct `first-tree <namespace> <command>` command.
+ * This is the most basic skill-health signal: "can an agent find the
+ * right tool in our surface area?"
+ *
+ * Each test seeds a minimal tmp git repo, runs a real Claude Code
+ * subprocess, and asserts on the actual Bash invocations the agent
+ * made. We allow exit_reason = error_max_turns because several of
+ * these tasks can reasonably stop mid-flow once the intended command
+ * has been issued.
+ *
+ * Gated by FIRST_TREE_AGENT_TESTS=1 + ANTHROPIC_API_KEY.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  agentAvailable,
+  assertInvokedCommand,
+  bashInvocations,
+  makeSeedRepo,
+  runAgent,
+} from "./helpers/run-agent.js";
+
+const REPO_ROOT = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+);
+
+/**
+ * Read the shipped SKILL.md and inline it into the agent prompt so
+ * the subprocess does not have to rely on host-machine skill
+ * discovery. This makes tests hermetic and independent of Claude
+ * Code's local skill search path.
+ */
+function loadSkill(relPath: string): string {
+  return readFileSync(join(REPO_ROOT, relPath), "utf-8");
+}
+
+function framePrompt(args: { intent: string; skills: string[] }): string {
+  const skillBlocks = args.skills
+    .map((rel) => {
+      const body = loadSkill(rel);
+      return `--- BEGIN ${rel} ---\n${body}\n--- END ${rel} ---`;
+    })
+    .join("\n\n");
+  return [
+    "You are helping a developer use the `first-tree` CLI. Follow the",
+    "skill files below. Use real shell commands via Bash. Do not",
+    "fabricate flags or subcommands — only use the ones documented.",
+    "",
+    skillBlocks,
+    "",
+    `Task: ${args.intent}`,
+  ].join("\n");
+}
+
+const d = agentAvailable() ? describe : describe.skip;
+
+interface Case {
+  label: string;
+  intent: string;
+  seed: Record<string, string>;
+  skills: string[];
+  expectPattern: RegExp;
+  hint: string;
+  maxTurns?: number;
+}
+
+const CASES: Case[] = [
+  {
+    label: "tree init for a brand-new repo",
+    intent:
+      "Please onboard this repository to a brand-new, dedicated Context Tree. Use the first-tree CLI; do not create files by hand.",
+    seed: {
+      "README.md": "# empty-repo\n",
+    },
+    skills: ["skills/first-tree/SKILL.md", "skills/tree/SKILL.md"],
+    expectPattern: /first-tree\s+tree\s+init/,
+    hint: "agent should call `first-tree tree init` to create a dedicated tree",
+  },
+  {
+    label: "tree bind for an existing shared tree",
+    intent:
+      "Bind this repository to the existing shared Context Tree at agent-team-foundation/example-context. Do not init a new tree.",
+    seed: {
+      "README.md": "# source-repo\n",
+      "src/index.ts": "export const ready = true;\n",
+    },
+    skills: ["skills/first-tree/SKILL.md", "skills/tree/SKILL.md"],
+    expectPattern: /first-tree\s+tree\s+bind\b/,
+    hint: "agent should call `first-tree tree bind` (not tree init)",
+  },
+  {
+    label: "breeze poll for notifications",
+    intent:
+      "Show me my GitHub notification inbox. I want to see what needs my attention right now. Use the first-tree CLI.",
+    seed: { "README.md": "# any-repo\n" },
+    skills: ["skills/first-tree/SKILL.md", "skills/breeze/SKILL.md"],
+    expectPattern: /first-tree\s+breeze\s+(poll|status|watch)\b/,
+    hint:
+      "agent should call a breeze inbox command (poll/status/watch), not a tree command",
+  },
+  {
+    label: "gardener respond to PR feedback",
+    intent:
+      "There's a new review comment on PR #123 in this repo. Please respond to the reviewer feedback using the first-tree gardener agent.",
+    seed: { "README.md": "# repo-with-pr\n" },
+    skills: ["skills/first-tree/SKILL.md", "skills/gardener/SKILL.md"],
+    expectPattern: /first-tree\s+gardener\s+respond\b.*(--pr\s+123|#123)/,
+    hint:
+      "agent should call `first-tree gardener respond --pr 123` with the PR number",
+  },
+  {
+    label: "skill upgrade instead of manual file edits",
+    intent:
+      "My first-tree skill files feel out of date. Please upgrade first-tree on this machine. Do not edit files by hand.",
+    seed: { "README.md": "# any-repo\n" },
+    skills: ["skills/first-tree/SKILL.md"],
+    expectPattern: /first-tree\s+skill\s+upgrade\b/,
+    hint:
+      "agent should call `first-tree skill upgrade`, not manually edit SKILL.md files",
+  },
+  {
+    label: "tree verify from a bound source repo",
+    intent:
+      "Verify that the Context Tree bound to this repo is in a good state. Use the first-tree CLI.",
+    seed: {
+      "README.md": "# bound-source\n",
+      ".first-tree/source.json": JSON.stringify(
+        {
+          tree: {
+            repo: "agent-team-foundation/example-context",
+            localPath: "../example-context",
+          },
+          mode: "shared-source",
+        },
+        null,
+        2,
+      ),
+    },
+    skills: ["skills/first-tree/SKILL.md", "skills/tree/SKILL.md"],
+    expectPattern: /first-tree\s+tree\s+verify\b/,
+    hint: "agent should call `first-tree tree verify`",
+  },
+];
+
+d("command discovery (real Claude subprocess)", () => {
+  const cleanups: Array<() => void> = [];
+
+  afterEach(() => {
+    while (cleanups.length > 0) cleanups.pop()?.();
+  });
+
+  it.each(CASES)(
+    "$label",
+    async ({ intent, seed, skills, expectPattern, hint, maxTurns }) => {
+      const { path, cleanup } = makeSeedRepo(seed);
+      cleanups.push(cleanup);
+      const result = await runAgent({
+        prompt: framePrompt({ intent, skills }),
+        workingDirectory: path,
+        maxTurns: maxTurns ?? 6,
+      });
+
+      expect(
+        ["success", "error_max_turns"],
+        `agent exited unexpectedly: ${result.exitReason}`,
+      ).toContain(result.exitReason);
+
+      try {
+        assertInvokedCommand(result, expectPattern, hint);
+      } catch (err) {
+        const dump = bashInvocations(result)
+          .map((c) => `  - ${c.slice(0, 200)}`)
+          .join("\n");
+        throw new Error(
+          `${(err as Error).message}\n\nFull bash log:\n${dump}`,
+        );
+      }
+    },
+    180_000,
+  );
+});

--- a/tests/agent-e2e/helpers/run-agent.ts
+++ b/tests/agent-e2e/helpers/run-agent.ts
@@ -1,0 +1,182 @@
+/**
+ * Thin wrapper around the existing eval session runner, specialised
+ * for small-box skill-behaviour tests.
+ *
+ * The real agent subprocess runner lives at evals/helpers/session-runner.ts
+ * (adapted from gstack). This wrapper:
+ *   - defaults to claude-code with a conservative maxTurns
+ *   - sets up a tmpdir with an initialised git repo
+ *   - exposes a concise `expectCommandInvoked(toolCalls, regex)` assert
+ *     that matches against Bash tool-use inputs
+ *   - guards behind FIRST_TREE_AGENT_TESTS=1 so it's a no-op elsewhere
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runSession } from "#evals/helpers/session-runner.js";
+import type {
+  AgentConfig,
+  SessionResult,
+} from "#evals/helpers/types.js";
+
+export const DEFAULT_AGENT: AgentConfig = {
+  cli: "claude-code",
+  model: "claude-sonnet-4-5",
+};
+
+export interface AgentRunResult extends SessionResult {
+  workingDirectory: string;
+  cleanup: () => void;
+}
+
+export function agentAvailable(): boolean {
+  if (process.env.FIRST_TREE_AGENT_TESTS !== "1") return false;
+  if (!process.env.ANTHROPIC_API_KEY) return false;
+  return true;
+}
+
+/**
+ * Create a tmp git repo seeded with the given files and return its path.
+ * Cleanup is the caller's responsibility (use the returned function).
+ */
+export function makeSeedRepo(files: Record<string, string>): {
+  path: string;
+  cleanup: () => void;
+} {
+  const dir = mkdtempSync(join(tmpdir(), "first-tree-agent-"));
+  execFileSync("git", ["init", "--quiet"], { cwd: dir });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.email=first-tree-agent-tests@example.com",
+      "-c",
+      "user.name=First Tree Agent Tests",
+      "-c",
+      "commit.gpgsign=false",
+      "commit",
+      "--allow-empty",
+      "--quiet",
+      "-m",
+      "initial",
+    ],
+    { cwd: dir },
+  );
+  for (const [rel, content] of Object.entries(files)) {
+    const full = join(dir, rel);
+    mkdirSync(join(full, ".."), { recursive: true });
+    writeFileSync(full, content);
+  }
+  return {
+    path: dir,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+/**
+ * Run an agent CLI subprocess in the given working directory.
+ * Defaults chosen for cheap skill tests: sonnet, 6 turns, 120s.
+ */
+export async function runAgent(options: {
+  prompt: string;
+  workingDirectory: string;
+  maxTurns?: number;
+  timeout?: number;
+  agent?: AgentConfig;
+  testName?: string;
+}): Promise<SessionResult> {
+  return runSession({
+    prompt: options.prompt,
+    workingDirectory: options.workingDirectory,
+    agent: options.agent ?? DEFAULT_AGENT,
+    maxTurns: options.maxTurns ?? 6,
+    timeout: options.timeout ?? 120_000,
+    testName: options.testName,
+  });
+}
+
+/** Every Bash tool call the agent made during the session. */
+export function bashInvocations(result: SessionResult): string[] {
+  return result.toolCalls
+    .filter((tc) => tc.tool === "Bash")
+    .map((tc) => {
+      const input = tc.input as { command?: string };
+      return input?.command ?? "";
+    });
+}
+
+/**
+ * Return the list of bash invocations that match the predicate.
+ * Useful for building more-specific assertions.
+ */
+export function bashMatching(
+  result: SessionResult,
+  pattern: RegExp,
+): string[] {
+  return bashInvocations(result).filter((cmd) => pattern.test(cmd));
+}
+
+/**
+ * Return true iff at least one Bash tool call matches.
+ * Paired with vitest `expect(...).toBe(true)`; the error message names
+ * the actual invocations for fast triage.
+ */
+export function invokedCommand(
+  result: SessionResult,
+  pattern: RegExp,
+): { matched: boolean; commands: string[] } {
+  const commands = bashInvocations(result);
+  const matched = commands.some((cmd) => pattern.test(cmd));
+  return { matched, commands };
+}
+
+/**
+ * Assertion helper: throw with a helpful message if the agent did NOT
+ * invoke any Bash command matching `pattern` during the session.
+ */
+export function assertInvokedCommand(
+  result: SessionResult,
+  pattern: RegExp,
+  hint: string,
+): void {
+  const { matched, commands } = invokedCommand(result, pattern);
+  if (!matched) {
+    throw new Error(
+      [
+        `Agent did not invoke ${pattern} (${hint}).`,
+        "Bash commands issued:",
+        ...commands.map((c) => `  - ${c.slice(0, 200)}`),
+        `(exit_reason=${result.exitReason}, turns=${result.toolCalls.length})`,
+      ].join("\n"),
+    );
+  }
+}
+
+/**
+ * Assertion helper: throw with a helpful message if the agent DID
+ * invoke any Bash command matching `pattern`. Used to guard against
+ * hallucinated commands.
+ */
+export function assertDidNotInvoke(
+  result: SessionResult,
+  pattern: RegExp,
+  hint: string,
+): void {
+  const matches = bashMatching(result, pattern);
+  if (matches.length > 0) {
+    throw new Error(
+      [
+        `Agent invoked ${pattern} (${hint}) but should not have.`,
+        "Offending commands:",
+        ...matches.map((c) => `  - ${c.slice(0, 200)}`),
+      ].join("\n"),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Stage B of the agent-e2e series. Six tests that spawn a real Claude Code subprocess, seed a tmp git repo with the shipped `SKILL.md` files, and assert which `first-tree <ns> <cmd>` the agent actually invokes via Bash.
- Pattern ported from gstack's `test/helpers/session-runner.ts` + `skill-e2e-plan.test.ts`. We reuse the existing `evals/helpers/session-runner.ts` (already adapted from gstack), adding only a thin wrapper in `tests/agent-e2e/helpers/run-agent.ts`.

## New test helper
`helpers/run-agent.ts`:
- `makeSeedRepo({ relPath: content })` — tmp git repo with `commit.gpgsign=false`
- `runAgent({ prompt, workingDirectory, maxTurns })` — sonnet-4-5, 6 turns, 120s default
- `bashInvocations(result)` — strip to Bash tool-use commands
- `assertInvokedCommand` / `assertDidNotInvoke` — focused error messages with full bash log on failure

## Six cases (one `it.each`)
| Intent | Expected |
|---|---|
| "onboard to a brand-new dedicated Context Tree" | `first-tree tree init` |
| "bind to existing shared tree" | `first-tree tree bind` (not init) |
| "show my GitHub notifications" | `first-tree breeze poll/status/watch` |
| "respond to review comment on PR #123" | `first-tree gardener respond --pr 123` |
| "upgrade first-tree" | `first-tree skill upgrade` (no manual edits) |
| "verify the bound tree" | `first-tree tree verify` |

Accepts `exit_reason ∈ {success, error_max_turns}` — we only care that the right command fired, not that the flow completed.

## What this catches that deterministic tests cannot
- Someone trims a section out of `skills/tree/SKILL.md` and agents start routing breeze tasks through `tree`.
- We add a new subcommand but forget to document it, so agents never discover it.
- A SKILL.md refactor flips the wording such that the agent now chooses `tree init` for an already-bound repo.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 927/927 (agent tests skipped, env off)
- [x] `pnpm test:agent` with no `ANTHROPIC_API_KEY` — 10/10 skipped
- [ ] Full agent-e2e run (Stage F will add cron CI with the secret)

https://claude.ai/code/session_01U5uJVMRpnQfr9C8mSV3s6a