### PR TITLE
fix(breeze): enforce per-identity singleton at daemon startup

### DIFF
--- a/src/products/breeze/engine/daemon/runner-skeleton.ts
+++ b/src/products/breeze/engine/daemon/runner-skeleton.ts
@@ -35,7 +35,12 @@ import { join } from "node:path";
 import { resolveBreezePaths } from "../runtime/paths.js";
 import { loadBreezeDaemonConfig, type DaemonConfig } from "../runtime/config.js";
 
-import { resolveDaemonIdentity, identityHasRequiredScope } from "./identity.js";
+import {
+  resolveDaemonIdentity,
+  identityHasRequiredScope,
+  type DaemonIdentity,
+} from "./identity.js";
+import { acquireServiceLock, type ServiceLockHandle } from "./claim.js";
 import { startHttpServer, type RunningHttpServer } from "./http.js";
 import { pollOnce, runPoller, type PollerLogger } from "./poller.js";
 import { GhClient as CoreGhClient } from "../runtime/gh.js";
@@ -243,8 +248,9 @@ export async function runDaemon(
   // Identity resolution is best-effort at startup. The daemon will still
   // try to poll if identity fails — the poller uses the host-only env,
   // not the login. But we log loudly so operators notice.
+  let identity: DaemonIdentity | null = null;
   try {
-    const identity = resolveDaemonIdentity({ host: config.host });
+    identity = resolveDaemonIdentity({ host: config.host });
     if (!identityHasRequiredScope(identity)) {
       logger.warn(
         `gh token for ${identity.login}@${identity.host} lacks \`repo\`/\`notifications\` scope; poll may return empty results`,
@@ -258,6 +264,31 @@ export async function runDaemon(
     logger.warn(
       `identity resolution failed (continuing): ${err instanceof Error ? err.message : String(err)}`,
     );
+  }
+
+  // Phase 5 singleton: one daemon per (host, login, profile) on this
+  // machine. The previous HTTP-port-only guard let a second daemon
+  // spin up its broker + dispatcher before the port conflict surfaced,
+  // so two dispatchers could briefly race on the same claim dir. This
+  // hard-rejects a racing start before any stateful work begins.
+  //
+  // Skipped when identity resolution failed — that path keeps old
+  // read-only degraded semantics for operators without a gh login.
+  let lockHandle: ServiceLockHandle | null = null;
+  if (identity) {
+    try {
+      lockHandle = await acquireServiceLock({
+        baseDir: join(resolveRunnerHome(), "locks"),
+        identity,
+        profile: "default",
+        note: "daemon starting",
+      });
+    } catch (err) {
+      logger.error(
+        `breeze daemon: refusing to start — ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return 1;
+    }
   }
 
   // Wire abort cascade. Tests may pass a pre-built signal directly.
@@ -496,6 +527,15 @@ export async function runDaemon(
     }
     bus.close();
     if (uninstallHandlers) uninstallHandlers();
+    if (lockHandle) {
+      try {
+        await lockHandle.release();
+      } catch (err) {
+        logger.warn(
+          `service lock release failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
   }
 
   logger.info("breeze daemon: shutdown complete");


### PR DESCRIPTION
## Summary
- Wire the existing `acquireServiceLock` helper into `runDaemon`. Prior to this, the only mutex between two daemons on the same machine was the HTTP port bind (`EADDRINUSE` on 7878); broker, dispatcher, and candidate loop all started before that point, so a racing second daemon briefly held two dispatchers pointing at the same claim dir and could double-process a notification before losing the port.
- Lock acquired right after identity resolution, released last in the shutdown cascade. If already held by a live pid, daemon exits 1 with a clear error.
- Identity-failure path is preserved — if `gh` is unavailable the lock step is skipped, matching the prior read-only-degraded behaviour relied on by tests.

## Repro (before this patch)
During the 22-issue concurrency smoke:
\`\`\`
$ first-tree breeze daemon --backend=ts --allow-repo bingran-you/breeze-smoke &
# (first daemon alive, 11 agents running)
$ first-tree breeze daemon --backend=ts --allow-repo bingran-you/breeze-smoke
breeze daemon: dispatcher ready (agents=codex,claude, broker=...)
ERROR: failed to start http server: EADDRINUSE
\`\`\`
Note "dispatcher ready" fired BEFORE the port conflict — the second daemon built up real state first.

## After
\`\`\`
ERROR: breeze daemon: refusing to start — breeze daemon is already running for <login> on <host> (pid N, profile "default")
\`\`\`
No broker, dispatcher, or http init. Exit 1.

## Test plan
- [x] `pnpm release:check` (932 unit tests pass, typecheck clean)
- [x] Lock primitive itself is covered by existing `tests/breeze/breeze-daemon-claim.test.ts` (stale reclaim, proper-lockfile fallback, held-by-live-pid)
- [ ] After merge: re-run the two-daemon race and confirm #2 exits 1 before any broker output