### PR TITLE
fix(breeze): pass through provider auth env to launchd

### DIFF
--- a/src/products/breeze/engine/daemon/launchd.ts
+++ b/src/products/breeze/engine/daemon/launchd.ts
@@ -98,6 +98,21 @@ export const PASSTHROUGH_ENV_VARS: readonly string[] = [
 ];
 
 /**
+ * Agent CLIs may authenticate via a wider provider-specific env surface than
+ * the small Rust-era static allowlist above (for example Azure test slots,
+ * OpenAI-compatible base URLs, Bedrock/Vertex creds). Discover those families
+ * dynamically so background launchd jobs inherit the same auth context as the
+ * interactive shell that started Breeze.
+ */
+export const PASSTHROUGH_ENV_PREFIXES: readonly string[] = [
+  "AZURE_OPENAI_",
+  "OPENAI_",
+  "ANTHROPIC_",
+  "AWS_",
+  "GOOGLE_",
+];
+
+/**
  * Resolve one env var value, falling back to `/bin/zsh -lc` so we pick
  * up variables the GUI session sets in the user's login shell. Mirrors
  * Rust `resolve_launchd_env_var` + `resolve_env_var_from_login_shell`.
@@ -121,6 +136,50 @@ export function resolveLaunchdEnvVar(
   } catch {
     return undefined;
   }
+}
+
+function matchesPassthroughPrefix(variable: string): boolean {
+  return PASSTHROUGH_ENV_PREFIXES.some((prefix) => variable.startsWith(prefix));
+}
+
+function parseEnvVarNames(raw: string): string[] {
+  const names: string[] = [];
+  for (const line of raw.split("\n")) {
+    const match = /^([A-Za-z_][A-Za-z0-9_]*)=/.exec(line.trim());
+    if (match?.[1]) names.push(match[1]);
+  }
+  return names;
+}
+
+function readLoginShellEnvVarNames(): string[] {
+  try {
+    const result = spawnSync("/bin/zsh", ["-lc", "env"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if (result.status !== 0) return [];
+    return parseEnvVarNames(result.stdout ?? "");
+  } catch {
+    return [];
+  }
+}
+
+export function collectLaunchdPassthroughEnvVars(
+  env: NodeJS.ProcessEnv = process.env,
+  loginShellVars: readonly string[] = readLoginShellEnvVarNames(),
+): string[] {
+  const ordered = [...PASSTHROUGH_ENV_VARS];
+  const seen = new Set<string>(ordered);
+  const candidates = [
+    ...Object.keys(env),
+    ...loginShellVars,
+  ].filter(matchesPassthroughPrefix);
+  for (const variable of candidates.sort()) {
+    if (seen.has(variable)) continue;
+    ordered.push(variable);
+    seen.add(variable);
+  }
+  return ordered;
 }
 
 /** Port of the `escape_xml` helper. */
@@ -157,7 +216,11 @@ export function renderLaunchdPlist(inputs: LaunchdPlistInputs): string {
   for (const [key, value] of Object.entries(inputs.env ?? {})) {
     pushEnv(key, value);
   }
-  for (const variable of PASSTHROUGH_ENV_VARS) {
+  const passthroughVars = collectLaunchdPassthroughEnvVars({
+    ...process.env,
+    ...(inputs.env ?? {}),
+  });
+  for (const variable of passthroughVars) {
     pushEnv(variable, inputs.env?.[variable] ?? resolveLaunchdEnvVar(variable));
   }
 

--- a/tests/breeze/breeze-daemon-launchd.test.ts
+++ b/tests/breeze/breeze-daemon-launchd.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  collectLaunchdPassthroughEnvVars,
   escapeXml,
   launchdLabel,
   launchdPlistPath,
@@ -76,6 +77,47 @@ describe("renderLaunchdPlist", () => {
       env: { PATH: "/a", HOME: "/b" },
     });
     expect(xml).toContain("hello &lt;world&gt; &amp; &apos;friends&apos;");
+  });
+
+  it("includes discovered provider auth env vars beyond the static allowlist", () => {
+    const xml = renderLaunchdPlist({
+      login: "alice",
+      profile: "default",
+      executable: "/usr/local/bin/first-tree",
+      arguments: ["breeze", "daemon", "--backend=ts"],
+      logPath: "/tmp/breeze.log",
+      env: {
+        PATH: "/opt/bin",
+        HOME: "/Users/alice",
+        AZURE_OPENAI_API_KEY_TEST: "test-slot-key",
+        AWS_PROFILE: "bedrock-profile",
+      },
+    });
+    expect(xml).toContain("<key>AZURE_OPENAI_API_KEY_TEST</key>");
+    expect(xml).toContain("<string>test-slot-key</string>");
+    expect(xml).toContain("<key>AWS_PROFILE</key>");
+    expect(xml).toContain("<string>bedrock-profile</string>");
+  });
+});
+
+describe("collectLaunchdPassthroughEnvVars", () => {
+  it("preserves the legacy allowlist and appends prefixed provider envs", () => {
+    const vars = collectLaunchdPassthroughEnvVars(
+      {
+        AZURE_OPENAI_API_KEY_TEST: "test",
+        OPENAI_BASE_URL: "https://example.test",
+        AWS_PROFILE: "bedrock",
+        CLAUDE_CODE_USE_BEDROCK: "1",
+        CODEX_THREAD_ID: "thread-123",
+      },
+      ["GOOGLE_APPLICATION_CREDENTIALS"],
+    );
+    expect(vars).toContain("CLAUDE_CODE_USE_BEDROCK");
+    expect(vars).toContain("AZURE_OPENAI_API_KEY_TEST");
+    expect(vars).toContain("OPENAI_BASE_URL");
+    expect(vars).toContain("AWS_PROFILE");
+    expect(vars).toContain("GOOGLE_APPLICATION_CREDENTIALS");
+    expect(vars).not.toContain("CODEX_THREAD_ID");
   });
 });
 


### PR DESCRIPTION
## Summary
- dynamically pass through provider auth env vars into the Breeze launchd job, instead of relying on a tiny static allowlist
- cover discovered Azure/OpenAI/AWS-style auth variables with focused launchd tests
- preserve the legacy allowlist while preventing unrelated Codex desktop session vars from leaking into the daemon

## Testing
- pnpm --dir first-tree exec vitest run tests/breeze/breeze-daemon-launchd.test.ts
- pnpm --dir first-tree typecheck