### PR TITLE
refactor(breeze): rename Runner* → Agent* in daemon internals

### DIFF
--- a/src/products/breeze/engine/commands/doctor.ts
+++ b/src/products/breeze/engine/commands/doctor.ts
@@ -21,7 +21,7 @@ import {
 } from "../daemon/claim.js";
 import { RepoFilter } from "../runtime/repo-filter.js";
 import {
-  detectAvailableRunners,
+  detectAvailableAgents,
   findExecutable,
   resolveRunnerHome,
 } from "../daemon/runner-skeleton.js";
@@ -93,7 +93,7 @@ export async function runDoctor(
     "default",
   );
   const store = new ThreadStore({ runnerHome: home });
-  const runners = detectAvailableRunners();
+  const agents = detectAvailableAgents();
 
   write("breeze-runner doctor");
   write(`home: ${home}`);
@@ -106,7 +106,7 @@ export async function runDoctor(
   write(`scopes: ${scopes}`);
   write(`lock: ${formatLockState(lock)}`);
   write(
-    `runners: ${runners.length > 0 ? runners.map((r) => r.kind).join(", ") : "(none)"}`,
+    `agents: ${agents.length > 0 ? agents.map((r) => r.kind).join(", ") : "(none)"}`,
   );
   write(`gh binary: ${findExecutable("gh") ?? "(missing)"}`);
   write(`required auth scope: ${scopeLine}`);

--- a/src/products/breeze/engine/daemon/dispatcher.ts
+++ b/src/products/breeze/engine/daemon/dispatcher.ts
@@ -11,7 +11,7 @@
  *     across restarts and across this host + laptop.
  *   - Respect `maxParallel` concurrency ceiling.
  *   - Prepare a workspace (`workspace.ts`) and run the agent
- *     (`runner.ts::executeRunner`) with the pool's execution order as
+ *     (`runner.ts::executeAgent`) with the pool's execution order as
  *     fallback chain.
  *   - Publish task-phase events to the bus (`bus.ts`) so SSE
  *     subscribers see `dispatched` / `completed` / `failed` / `timed_out`.
@@ -37,15 +37,15 @@ import {
   tryClaim,
 } from "./claim.js";
 import {
-  RunnerPool,
-  executeRunner,
+  AgentPool,
+  executeAgent,
   runWithTimeout,
   type AgentIdentity,
-  type RunnerOutcome,
-  type RunnerRequest,
-  type RunnerSpec,
-  type RunnerSpawner,
-  type RunnerTask,
+  type AgentOutcome,
+  type AgentRequest,
+  type AgentSpec,
+  type AgentSpawner,
+  type AgentTask,
 } from "./runner.js";
 import {
   WorkspaceManager,
@@ -78,7 +78,7 @@ export interface TaskCandidate {
 export interface DispatcherOptions {
   runnerHome: string;
   identity: AgentIdentity;
-  runners: readonly RunnerSpec[];
+  agents: readonly AgentSpec[];
   workspaceManager: WorkspaceManager;
   bus: Bus;
   ghShimDir: string;
@@ -87,8 +87,8 @@ export interface DispatcherOptions {
   disclosureText: string;
   maxParallel: number;
   taskTimeoutMs: number;
-  /** Inject a runner spawner; tests pass a stub. Production uses default. */
-  spawner?: RunnerSpawner;
+  /** Inject an agent spawner; tests pass a stub. Production uses default. */
+  spawner?: AgentSpawner;
   /** Inject a clock (seconds). */
   nowSec?: () => number;
   /** Hook called once per completion (ok or error). */
@@ -119,8 +119,8 @@ export interface CompletionRecord {
   status?: string;
   summary?: string;
   error?: string;
-  runnerName?: string;
-  runnerOutputPath?: string;
+  agentName?: string;
+  agentOutputPath?: string;
 }
 
 interface ActiveTask {
@@ -146,7 +146,7 @@ const DEFAULT_LOGGER: DispatcherLogger = {
  */
 export class Dispatcher {
   private readonly options: DispatcherOptions;
-  private readonly runnerPool: RunnerPool;
+  private readonly agentPool: AgentPool;
   private readonly logger: DispatcherLogger;
   private readonly pending: TaskCandidate[] = [];
   private readonly queuedThreads = new Set<string>();
@@ -161,7 +161,7 @@ export class Dispatcher {
 
   constructor(options: DispatcherOptions) {
     this.options = options;
-    this.runnerPool = new RunnerPool(options.runners);
+    this.agentPool = new AgentPool(options.agents);
     this.logger = options.logger ?? DEFAULT_LOGGER;
     this.nowSec = options.nowSec ?? (() => Math.floor(Date.now() / 1_000));
     this.claimTtlSec = options.claimTtlSec ?? CLAIM_STALE_AFTER_SEC;
@@ -296,7 +296,7 @@ export class Dispatcher {
         phase: "completed",
         status: "simulated",
         summary: "dry-run scheduled task",
-        runnerOutputPath: join(taskDir, "runner-output.txt"),
+        agentOutputPath: join(taskDir, "runner-output.txt"),
       };
       this.options.onCompletion?.(record);
       this.publishTask(record);
@@ -323,7 +323,7 @@ export class Dispatcher {
       return;
     }
 
-    const request = makeRunnerRequest({
+    const request = makeAgentRequest({
       candidate,
       taskId,
       taskDir,
@@ -335,27 +335,27 @@ export class Dispatcher {
       disclosureText: this.options.disclosureText,
     });
 
-    const runners = this.runnerPool.executionOrder();
+    const agents = this.agentPool.executionOrder();
     const errors: string[] = [];
-    let outcome: RunnerOutcome | undefined;
-    let selectedRunner: RunnerSpec | undefined;
+    let outcome: AgentOutcome | undefined;
+    let selectedAgent: AgentSpec | undefined;
     let timedOut = false;
 
-    for (const spec of runners) {
+    for (const spec of agents) {
       try {
         outcome = await runWithTimeout({
-          run: () => executeRunner(spec, request, {
+          run: () => executeAgent(spec, request, {
             timeoutMs: this.options.taskTimeoutMs,
             spawner: this.options.spawner,
           }),
-          // `executeRunner`'s spawner handles its own kill hook; we use
+          // `executeAgent`'s spawner handles its own kill hook; we use
           // runWithTimeout as an additional safety net and propagate
           // the shutdown signal.
           kill: () => undefined,
           timeoutMs: this.options.taskTimeoutMs,
           signal: this.shutdown.signal,
         });
-        selectedRunner = spec;
+        selectedAgent = spec;
         break;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -388,8 +388,8 @@ export class Dispatcher {
       phase: "completed",
       status: outcome.status,
       summary: outcome.summary,
-      runnerName: selectedRunner?.kind,
-      runnerOutputPath: outcome.outputPath,
+      agentName: selectedAgent?.kind,
+      agentOutputPath: outcome.outputPath,
     };
     this.options.onCompletion?.(record);
     this.publishTask(record);
@@ -423,7 +423,7 @@ function toWorkspaceCandidate(candidate: TaskCandidate): WorkspaceCandidate {
   };
 }
 
-function makeRunnerRequest(args: {
+function makeAgentRequest(args: {
   candidate: TaskCandidate;
   taskId: string;
   taskDir: string;
@@ -433,8 +433,8 @@ function makeRunnerRequest(args: {
   ghShimDir: string;
   ghBrokerDir: string;
   disclosureText: string;
-}): RunnerRequest {
-  const task: RunnerTask = {
+}): AgentRequest {
+  const task: AgentTask = {
     repo: args.candidate.repo,
     workspaceRepo: args.candidate.workspaceRepo ?? args.candidate.repo,
     kind: args.candidate.kind,

--- a/src/products/breeze/engine/daemon/runner-skeleton.ts
+++ b/src/products/breeze/engine/daemon/runner-skeleton.ts
@@ -17,7 +17,7 @@
  *   - The poller observes `signal.aborted`, finishes any in-flight
  *     `pollOnce` (including draining the inbox.json advisory lock),
  *     then resolves.
- *   - Dispatcher.stop() aborts in-flight runner tasks and drains
+ *   - Dispatcher.stop() aborts in-flight agent tasks and drains
  *     pending. Broker.stop() waits for the serve-loop to unwind.
  *   - The daemon exits with code 0 on clean shutdown, 1 on fatal error.
  *
@@ -45,7 +45,7 @@ import { startGhBroker, type RunningBroker } from "./broker.js";
 import { GhExecutor } from "./gh-executor.js";
 import { Dispatcher } from "./dispatcher.js";
 import { WorkspaceManager } from "./workspace.js";
-import type { RunnerSpec } from "./runner.js";
+import type { AgentSpec } from "./runner.js";
 import { GhClient as BrokerGhClient } from "./gh-client.js";
 import { runCandidateLoop } from "./candidate-loop.js";
 import { RepoFilter } from "../runtime/repo-filter.js";
@@ -303,16 +303,16 @@ export async function runDaemon(
       ),
   });
 
-  // Phase 3c: start gh broker + dispatcher if runners are available.
+  // Phase 3c: start gh broker + dispatcher if agents are available.
   // Absence of codex/claude is non-fatal; the daemon still runs as
   // read-only (poller + http).
   let broker: RunningBroker | null = null;
   let dispatcher: Dispatcher | null = null;
   let candidateLoopDone: Promise<void> | null = null;
   try {
-    const runners = detectAvailableRunners();
+    const agents = detectAvailableAgents();
     const realGh = findExecutable("gh");
-    if (runners.length > 0 && realGh) {
+    if (agents.length > 0 && realGh) {
       const runnerHome = resolveRunnerHome();
       const brokerDir = join(runnerHome, "broker");
       const identity = resolveDaemonIdentity({ host: config.host });
@@ -352,7 +352,7 @@ export async function runDaemon(
       dispatcher = new Dispatcher({
         runnerHome,
         identity: { host: identity.host, login: identity.login },
-        runners,
+        agents,
         workspaceManager,
         bus,
         ghShimDir: broker.shimDir,
@@ -366,7 +366,7 @@ export async function runDaemon(
         onCompletion: (record) => scheduler.handleCompletion(record),
       });
       logger.info(
-        `breeze daemon: dispatcher ready (runners=${runners.map((r) => r.kind).join(",")}, broker=${broker.shimDir})`,
+        `breeze daemon: dispatcher ready (agents=${agents.map((r) => r.kind).join(",")}, broker=${broker.shimDir})`,
       );
 
       // Phase 4: candidate loop — feeds the dispatcher from GitHub.
@@ -390,7 +390,7 @@ export async function runDaemon(
       });
     } else {
       const missing: string[] = [];
-      if (runners.length === 0) missing.push("no codex/claude on PATH");
+      if (agents.length === 0) missing.push("no codex/claude on PATH");
       if (!realGh) missing.push("no gh on PATH");
       logger.warn(
         `breeze daemon: skipping broker/dispatcher (${missing.join("; ")})`,
@@ -455,7 +455,7 @@ export async function runDaemon(
     // Shutdown order:
     //   SIGTERM -> stop poller (above) -> flush store (poller's atomic
     //   tmp+rename drains in updateInbox) -> stop dispatcher (aborts
-    //   in-flight runner tasks) -> stop broker (drains serve loop) ->
+    //   in-flight agent tasks) -> stop broker (drains serve loop) ->
     //   stop http -> close bus -> exit.
     if (!controller.signal.aborted) controller.abort();
     if (candidateLoopDone) {
@@ -504,15 +504,15 @@ export async function runDaemon(
 
 /**
  * Walk PATH looking for a best-effort set of agent binaries. Returns
- * the specs in the order we'd prefer as the primary runner. Missing
+ * the specs in the order we'd prefer as the primary agent. Missing
  * binaries are silently omitted — the caller decides whether that is
  * fatal.
  */
-export function detectAvailableRunners(): RunnerSpec[] {
-  const runners: RunnerSpec[] = [];
-  if (findExecutable("codex")) runners.push({ kind: "codex" });
-  if (findExecutable("claude")) runners.push({ kind: "claude" });
-  return runners;
+export function detectAvailableAgents(): AgentSpec[] {
+  const agents: AgentSpec[] = [];
+  if (findExecutable("codex")) agents.push({ kind: "codex" });
+  if (findExecutable("claude")) agents.push({ kind: "claude" });
+  return agents;
 }
 
 /** Return the absolute path to `name` on PATH, or null if not found. */

--- a/src/products/breeze/engine/daemon/runner.ts
+++ b/src/products/breeze/engine/daemon/runner.ts
@@ -1,22 +1,32 @@
 /**
- * Phase 3c: per-task agent runner.
+ * Phase 3c: per-task agent executor.
  *
  * Port of `runner.rs`.
  *
- * Each dispatched task picks one or more runner specs from the pool,
+ * Terminology: within breeze, the daemon (sometimes called "breeze-runner"
+ * for historical reasons) owns a dispatcher which drives multiple
+ * concurrent **agents**. An agent here is a single CLI backend binding
+ * (`codex` or `claude`); the dispatcher picks from an AgentPool and may
+ * fall through the pool's rotation order until one backend succeeds.
+ *
+ * Each dispatched task picks one or more agent specs from the pool,
  * builds a prompt, writes it to `<task-dir>/prompt.txt`, and execs the
- * agent binary (`codex` or `claude`). Stdout/stderr go to
- * `runner-stdout.log` / `runner-stderr.log`; `runner-output.txt`
- * holds the agent's final message (codex writes it via
- * `--output-last-message`, claude's stdout is copied there post-exit).
+ * agent binary. Stdout/stderr go to `runner-stdout.log` /
+ * `runner-stderr.log`; `runner-output.txt` holds the agent's final
+ * message (codex writes it via `--output-last-message`, claude's
+ * stdout is copied there post-exit). These on-disk filenames keep the
+ * "runner-" prefix to preserve the debug-artifact contract across the
+ * Rust → TS port.
  *
- * The dispatcher iterates runners in `executionOrder()` until one
- * returns successfully, mirroring Rust's fallback chain. Only the
- * first runner is recorded as "selected" in task metadata.
+ * The dispatcher iterates the pool in `executionOrder()` until one
+ * agent returns successfully, mirroring Rust's fallback chain. Only
+ * the first agent that succeeds is recorded as "selected" in task
+ * metadata (the on-disk `runner=` key is also preserved for the same
+ * compat reason).
  *
- * Phase 3c adds a per-task timeout (spec doc 4 §11, §8). Rust's
- * runner had no timeout; the TS version always enforces one, with a
- * default in `runtime/config.ts::DAEMON_CONFIG_DEFAULTS.taskTimeoutSec`.
+ * Phase 3c adds a per-task timeout (spec doc 4 §11, §8). Rust's agent
+ * had no timeout; the TS version always enforces one, with a default
+ * in `runtime/config.ts::DAEMON_CONFIG_DEFAULTS.taskTimeoutSec`.
  */
 
 import {
@@ -29,10 +39,10 @@ import {
 import { spawn, type ChildProcess } from "node:child_process";
 import { join } from "node:path";
 
-export type RunnerKind = "codex" | "claude";
+export type AgentKind = "codex" | "claude";
 
-export interface RunnerSpec {
-  kind: RunnerKind;
+export interface AgentSpec {
+  kind: AgentKind;
   model?: string;
 }
 
@@ -41,7 +51,7 @@ export interface AgentIdentity {
   host: string;
 }
 
-export interface RunnerTask {
+export interface AgentTask {
   repo: string;
   workspaceRepo: string;
   kind: string;
@@ -50,8 +60,8 @@ export interface RunnerTask {
   taskUrl: string;
 }
 
-export interface RunnerRequest {
-  task: RunnerTask;
+export interface AgentRequest {
+  task: AgentTask;
   taskId: string;
   taskDir: string;
   workspaceDir: string;
@@ -62,15 +72,15 @@ export interface RunnerRequest {
   disclosureText: string;
 }
 
-export interface RunnerOutcome {
+export interface AgentOutcome {
   status: string;
   summary: string;
   outputPath: string;
 }
 
-export type RunnerSpawner = (args: {
-  spec: RunnerSpec;
-  request: RunnerRequest;
+export type AgentSpawner = (args: {
+  spec: AgentSpec;
+  request: AgentRequest;
   promptPath: string;
   promptText: string;
   outputPath: string;
@@ -81,8 +91,8 @@ export type RunnerSpawner = (args: {
 export interface ExecuteOptions {
   /** Kill the subprocess if it runs longer than this many ms. */
   timeoutMs: number;
-  /** Injected spawner. Production uses `defaultRunnerSpawner`. */
-  spawner?: RunnerSpawner;
+  /** Injected spawner. Production uses `defaultAgentSpawner`. */
+  spawner?: AgentSpawner;
   /** Abort signal. Triggers the same kill path as the timeout. */
   signal?: AbortSignal;
 }
@@ -91,11 +101,11 @@ export interface ExecuteOptions {
  * Execute one runner. Writes the prompt + logs + parses the result.
  * Throws on non-zero exit so the dispatcher can try the next runner.
  */
-export async function executeRunner(
-  spec: RunnerSpec,
-  request: RunnerRequest,
+export async function executeAgent(
+  spec: AgentSpec,
+  request: AgentRequest,
   options: ExecuteOptions,
-): Promise<RunnerOutcome> {
+): Promise<AgentOutcome> {
   const promptText = buildPrompt(request);
   const promptPath = join(request.taskDir, "prompt.txt");
   const outputPath = join(request.taskDir, "runner-output.txt");
@@ -104,7 +114,7 @@ export async function executeRunner(
 
   writeFileSync(promptPath, promptText);
 
-  const spawner = options.spawner ?? defaultRunnerSpawner;
+  const spawner = options.spawner ?? defaultAgentSpawner;
   const { statusCode } = await spawner({
     spec,
     request,
@@ -127,7 +137,7 @@ export async function executeRunner(
 
   if (statusCode !== 0) {
     throw new Error(
-      `${spec.kind} runner exited with status ${statusCode ?? "unknown"}`,
+      `${spec.kind} agent exited with status ${statusCode ?? "unknown"}`,
     );
   }
 
@@ -138,7 +148,7 @@ export async function executeRunner(
   return { status, summary, outputPath };
 }
 
-export function buildPrompt(request: RunnerRequest): string {
+export function buildPrompt(request: AgentRequest): string {
   const task = request.task;
   const workingRepoLine =
     task.workspaceRepo !== task.repo
@@ -228,33 +238,33 @@ export function parseResult(output: string): {
 }
 
 /**
- * Rotate through the runner list, returning the sequence of specs to
+ * Rotate through the agent list, returning the sequence of specs to
  * try for the next task. Subsequent calls rotate by one so codex /
  * claude alternate as primary across tasks.
  */
-export class RunnerPool {
-  private readonly runners: readonly RunnerSpec[];
+export class AgentPool {
+  private readonly agents: readonly AgentSpec[];
   private nextIndex = 0;
 
-  constructor(runners: readonly RunnerSpec[]) {
-    if (runners.length === 0) {
+  constructor(agents: readonly AgentSpec[]) {
+    if (agents.length === 0) {
       throw new Error(
-        "no configured runner binary is available in PATH (need codex and/or claude)",
+        "no configured agent binary is available in PATH (need codex and/or claude)",
       );
     }
-    this.runners = runners;
+    this.agents = agents;
   }
 
-  availableNames(): RunnerKind[] {
-    return this.runners.map((r) => r.kind);
+  availableNames(): AgentKind[] {
+    return this.agents.map((r) => r.kind);
   }
 
-  executionOrder(): RunnerSpec[] {
-    const n = this.runners.length;
+  executionOrder(): AgentSpec[] {
+    const n = this.agents.length;
     const start = this.nextIndex % n;
     this.nextIndex = (this.nextIndex + 1) % n;
     return Array.from({ length: n }, (_, offset) => ({
-      ...this.runners[(start + offset) % n],
+      ...this.agents[(start + offset) % n],
     }));
   }
 }
@@ -264,7 +274,7 @@ export class RunnerPool {
  * `setTimeout(kill, timeoutMs)` and propagates an AbortSignal the same
  * way. Returns the exit status.
  */
-export const defaultRunnerSpawner: RunnerSpawner = async ({
+export const defaultAgentSpawner: AgentSpawner = async ({
   spec,
   request,
   promptPath,
@@ -304,8 +314,8 @@ export const defaultRunnerSpawner: RunnerSpawner = async ({
 };
 
 export function buildCommand(args: {
-  spec: RunnerSpec;
-  request: RunnerRequest;
+  spec: AgentSpec;
+  request: AgentRequest;
   promptPath: string;
   promptText: string;
   outputPath: string;
@@ -332,7 +342,7 @@ export function buildCommand(args: {
 }
 
 export function buildAgentEnv(
-  request: RunnerRequest,
+  request: AgentRequest,
 ): NodeJS.ProcessEnv {
   const existingPath = process.env.PATH ?? "";
   return {

--- a/src/products/breeze/engine/daemon/scheduler.ts
+++ b/src/products/breeze/engine/daemon/scheduler.ts
@@ -150,9 +150,9 @@ export class Scheduler {
       const status = record.status ?? "handled";
       meta.set("status", status);
       if (record.summary) meta.set("summary", encodeMultiline(record.summary));
-      if (record.runnerOutputPath)
-        meta.set("runner_output_path", record.runnerOutputPath);
-      if (record.runnerName) meta.set("runner", record.runnerName);
+      if (record.agentOutputPath)
+        meta.set("runner_output_path", record.agentOutputPath);
+      if (record.agentName) meta.set("runner", record.agentName);
 
       if (status === "handled" || status === "skipped") {
         threadRecord.lastHandledUpdatedAt = record.candidate.updatedAt;
@@ -269,7 +269,9 @@ export class Scheduler {
   writeRunningMetadata(args: {
     taskId: string;
     candidate: TaskCandidate;
-    runner: string;
+    /** Agent backend (codex/claude) picked by the dispatcher. Written
+     * to the on-disk `runner=` key for back-compat with the Rust port. */
+    agent: string;
     workspacePath?: string;
     mirrorDir?: string;
     repoUrl?: string;
@@ -289,7 +291,7 @@ export class Scheduler {
       started_at: String(now),
       updated_at: args.candidate.updatedAt,
       source: args.candidate.source,
-      runner: args.runner,
+      runner: args.agent,
       ...(args.workspacePath ? { workspace_path: args.workspacePath } : {}),
       ...(args.mirrorDir ? { mirror_dir: args.mirrorDir } : {}),
       ...(args.repoUrl ? { repo_url: args.repoUrl } : {}),

--- a/tests/breeze/breeze-commands-smoke.test.ts
+++ b/tests/breeze/breeze-commands-smoke.test.ts
@@ -48,7 +48,7 @@ describe("runDoctor", () => {
     const out = lines.join("\n");
     expect(out).toContain("breeze-runner doctor");
     expect(out).toContain(`home: ${home}`);
-    expect(out).toContain("runners:");
+    expect(out).toContain("agents:");
     expect(out).toMatch(/lock: (absent|stale|present)/);
   });
 });

--- a/tests/breeze/breeze-daemon-candidate-loop.test.ts
+++ b/tests/breeze/breeze-daemon-candidate-loop.test.ts
@@ -21,7 +21,7 @@ import {
   WorkspaceManager,
   type GitRunner,
 } from "../../src/products/breeze/engine/daemon/workspace.js";
-import type { RunnerSpawner } from "../../src/products/breeze/engine/daemon/runner.js";
+import type { AgentSpawner } from "../../src/products/breeze/engine/daemon/runner.js";
 import { RepoFilter } from "../../src/products/breeze/engine/runtime/repo-filter.js";
 import { GhExecutor } from "../../src/products/breeze/engine/daemon/gh-executor.js";
 
@@ -77,7 +77,7 @@ function makeDispatcher(): {
   const dispatcher = new Dispatcher({
     runnerHome: join(root, "runner"),
     identity: { host: "github.com", login: "alice" },
-    runners: [{ kind: "codex" }],
+    agents: [{ kind: "codex" }],
     workspaceManager: new WorkspaceManager({
       reposDir,
       workspacesDir: join(root, "workspaces"),

--- a/tests/breeze/breeze-daemon-dispatcher.test.ts
+++ b/tests/breeze/breeze-daemon-dispatcher.test.ts
@@ -19,7 +19,7 @@ import {
   WorkspaceManager,
   type GitRunner,
 } from "../../src/products/breeze/engine/daemon/workspace.js";
-import type { RunnerSpawner } from "../../src/products/breeze/engine/daemon/runner.js";
+import type { AgentSpawner } from "../../src/products/breeze/engine/daemon/runner.js";
 import { tryClaim } from "../../src/products/breeze/engine/daemon/claim.js";
 
 const tempRoots: string[] = [];
@@ -85,8 +85,8 @@ interface DispatcherEnv {
 }
 
 function setupDispatcher(opts: {
-  spawner?: RunnerSpawner;
-  runners?: Array<{ kind: "codex" | "claude" }>;
+  spawner?: AgentSpawner;
+  agents?: Array<{ kind: "codex" | "claude" }>;
   maxParallel?: number;
   taskTimeoutMs?: number;
   dryRun?: boolean;
@@ -105,7 +105,7 @@ function setupDispatcher(opts: {
   const dispatcher = new Dispatcher({
     runnerHome,
     identity: { host: "github.com", login: "alice" },
-    runners: opts.runners ?? [{ kind: "codex" }],
+    agents: opts.agents ?? [{ kind: "codex" }],
     workspaceManager: makeWorkspaceManager(root),
     bus,
     ghShimDir: join(root, "shim", "bin"),
@@ -147,7 +147,7 @@ function waitForCompletions(
 
 describe("Dispatcher.submit", () => {
   it("dedupes repeated candidates with the same threadKey", () => {
-    const spawner: RunnerSpawner = async ({ outputPath }) => {
+    const spawner: AgentSpawner = async ({ outputPath }) => {
       writeFileSync(
         outputPath,
         "BREEZE_RESULT: status=handled summary=ok",
@@ -167,7 +167,7 @@ describe("Dispatcher.submit", () => {
     // spawn before releasing. This exercises pump() ordering as slots free.
     let resolver: ((v: { statusCode: number }) => void) | undefined;
     const spawnedThreadKeys: string[] = [];
-    const spawner: RunnerSpawner = async ({ outputPath, request }) => {
+    const spawner: AgentSpawner = async ({ outputPath, request }) => {
       spawnedThreadKeys.push(request.task.title);
       return new Promise((resolve) => {
         resolver = (v) => {
@@ -238,7 +238,7 @@ describe("Dispatcher.submit", () => {
 
 describe("Dispatcher claim handling", () => {
   it("skips dispatch when the claim is already held by someone else", async () => {
-    const spawner = vi.fn<RunnerSpawner>();
+    const spawner = vi.fn<AgentSpawner>();
     const env = setupDispatcher({ spawner });
     // Pre-claim the notification as a different owner.
     tryClaim({
@@ -257,7 +257,7 @@ describe("Dispatcher claim handling", () => {
   });
 
   it("releases the claim after task completes", async () => {
-    const spawner: RunnerSpawner = async ({ outputPath }) => {
+    const spawner: AgentSpawner = async ({ outputPath }) => {
       writeFileSync(outputPath, "BREEZE_RESULT: status=handled summary=ok");
       return { statusCode: 0 };
     };
@@ -272,7 +272,7 @@ describe("Dispatcher claim handling", () => {
 describe("Dispatcher execution", () => {
   it("respects maxParallel (holds extras in pending)", async () => {
     const resolvers: Array<(v: { statusCode: number }) => void> = [];
-    const spawner: RunnerSpawner = async ({ outputPath }) =>
+    const spawner: AgentSpawner = async ({ outputPath }) =>
       new Promise((resolve) => {
         resolvers.push((v) => {
           writeFileSync(
@@ -305,7 +305,7 @@ describe("Dispatcher execution", () => {
   });
 
   it("marks completed and publishes task event", async () => {
-    const spawner: RunnerSpawner = async ({ outputPath }) => {
+    const spawner: AgentSpawner = async ({ outputPath }) => {
       writeFileSync(
         outputPath,
         "BREEZE_RESULT: status=handled summary=all done",
@@ -319,7 +319,7 @@ describe("Dispatcher execution", () => {
     expect(record.phase).toBe("completed");
     expect(record.status).toBe("handled");
     expect(record.summary).toBe("all done");
-    expect(record.runnerName).toBe("codex");
+    expect(record.agentName).toBe("codex");
 
     const phases = env.events
       .filter((e) => e.kind === "task")
@@ -329,7 +329,7 @@ describe("Dispatcher execution", () => {
 
   it("falls through to the next runner on non-timeout failure", async () => {
     const calls: string[] = [];
-    const spawner: RunnerSpawner = async ({ spec, outputPath, stdoutPath }) => {
+    const spawner: AgentSpawner = async ({ spec, outputPath, stdoutPath }) => {
       calls.push(spec.kind);
       if (spec.kind === "codex") {
         return { statusCode: 1 };
@@ -343,20 +343,20 @@ describe("Dispatcher execution", () => {
     };
     const env = setupDispatcher({
       spawner,
-      runners: [{ kind: "codex" }, { kind: "claude" }],
+      agents: [{ kind: "codex" }, { kind: "claude" }],
     });
     env.dispatcher.submit(fakeCandidate());
     await waitForCompletions(env, 1);
     expect(calls).toEqual(["codex", "claude"]);
     expect(env.completions[0].phase).toBe("completed");
-    expect(env.completions[0].runnerName).toBe("claude");
+    expect(env.completions[0].agentName).toBe("claude");
   });
 
   it("publishes failed when every runner errors", async () => {
-    const spawner: RunnerSpawner = async () => ({ statusCode: 7 });
+    const spawner: AgentSpawner = async () => ({ statusCode: 7 });
     const env = setupDispatcher({
       spawner,
-      runners: [{ kind: "codex" }, { kind: "claude" }],
+      agents: [{ kind: "codex" }, { kind: "claude" }],
     });
     env.dispatcher.submit(fakeCandidate());
     await waitForCompletions(env, 1);
@@ -371,14 +371,14 @@ describe("Dispatcher execution", () => {
     ).toEqual(["dispatched", "failed"]);
   });
 
-  it("publishes timed_out and stops trying further runners when timeout fires", async () => {
-    const spawner: RunnerSpawner = () =>
+  it("publishes timed_out and stops trying further agents when timeout fires", async () => {
+    const spawner: AgentSpawner = () =>
       new Promise(() => {
         /* never resolves */
       });
     const env = setupDispatcher({
       spawner,
-      runners: [{ kind: "codex" }, { kind: "claude" }],
+      agents: [{ kind: "codex" }, { kind: "claude" }],
       taskTimeoutMs: 40,
     });
     env.dispatcher.submit(fakeCandidate());
@@ -393,7 +393,7 @@ describe("Dispatcher execution", () => {
   });
 
   it("dryRun short-circuits agent execution", async () => {
-    const spawner = vi.fn<RunnerSpawner>();
+    const spawner = vi.fn<AgentSpawner>();
     const env = setupDispatcher({ spawner, dryRun: true });
     env.dispatcher.submit(fakeCandidate());
     await waitForCompletions(env, 1);
@@ -405,7 +405,7 @@ describe("Dispatcher execution", () => {
 
 describe("Dispatcher.stop", () => {
   it("aborts in-flight tasks and drains pending", async () => {
-    const spawner: RunnerSpawner = () =>
+    const spawner: AgentSpawner = () =>
       new Promise(() => {
         /* never resolves */
       });
@@ -456,7 +456,7 @@ describe("Dispatcher workspace failure", () => {
     const dispatcher = new Dispatcher({
       runnerHome,
       identity: { host: "github.com", login: "alice" },
-      runners: [{ kind: "codex" }],
+      agents: [{ kind: "codex" }],
       workspaceManager: new WorkspaceManager({
         reposDir,
         workspacesDir: join(root, "workspaces"),
@@ -470,7 +470,7 @@ describe("Dispatcher workspace failure", () => {
       disclosureText: "n",
       maxParallel: 1,
       taskTimeoutMs: 1_000,
-      spawner: vi.fn<RunnerSpawner>(),
+      spawner: vi.fn<AgentSpawner>(),
       onCompletion: (rec) => completions.push(rec),
       logger: { info: () => {}, warn: () => {}, error: () => {} },
     });

--- a/tests/breeze/breeze-daemon-runner-agent.test.ts
+++ b/tests/breeze/breeze-daemon-runner-agent.test.ts
@@ -11,15 +11,15 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
-  RunnerPool,
+  AgentPool,
   buildAgentEnv,
   buildCommand,
   buildPrompt,
-  executeRunner,
+  executeAgent,
   parseResult,
   runWithTimeout,
-  type RunnerRequest,
-  type RunnerSpawner,
+  type AgentRequest,
+  type AgentSpawner,
 } from "../../src/products/breeze/engine/daemon/runner.js";
 
 const tempRoots: string[] = [];
@@ -39,8 +39,8 @@ function makeTempDir(prefix: string): string {
   return dir;
 }
 
-function fakeRequest(overrides: Partial<RunnerRequest> = {}): RunnerRequest {
-  const base: RunnerRequest = {
+function fakeRequest(overrides: Partial<AgentRequest> = {}): AgentRequest {
+  const base: AgentRequest = {
     task: {
       repo: "owner/repo",
       workspaceRepo: "owner/repo",
@@ -175,9 +175,9 @@ describe("buildAgentEnv", () => {
   });
 });
 
-describe("RunnerPool", () => {
+describe("AgentPool", () => {
   it("rotates execution order across calls", () => {
-    const pool = new RunnerPool([
+    const pool = new AgentPool([
       { kind: "codex" },
       { kind: "claude" },
     ]);
@@ -187,27 +187,27 @@ describe("RunnerPool", () => {
     expect(second).toEqual(["claude", "codex"]);
   });
 
-  it("throws when no runners are configured", () => {
-    expect(() => new RunnerPool([])).toThrow(/no configured runner/);
+  it("throws when no agents are configured", () => {
+    expect(() => new AgentPool([])).toThrow(/no configured agent/);
   });
 
   it("exposes available names", () => {
-    const pool = new RunnerPool([{ kind: "claude" }]);
+    const pool = new AgentPool([{ kind: "claude" }]);
     expect(pool.availableNames()).toEqual(["claude"]);
   });
 });
 
-describe("executeRunner", () => {
+describe("executeAgent", () => {
   it("writes prompt, invokes spawner, parses result", async () => {
     const request = fakeRequest();
-    const spawner: RunnerSpawner = async ({ outputPath }) => {
+    const spawner: AgentSpawner = async ({ outputPath }) => {
       writeFileSync(
         outputPath,
         "doing things\nBREEZE_RESULT: status=handled summary=all good",
       );
       return { statusCode: 0 };
     };
-    const outcome = await executeRunner(
+    const outcome = await executeAgent(
       { kind: "codex" },
       request,
       { timeoutMs: 1_000, spawner },
@@ -219,14 +219,14 @@ describe("executeRunner", () => {
 
   it("copies claude stdout into runner-output.txt", async () => {
     const request = fakeRequest();
-    const spawner: RunnerSpawner = async ({ stdoutPath }) => {
+    const spawner: AgentSpawner = async ({ stdoutPath }) => {
       writeFileSync(
         stdoutPath,
         "chatter\nBREEZE_RESULT: status=handled summary=ok",
       );
       return { statusCode: 0 };
     };
-    const outcome = await executeRunner(
+    const outcome = await executeAgent(
       { kind: "claude" },
       request,
       { timeoutMs: 1_000, spawner },
@@ -238,9 +238,9 @@ describe("executeRunner", () => {
   });
 
   it("throws on non-zero exit code", async () => {
-    const spawner: RunnerSpawner = async () => ({ statusCode: 42 });
+    const spawner: AgentSpawner = async () => ({ statusCode: 42 });
     await expect(
-      executeRunner({ kind: "codex" }, fakeRequest(), {
+      executeAgent({ kind: "codex" }, fakeRequest(), {
         timeoutMs: 1_000,
         spawner,
       }),


### PR DESCRIPTION
## Summary
Collapse the overloaded \`runner\` vocabulary in breeze. Inside the daemon, both "the long-running broker process" and "the per-task codex/claude CLI backend" were called *runners*, which made two concurrent agent subprocesses look like two independent runner services in debug output.

After this PR:
- **agent** = per-task CLI backend (codex or claude) and the types/functions that describe it
- **runner** / **breeze-runner** = the daemon process itself, plus its on-disk artifacts and the user-facing \`breeze run\` CLI

Pure rename — no behaviour change, no new tests needed, existing tests updated to match the new identifiers.

## Renamed (TS identifiers only)
\`\`\`
RunnerSpec/Kind/Task/Request/Outcome/Spawner/Pool → Agent*
defaultRunnerSpawner → defaultAgentSpawner
executeRunner → executeAgent
detectAvailableRunners → detectAvailableAgents
makeRunnerRequest → makeAgentRequest
runnerPool / runners (field+var) → agentPool / agents
runnerName / runnerOutputPath (CompletionRecord) → agentName / agentOutputPath
selectedRunner → selectedAgent
Scheduler.writeRunningMetadata arg \`runner:\` → \`agent:\`
doctor output label \`runners:\` → \`agents:\`
\`\`\`

## Preserved (disk / user contract, intentionally unchanged)
- task.env keys: \`runner=\`, \`runner_output_path=\`
- debug artifacts: \`runner-output.txt\`, \`runner-stdout.log\`, \`runner-stderr.log\`
- \`$BREEZE_HOME\` layout under \`~/.breeze/runner/\`
- launchd label: \`com.breeze.runner.<login>.<profile>\`
- user-facing CLI: \`breeze run\`, \`breeze-runner\` wording in docs

The one boundary between new TS names and preserved disk keys lives in \`Scheduler.handleCompletion\` / \`writeRunningMetadata\` (TS reads \`args.agent\`, writes \`runner: args.agent\` to disk) and is commented accordingly.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` (929 passed / 51 skipped / 0 failed) — the only assertion that needed updating was the \`new AgentPool([])\` error regex (\`/no configured runner/\` → \`/no configured agent/\`) and the \`breeze doctor\` smoke that asserts the \`agents:\` label
- [x] \`pnpm build\` clean
- [x] \`git grep\` confirms zero remaining \`Runner(Spec|Kind|Task|Request|Outcome|Spawner|Pool)\` / \`runnerPool\` / \`detectAvailableRunners\` / etc. in the codebase