### PR TITLE
test(agent-e2e): wire weekly cron workflow + docs

### DIFF
--- a/.github/workflows/agent-e2e.yml
+++ b/.github/workflows/agent-e2e.yml
@@ -1,0 +1,65 @@
+name: Agent E2E
+
+# Behavioural tier that exercises the SKILL.md files and CLI help
+# surface via a real Claude subprocess. Kept off every-PR CI because
+# (a) it costs money and (b) LLM flake would create noisy red builds.
+# Runs on cron plus manual dispatch (e.g. pre-release).
+
+on:
+  schedule:
+    # Weekly on Monday 07:00 UTC — an hour after the npm publish
+    # window, so drift from a new model or a merged SKILL.md refactor
+    # shows up early in the week.
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+    inputs:
+      stage:
+        description: "Filter (vitest name pattern). Empty = whole tier."
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  agent-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    # Gate on the secret so forks without the key don't attempt the job.
+    if: ${{ github.event_name != 'schedule' || github.repository == 'agent-team-foundation/first-tree' }}
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # dist/cli.js is required by the help-self-sufficiency suite and
+      # by any future subprocess test that invokes the bundled CLI.
+      - run: pnpm build
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Fail fast if the API key is missing
+        run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "ANTHROPIC_API_KEY is not available to this run; skipping agent-e2e." >&2
+            exit 0
+          fi
+
+      - name: Run agent-e2e tier
+        if: env.ANTHROPIC_API_KEY != ''
+        run: |
+          if [ -n "${{ inputs.stage }}" ]; then
+            pnpm test:agent -- -t "${{ inputs.stage }}"
+          else
+            pnpm test:agent
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,9 +89,13 @@ pnpm test
 pnpm build
 pnpm test:dist     # post-build binary smoke (requires a prior pnpm build)
 pnpm test:release  # pack + npm install <tarball> smoke
+pnpm test:agent    # LLM-judge + real-Claude skill behaviour (needs ANTHROPIC_API_KEY; out-of-band from release:check)
 ```
 
-See `docs/testing/overview.md` for the layered gate contract.
+See `docs/testing/overview.md` for the layered gate contract. The
+agent-e2e tier runs on a weekly cron via `.github/workflows/agent-e2e.yml`
+and can be dispatched manually before a release; it is not part of
+every-PR CI.
 
 Maintainer-only eval tooling lives in `evals/`. See `evals/README.md` before
 running `EVALS=1 pnpm eval`.

--- a/docs/testing/overview.md
+++ b/docs/testing/overview.md
@@ -100,11 +100,69 @@ Useful for manual tarball inspection. For automated coverage,
 the package contents; you shouldn't need to run `pnpm pack` by hand unless
 you're diagnosing a specific packaging regression.
 
+## Agent-E2E Tier
+
+A separate, out-of-band tier exercises the agent-facing behaviour of
+the shipped `SKILL.md` files and CLI `--help` output via a real Claude
+Code subprocess. It is intentionally **not** part of `release:check`:
+LLM flake would create noisy red PRs, and every run costs money.
+
+```bash
+pnpm test:agent
+```
+
+Requires `ANTHROPIC_API_KEY` and `FIRST_TREE_AGENT_TESTS=1` (the script
+sets the flag). Without either, every test in the tier skips cleanly.
+
+### Suites
+
+- `tests/agent-e2e/skill-quality.test.ts` — LLM judge scores each of the
+  four `SKILL.md` files on clarity / completeness / actionability
+  (≥4/5, regression check against `baselines/skill-quality.json`).
+- `tests/agent-e2e/command-discovery.test.ts` — spawns a real Claude
+  subprocess against six intent prompts and asserts the correct
+  `first-tree <ns> <cmd>` was invoked.
+- `tests/agent-e2e/path-disambiguation.test.ts` — three scenarios that
+  verify the agent picks the right command among source-repo vs
+  dedicated-tree vs workspace contexts.
+- `tests/agent-e2e/anti-hallucination.test.ts` — three negative tests
+  that assert the agent does **not** fabricate plausible-but-fake verbs
+  (`tree owner-set`, `tree status`, `breeze ack`, etc.).
+- `tests/agent-e2e/help-self-sufficiency.test.ts` — LLM judge on
+  `first-tree <ns> --help` for all four namespaces (baseline in
+  `baselines/help-quality.json`).
+
+### When it runs
+
+- **Weekly cron** via `.github/workflows/agent-e2e.yml` (Monday 07:00 UTC),
+  so SKILL.md or prompt drift caused by a recent merge shows up early in
+  the week without gating individual PRs.
+- **Manual dispatch** — run via GitHub Actions → "Agent E2E" before a
+  release, optionally filtering with a vitest name pattern.
+- **Locally** — `ANTHROPIC_API_KEY=… pnpm test:agent`.
+
+### Baselines
+
+Stage A (skill quality) and Stage E (help quality) use pinned baselines
+that maintainers hand-bump. To seed or update them:
+
+```bash
+ANTHROPIC_API_KEY=… pnpm test:agent
+# Review the printed scores; if acceptable, commit updated baseline
+# files under tests/agent-e2e/baselines/.
+```
+
+Never update a baseline automatically on a passing run — regressions
+should be an explicit human sign-off.
+
 ## Repo-Only Evals
 
-The end-to-end eval harness is intentionally not part of the distributed skill.
-It lives under root `evals/` for `first-tree` maintainers working in this
-source repo. Use `evals/README.md` when you need to run or update it.
+The full end-to-end bug-fix eval harness is intentionally not part of
+the distributed skill. It lives under root `evals/` for `first-tree`
+maintainers working in this source repo. Use `evals/README.md` when
+you need to run or update it. Agent-e2e (above) is cheaper and
+behaviour-focused; evals are higher-fidelity and fix-a-real-bug
+focused.
 
 ## Change Discipline
 


### PR DESCRIPTION
## Summary
- Stage F (final) of the agent-e2e series. Wires the tier into CI and documents it.
- `.github/workflows/agent-e2e.yml`: weekly Monday 07:00 UTC cron + `workflow_dispatch`. Gates on `ANTHROPIC_API_KEY` secret so forks without the secret skip cleanly. Dispatch input `stage` forwards to vitest's `-t` name filter for targeted runs.
- `docs/testing/overview.md`: new "Agent-E2E Tier" section — five suites, baseline-bumping workflow, explicit rationale for staying out-of-band from `release:check`.
- `AGENTS.md`: adds `pnpm test:agent` to the validation quick-reference.

## Why cron, not per-PR
LLM flake on a per-PR gate trains maintainers to treat the tier as noisy and start ignoring it. `release:check` continues to gate every PR deterministically; the agent-e2e cron catches drift in the behavioural surface between those gates.

## Series summary (closes the PR family #203–#208)
| Stage | PR | Contents | Tests |
|---|---|---|---|
| A | #203 | harness + LLM-judge + static SKILL quality | 4 |
| B | #204 | command-discovery | 6 |
| C | #205 | path-disambiguation | 3 |
| D | #206 | anti-hallucination | 3 |
| E | #207 | help self-sufficiency | 4 |
| F | this | CI cron + docs + AGENTS.md | 0 new tests |

Total: **20 env-gated agent-e2e tests** that together guard the skill/CLI surface an agent actually sees, on top of `release:check` which guarantees the deterministic "install and run" surface.

## Test plan
- [x] `pnpm typecheck` clean.
- [x] `pnpm test` 927/927 passing; agent-e2e tier skipped.
- [x] `pnpm release:check` green end-to-end.
- [x] `pnpm test:agent` with env off — 20 skipped across 5 files.
- [ ] First cron run on next Monday (or maintainer triggers the workflow manually to prime baselines before a release).

https://claude.ai/code/session_01U5uJVMRpnQfr9C8mSV3s6a