### PR TITLE
docs(tree): align SKILL.md and README command tables with current CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,15 +188,20 @@ continue to work cleanly for multi-repo workspaces.
 | `first-tree tree bind` | Bind the current repo/workspace root to an existing tree repo |
 | `first-tree tree workspace sync` | Bind discovered child repos to the same shared tree |
 | `first-tree tree publish` | Publish a dedicated tree repo or shared tree repo to GitHub and refresh locally bound source/workspace repos |
+| `first-tree tree sync` | Detect drift between a tree repo and its bound source repos; supports `--propose` and `--apply` |
 | `first-tree tree verify` | Run verification checks against a tree repo |
 | `first-tree tree upgrade` | Refresh installed source/workspace integration or tree metadata from the current package |
 | `first-tree tree generate-codeowners` | Generate `.github/CODEOWNERS` from tree ownership frontmatter |
 | `first-tree tree review` | Run the Claude Code PR review helper for a tree repo in CI |
+| `first-tree tree invite` | Invite a new member to the Context Tree (human, personal_assistant, or autonomous_agent) |
+| `first-tree tree join` | Accept an invite and join a Context Tree |
 | `first-tree tree inject-context` | Output a Claude Code SessionStart hook payload from the root `NODE.md` |
 | `first-tree tree help onboarding` | Print the full onboarding guide |
 | `first-tree skill install` | Install the four shipped skills under `.agents/skills/*` and `.claude/skills/*` |
 | `first-tree skill upgrade` | Wipe and reinstall the four shipped skills from the current package |
+| `first-tree skill list` | Print the four shipped skills with their installed status and version |
 | `first-tree skill doctor` | Diagnose whether the four shipped skills are installed and healthy |
+| `first-tree skill link` | Idempotently repair the `.claude/skills/*` alias symlinks |
 
 ---
 

--- a/skills/tree/SKILL.md
+++ b/skills/tree/SKILL.md
@@ -49,6 +49,7 @@ During `bind` / `init`, the CLI also ensures the tree repo has the bundled
 | Command | Purpose |
 |---|---|
 | `first-tree tree inspect` | Classify the current folder and report bindings / child repos |
+| `first-tree tree status` | Alias for `inspect` (human-friendly name) |
 | `first-tree tree init` | High-level onboarding wrapper for single repos, shared trees, and workspace roots |
 | `first-tree tree bootstrap` | Low-level tree bootstrap for an explicit tree checkout |
 | `first-tree tree bind` | Bind the current repo/workspace root to an existing tree repo |
@@ -56,8 +57,11 @@ During `bind` / `init`, the CLI also ensures the tree repo has the bundled
 | `first-tree tree verify` | Validate a tree repo: frontmatter, owners, soft_links, members, progress |
 | `first-tree tree upgrade` | Refresh the installed skill payloads or tree metadata from the bundled package |
 | `first-tree tree publish` | Publish a tree repo to GitHub and refresh locally bound source/workspace repos |
+| `first-tree tree sync` | Detect drift between a tree repo and its bound source repos; supports `--propose` and `--apply` |
 | `first-tree tree review` | CI helper: run Claude Code PR review against tree changes |
 | `first-tree tree generate-codeowners` | Regenerate `.github/CODEOWNERS` from tree ownership |
+| `first-tree tree invite` | Invite a new member to the Context Tree (human, personal_assistant, or autonomous_agent) |
+| `first-tree tree join` | Accept an invite and join a Context Tree |
 | `first-tree tree inject-context` | Output a Claude Code SessionStart hook payload from `NODE.md` |
 | `first-tree tree help onboarding` | Show the onboarding narrative |
 


### PR DESCRIPTION
## Summary
- Audit found `skills/tree/SKILL.md` and the root `README.md` command tables were missing CLI-level commands that already ship in `src/products/tree/cli.ts` and `src/meta/skill-tools/cli.ts`.
- Added `tree status` (alias), `tree sync`, `tree invite`, `tree join`, plus the `skill list` and `skill link` rows.
- Tightened the `skill list` / `skill link` blurbs so they match the live `SKILL_USAGE` text.
- No CLI behavior changed — pure docs alignment.

## Test plan
- [x] `pnpm validate:skill`
- [x] `pnpm typecheck`
- [x] `pnpm test` (976 passed, 51 skipped)