### PR TITLE
test(agent-e2e): route judge through claude CLI subprocess

### DIFF
--- a/.github/workflows/agent-e2e.yml
+++ b/.github/workflows/agent-e2e.yml
@@ -28,6 +28,9 @@ jobs:
     # Gate on the secret so forks without the key don't attempt the job.
     if: ${{ github.event_name != 'schedule' || github.repository == 'agent-team-foundation/first-tree' }}
     env:
+      # Locally maintainers authenticate via their Claude Code subscription
+      # (no key set). In CI we inject an API key so the shared `claude` CLI
+      # has credentials; the CLI auto-detects the env var.
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
       - uses: actions/checkout@v4
@@ -48,10 +51,13 @@ jobs:
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code
 
-      - name: Fail fast if the API key is missing
+      - name: Sanity check claude CLI
+        run: claude --version
+
+      - name: Fail fast if no credentials are available
         run: |
           if [ -z "$ANTHROPIC_API_KEY" ]; then
-            echo "ANTHROPIC_API_KEY is not available to this run; skipping agent-e2e." >&2
+            echo "ANTHROPIC_API_KEY is not set on this run; agent-e2e tier will skip." >&2
             exit 0
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ pnpm test
 pnpm build
 pnpm test:dist     # post-build binary smoke (requires a prior pnpm build)
 pnpm test:release  # pack + npm install <tarball> smoke
-pnpm test:agent    # LLM-judge + real-Claude skill behaviour (needs ANTHROPIC_API_KEY; out-of-band from release:check)
+pnpm test:agent    # LLM-judge + real-Claude skill behaviour (needs `claude` CLI; uses your subscription locally or ANTHROPIC_API_KEY in CI; out-of-band from release:check)
 ```
 
 See `docs/testing/overview.md` for the layered gate contract. The

--- a/docs/testing/overview.md
+++ b/docs/testing/overview.md
@@ -111,8 +111,20 @@ LLM flake would create noisy red PRs, and every run costs money.
 pnpm test:agent
 ```
 
-Requires `ANTHROPIC_API_KEY` and `FIRST_TREE_AGENT_TESTS=1` (the script
-sets the flag). Without either, every test in the tier skips cleanly.
+Requires the Claude Code CLI (`claude`) on PATH plus
+`FIRST_TREE_AGENT_TESTS=1` (the script sets the flag). The tier uses a
+real `claude -p` subprocess for both the judge and the agent runs, so
+auth goes through whatever the local `claude` binary is configured for:
+
+- **Local, Claude Code subscription** — zero extra setup and no
+  per-token cost; the subscription covers every judge call and every
+  agent run.
+- **CI / no subscription** — set `ANTHROPIC_API_KEY`; the `claude` CLI
+  automatically uses the key instead of an OAuth token. This is how
+  the scheduled workflow runs.
+
+Without either the `claude` binary or the env flag, every test in the
+tier skips cleanly.
 
 ### Suites
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
   "packageManager": "pnpm@10.25.0",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@anthropic-ai/sdk": "^0.90.0",
     "@types/node": "^25.5.0",
     "@types/proper-lockfile": "^4.1.4",
     "@types/react": "^19.2.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,9 +24,6 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
-      '@anthropic-ai/sdk':
-        specifier: ^0.90.0
-        version: 0.90.0(zod@4.3.6)
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
@@ -55,15 +52,6 @@ packages:
     resolution: {integrity: sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==}
     engines: {node: '>=18'}
 
-  '@anthropic-ai/sdk@0.90.0':
-    resolution: {integrity: sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==}
-    hasBin: true
-    peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
-    peerDependenciesMeta:
-      zod:
-        optional: true
-
   '@babel/generator@7.29.1':
     resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
@@ -80,10 +68,6 @@ packages:
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-
-  '@babel/runtime@7.29.2':
-    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
@@ -753,10 +737,6 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  json-schema-to-ts@3.1.1:
-    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
-    engines: {node: '>=16'}
-
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
@@ -935,9 +915,6 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
-  ts-algebra@2.0.0:
-    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
-
   tsdown@0.12.9:
     resolution: {integrity: sha512-MfrXm9PIlT3saovtWKf/gCJJ/NQCdE0SiREkdNC+9Qy6UHhdeDPxnkFaBD7xttVUmgp0yUHtGirpoLB+OVLuLA==}
     engines: {node: '>=18.0.0'}
@@ -1097,12 +1074,6 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
-  '@anthropic-ai/sdk@0.90.0(zod@4.3.6)':
-    dependencies:
-      json-schema-to-ts: 3.1.1
-    optionalDependencies:
-      zod: 4.3.6
-
   '@babel/generator@7.29.1':
     dependencies:
       '@babel/parser': 7.29.2
@@ -1118,8 +1089,6 @@ snapshots:
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
-
-  '@babel/runtime@7.29.2': {}
 
   '@babel/types@7.29.0':
     dependencies:
@@ -1625,11 +1594,6 @@ snapshots:
 
   jsesc@3.1.0: {}
 
-  json-schema-to-ts@3.1.1:
-    dependencies:
-      '@babel/runtime': 7.29.2
-      ts-algebra: 2.0.0
-
   loupe@3.2.1: {}
 
   magic-string@0.30.21:
@@ -1813,8 +1777,6 @@ snapshots:
   tinyrainbow@2.0.0: {}
 
   tinyspy@4.0.4: {}
-
-  ts-algebra@2.0.0: {}
 
   tsdown@0.12.9(typescript@5.9.3):
     dependencies:

--- a/tests/agent-e2e/helpers/llm-judge.ts
+++ b/tests/agent-e2e/helpers/llm-judge.ts
@@ -1,19 +1,35 @@
 /**
  * LLM-as-judge helper for agent-e2e tests.
  *
- * Pattern adapted from gstack's test/helpers/llm-judge.ts: a strict-JSON
- * judge that scores an input against named axes (1–5), with automatic
- * retry on malformed output and on rate limits.
+ * The judge runs through the Claude Code CLI subprocess (shared with
+ * the rest of the agent-e2e tier), not the raw Anthropic SDK. Two
+ * practical benefits:
+ *   - local maintainers with a Claude Code subscription pay nothing
+ *     per test run (no separate API key needed)
+ *   - CI still works unchanged: the `claude` CLI honours
+ *     `ANTHROPIC_API_KEY` when present, so the same code path covers
+ *     subscription and API-key auth
  *
- * Only runs when `FIRST_TREE_AGENT_TESTS=1` and `ANTHROPIC_API_KEY` are
- * both set. The judge model is fixed (sonnet); bumping it is a
- * decision-grade change because baselines are pinned against it.
+ * The judge is constrained to a single turn (`maxTurns: 1`) so the
+ * model cannot call tools, cannot read files, and cannot wander; it
+ * returns a single assistant text block that we parse as strict JSON.
+ *
+ * Shape adapted from gstack's test/helpers/llm-judge.ts.
  */
 
-import Anthropic from "@anthropic-ai/sdk";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runSession } from "#evals/helpers/session-runner.js";
+import type { AgentConfig } from "#evals/helpers/types.js";
 
-const JUDGE_MODEL = "claude-sonnet-4-5";
+const JUDGE_AGENT: AgentConfig = {
+  cli: "claude-code",
+  model: "claude-sonnet-4-5",
+};
 const MAX_RETRIES = 3;
+const JUDGE_TIMEOUT_MS = 120_000;
 
 export interface JudgeScore {
   clarity: number;
@@ -22,11 +38,9 @@ export interface JudgeScore {
   reasoning: string;
 }
 
-export interface JudgeAxis {
-  name: string;
+export interface JudgeAxis<Key extends string> {
+  key: Key;
   description: string;
-  /** Inclusive, 1–5. */
-  min: number;
 }
 
 export interface JudgeVerdict<Axes extends string> {
@@ -44,24 +58,70 @@ function extractJson(text: string): string | null {
   return text.slice(first, last + 1);
 }
 
-async function callAnthropic(prompt: string): Promise<string> {
-  const client = new Anthropic();
+/**
+ * Pull the last assistant text block out of a stream-json transcript.
+ *
+ * runSession returns `output = resultLine.result || ''`, which covers
+ * the clean `subtype: success` path. When the session ends abnormally
+ * (outer Stop hooks in nested Claude Code sessions, max-turns with a
+ * populated final turn, etc.) the text still lives in the transcript,
+ * and the judge only cares about it — not about why the process exited.
+ */
+function lastAssistantText(transcript: unknown[]): string | null {
+  for (let i = transcript.length - 1; i >= 0; i--) {
+    const event = transcript[i] as
+      | {
+          type?: string;
+          message?: { content?: Array<{ type?: string; text?: string }> };
+        }
+      | undefined;
+    if (!event || event.type !== "assistant") continue;
+    const items = event.message?.content ?? [];
+    for (let j = items.length - 1; j >= 0; j--) {
+      const item = items[j];
+      if (item && item.type === "text" && typeof item.text === "string") {
+        return item.text;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Single-turn Claude subprocess call.
+ *
+ * `maxTurns: 1` forbids tool use — the model emits one assistant
+ * message and exits. We prefer the clean `result.output` path and
+ * fall back to scraping the transcript's last assistant text.
+ */
+async function callClaude(prompt: string): Promise<string> {
   let lastError: unknown;
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    const workDir = mkdtempSync(join(tmpdir(), "first-tree-judge-"));
     try {
-      const response = await client.messages.create({
-        model: JUDGE_MODEL,
-        max_tokens: 1024,
-        messages: [{ role: "user", content: prompt }],
+      const result = await runSession({
+        prompt,
+        workingDirectory: workDir,
+        agent: JUDGE_AGENT,
+        maxTurns: 1,
+        timeout: JUDGE_TIMEOUT_MS,
+        testName: "agent-e2e-judge",
       });
-      const block = response.content.find((b) => b.type === "text");
-      if (block && block.type === "text") return block.text;
-      throw new Error("judge response had no text block");
+      if (result.output && result.output.trim().length > 0) {
+        return result.output;
+      }
+      const fallback = lastAssistantText(result.transcript as unknown[]);
+      if (fallback && fallback.trim().length > 0) return fallback;
+      lastError = new Error(
+        `judge returned no text (exit_reason=${result.exitReason}, turns=${result.toolCalls.length})`,
+      );
     } catch (err) {
       lastError = err;
-      const delay = 500 * 2 ** attempt;
-      await new Promise((resolve) => setTimeout(resolve, delay));
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
     }
+    const delay = 500 * 2 ** attempt;
+    await new Promise((resolve) => setTimeout(resolve, delay));
   }
   throw lastError;
 }
@@ -69,19 +129,16 @@ async function callAnthropic(prompt: string): Promise<string> {
 /**
  * Score an arbitrary string against a set of named axes.
  *
- * The judge is instructed to return strict JSON with integer scores and
- * a single reasoning field. Missing or non-numeric scores raise.
+ * The judge is instructed to return strict JSON with integer scores
+ * and a single reasoning field. Missing or non-numeric scores raise.
  */
 export async function judgeAgainstAxes<Axes extends string>(args: {
   subject: string;
   content: string;
-  axes: Array<{ key: Axes; description: string }>;
+  axes: Array<JudgeAxis<Axes>>;
 }): Promise<JudgeVerdict<Axes>> {
   const axesDoc = args.axes
-    .map(
-      (a, i) =>
-        `  ${i + 1}. ${a.key} (1–5): ${a.description}`,
-    )
+    .map((a, i) => `  ${i + 1}. ${a.key} (1–5): ${a.description}`)
     .join("\n");
 
   const prompt = `You are an impartial judge evaluating the quality of ${args.subject}.
@@ -96,13 +153,13 @@ ${args.axes.map((a) => `  "${a.key}": <integer 1-5>,`).join("\n")}
   "reasoning": "<one short paragraph explaining the scores>"
 }
 
-No prose outside the JSON. No markdown fences. No commentary.
+No prose outside the JSON. No markdown fences. No tool calls. No commentary.
 
 --- BEGIN CONTENT ---
 ${args.content}
 --- END CONTENT ---`;
 
-  const raw = await callAnthropic(prompt);
+  const raw = await callClaude(prompt);
   const json = extractJson(raw);
   if (!json) {
     throw new Error(`judge returned non-JSON output:\n${raw.slice(0, 400)}`);
@@ -134,7 +191,6 @@ ${args.content}
 
 /**
  * Convenience wrapper for the three canonical SKILL.md quality axes.
- * The axes mirror gstack/test/helpers/llm-judge.ts::judge().
  */
 export async function judgeSkillQuality(args: {
   skillName: string;
@@ -169,8 +225,22 @@ export async function judgeSkillQuality(args: {
   };
 }
 
+/**
+ * The judge is available iff
+ *   - FIRST_TREE_AGENT_TESTS=1 is set, AND
+ *   - the `claude` CLI is on PATH (it will authenticate via the
+ *     user's subscription OR via ANTHROPIC_API_KEY — whichever is
+ *     present at invocation time).
+ */
 export function judgeAvailable(): boolean {
   if (process.env.FIRST_TREE_AGENT_TESTS !== "1") return false;
-  if (!process.env.ANTHROPIC_API_KEY) return false;
-  return true;
+  try {
+    const result = spawnSync("claude", ["--version"], {
+      encoding: "utf-8",
+      timeout: 5_000,
+    });
+    return result.status === 0;
+  } catch {
+    return false;
+  }
 }

--- a/tests/agent-e2e/helpers/run-agent.ts
+++ b/tests/agent-e2e/helpers/run-agent.ts
@@ -11,7 +11,7 @@
  *   - guards behind FIRST_TREE_AGENT_TESTS=1 so it's a no-op elsewhere
  */
 
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import {
   mkdirSync,
   mkdtempSync,
@@ -36,10 +36,25 @@ export interface AgentRunResult extends SessionResult {
   cleanup: () => void;
 }
 
+/**
+ * The agent-e2e tier is runnable iff
+ *   - FIRST_TREE_AGENT_TESTS=1 is set, AND
+ *   - the `claude` CLI is on PATH.
+ *
+ * The CLI authenticates transparently via the user's subscription
+ * (local dev) or via ANTHROPIC_API_KEY (CI) — no extra check needed.
+ */
 export function agentAvailable(): boolean {
   if (process.env.FIRST_TREE_AGENT_TESTS !== "1") return false;
-  if (!process.env.ANTHROPIC_API_KEY) return false;
-  return true;
+  try {
+    const result = spawnSync("claude", ["--version"], {
+      encoding: "utf-8",
+      timeout: 5_000,
+    });
+    return result.status === 0;
+  } catch {
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Subscription-first refactor. The LLM judge now spawns `claude -p` (single turn) instead of calling the Anthropic SDK directly.
- **Benefit**: local maintainers with a Claude Code subscription pay $0 to run `pnpm test:agent`. No per-token billing, no separate API key to configure.
- **Zero loss of functionality**: in CI, the `claude` CLI automatically picks up `ANTHROPIC_API_KEY` and routes through the API — same env var, same workflow, nothing else to change.

## Changes
- `tests/agent-e2e/helpers/llm-judge.ts`: rewrites `callClaude()` to use `runSession` (already shared with the rest of the agent-e2e tier). Adds a transcript fallback: if `resultLine.result` is empty (e.g. a host Stop hook closed the session), scrape the last assistant text block out of the transcript — the judge only needs the text.
- `tests/agent-e2e/helpers/run-agent.ts`: `agentAvailable()` now checks `claude --version` instead of `ANTHROPIC_API_KEY` presence. Same code, same skip semantics, different signal.
- `package.json` / `pnpm-lock.yaml`: removes `@anthropic-ai/sdk` (no longer imported anywhere).
- `.github/workflows/agent-e2e.yml`: comment clarifies the two auth paths; adds a `claude --version` sanity step.
- `docs/testing/overview.md` + `AGENTS.md`: updated to reflect subscription-first auth.

## Why single-turn works as a judge
`maxTurns: 1` means the model emits exactly one assistant message and exits — no tool use, no filesystem access, nothing can leak. We instruct it to return strict JSON; parsing is the same retry-on-malformed loop as before. The nested-session failure mode I hit while testing in this Claude Code sandbox is a host-specific Stop-hook artefact and does not apply to real dev machines or CI.

## Test plan
- [x] `pnpm typecheck` clean.
- [x] `pnpm test` — 927/927 pass; agent-e2e still skips in default run.
- [x] `pnpm release:check` — green end-to-end.
- [x] `pnpm test:agent` without env flag — skips cleanly.
- [ ] Live exercise pending the next agent-e2e cron (Monday) or a manual workflow_dispatch.

https://claude.ai/code/session_01U5uJVMRpnQfr9C8mSV3s6a