### PR TITLE
fix(breeze): survive broker request-dir cleanup race

### DIFF
--- a/src/products/breeze/engine/daemon/broker.ts
+++ b/src/products/breeze/engine/daemon/broker.ts
@@ -210,11 +210,21 @@ export async function startGhBroker(
             now,
           });
         } catch (err) {
-          writeFailureResponse(
-            requestDir,
-            err instanceof Error ? err.message : String(err),
-            now,
-          );
+          try {
+            writeFailureResponse(
+              requestDir,
+              err instanceof Error ? err.message : String(err),
+              now,
+            );
+          } catch (writeErr) {
+            logger.warn(
+              `broker: failed to write failure response for ${requestDir}: ${
+                writeErr instanceof Error
+                  ? writeErr.message
+                  : String(writeErr)
+              }`,
+            );
+          }
         }
       }
     }
@@ -461,6 +471,10 @@ interface WriteSuccessOptions {
 }
 
 function writeSuccessResponse(opts: WriteSuccessOptions): void {
+  // Defensive: the shim's request dir can be cleaned up concurrently
+  // (external reaper, shim timeout abandon). Recreate it so our writes
+  // don't ENOENT and crash the broker loop.
+  ensureDir(opts.requestDir);
   const stdoutPath = join(opts.requestDir, "stdout.txt");
   const stderrPath = join(opts.requestDir, "stderr.txt");
   writeFileSync(stdoutPath, opts.stdout);
@@ -482,6 +496,8 @@ function writeFailureResponse(
   error: string,
   now: () => number,
 ): void {
+  // Defensive: same concurrent-cleanup rationale as writeSuccessResponse.
+  ensureDir(requestDir);
   const stdoutPath = join(requestDir, "stdout.txt");
   const stderrPath = join(requestDir, "stderr.txt");
   writeFileSync(stdoutPath, "");

--- a/tests/breeze/breeze-daemon-broker.test.ts
+++ b/tests/breeze/breeze-daemon-broker.test.ts
@@ -294,6 +294,57 @@ describe("startGhBroker serve loop", () => {
     }
   });
 
+  it("recovers when the request dir vanishes mid-handle", async () => {
+    // Regression: the shim's request dir could be reaped (by an external
+    // cleaner or an abandoned shim timeout) after the broker picked it
+    // up. The broker's writeFailureResponse then hit ENOENT and killed
+    // the serve loop with an unhandled rejection, losing every in-flight
+    // agent's gh request.
+    const brokerDir = makeTempDir("reap");
+    const reqDir = join(brokerDir, "requests", "req-reap");
+    const executor = new GhExecutor({
+      realGh: "/usr/bin/gh",
+      writeCooldownMs: 0,
+      spawnGh: async () => {
+        // Simulate the external reap racing against broker response write.
+        rmSync(reqDir, { recursive: true, force: true });
+        throw new Error("network boom");
+      },
+      now: () => 0,
+      sleep: async () => {},
+    });
+    const broker = await startGhBroker({
+      brokerDir,
+      executor,
+      pollIntervalMs: 5,
+    });
+    try {
+      mkdirSync(reqDir, { recursive: true });
+      writeFileSync(join(reqDir, "argv.txt"), "api\n/notifications\n");
+      writeFileSync(join(reqDir, "cwd.txt"), "/tmp\n");
+      await waitFor(
+        () => existsSync(join(reqDir, "response.env")),
+        2_000,
+      );
+      expect(readFileSync(join(reqDir, "response.env"), "utf8")).toContain(
+        "status_code=1",
+      );
+      // Serve loop survived: a subsequent request still completes.
+      const reqDir2 = join(brokerDir, "requests", "req-after");
+      mkdirSync(reqDir2, { recursive: true });
+      writeFileSync(join(reqDir2, "argv.txt"), "api\n/rate_limit\n");
+      writeFileSync(join(reqDir2, "cwd.txt"), "/tmp\n");
+      // The executor was primed to throw for every call, but handleRequest
+      // will still write a failure response and keep the loop alive.
+      await waitFor(
+        () => existsSync(join(reqDir2, "response.env")),
+        2_000,
+      );
+    } finally {
+      await broker.stop();
+    }
+  });
+
   it("writes failure response when executor throws", async () => {
     const brokerDir = makeTempDir("fail");
     const executor = new GhExecutor({


### PR DESCRIPTION
## Summary
- The gh broker's `writeFailureResponse` assumed the shim's request directory still exists when the executor rejects. Under concurrent load, an external reaper (or an abandoned shim) could remove the dir between `listPendingRequests` and the failure write; the resulting ENOENT escaped the serve loop as an unhandled rejection, killing the daemon and orphaning every in-flight agent.
- `writeSuccessResponse` / `writeFailureResponse` now `ensureDir` their target, and the outer catch wraps the failure-write so any residual I/O error is logged rather than terminating the process.

## How it was found
Live reproduction during a 22-issue / 11-agent concurrency smoke on `bingran-you/breeze-smoke`. After ~7 minutes the daemon died with:
\`\`\`
Error: ENOENT: no such file or directory, open '.../broker/requests/req-.../stdout.txt'
    at writeFailureResponse (...runner-skeleton...:1572)
\`\`\`
Unit-level regression test added: executor `rm -rf`s the request dir before throwing; broker must still publish the failure response and keep serving subsequent requests.

## Test plan
- [x] `pnpm test` (930 pass, +1 new test)
- [x] `pnpm release:check` (validate:skill + typecheck + test + build + test:dist + test:release)
- [ ] Re-run the 22-issue concurrency smoke after merge to confirm daemon survives