### PR TITLE
fix(tree): sharpen init UX after ADHD onboarding dogfood test

### DIFF
--- a/src/products/tree/cli.ts
+++ b/src/products/tree/cli.ts
@@ -13,6 +13,7 @@ export const TREE_USAGE = `usage: first-tree tree <command>
 
 Commands:
   inspect               Classify the current folder before onboarding
+  status                Alias for \`inspect\` (human-friendly name)
   init                  High-level onboarding wrapper for repo/workspace roots
   bootstrap             Low-level tree-repo bootstrap for an explicit tree checkout
   bind                  Bind the current repo/workspace root to an existing tree repo
@@ -76,7 +77,8 @@ export async function runTree(
       );
       return runBootstrap(args.slice(1), write);
     }
-    case "inspect": {
+    case "inspect":
+    case "status": {
       const { runInspect } = await import(
         "#products/tree/engine/commands/inspect.js"
       );

--- a/src/products/tree/engine/init.ts
+++ b/src/products/tree/engine/init.ts
@@ -15,7 +15,6 @@ import {
 } from "#products/tree/engine/dedicated-tree.js";
 import { inspectRepo } from "#products/tree/engine/inspect.js";
 import { Repo } from "#products/tree/engine/repo.js";
-import { ONBOARDING_TEXT } from "#products/tree/engine/onboarding.js";
 import { evaluateAll } from "#products/tree/engine/rules/index.js";
 import type { RuleResult } from "#products/tree/engine/rules/index.js";
 import {
@@ -512,8 +511,14 @@ export function runInit(repo?: Repo, options?: InitOptions): number {
     });
   }
 
-  console.log(ONBOARDING_TEXT);
-  console.log("---\n");
+  // Agents running `first-tree tree init` have already loaded the skill
+  // payload, which includes the full onboarding handbook. Dumping 200+ lines
+  // of the same markdown here is noise. Print a short pointer instead; any
+  // caller that wants the full text can run `first-tree tree help onboarding`.
+  console.log(
+    "Onboarding handbook: run `first-tree tree help onboarding` for the full reference.",
+  );
+  console.log();
 
   const groups = addSeededMemberReviewGroup(
     evaluateAll(r),

--- a/src/products/tree/engine/rules/agent-instructions.ts
+++ b/src/products/tree/engine/rules/agent-instructions.ts
@@ -68,7 +68,7 @@ export function evaluate(repo: Repo): RuleResult {
         );
       if (lines.length === 0) {
         tasks.push(
-          `Add your project-specific instructions below the framework markers in ${AGENT_INSTRUCTIONS_FILE}`,
+          `In this tree repo, add your project-specific instructions below the framework markers in ${AGENT_INSTRUCTIONS_FILE} (source repos keep ${AGENT_INSTRUCTIONS_FILE} as framework-only — do not edit the source repo's copy)`,
         );
       }
     }
@@ -99,7 +99,7 @@ export function evaluate(repo: Repo): RuleResult {
           );
         if (lines.length === 0) {
           tasks.push(
-            `Add your project-specific instructions below the framework markers in ${CLAUDE_INSTRUCTIONS_FILE}`,
+            `In this tree repo, add your project-specific instructions below the framework markers in ${CLAUDE_INSTRUCTIONS_FILE} (source repos keep ${CLAUDE_INSTRUCTIONS_FILE} as framework-only — do not edit the source repo's copy)`,
           );
         }
       }

--- a/tests/e2e/thin-cli.test.ts
+++ b/tests/e2e/thin-cli.test.ts
@@ -8,7 +8,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { USAGE, isDirectExecution, runCli, stripGlobalFlags } from "../../src/cli.js";
 import { TREE_USAGE } from "../../src/products/tree/cli.js";
 
@@ -66,6 +66,33 @@ describe("thin CLI shell", () => {
     expect(TREE_USAGE).toContain("review");
     expect(TREE_USAGE).toContain("generate-codeowners");
     expect(TREE_USAGE).toContain("inject-context");
+    expect(TREE_USAGE).toContain("status");
+  });
+
+  it("routes `tree status` through inspect", async () => {
+    // `runInspect` writes via console.log directly rather than the output
+    // callback, so we spy on console.log to capture the inspect payload.
+    const logs: string[] = [];
+    const spy = vi.spyOn(console, "log").mockImplementation((...args) => {
+      logs.push(args.map(String).join(" "));
+    });
+    try {
+      const discard = (_text: string) => undefined;
+      const code = await runCli(
+        ["--skip-version-check", "tree", "status", "--json"],
+        discard,
+      );
+      expect(code).toBe(0);
+      const combined = logs.join("\n");
+      // `tree inspect --json` emits a JSON payload with classification +
+      // rootKind; `tree status` should produce the same output.
+      expect(combined).toContain("\"classification\"");
+      expect(combined).toContain("\"rootKind\"");
+      // And it should not be the "Unknown command" fallback.
+      expect(combined).not.toContain("Unknown command");
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it("treats a symlinked npm bin path as direct execution", () => {

--- a/tests/tree/rules.test.ts
+++ b/tests/tree/rules.test.ts
@@ -221,6 +221,30 @@ describe("agentInstructions rule", () => {
     const result = agentInstructions.evaluate(repo);
     expect(result.tasks).toEqual([]);
   });
+
+  it("clarifies that the project-specific task targets the tree repo, not source repos", () => {
+    // The `Add your project-specific instructions below the framework
+    // markers...` task only fires on repos that have CONTEXT-TREE FRAMEWORK
+    // markers (tree repos). Source repos use FIRST-TREE-SOURCE-INTEGRATION
+    // markers instead, so the rule can't trip on them today. Still, an agent
+    // reading the checklist needs the task text itself to make clear that the
+    // only AGENTS.md/CLAUDE.md to edit is the tree repo's copy — never the
+    // source repo's managed marker block.
+    const tmp = useTmpDir();
+    makeAgentsMd(tmp.path, { markers: true, userContent: false });
+    makeClaudeMd(tmp.path, { markers: true, userContent: false });
+    const repo = new Repo(tmp.path);
+    const result = agentInstructions.evaluate(repo);
+    const projectTasks = result.tasks.filter((t) =>
+      t.toLowerCase().includes("project-specific"),
+    );
+    expect(projectTasks.length).toBeGreaterThan(0);
+    for (const task of projectTasks) {
+      expect(task).toContain("tree repo");
+      expect(task).toContain("source repo");
+      expect(task).toContain("framework-only");
+    }
+  });
 });
 
 // --- members rule ---


### PR DESCRIPTION
## Summary

Three papercuts surfaced while running `tree init` end-to-end on a fresh source repo (`bingran-you/ADHD`) with no prior first-tree artifacts:

- **`tree status` alias** — the onboarding skill and the prompt we use in dogfood tests both reach for `tree status` as a human-friendly check, but the command didn't exist. Now routes to `tree inspect`.
- **No more 200-line `ONBOARDING_TEXT` dump** at the end of `tree init`. Any caller invoking `init` has already loaded the skill payload, so replaying the full handbook was pure noise. Replaced with a one-line pointer to `first-tree tree help onboarding`. Verified: `tree init` stdout went from ~280 lines to 73 on a fresh ADHD clone.
- **Clarified the "Add your project-specific instructions…" task.** Old text was ambiguous between the tree repo's `AGENTS.md` and the source repo's managed marker block — an inattentive agent could have edited the source copy and broken the `FIRST-TREE-SOURCE-INTEGRATION` section. Reworded to call out the tree repo explicitly and warn that source `AGENTS.md`/`CLAUDE.md` stays framework-only.

## Test plan

- [x] `pnpm release:check` passes (version:check, validate:skill, typecheck, test, build, test:dist, test:release)
- [x] New unit test: `agentInstructions rule > clarifies that the project-specific task targets the tree repo, not source repos`
- [x] New e2e test: `thin CLI shell > routes \`tree status\` through inspect`
- [x] Manual: `node dist/cli.js tree status` on a source repo prints the inspect report
- [x] Manual: `node dist/cli.js tree init` on a fresh ADHD clone (baseline commit `4536216`) — no `ONBOARDING_TEXT` dump, `progress.md` tasks now say "In this tree repo, add your project-specific instructions..."