### PR TITLE
feat(gardener): wire real edit orchestrator into respond (closes #160)

### DIFF
--- a/src/products/gardener/engine/edit-orchestrator.ts
+++ b/src/products/gardener/engine/edit-orchestrator.ts
@@ -1,0 +1,278 @@
+/**
+ * gardener respond — edit orchestrator primitive.
+ *
+ * The respond CLI reads reviewer feedback on a sync PR and (historically)
+ * posted a placeholder acknowledgement reply. This primitive is the seam
+ * where a real edit-plan → file edits → commit → push actually lands.
+ *
+ * v1 scope (per #160 / signoff on #219):
+ *   - one deterministic heuristic: `parent_subdomain_missing`.
+ *     Detected by matching reviewer body text for the "child not listed
+ *     in parent NODE.md Sub-domains" pattern produced by gardener-sync.
+ *     The fix appends a canonical `- \`<dir>/\` — <title>` line under
+ *     the parent's `## Sub-domains` section.
+ *   - an injected `planner` seam that can be swapped in later for an
+ *     LLM-driven planner. When unset and the heuristic does not match,
+ *     we return `deferred` so respond falls back to its placeholder
+ *     reply path.
+ *
+ * Push semantics (per signoff):
+ *   - `git push origin HEAD` only. No force-push, no `--force-with-lease`.
+ *   - Non-fast-forwardable → `{ kind: "deferred", reason: "rebase_needed" }`.
+ *
+ * Attempts counter semantics (per signoff, owned by caller):
+ *   - applied  → caller leaves the attempts counter unchanged
+ *   - deferred → caller bumps the attempts counter (placeholder path)
+ *   - failed   → caller leaves the attempts counter unchanged
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+import type { PrReview, PrIssueComment, PrView, ShellRun } from "./respond.js";
+
+export interface EditFeedback {
+  reviews: PrReview[];
+  issueComments: PrIssueComment[];
+  reviewerLogin?: string;
+}
+
+export interface EditPlan {
+  pattern: string;
+  summary: string;
+  replyBody: string;
+  files: Array<{ path: string; before: string; after: string }>;
+}
+
+export interface EditPlanner {
+  (input: {
+    feedback: EditFeedback;
+    prView: PrView;
+    treeRoot: string;
+  }): Promise<EditPlan | null> | EditPlan | null;
+}
+
+export interface OrchestrateEditOptions {
+  repo: string;
+  pr: number;
+  treeRoot: string;
+  feedback: EditFeedback;
+  prView: PrView;
+  shell: ShellRun;
+  dryRun: boolean;
+  planner?: EditPlanner;
+}
+
+export type OrchestrateEditResult =
+  | { kind: "applied"; sha: string; pattern: string; replyBody: string }
+  | { kind: "deferred"; reason: string; replyBody?: string }
+  | { kind: "failed"; reason: string };
+
+const PARENT_SUBDOMAIN_PATTERNS = [
+  /not listed in (?:the )?parent\s+NODE\.md/i,
+  /missing from (?:the )?(?:parent'?s? )?Sub-?domains/i,
+  /add (?:this|the new) (?:child |sub-?domain )?(?:to|under) (?:the )?parent/i,
+];
+
+/**
+ * Detect the `parent_subdomain_missing` pattern from reviewer text.
+ *
+ * Returns a plan only when we can identify both the parent NODE.md path
+ * and a child dirName + title pair from the PR context. Anything fuzzier
+ * than that is handed to the planner seam (or deferred).
+ */
+function detectParentSubdomainMissing(
+  feedback: EditFeedback,
+  prView: PrView,
+  treeRoot: string,
+): EditPlan | null {
+  const reviewTexts = feedback.reviews
+    .filter((r) => r.state === "CHANGES_REQUESTED")
+    .map((r) => r.body ?? "");
+  const commentTexts = feedback.issueComments.map((c) => c.body ?? "");
+  const blob = [...reviewTexts, ...commentTexts].join("\n\n");
+  if (!blob.trim()) return null;
+
+  const matched = PARENT_SUBDOMAIN_PATTERNS.some((re) => re.test(blob));
+  if (!matched) return null;
+
+  // Extract parent path + child info from reviewer body.
+  //
+  // We accept either:
+  //   - an explicit `parent: <path>` hint
+  //   - a `<dir>/NODE.md` reference, from which we infer the parent as
+  //     the NODE.md one level up.
+  const parentHint = blob.match(/parent(?:\s+NODE\.md)?\s*[:=]\s*([^\s`]+)/i);
+  const childRef = blob.match(/([A-Za-z0-9._-]+)\/NODE\.md/);
+  const titleHint = blob.match(/title\s*[:=]\s*["']?([^"'\n]+)["']?/i);
+
+  let parentPath: string | null = null;
+  let childDir: string | null = null;
+
+  if (childRef) {
+    childDir = childRef[1];
+  }
+
+  if (parentHint) {
+    parentPath = resolve(treeRoot, parentHint[1].replace(/^\.\//, ""));
+  } else if (childDir) {
+    // Parent NODE.md is one level up from the child's NODE.md.
+    const childNodePath = resolve(treeRoot, `${childDir}/NODE.md`);
+    parentPath = resolve(dirname(dirname(childNodePath)), "NODE.md");
+  }
+
+  if (!parentPath || !childDir) return null;
+
+  let before: string;
+  try {
+    before = readFileSync(parentPath, "utf-8");
+  } catch {
+    return null;
+  }
+
+  // Idempotency: if the child is already listed, nothing to do.
+  const escaped = childDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const entryRe = new RegExp(`(^|\\n)\\s*-\\s+[^\\n]*\\b${escaped}/`);
+  const subDomainsMatch = before.match(
+    /(##\s*Sub-?domains?[^\n]*\n)([\s\S]*?)(\n##|\n---|$)/i,
+  );
+  if (subDomainsMatch && entryRe.test(subDomainsMatch[2])) return null;
+
+  const title = (titleHint?.[1] ?? childDir).trim();
+  const newLine = `- \`${childDir}/\` — ${title}\n`;
+
+  let after: string;
+  if (subDomainsMatch) {
+    const [, header, block, trailer] = subDomainsMatch;
+    const newBlock = block.endsWith("\n") ? `${block}${newLine}` : `${block}\n${newLine}`;
+    after = before.replace(subDomainsMatch[0], `${header}${newBlock}${trailer}`);
+  } else {
+    // No Sub-domains section yet — append one at the end.
+    const sep = before.endsWith("\n") ? "" : "\n";
+    after = `${before}${sep}\n## Sub-domains\n\n${newLine}`;
+  }
+
+  if (after === before) return null;
+
+  return {
+    pattern: "parent_subdomain_missing",
+    summary: `add ${childDir}/ to parent Sub-domains`,
+    replyBody:
+      `Added \`${childDir}/\` to the parent \`NODE.md\` Sub-domains section.`,
+    files: [{ path: parentPath, before, after }],
+  };
+}
+
+function ensureTrailingNewline(text: string): string {
+  return text.endsWith("\n") ? text : `${text}\n`;
+}
+
+/**
+ * Apply a plan to the working tree, commit, and push.
+ *
+ * Never force-pushes. If the branch can't fast-forward, returns
+ * `{ kind: "deferred", reason: "rebase_needed" }` so the caller falls
+ * back to the placeholder reply.
+ */
+export async function orchestrateEdit(
+  opts: OrchestrateEditOptions,
+): Promise<OrchestrateEditResult> {
+  const { treeRoot, feedback, prView, shell, dryRun, planner } = opts;
+
+  let plan: EditPlan | null =
+    detectParentSubdomainMissing(feedback, prView, treeRoot);
+
+  if (!plan && planner) {
+    try {
+      const result = await planner({ feedback, prView, treeRoot });
+      plan = result ?? null;
+    } catch (err) {
+      return {
+        kind: "failed",
+        reason: `planner error: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  }
+
+  if (!plan) {
+    return { kind: "deferred", reason: "unsupported_pattern" };
+  }
+
+  if (plan.files.length === 0) {
+    return { kind: "deferred", reason: "empty_plan" };
+  }
+
+  if (dryRun) {
+    return {
+      kind: "applied",
+      sha: "dry-run",
+      pattern: plan.pattern,
+      replyBody: plan.replyBody,
+    };
+  }
+
+  // Apply edits to disk.
+  for (const file of plan.files) {
+    try {
+      const current = readFileSync(file.path, "utf-8");
+      if (current !== file.before) {
+        return {
+          kind: "deferred",
+          reason: "stale_base",
+        };
+      }
+      writeFileSync(file.path, ensureTrailingNewline(file.after), "utf-8");
+    } catch (err) {
+      return {
+        kind: "failed",
+        reason: `write failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  }
+
+  // Stage, commit, push (origin HEAD, no force).
+  const relativePaths = plan.files.map((f) => f.path);
+  const addRes = await shell("git", ["add", "--", ...relativePaths], {
+    cwd: treeRoot,
+  });
+  if (addRes.code !== 0) {
+    return { kind: "failed", reason: `git add: ${addRes.stderr.trim()}` };
+  }
+
+  const commitMsg = `gardener: ${plan.summary}\n\nApplied by gardener-respond for PR #${prView.number}.`;
+  const commitRes = await shell(
+    "git",
+    ["commit", "-m", commitMsg],
+    { cwd: treeRoot },
+  );
+  if (commitRes.code !== 0) {
+    const out = `${commitRes.stdout}\n${commitRes.stderr}`;
+    if (/nothing to commit/i.test(out)) {
+      return { kind: "deferred", reason: "nothing_to_commit" };
+    }
+    return { kind: "failed", reason: `git commit: ${commitRes.stderr.trim()}` };
+  }
+
+  const pushRes = await shell(
+    "git",
+    ["push", "origin", "HEAD"],
+    { cwd: treeRoot },
+  );
+  if (pushRes.code !== 0) {
+    const out = `${pushRes.stdout}\n${pushRes.stderr}`;
+    if (/non-fast-forward|fetch first|rejected/i.test(out)) {
+      return { kind: "deferred", reason: "rebase_needed" };
+    }
+    return { kind: "failed", reason: `git push: ${pushRes.stderr.trim()}` };
+  }
+
+  const shaRes = await shell("git", ["rev-parse", "HEAD"], { cwd: treeRoot });
+  const sha = shaRes.code === 0 ? shaRes.stdout.trim() : "unknown";
+
+  return {
+    kind: "applied",
+    sha,
+    pattern: plan.pattern,
+    replyBody: plan.replyBody,
+  };
+}

--- a/src/products/gardener/engine/edit-orchestrator.ts
+++ b/src/products/gardener/engine/edit-orchestrator.ts
@@ -27,7 +27,7 @@
  */
 
 import { readFileSync, writeFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, relative, resolve, sep } from "node:path";
 
 import type { PrReview, PrIssueComment, PrView, ShellRun } from "./respond.js";
 
@@ -68,6 +68,30 @@ export type OrchestrateEditResult =
   | { kind: "deferred"; reason: string; replyBody?: string }
   | { kind: "failed"; reason: string };
 
+/**
+ * Resolve a reviewer-supplied relative path against the tree root and
+ * require it to:
+ *   - stay inside the tree checkout (no `..` traversal, no absolute paths)
+ *   - target a file named `NODE.md`
+ *
+ * Returns null on any violation so callers can deferred-fall-back
+ * without touching disk.
+ */
+function resolveInsideTree(treeRoot: string, input: string): string | null {
+  const cleaned = input.replace(/^\.?\/+/, "").trim();
+  if (!cleaned) return null;
+  // Reject absolute paths outright — reviewer text must be tree-relative.
+  if (cleaned.startsWith("/") || /^[a-zA-Z]:[\\/]/.test(cleaned)) return null;
+  const rootAbs = resolve(treeRoot);
+  const target = resolve(rootAbs, cleaned);
+  const rel = relative(rootAbs, target);
+  if (rel.startsWith("..") || rel === "" || rel.split(sep).includes("..")) {
+    return null;
+  }
+  if (basename(target) !== "NODE.md") return null;
+  return target;
+}
+
 const PARENT_SUBDOMAIN_PATTERNS = [
   /not listed in (?:the )?parent\s+NODE\.md/i,
   /missing from (?:the )?(?:parent'?s? )?Sub-?domains/i,
@@ -100,25 +124,37 @@ function detectParentSubdomainMissing(
   //
   // We accept either:
   //   - an explicit `parent: <path>` hint
-  //   - a `<dir>/NODE.md` reference, from which we infer the parent as
-  //     the NODE.md one level up.
+  //   - a `<path>/<dir>/NODE.md` reference, from which we infer the
+  //     parent as the NODE.md one level up. The full relative path is
+  //     preserved so nested nodes (e.g. `engineering/mcp/NODE.md`) resolve
+  //     to the right parent (`engineering/NODE.md`), not the tree root.
   const parentHint = blob.match(/parent(?:\s+NODE\.md)?\s*[:=]\s*([^\s`]+)/i);
-  const childRef = blob.match(/([A-Za-z0-9._-]+)\/NODE\.md/);
+  const childRef = blob.match(/([A-Za-z0-9._\-/]+?)\/NODE\.md/);
   const titleHint = blob.match(/title\s*[:=]\s*["']?([^"'\n]+)["']?/i);
 
   let parentPath: string | null = null;
   let childDir: string | null = null;
+  let childRelative: string | null = null;
 
   if (childRef) {
-    childDir = childRef[1];
+    childRelative = childRef[1].replace(/^\.?\/+/, "");
+    childDir = basename(childRelative);
   }
 
   if (parentHint) {
-    parentPath = resolve(treeRoot, parentHint[1].replace(/^\.\//, ""));
-  } else if (childDir) {
-    // Parent NODE.md is one level up from the child's NODE.md.
-    const childNodePath = resolve(treeRoot, `${childDir}/NODE.md`);
-    parentPath = resolve(dirname(dirname(childNodePath)), "NODE.md");
+    const hinted = resolveInsideTree(treeRoot, parentHint[1]);
+    if (!hinted) return null;
+    parentPath = hinted;
+  } else if (childRelative) {
+    // Parent NODE.md is one level up from the child's NODE.md — preserve
+    // the full relative path so nested children resolve correctly.
+    const parentDir = dirname(childRelative);
+    const parentRel = parentDir === "." || parentDir === ""
+      ? "NODE.md"
+      : `${parentDir}/NODE.md`;
+    const resolved = resolveInsideTree(treeRoot, parentRel);
+    if (!resolved) return null;
+    parentPath = resolved;
   }
 
   if (!parentPath || !childDir) return null;

--- a/src/products/gardener/engine/respond.ts
+++ b/src/products/gardener/engine/respond.ts
@@ -37,6 +37,11 @@ import {
   isModuleEnabled,
   loadGardenerConfig,
 } from "./runtime/config.js";
+import {
+  orchestrateEdit,
+  type EditPlanner,
+  type OrchestrateEditResult,
+} from "./edit-orchestrator.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -97,6 +102,12 @@ export interface RespondDeps {
   now?: () => Date;
   env?: NodeJS.ProcessEnv;
   write?: (line: string) => void;
+  /**
+   * Optional planner seam. When set, the edit orchestrator will call
+   * this for any feedback pattern its built-in heuristics can't match.
+   * Left unset by default so v1 stays deterministic.
+   */
+  planner?: EditPlanner;
 }
 
 async function defaultShellRun(
@@ -322,7 +333,7 @@ export function latestChangesRequestedAt(reviews: PrReview[]): string | null {
   return latest;
 }
 
-function latestReviewerLogin(reviews: PrReview[]): string | undefined {
+export function latestReviewerLogin(reviews: PrReview[]): string | undefined {
   let latestAt: string | undefined;
   let latestLogin: string | undefined;
   for (const review of reviews) {
@@ -500,12 +511,25 @@ interface RespondSinglePrOpts {
   write: (line: string) => void;
   now: () => Date;
   gardenerLogin: string;
+  treeRoot: string;
+  planner?: EditPlanner;
 }
 
 async function respondSinglePr(
   opts: RespondSinglePrOpts,
 ): Promise<{ status: RespondStatus; summary: string }> {
-  const { repo, pr, dryRun, shell, env, write, now, gardenerLogin } = opts;
+  const {
+    repo,
+    pr,
+    dryRun,
+    shell,
+    env,
+    write,
+    now,
+    gardenerLogin,
+    treeRoot,
+    planner,
+  } = opts;
 
   const snapshotDir = env.BREEZE_SNAPSHOT_DIR;
   const bundle = snapshotDir
@@ -643,15 +667,85 @@ async function respondSinglePr(
     };
   }
 
-  // Step 3b-3e: Read feedback, read source, apply fix, reply.
-  // The TS port delegates the actual edit to a Claude Code session
-  // orchestrated externally — here we record that a fix was attempted,
-  // bump the attempts counter, and emit a reply comment stub. The
-  // runbook's "apply edits" step is a semantic change that lives in the
-  // calling agent; this CLI is the deterministic scaffold around it.
+  // Step 3b-3e: Read feedback, try the edit orchestrator, reply.
+  //
+  // The orchestrator applies a real fix when its built-in heuristic
+  // (or an injected planner) recognizes the pattern. Any other case
+  // returns `deferred` and we fall back to the original placeholder
+  // reply path (which bumps the attempts counter).
   const reviewer = latestReviewerLogin(reviews) ?? "reviewer";
   const sourceInfo = extractSourcePr(prView.body);
 
+  let orchestration: OrchestrateEditResult = {
+    kind: "deferred",
+    reason: "orchestrator_skipped",
+  };
+  try {
+    orchestration = await orchestrateEdit({
+      repo,
+      pr,
+      treeRoot,
+      feedback: {
+        reviews,
+        issueComments,
+        reviewerLogin: reviewer,
+      },
+      prView,
+      shell,
+      dryRun,
+      planner,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    orchestration = { kind: "failed", reason: `orchestrator crash: ${message}` };
+  }
+
+  if (orchestration.kind === "applied") {
+    // Attempts counter unchanged on applied (per signoff on #219).
+    if (!dryRun) {
+      await shell("gh", [
+        "pr",
+        "comment",
+        String(pr),
+        "--repo",
+        repo,
+        "--body",
+        `${orchestration.replyBody}\n\n`
+          + `<!-- gardener:respond-applied=${orchestration.pattern} -->`,
+      ]);
+    }
+    logEvent(env, {
+      kind: "fix",
+      pr_number: pr,
+      pattern: orchestration.pattern,
+      summary: `applied @${orchestration.sha}`,
+    });
+    logEvent(env, { kind: "reply", pr_number: pr, reviewer });
+    write(
+      `\u2713 #${pr}: applied ${orchestration.pattern} @${orchestration.sha.slice(0, 7)}`,
+    );
+    return {
+      status: "handled",
+      summary: `applied ${orchestration.pattern}`,
+    };
+  }
+
+  if (orchestration.kind === "failed") {
+    // Attempts unchanged on failed (per signoff on #219).
+    logEvent(env, {
+      kind: "error",
+      pr_number: pr,
+      message: orchestration.reason,
+    });
+    write(`\u274c #${pr}: orchestrator failed: ${orchestration.reason}`);
+    return {
+      status: "failed",
+      summary: `orchestrator failed: ${orchestration.reason}`,
+    };
+  }
+
+  // Deferred: bump attempts counter and post the placeholder reply.
+  const deferredReason = orchestration.reason;
   if (!dryRun) {
     const nextBody = writeRespondAttempts(prView.body, attempts + 1);
     await shell("gh", [
@@ -679,18 +773,18 @@ async function respondSinglePr(
   logEvent(env, {
     kind: "fix",
     pr_number: pr,
-    pattern: "unclassified",
-    summary: `attempt ${attempts + 1}`,
+    pattern: "deferred",
+    summary: `attempt ${attempts + 1} (${deferredReason})`,
   });
   logEvent(env, { kind: "reply", pr_number: pr, reviewer });
 
   write(
-    `\u2713 #${pr}: acknowledged CHANGES_REQUESTED (attempt ${attempts + 1}/${RESPOND_MAX_ATTEMPTS})`,
+    `\u2713 #${pr}: deferred (${deferredReason}), attempt ${attempts + 1}/${RESPOND_MAX_ATTEMPTS}`,
   );
 
   return {
     status: "handled",
-    summary: `attempt ${attempts + 1}/${RESPOND_MAX_ATTEMPTS} acknowledged`,
+    summary: `deferred ${deferredReason} attempt ${attempts + 1}/${RESPOND_MAX_ATTEMPTS}`,
   };
 }
 
@@ -762,6 +856,8 @@ export async function runRespond(
       write,
       now,
       gardenerLogin,
+      treeRoot,
+      planner: deps.planner,
     });
     emitBreezeResult(write, result.status, result.summary);
     return result.status === "failed" ? 1 : 0;

--- a/tests/gardener/gardener-edit-orchestrator.test.ts
+++ b/tests/gardener/gardener-edit-orchestrator.test.ts
@@ -1,0 +1,315 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { orchestrateEdit } from "#products/gardener/engine/edit-orchestrator.js";
+import type { PrView, ShellResult, ShellRun } from "#products/gardener/engine/respond.js";
+import { useTmpDir } from "../helpers.js";
+
+interface ShellCall {
+  command: string;
+  args: string[];
+  cwd?: string;
+}
+
+function makeShell(
+  handler: (call: ShellCall) => ShellResult,
+  calls: ShellCall[] = [],
+): ShellRun {
+  return async (command, args, options) => {
+    const call: ShellCall = { command, args, cwd: options?.cwd };
+    calls.push(call);
+    return handler(call);
+  };
+}
+
+const DEFAULT_PR_VIEW: PrView = {
+  number: 42,
+  headRefName: "first-tree/sync-foo",
+};
+
+function seedParent(dir: string, relPath: string, body: string): string {
+  const full = join(dir, relPath);
+  mkdirSync(join(full, ".."), { recursive: true });
+  writeFileSync(full, body);
+  return full;
+}
+
+describe("edit-orchestrator: parent_subdomain_missing heuristic", () => {
+  it("appends the missing child under ## Sub-domains and pushes", async () => {
+    const tree = useTmpDir().path;
+    seedParent(
+      tree,
+      "NODE.md",
+      "# Root\n\n## Sub-domains\n\n- `alpha/` — Alpha\n",
+    );
+
+    const calls: ShellCall[] = [];
+    const shell = makeShell((call) => {
+      if (call.command === "git" && call.args[0] === "rev-parse") {
+        return { stdout: "deadbeef1234567\n", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    }, calls);
+
+    const result = await orchestrateEdit({
+      repo: "acme/tree",
+      pr: 42,
+      treeRoot: tree,
+      feedback: {
+        reviews: [
+          {
+            state: "CHANGES_REQUESTED",
+            body: "beta/NODE.md is not listed in parent NODE.md. title: Beta",
+          },
+        ],
+        issueComments: [],
+      },
+      prView: DEFAULT_PR_VIEW,
+      shell,
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("applied");
+    if (result.kind !== "applied") throw new Error("unreachable");
+    expect(result.pattern).toBe("parent_subdomain_missing");
+    expect(result.sha).toBe("deadbeef1234567");
+
+    const updated = readFileSync(join(tree, "NODE.md"), "utf-8");
+    expect(updated).toContain("- `beta/` — Beta");
+    expect(updated).toContain("- `alpha/` — Alpha");
+
+    const gitCmds = calls.filter((c) => c.command === "git").map((c) => c.args[0]);
+    expect(gitCmds).toEqual(["add", "commit", "push", "rev-parse"]);
+    const pushCall = calls.find((c) => c.command === "git" && c.args[0] === "push");
+    expect(pushCall?.args).toEqual(["push", "origin", "HEAD"]);
+    // Never force-push.
+    expect(pushCall?.args).not.toContain("--force");
+    expect(pushCall?.args).not.toContain("--force-with-lease");
+  });
+
+  it("is idempotent when the child is already listed", async () => {
+    const tree = useTmpDir().path;
+    seedParent(
+      tree,
+      "NODE.md",
+      "# Root\n\n## Sub-domains\n\n- `beta/` — Beta\n",
+    );
+
+    const result = await orchestrateEdit({
+      repo: "acme/tree",
+      pr: 42,
+      treeRoot: tree,
+      feedback: {
+        reviews: [
+          {
+            state: "CHANGES_REQUESTED",
+            body: "beta/NODE.md is not listed in parent NODE.md",
+          },
+        ],
+        issueComments: [],
+      },
+      prView: DEFAULT_PR_VIEW,
+      shell: makeShell(() => ({ stdout: "", stderr: "", code: 0 })),
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("deferred");
+  });
+
+  it("returns deferred rebase_needed on non-fast-forward push", async () => {
+    const tree = useTmpDir().path;
+    seedParent(tree, "NODE.md", "# Root\n\n## Sub-domains\n\n");
+
+    const shell = makeShell((call) => {
+      if (call.command === "git" && call.args[0] === "push") {
+        return {
+          stdout: "",
+          stderr: "! [rejected] HEAD -> main (non-fast-forward)",
+          code: 1,
+        };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    });
+
+    const result = await orchestrateEdit({
+      repo: "acme/tree",
+      pr: 42,
+      treeRoot: tree,
+      feedback: {
+        reviews: [
+          {
+            state: "CHANGES_REQUESTED",
+            body: "gamma/NODE.md is not listed in parent NODE.md. title: Gamma",
+          },
+        ],
+        issueComments: [],
+      },
+      prView: DEFAULT_PR_VIEW,
+      shell,
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("deferred");
+    if (result.kind !== "deferred") throw new Error("unreachable");
+    expect(result.reason).toBe("rebase_needed");
+  });
+
+  it("returns deferred unsupported_pattern when heuristic doesn't match and no planner", async () => {
+    const tree = useTmpDir().path;
+    const result = await orchestrateEdit({
+      repo: "acme/tree",
+      pr: 42,
+      treeRoot: tree,
+      feedback: {
+        reviews: [
+          {
+            state: "CHANGES_REQUESTED",
+            body: "please rewrite the whole section",
+          },
+        ],
+        issueComments: [],
+      },
+      prView: DEFAULT_PR_VIEW,
+      shell: makeShell(() => ({ stdout: "", stderr: "", code: 0 })),
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("deferred");
+    if (result.kind !== "deferred") throw new Error("unreachable");
+    expect(result.reason).toBe("unsupported_pattern");
+  });
+
+  it("dry-run returns applied without touching the filesystem or shell", async () => {
+    const tree = useTmpDir().path;
+    const parentPath = seedParent(
+      tree,
+      "NODE.md",
+      "# Root\n\n## Sub-domains\n\n",
+    );
+    const before = readFileSync(parentPath, "utf-8");
+
+    const calls: ShellCall[] = [];
+    const shell = makeShell(
+      () => ({ stdout: "", stderr: "", code: 0 }),
+      calls,
+    );
+
+    const result = await orchestrateEdit({
+      repo: "acme/tree",
+      pr: 42,
+      treeRoot: tree,
+      feedback: {
+        reviews: [
+          {
+            state: "CHANGES_REQUESTED",
+            body: "delta/NODE.md is not listed in parent NODE.md. title: Delta",
+          },
+        ],
+        issueComments: [],
+      },
+      prView: DEFAULT_PR_VIEW,
+      shell,
+      dryRun: true,
+    });
+
+    expect(result.kind).toBe("applied");
+    expect(calls).toHaveLength(0);
+    expect(readFileSync(parentPath, "utf-8")).toBe(before);
+  });
+
+  it("invokes the injected planner when the heuristic does not match", async () => {
+    const tree = useTmpDir().path;
+    seedParent(tree, "NOTES.md", "old content\n");
+
+    const calls: ShellCall[] = [];
+    const shell = makeShell((call) => {
+      if (call.command === "git" && call.args[0] === "rev-parse") {
+        return { stdout: "planner-sha\n", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    }, calls);
+
+    const result = await orchestrateEdit({
+      repo: "acme/tree",
+      pr: 42,
+      treeRoot: tree,
+      feedback: {
+        reviews: [{ state: "CHANGES_REQUESTED", body: "do something custom" }],
+        issueComments: [],
+      },
+      prView: DEFAULT_PR_VIEW,
+      shell,
+      dryRun: false,
+      planner: async () => ({
+        pattern: "custom_pattern",
+        summary: "rewrite notes",
+        replyBody: "Done.",
+        files: [
+          {
+            path: join(tree, "NOTES.md"),
+            before: "old content\n",
+            after: "new content\n",
+          },
+        ],
+      }),
+    });
+
+    expect(result.kind).toBe("applied");
+    if (result.kind !== "applied") throw new Error("unreachable");
+    expect(result.pattern).toBe("custom_pattern");
+    expect(readFileSync(join(tree, "NOTES.md"), "utf-8")).toBe("new content\n");
+  });
+
+  it("returns deferred stale_base when file on disk diverges from plan.before", async () => {
+    const tree = useTmpDir().path;
+    const parentPath = seedParent(tree, "NOTES.md", "actual disk content\n");
+
+    const result = await orchestrateEdit({
+      repo: "acme/tree",
+      pr: 42,
+      treeRoot: tree,
+      feedback: {
+        reviews: [{ state: "CHANGES_REQUESTED", body: "custom" }],
+        issueComments: [],
+      },
+      prView: DEFAULT_PR_VIEW,
+      shell: makeShell(() => ({ stdout: "", stderr: "", code: 0 })),
+      dryRun: false,
+      planner: () => ({
+        pattern: "custom",
+        summary: "s",
+        replyBody: "r",
+        files: [
+          { path: parentPath, before: "stale\n", after: "new\n" },
+        ],
+      }),
+    });
+
+    expect(result.kind).toBe("deferred");
+    if (result.kind !== "deferred") throw new Error("unreachable");
+    expect(result.reason).toBe("stale_base");
+  });
+
+  it("returns failed when the planner throws", async () => {
+    const tree = useTmpDir().path;
+    const result = await orchestrateEdit({
+      repo: "acme/tree",
+      pr: 42,
+      treeRoot: tree,
+      feedback: {
+        reviews: [{ state: "CHANGES_REQUESTED", body: "custom" }],
+        issueComments: [],
+      },
+      prView: DEFAULT_PR_VIEW,
+      shell: makeShell(() => ({ stdout: "", stderr: "", code: 0 })),
+      dryRun: false,
+      planner: () => {
+        throw new Error("planner boom");
+      },
+    });
+
+    expect(result.kind).toBe("failed");
+    if (result.kind !== "failed") throw new Error("unreachable");
+    expect(result.reason).toContain("planner boom");
+  });
+});

--- a/tests/gardener/gardener-edit-orchestrator.test.ts
+++ b/tests/gardener/gardener-edit-orchestrator.test.ts
@@ -290,6 +290,132 @@ describe("edit-orchestrator: parent_subdomain_missing heuristic", () => {
     expect(result.reason).toBe("stale_base");
   });
 
+  it("resolves nested child to the correct parent (not tree root) — #229 review", async () => {
+    const tree = useTmpDir().path;
+    // engineering/NODE.md is the correct parent for engineering/mcp/
+    seedParent(
+      tree,
+      "engineering/NODE.md",
+      "# Engineering\n\n## Sub-domains\n\n",
+    );
+    // A tree-root NODE.md also exists — we should NOT write to it.
+    seedParent(tree, "NODE.md", "# Root\n\n## Sub-domains\n\n- `alpha/` — Alpha\n");
+
+    const shell = makeShell((call) => {
+      if (call.command === "git" && call.args[0] === "rev-parse") {
+        return { stdout: "nestedsha\n", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    });
+
+    const result = await orchestrateEdit({
+      repo: "acme/tree",
+      pr: 42,
+      treeRoot: tree,
+      feedback: {
+        reviews: [
+          {
+            state: "CHANGES_REQUESTED",
+            body: "engineering/mcp/NODE.md is not listed in parent NODE.md. title: MCP",
+          },
+        ],
+        issueComments: [],
+      },
+      prView: DEFAULT_PR_VIEW,
+      shell,
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("applied");
+
+    const engParent = readFileSync(join(tree, "engineering/NODE.md"), "utf-8");
+    expect(engParent).toContain("- `mcp/` — MCP");
+
+    // Root NODE.md should be untouched — no `mcp/` entry written to it.
+    const rootParent = readFileSync(join(tree, "NODE.md"), "utf-8");
+    expect(rootParent).not.toContain("mcp/");
+  });
+
+  it("rejects path-traversal parent hint — #229 review", async () => {
+    const tree = useTmpDir().path;
+    seedParent(tree, "NODE.md", "# Root\n\n## Sub-domains\n\n");
+
+    const shell = makeShell(() => ({ stdout: "", stderr: "", code: 0 }));
+
+    const result = await orchestrateEdit({
+      repo: "acme/tree",
+      pr: 42,
+      treeRoot: tree,
+      feedback: {
+        reviews: [
+          {
+            state: "CHANGES_REQUESTED",
+            body:
+              "parent: ../../../../tmp/pwn/NODE.md — child/NODE.md is not listed in parent NODE.md. title: Child",
+          },
+        ],
+        issueComments: [],
+      },
+      prView: DEFAULT_PR_VIEW,
+      shell,
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("deferred");
+  });
+
+  it("rejects absolute parent hint — #229 review", async () => {
+    const tree = useTmpDir().path;
+    seedParent(tree, "NODE.md", "# Root\n\n## Sub-domains\n\n");
+
+    const result = await orchestrateEdit({
+      repo: "acme/tree",
+      pr: 42,
+      treeRoot: tree,
+      feedback: {
+        reviews: [
+          {
+            state: "CHANGES_REQUESTED",
+            body:
+              "parent: /etc/NODE.md — child/NODE.md is not listed in parent NODE.md",
+          },
+        ],
+        issueComments: [],
+      },
+      prView: DEFAULT_PR_VIEW,
+      shell: makeShell(() => ({ stdout: "", stderr: "", code: 0 })),
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("deferred");
+  });
+
+  it("rejects parent hint not targeting NODE.md — #229 review", async () => {
+    const tree = useTmpDir().path;
+    seedParent(tree, "NODE.md", "# Root\n\n## Sub-domains\n\n");
+
+    const result = await orchestrateEdit({
+      repo: "acme/tree",
+      pr: 42,
+      treeRoot: tree,
+      feedback: {
+        reviews: [
+          {
+            state: "CHANGES_REQUESTED",
+            body:
+              "parent: README.md — child/NODE.md is not listed in parent NODE.md",
+          },
+        ],
+        issueComments: [],
+      },
+      prView: DEFAULT_PR_VIEW,
+      shell: makeShell(() => ({ stdout: "", stderr: "", code: 0 })),
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("deferred");
+  });
+
   it("returns failed when the planner throws", async () => {
     const tree = useTmpDir().path;
     const result = await orchestrateEdit({


### PR DESCRIPTION
## Summary

Phase 5 of the gardener sub-CLI migration, per bingran's signoff on #219.

- New `src/products/gardener/engine/edit-orchestrator.ts` primitive with v1 deterministic heuristic for `parent_subdomain_missing` + injected planner seam for future LLM wiring.
- `git push origin HEAD` only — no force-push. Non-fast-forward → `deferred` with `reason="rebase_needed"`.
- Wired into `respond.ts`: `applied` posts real reply (attempts unchanged), `deferred` falls back to the existing placeholder path (attempts++), `failed` surfaces as BREEZE_RESULT=failed (attempts unchanged).

Closes #160.

## Design notes

- V1 heuristic limited to `parent_subdomain_missing`; anything else returns `deferred → unsupported_pattern` and falls through to the placeholder reply so existing respond behavior is preserved.
- Idempotency: stale-base check (on-disk ≠ `plan.before` → deferred), already-listed check against parent's `## Sub-domains` block.
- Attempts-counter semantics owned by the caller (`respond.ts`), matching the signoff: applied=unchanged, deferred=++, failed=unchanged.

## Test plan

- [x] New orchestrator tests — 8/8 passing (applied, idempotent, rebase_needed, unsupported_pattern, dry-run, planner seam, stale_base, planner crash).
- [x] All 151 gardener tests pass.
- [x] `tsc --noEmit` clean.
- [x] Full suite: same 5 pre-existing unrelated failures (breeze-daemon-launchd timeouts, cli-e2e timeouts, skill-artifacts python3 timeout) — none touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)