### PR TITLE
fix(breeze): refresh daemon runtime status

### DIFF
--- a/src/products/breeze/engine/daemon/runner-skeleton.ts
+++ b/src/products/breeze/engine/daemon/runner-skeleton.ts
@@ -276,6 +276,7 @@ export async function runDaemon(
   }
 
   const paths = resolveBreezePaths();
+  const runnerHome = resolveRunnerHome();
 
   // Identity resolution is best-effort at startup. The daemon will still
   // try to poll if identity fails — the poller uses the host-only env,
@@ -314,7 +315,7 @@ export async function runDaemon(
   if (identity && !(options.signal?.aborted ?? false)) {
     try {
       lockHandle = await acquireServiceLock({
-        baseDir: join(resolveRunnerHome(), "locks"),
+        baseDir: join(runnerHome, "locks"),
         identity,
         profile: "default",
         note: "daemon starting",
@@ -355,8 +356,52 @@ export async function runDaemon(
     logger.error(
       `invalid --allow-repo value: ${err instanceof Error ? err.message : String(err)}`,
     );
+    if (lockHandle) await lockHandle.release().catch(() => undefined);
     return 1;
   }
+
+  let dispatcher: Dispatcher | null = null;
+  const runtimeStore = new ThreadStore({ runnerHome });
+  const allowedReposLabel = repoFilter.isEmpty()
+    ? "all"
+    : repoFilter.displayPatterns();
+  const runtimeStatus: Record<string, string> = {
+    last_identity: identity
+      ? `${identity.login}@${identity.host}`
+      : `unknown@${config.host}`,
+    allowed_repos: allowedReposLabel,
+    active_tasks: "0",
+    queued_tasks: "0",
+    last_note: "daemon starting",
+  };
+  const publishRuntimeStatus = (
+    note?: string,
+    extra: Record<string, string | undefined> = {},
+  ): void => {
+    if (note !== undefined) runtimeStatus.last_note = note;
+    runtimeStatus.last_identity = identity
+      ? `${identity.login}@${identity.host}`
+      : `unknown@${config.host}`;
+    runtimeStatus.allowed_repos = allowedReposLabel;
+    runtimeStatus.active_tasks = String(dispatcher?.activeCount() ?? 0);
+    runtimeStatus.queued_tasks = String(dispatcher?.pendingCount() ?? 0);
+    for (const [key, value] of Object.entries(extra)) {
+      if (value === undefined || value.length === 0) delete runtimeStatus[key];
+      else runtimeStatus[key] = value;
+    }
+    runtimeStore.writeRuntimeStatus(runtimeStatus);
+    lockHandle?.refresh(
+      Number.parseInt(runtimeStatus.active_tasks, 10) || 0,
+      runtimeStatus.last_note,
+    );
+  };
+  publishRuntimeStatus();
+  const runtimeRefreshMs = Math.max(
+    1_000,
+    Math.min(config.pollIntervalSec * 1_000, 30_000),
+  );
+  const runtimeTicker = setInterval(() => publishRuntimeStatus(), runtimeRefreshMs);
+  runtimeTicker.unref?.();
 
   logger.info(
     `breeze daemon: poll-interval=${config.pollIntervalSec}s host=${config.host} http-port=${config.httpPort} max-parallel=${config.maxParallel} search-limit=${config.searchLimit} allow-repo=${repoFilter.isEmpty() ? "all" : repoFilter.displayPatterns()}`,
@@ -374,7 +419,6 @@ export async function runDaemon(
   // Absence of codex/claude is non-fatal; the daemon still runs as
   // read-only (poller + http).
   let broker: RunningBroker | null = null;
-  let dispatcher: Dispatcher | null = null;
   let candidateLoopDone: Promise<void> | null = null;
   let candidateRuntime:
     | {
@@ -387,7 +431,6 @@ export async function runDaemon(
     const agents = detectAvailableAgents();
     const realGh = findExecutable("gh");
     if (agents.length > 0 && realGh) {
-      const runnerHome = resolveRunnerHome();
       const brokerDir = join(runnerHome, "broker");
       const identity = resolveDaemonIdentity({ host: config.host });
       const executor = new GhExecutor({
@@ -461,6 +504,12 @@ export async function runDaemon(
           signal: controller.signal,
           logger,
           scheduler,
+          onCycle: () =>
+            publishRuntimeStatus(undefined, {
+              next_search_reconcile_epoch: String(
+                Math.floor(Date.now() / 1_000) + config.pollIntervalSec,
+              ),
+            }),
           recoverableCandidates: () =>
             scheduler.enqueueRecoverableTasks(identity.host),
         }).catch((err) => {
@@ -504,12 +553,15 @@ export async function runDaemon(
       logger.error(
         `failed to start http server: ${err instanceof Error ? err.message : String(err)}`,
       );
+      clearInterval(runtimeTicker);
       if (dispatcher) await dispatcher.stop();
       if (broker) await broker.stop();
       if (uninstallHandlers) uninstallHandlers();
+      if (lockHandle) await lockHandle.release().catch(() => undefined);
       return 1;
     }
   }
+  publishRuntimeStatus("running");
 
   let exitCode = 0;
   try {
@@ -548,6 +600,7 @@ export async function runDaemon(
     );
     exitCode = 1;
   } finally {
+    clearInterval(runtimeTicker);
     // Shutdown order:
     //   SIGTERM -> stop poller (above) -> flush store (poller's atomic
     //   tmp+rename drains in updateInbox) -> stop dispatcher (aborts

--- a/tests/breeze/breeze-daemon-runner.test.ts
+++ b/tests/breeze/breeze-daemon-runner.test.ts
@@ -7,13 +7,65 @@
  *   - `daemon --backend=ts` invokes the TS runner; `--backend=rust` bridges
  */
 
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import * as identityModule from "../../src/products/breeze/engine/daemon/identity.js";
+import * as httpModule from "../../src/products/breeze/engine/daemon/http.js";
+import * as pollerModule from "../../src/products/breeze/engine/daemon/poller.js";
 import {
   parseDaemonArgs,
   runDaemon,
 } from "../../src/products/breeze/engine/daemon/runner-skeleton.js";
 import { extractBackendFlag } from "../../src/products/breeze/cli.js";
+
+const tempRoots: string[] = [];
+const ORIGINAL_BREEZE_DIR = process.env.BREEZE_DIR;
+const ORIGINAL_BREEZE_HOME = process.env.BREEZE_HOME;
+const ORIGINAL_PATH = process.env.PATH;
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (root && existsSync(root)) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+  if (ORIGINAL_BREEZE_DIR === undefined) delete process.env.BREEZE_DIR;
+  else process.env.BREEZE_DIR = ORIGINAL_BREEZE_DIR;
+  if (ORIGINAL_BREEZE_HOME === undefined) delete process.env.BREEZE_HOME;
+  else process.env.BREEZE_HOME = ORIGINAL_BREEZE_HOME;
+  if (ORIGINAL_PATH === undefined) delete process.env.PATH;
+  else process.env.PATH = ORIGINAL_PATH;
+  vi.useRealTimers();
+});
+
+function makeTempRoot(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), `breeze-daemon-${prefix}-`));
+  tempRoots.push(dir);
+  return dir;
+}
+
+function parseEnvFile(path: string): Record<string, string> {
+  return Object.fromEntries(
+    readFileSync(path, "utf8")
+      .trim()
+      .split("\n")
+      .filter((line) => line.length > 0)
+      .map((line) => {
+        const idx = line.indexOf("=");
+        return [line.slice(0, idx), line.slice(idx + 1)];
+      }),
+  );
+}
 
 describe("parseDaemonArgs", () => {
   it("parses all recognised flags", () => {
@@ -155,6 +207,84 @@ describe("runDaemon end-to-end skeleton", () => {
     });
     expect(code).toBe(0);
     expect(logs.some((l) => l.includes("shutdown complete"))).toBe(true);
+  });
+
+  it("refreshes the service lock heartbeat and writes runtime status while running", async () => {
+    const breezeDir = makeTempRoot("status");
+    process.env.BREEZE_DIR = breezeDir;
+    delete process.env.BREEZE_HOME;
+    process.env.PATH = "";
+
+    vi.spyOn(identityModule, "resolveDaemonIdentity").mockReturnValue({
+        host: "github.com",
+        login: "tester",
+        gitProtocol: "https",
+        scopes: ["repo", "notifications"],
+      });
+    vi.spyOn(identityModule, "identityHasRequiredScope").mockReturnValue(true);
+    vi.spyOn(httpModule, "startHttpServer").mockImplementation(
+      async ({ signal }: { signal?: AbortSignal }) => ({
+        port: 7878,
+        done: signal?.aborted
+          ? Promise.resolve()
+          : new Promise<void>((resolve) => {
+              signal?.addEventListener("abort", () => resolve(), { once: true });
+            }),
+        stop: async () => undefined,
+      }),
+    );
+    vi.spyOn(pollerModule, "runPoller").mockImplementation(
+      async ({ signal }: { signal?: AbortSignal }) =>
+        await new Promise<void>((resolve) => {
+          if (signal?.aborted) {
+            resolve();
+            return;
+          }
+          signal?.addEventListener("abort", () => resolve(), { once: true });
+        }),
+    );
+
+    const controller = new AbortController();
+    const runPromise = runDaemon([], {
+      cliOverrides: { pollIntervalSec: 1 },
+      installSignalHandlers: false,
+      signal: controller.signal,
+      logger: {
+        info: () => undefined,
+        warn: () => undefined,
+        error: () => undefined,
+      },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 2_200));
+
+    const runnerHome = join(breezeDir, "runner");
+    const lockPath = join(
+      runnerHome,
+      "locks",
+      "github.com__tester__default",
+      "lock.env",
+    );
+    const runtimePath = join(runnerHome, "runtime", "status.env");
+
+    expect(existsSync(lockPath)).toBe(true);
+    expect(existsSync(runtimePath)).toBe(true);
+
+    const lock = parseEnvFile(lockPath);
+    expect(Number(lock.heartbeat_epoch)).toBeGreaterThan(
+      Number(lock.started_epoch),
+    );
+    expect(lock.note).toBe("running");
+
+    const runtime = parseEnvFile(runtimePath);
+    expect(runtime.last_note).toBe("running");
+    expect(runtime.last_identity).toBe("tester@github.com");
+    expect(runtime.allowed_repos).toBe("all");
+    expect(runtime.active_tasks).toBe("0");
+    expect(runtime.queued_tasks).toBe("0");
+
+    controller.abort();
+    await expect(runPromise).resolves.toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary
- refresh the daemon service lock heartbeat while breeze is running
- write runtime/status.env so status and doctor read live daemon state instead of a stale startup snapshot
- add a daemon regression test that proves heartbeat and runtime status keep updating

## Testing
- pnpm typecheck
- pnpm test tests/breeze/breeze-daemon-runner.test.ts tests/breeze/breeze-commands-smoke.test.ts tests/breeze/breeze-daemon-claim.test.ts