### PR TITLE
feat(breeze): expose maxParallel + searchLimit; bump default to 20

### DIFF
--- a/src/products/breeze/engine/daemon/runner-skeleton.ts
+++ b/src/products/breeze/engine/daemon/runner-skeleton.ts
@@ -323,7 +323,7 @@ export async function runDaemon(
   }
 
   logger.info(
-    `breeze daemon: poll-interval=${config.pollIntervalSec}s host=${config.host} http-port=${config.httpPort} allow-repo=${repoFilter.isEmpty() ? "all" : repoFilter.displayPatterns()}`,
+    `breeze daemon: poll-interval=${config.pollIntervalSec}s host=${config.host} http-port=${config.httpPort} max-parallel=${config.maxParallel} search-limit=${config.searchLimit} allow-repo=${repoFilter.isEmpty() ? "all" : repoFilter.displayPatterns()}`,
   );
 
   // Phase 3c: shared in-process bus drives SSE + broker task events.
@@ -391,7 +391,7 @@ export async function runDaemon(
         claimsDir: paths.claimsDir,
         disclosureText:
           "This reply was drafted by breeze, an autonomous agent running on behalf of the account owner.",
-        maxParallel: 2,
+        maxParallel: config.maxParallel,
         taskTimeoutMs: config.taskTimeoutSec * 1_000,
         logger,
         onCompletion: (record) => scheduler.handleCompletion(record),
@@ -406,7 +406,7 @@ export async function runDaemon(
         dispatcher,
         bus,
         pollIntervalSec: config.pollIntervalSec,
-        searchLimit: 10,
+        searchLimit: config.searchLimit,
         includeSearch: true,
         lookbackSecs: 24 * 3_600,
         signal: controller.signal,

--- a/src/products/breeze/engine/runtime/config.ts
+++ b/src/products/breeze/engine/runtime/config.ts
@@ -66,6 +66,19 @@ export interface DaemonConfig {
   httpPort: number;
   /** GitHub API host. */
   host: string;
+  /**
+   * Max concurrent agent tasks the dispatcher may run at once.
+   * Formerly hardcoded to 2; bumped to 20 after a live smoke showed
+   * the infra handles that comfortably. Tunable via
+   * `BREEZE_MAX_PARALLEL` or `max_parallel` in yaml.
+   */
+  maxParallel: number;
+  /**
+   * Per-poll cap on search-based candidates. Only the search path is
+   * limited; the notifications path returns everything it sees.
+   * Tunable via `BREEZE_SEARCH_LIMIT` or `search_limit` in yaml.
+   */
+  searchLimit: number;
 }
 
 export const DAEMON_CONFIG_DEFAULTS: DaemonConfig = {
@@ -78,6 +91,8 @@ export const DAEMON_CONFIG_DEFAULTS: DaemonConfig = {
   logLevel: "info",
   httpPort: 7878,
   host: "github.com",
+  maxParallel: 20,
+  searchLimit: 10,
 };
 
 export interface DaemonCliOverrides {
@@ -86,6 +101,8 @@ export interface DaemonCliOverrides {
   logLevel?: string;
   httpPort?: number;
   host?: string;
+  maxParallel?: number;
+  searchLimit?: number;
 }
 
 export interface LoadDaemonConfigDeps {
@@ -123,6 +140,10 @@ interface RawYamlConfig {
   http_port?: unknown;
   httpPort?: unknown;
   host?: unknown;
+  max_parallel?: unknown;
+  maxParallel?: unknown;
+  search_limit?: unknown;
+  searchLimit?: unknown;
 }
 
 function pickNumber(...values: unknown[]): number | undefined {
@@ -166,6 +187,8 @@ function pickLogLevel(value: unknown): DaemonConfig["logLevel"] | undefined {
  *   BREEZE_LOG_LEVEL
  *   BREEZE_HOST / GH_HOST
  *   BREEZE_TASK_TIMEOUT_SECS
+ *   BREEZE_MAX_PARALLEL
+ *   BREEZE_SEARCH_LIMIT
  *
  * The yaml schema accepts snake_case (preferred) or camelCase keys.
  * Unknown yaml keys are ignored (forward-compat).
@@ -216,6 +239,10 @@ export function loadBreezeDaemonConfig(
       }
       const host = pickString(y.host);
       if (host !== undefined) config.host = host;
+      const maxParallel = pickNumber(y.max_parallel, y.maxParallel);
+      if (maxParallel !== undefined) config.maxParallel = maxParallel;
+      const searchLimit = pickNumber(y.search_limit, y.searchLimit);
+      if (searchLimit !== undefined) config.searchLimit = searchLimit;
     }
     // First existing file wins — stop searching.
     break;
@@ -235,6 +262,10 @@ export function loadBreezeDaemonConfig(
   if (envPort !== undefined && envPort < 65_536) config.httpPort = envPort;
   const envHost = pickString(env("BREEZE_HOST"), env("GH_HOST"));
   if (envHost !== undefined) config.host = envHost;
+  const envMaxParallel = pickNumber(env("BREEZE_MAX_PARALLEL"));
+  if (envMaxParallel !== undefined) config.maxParallel = envMaxParallel;
+  const envSearchLimit = pickNumber(env("BREEZE_SEARCH_LIMIT"));
+  if (envSearchLimit !== undefined) config.searchLimit = envSearchLimit;
 
   // 4. CLI overrides.
   if (cli.pollIntervalSec !== undefined && cli.pollIntervalSec > 0) {
@@ -254,6 +285,12 @@ export function loadBreezeDaemonConfig(
   }
   if (cli.host !== undefined && cli.host.length > 0) {
     config.host = cli.host;
+  }
+  if (cli.maxParallel !== undefined && cli.maxParallel > 0) {
+    config.maxParallel = cli.maxParallel;
+  }
+  if (cli.searchLimit !== undefined && cli.searchLimit > 0) {
+    config.searchLimit = cli.searchLimit;
   }
 
   return config;

--- a/tests/breeze/breeze-daemon-config.test.ts
+++ b/tests/breeze/breeze-daemon-config.test.ts
@@ -160,6 +160,76 @@ httpPort: 8080
     expect(cfg).toEqual(DAEMON_CONFIG_DEFAULTS);
   });
 
+  it("defaults maxParallel to 20 and searchLimit to 10", () => {
+    const cfg = loadBreezeDaemonConfig({
+      env: () => undefined,
+      fileExists: () => false,
+      readFile: () => "",
+      homeDir: () => tmp,
+    });
+    expect(cfg.maxParallel).toBe(20);
+    expect(cfg.searchLimit).toBe(10);
+  });
+
+  it("reads max_parallel and search_limit from yaml", () => {
+    const configPath = join(tmp, "config.yaml");
+    writeFileSync(
+      configPath,
+      "max_parallel: 4\nsearch_limit: 50\n",
+      "utf-8",
+    );
+    const cfg = loadBreezeDaemonConfig({
+      env: () => undefined,
+      configPath,
+    });
+    expect(cfg.maxParallel).toBe(4);
+    expect(cfg.searchLimit).toBe(50);
+  });
+
+  it("env vars override yaml for concurrency knobs", () => {
+    const configPath = join(tmp, "config.yaml");
+    writeFileSync(
+      configPath,
+      "max_parallel: 4\nsearch_limit: 50\n",
+      "utf-8",
+    );
+    const envBag: Record<string, string> = {
+      BREEZE_MAX_PARALLEL: "30",
+      BREEZE_SEARCH_LIMIT: "25",
+    };
+    const cfg = loadBreezeDaemonConfig({
+      env: (name) => envBag[name],
+      configPath,
+    });
+    expect(cfg.maxParallel).toBe(30);
+    expect(cfg.searchLimit).toBe(25);
+  });
+
+  it("CLI overrides beat env for concurrency knobs", () => {
+    const envBag: Record<string, string> = {
+      BREEZE_MAX_PARALLEL: "30",
+      BREEZE_SEARCH_LIMIT: "25",
+    };
+    const cfg = loadBreezeDaemonConfig({
+      env: (name) => envBag[name],
+      configPath: join(tmp, "no-such.yaml"),
+      cliOverrides: { maxParallel: 100, searchLimit: 5 },
+    });
+    expect(cfg.maxParallel).toBe(100);
+    expect(cfg.searchLimit).toBe(5);
+  });
+
+  it("rejects non-positive maxParallel / searchLimit overrides silently", () => {
+    const cfg = loadBreezeDaemonConfig({
+      env: () => undefined,
+      configPath: join(tmp, "no-such.yaml"),
+      cliOverrides: { maxParallel: -1, searchLimit: 0 },
+    });
+    // Fall back to defaults.
+    expect(cfg.maxParallel).toBe(20);
+    expect(cfg.searchLimit).toBe(10);
+  });
+
   it("accepts first existing yaml in the search order (first-tree wins)", () => {
     const primaryDir = join(tmp, ".first-tree", "breeze");
     const legacyDir = join(tmp, ".breeze");


### PR DESCRIPTION
## Summary
Two concurrency knobs were hardcoded inside `runDaemon`:
- Dispatcher `maxParallel: 2`
- candidate loop `searchLimit: 10`

Neither was reachable from yaml, env, or CLI. Operators with a real notification backlog could never scale past 2 concurrent agents or 10 candidates per poll.

This PR promotes both into `DaemonConfig`, overridable via (in priority order) CLI > env > yaml > defaults.

## Defaults
- `maxParallel = 20` — a live 22-issue smoke saturated 11 concurrent agents without contention; 20 gives headroom without being reckless on memory.
- `searchLimit = 10` — unchanged, just exposed.

## Surface
- Env vars: `BREEZE_MAX_PARALLEL`, `BREEZE_SEARCH_LIMIT`
- Yaml keys: `max_parallel` / `maxParallel`, `search_limit` / `searchLimit`
- Startup log now echoes both values, e.g.:
  \`\`\`
  breeze daemon: poll-interval=15s host=github.com http-port=7878 max-parallel=20 search-limit=10 allow-repo=bingran-you/breeze-smoke
  \`\`\`

## Test plan
- [x] `pnpm release:check` (5 new config tests covering defaults, yaml, env, CLI override precedence, invalid-value rejection)
- [ ] Re-run the 22-issue smoke with default config and confirm ≥20 concurrent workspaces when candidates allow