### PR TITLE
fix(breeze): raise gh spawnSync maxBuffer to 64 MiB

### DIFF
--- a/src/products/breeze/engine/runtime/gh.ts
+++ b/src/products/breeze/engine/runtime/gh.ts
@@ -59,15 +59,32 @@ export interface GhClientDeps {
   spawn?: GhSpawnFn;
   /** Binary name/path; defaults to `"gh"`. */
   binary?: string;
+  /**
+   * Max bytes captured from gh's stdout/stderr. Defaults to 64 MiB
+   * — the default `spawnSync` cap of ~1 MiB is trivially exceeded by
+   * `gh api notifications` on accounts with a few hundred threads,
+   * which makes the whole poll cycle fail with ENOBUFS.
+   */
+  maxBufferBytes?: number;
 }
+
+/**
+ * 64 MiB. Big enough for a fully-hydrated `gh api notifications`
+ * payload on heavy accounts (observed ~1 MB empirically, but GitHub
+ * can return much more when repos expand), still a tiny fraction of
+ * process RAM so we'd rather cap than hang.
+ */
+export const DEFAULT_GH_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
 
 export class GhClient {
   private readonly spawn: GhSpawnFn;
   private readonly binary: string;
+  private readonly maxBuffer: number;
 
   constructor(deps: GhClientDeps = {}) {
     this.spawn = deps.spawn ?? (spawnSync as GhSpawnFn);
     this.binary = deps.binary ?? "gh";
+    this.maxBuffer = deps.maxBufferBytes ?? DEFAULT_GH_MAX_BUFFER_BYTES;
   }
 
   /**
@@ -77,6 +94,7 @@ export class GhClient {
   run(args: readonly string[]): GhExecResult {
     const result = this.spawn(this.binary, args, {
       stdio: ["ignore", "pipe", "pipe"],
+      maxBuffer: this.maxBuffer,
     });
     if (result.error) {
       return {

--- a/tests/breeze/breeze-gh.test.ts
+++ b/tests/breeze/breeze-gh.test.ts
@@ -7,7 +7,11 @@ import type { SpawnSyncReturns } from "node:child_process";
 
 import { describe, expect, it, vi } from "vitest";
 
-import { GhClient, GhExecError } from "../../src/products/breeze/engine/runtime/gh.js";
+import {
+  DEFAULT_GH_MAX_BUFFER_BYTES,
+  GhClient,
+  GhExecError,
+} from "../../src/products/breeze/engine/runtime/gh.js";
 
 type SpawnFn = ConstructorParameters<typeof GhClient>[0] extends
   | { spawn?: infer S }
@@ -67,6 +71,36 @@ describe("GhClient.run", () => {
       "/opt/gh",
       ["api", "/user"],
       expect.anything(),
+    );
+  });
+
+  it("passes a generous maxBuffer so gh api notifications does not ENOBUFS", () => {
+    // Regression: the default spawnSync maxBuffer (~1 MiB) was silently
+    // blowing up on accounts with a few hundred open notification threads,
+    // because `gh api notifications` returns >1 MiB of JSON. That killed
+    // the entire candidate-poll path and degraded the daemon to
+    // search-only (which caps candidates at 10/poll).
+    const spawn = stubSuccess("[]");
+    const gh = new GhClient({ spawn });
+    gh.run(["api", "notifications"]);
+    expect(spawn).toHaveBeenCalledWith(
+      "gh",
+      ["api", "notifications"],
+      expect.objectContaining({ maxBuffer: DEFAULT_GH_MAX_BUFFER_BYTES }),
+    );
+    expect(DEFAULT_GH_MAX_BUFFER_BYTES).toBeGreaterThanOrEqual(
+      16 * 1024 * 1024,
+    );
+  });
+
+  it("honors a custom maxBufferBytes override", () => {
+    const spawn = stubSuccess();
+    const gh = new GhClient({ spawn, maxBufferBytes: 128 });
+    gh.run(["api", "/user"]);
+    expect(spawn).toHaveBeenCalledWith(
+      "gh",
+      ["api", "/user"],
+      expect.objectContaining({ maxBuffer: 128 }),
     );
   });
 });


### PR DESCRIPTION
## Summary
- `GhClient.run` relied on `spawnSync`'s default ~1 MiB stdout cap. `gh api notifications` on an account with a few hundred open threads easily exceeds that, so every poll cycle failed with `ENOBUFS` and the entire notification-driven candidate path silently degraded to the search-only fallback (capped at 10 candidates per poll).
- Pass an explicit 64 MiB cap, exposed as `DEFAULT_GH_MAX_BUFFER_BYTES` and overridable via `maxBufferBytes`.

## Observed
In the 22-issue concurrency smoke on `bingran-you/breeze-smoke`:
\`\`\`
WARN: GitHub notifications fetch failed: gh fetch notifications failed (exit signal): spawnSync gh ENOBUFS
\`\`\`
repeated every poll (every 15 s). Notifications path was effectively dead the whole run.

## Test plan
- [x] `pnpm release:check` (2 new unit tests: default maxBuffer passed through; custom override honored)
- [ ] After merge, repeat the smoke and confirm `polled <n> notifications` returns non-zero