### PR TITLE
fix(breeze): point launchd plist at first-tree bin, not `node breeze`

### DIFF
--- a/src/products/breeze/engine/commands/start.ts
+++ b/src/products/breeze/engine/commands/start.ts
@@ -6,7 +6,7 @@
  * we fall back to `spawn(... detached: true)` with stdout redirected.
  */
 
-import { mkdirSync, openSync } from "node:fs";
+import { mkdirSync, openSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 import { spawn } from "node:child_process";
 
@@ -22,7 +22,13 @@ export interface RunStartOptions {
   write?: (line: string) => void;
   runnerHome?: string;
   profile?: string;
-  /** CLI entrypoint. Defaults to `process.execPath` (node) + first-tree bin. */
+  /**
+   * Absolute path to the `first-tree` bin launchd should exec. The bin
+   * carries a `#!/usr/bin/env node` shebang, so we point launchd at it
+   * directly rather than at `node` + a script argument. Defaults to the
+   * currently-running script (`process.argv[1]`, resolved through
+   * `realpath`).
+   */
   executable?: string;
   /** Args after the executable (forwarded to the daemon). */
   daemonArgs?: readonly string[];
@@ -52,7 +58,15 @@ export async function runStart(
   const nowSec = Math.floor(Date.now() / 1_000);
   const logPath = join(logsDir, `breeze-daemon-${nowSec}.log`);
 
-  const executable = options.executable ?? process.execPath;
+  let executable: string;
+  try {
+    executable = options.executable ?? resolveDefaultExecutable();
+  } catch (err) {
+    write(
+      `breeze: start failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return 1;
+  }
   const daemonArgs = options.daemonArgs ?? defaultDaemonArgs(argv);
 
   if (supportsLaunchd()) {
@@ -113,17 +127,41 @@ function parseProfile(argv: readonly string[]): string | undefined {
 }
 
 /**
+ * Resolve the path launchd (or the fallback detached spawn) should exec.
+ * We want the `first-tree` bin itself — it has a `#!/usr/bin/env node`
+ * shebang and knows how to dispatch `breeze daemon`. Using `node` as the
+ * executable with `breeze` as the first argument does not work: node
+ * would try to resolve `breeze` as a script path relative to cwd (which
+ * launchd sets to `/`), producing `Cannot find module '/breeze'`.
+ */
+export function resolveDefaultExecutable(
+  argv1: string | undefined = process.argv[1],
+): string {
+  if (!argv1) {
+    throw new Error(
+      "could not resolve first-tree CLI path (process.argv[1] is unset); pass `executable` explicitly",
+    );
+  }
+  try {
+    return realpathSync(argv1);
+  } catch {
+    return argv1;
+  }
+}
+
+/**
  * Build the forwarded argv for the background daemon. The incoming
  * `start` argv may contain flags like `--allow-repo` that we pass
  * through to the foreground daemon entrypoint. We also drop
  * `--home`/`--profile` because those are interpreted by this command
  * and may differ from the daemon's own resolution.
+ *
+ * Exported for tests.
  */
-function defaultDaemonArgs(argv: readonly string[]): string[] {
+export function defaultDaemonArgs(argv: readonly string[]): string[] {
   // The ported daemon entrypoint is `first-tree breeze daemon --backend=ts`.
-  // In the fallback spawn path, executable is process.execPath so we
-  // cannot embed the CLI; we assume the caller set `executable` to the
-  // `first-tree` bin. See RunStartOptions.
+  // Executable is the `first-tree` bin (see `resolveDefaultExecutable`),
+  // so these are the args *after* the bin — the CLI's own argv[2:].
   const forwarded: string[] = [];
   for (let i = 0; i < argv.length; i += 1) {
     const a = argv[i];

--- a/tests/breeze/breeze-start.test.ts
+++ b/tests/breeze/breeze-start.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for the breeze `start` command's argv wiring.
+ *
+ * Regression for the bug where `runStart` defaulted `executable` to
+ * `process.execPath` (node) while `defaultDaemonArgs` started the
+ * argument list with `"breeze"` — launchd then tried to exec
+ * `node breeze daemon ...` and failed with `Cannot find module '/breeze'`.
+ * The fix points launchd at the `first-tree` bin directly (it carries a
+ * `#!/usr/bin/env node` shebang) and keeps the subcommand argv as the
+ * bin's own argv[2:].
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  defaultDaemonArgs,
+  resolveDefaultExecutable,
+} from "../../src/products/breeze/engine/commands/start.js";
+
+describe("defaultDaemonArgs", () => {
+  it("prepends the `breeze daemon --backend=ts` dispatch triple", () => {
+    expect(defaultDaemonArgs([])).toEqual([
+      "breeze",
+      "daemon",
+      "--backend=ts",
+    ]);
+  });
+
+  it("forwards unknown flags like --allow-repo through to the daemon", () => {
+    expect(
+      defaultDaemonArgs([
+        "--allow-repo",
+        "bingran-you/breeze-smoke,agent-team-foundation/first-tree",
+      ]),
+    ).toEqual([
+      "breeze",
+      "daemon",
+      "--backend=ts",
+      "--allow-repo",
+      "bingran-you/breeze-smoke,agent-team-foundation/first-tree",
+    ]);
+  });
+
+  it("drops --home/--profile (plus their values) since runStart handles them locally", () => {
+    expect(
+      defaultDaemonArgs([
+        "--home",
+        "/tmp/breeze",
+        "--profile",
+        "ci",
+        "--allow-repo=owner/repo",
+      ]),
+    ).toEqual([
+      "breeze",
+      "daemon",
+      "--backend=ts",
+      "--allow-repo=owner/repo",
+    ]);
+  });
+
+  it("also drops --home=... and --profile=... equals forms", () => {
+    expect(
+      defaultDaemonArgs([
+        "--home=/tmp/breeze",
+        "--profile=ci",
+        "--allow-repo=owner/repo",
+      ]),
+    ).toEqual([
+      "breeze",
+      "daemon",
+      "--backend=ts",
+      "--allow-repo=owner/repo",
+    ]);
+  });
+
+  it("does not emit `node` or any script-path placeholder in the first slot (regression: launchd plist was `node breeze ...`)", () => {
+    const args = defaultDaemonArgs([]);
+    expect(args[0]).toBe("breeze");
+    expect(args).not.toContain("node");
+    expect(args[0]).not.toMatch(/\.js$/);
+  });
+});
+
+describe("resolveDefaultExecutable", () => {
+  it("returns the realpath of the given argv[1] (resolves symlinks)", () => {
+    const tmp = realpathSync(
+      mkdtempSync(join(tmpdir(), "breeze-start-exec-")),
+    );
+    const target = join(tmp, "first-tree.js");
+    const link = join(tmp, "first-tree");
+    writeFileSync(target, "#!/usr/bin/env node\n", { mode: 0o755 });
+    symlinkSync(target, link);
+    try {
+      expect(resolveDefaultExecutable(link)).toBe(target);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("returns the raw path when realpath fails (e.g. nonexistent)", () => {
+    const ghost = "/does/not/exist/first-tree";
+    expect(resolveDefaultExecutable(ghost)).toBe(ghost);
+  });
+
+  it("throws a clear error when argv[1] is empty/unset", () => {
+    // Empty string skips the `= process.argv[1]` default so we can exercise
+    // the "nothing to resolve" branch deterministically under vitest.
+    expect(() => resolveDefaultExecutable("")).toThrow(
+      /process\.argv\[1\] is unset/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`first-tree breeze start` on macOS has been silently broken: launchd
received a plist whose `ProgramArguments` was `[node, breeze, daemon,
--backend=ts, ...]`. With launchd's working directory of `/`, node
resolved `breeze` as the script path `/breeze` and crashed before the
daemon could bind 7878 or acquire the runner lock:

```
Error: Cannot find module '/breeze'
    at Module._resolveFilename ...
Node.js v25.6.1
```

`KeepAlive: true` then restarted the same broken invocation on a tight
loop. The only reason no one hit this earlier is that this was the
first real use of `breeze start` on my box — foreground `breeze run`
and `breeze daemon` were fine.

Root cause: `runStart` defaults `executable` to `process.execPath`
(node), while `defaultDaemonArgs` starts the argv with `"breeze"` —
the shape the launchd test (`breeze-daemon-launchd.test.ts`) already
expects for a first-tree-bin executable. The CLI dispatcher at
[cli.ts:188-189](src/products/breeze/cli.ts:188) also never overrode
`executable`, so the default always won.

## Fix

Default `executable` to the running `first-tree` bin — `process.argv[1]`
resolved through `realpath` so a symlinked `~/.local/bin/first-tree`
still exec's the real script. The bin carries `#!/usr/bin/env node`, so
launchd's plist now contains e.g.:

```xml
<string>/Users/.../lib/node_modules/first-tree/dist/cli.js</string>
<string>breeze</string>
<string>daemon</string>
<string>--backend=ts</string>
<string>--allow-repo=owner/repo</string>
```

No other callers pass an explicit `options.executable`, so the change
is source-compatible; tests that exercise the launchd helper directly
keep passing because they already provide an explicit first-tree path.

## Test plan

- [x] `pnpm release:check` — validate:skill + typecheck + 953 unit
      tests + build + dist binary smoke + pack/install smoke, all green
- [x] New `tests/breeze/breeze-start.test.ts` covers:
  - `defaultDaemonArgs[0] === "breeze"` (never `node` or a `.js` path)
  - `--allow-repo` passthrough; `--home`/`--profile` stripped
  - `resolveDefaultExecutable` follows symlinks and errors clearly when
    argv[1] is empty
- [ ] Post-merge manual: `first-tree breeze start --allow-repo=...` on
      macOS, confirm `first-tree breeze status` shows
      `lock: running pid=<live>` and 7878 is bound by the daemon