### PR TITLE
fix(breeze): recover required-review backlog after restart

### DIFF
--- a/src/products/breeze/engine/daemon/gh-client.ts
+++ b/src/products/breeze/engine/daemon/gh-client.ts
@@ -2,10 +2,10 @@
  * Phase 4: TS port of `gh.rs`.
  *
  * `GhClient` wraps a `GhExecutor` with the GitHub-specific query set
- * (notifications, review requests, assigned issues/PRs) and the
- * snapshot-hydration path (`writeTaskSnapshot`). Rate limiting +
- * write-cooldown are handled entirely by the executor; this module
- * only builds argv.
+ * (notifications, direct review requests, required-review backlog,
+ * assigned issues/PRs) and the snapshot-hydration path
+ * (`writeTaskSnapshot`). Rate limiting + write-cooldown are handled
+ * entirely by the executor; this module only builds argv.
  *
  * Pure behaviour, except for the file writes in `writeTaskSnapshot`.
  */
@@ -29,6 +29,7 @@ import {
 import {
   buildAssignedCandidate,
   buildNotificationCandidate,
+  buildRequiredReviewCandidate,
   buildReviewRequestCandidate,
   taskIssueNumber,
   taskPrNumber,
@@ -213,6 +214,110 @@ export class GhClient {
     return deduplicate(tasks);
   }
 
+  /**
+   * Recovery path for review backlog. This complements
+   * `--review-requested=@me`: when breeze was offline, a PR may still be
+   * awaiting review even though the explicit reviewer-request signal is no
+   * longer visible. Exact repo scopes use `gh pr list` for fresher data;
+   * owner/all scopes fall back to `gh search prs --review required`.
+   */
+  async requiredReviewBacklog(limit: number): Promise<TaskCandidate[]> {
+    const tasks: TaskCandidate[] = [];
+    const repoListJq =
+      '.[] | [((.number | tostring) // "0"), (.title // ""), (.url // ""), (.updatedAt // ""), (if .isDraft then "1" else "0" end), (.reviewDecision // "")] | @tsv';
+    for (const repo of this.repoFilter.repos()) {
+      const stdout = await this.runChecked(
+        "list required-review backlog",
+        [
+          "pr",
+          "list",
+          "--repo",
+          repo,
+          "--state",
+          "open",
+          "--search",
+          "review:required sort:updated-desc",
+          "--limit",
+          String(limit),
+          "--json",
+          "number,title,url,updatedAt,isDraft,reviewDecision",
+          "--jq",
+          repoListJq,
+        ],
+        "core",
+      );
+      for (const line of stdout.split("\n")) {
+        if (line.trim().length === 0) continue;
+        const fields = parseTsvLine(line);
+        if (fields.length < 6) continue;
+        const number = Number.parseInt(fields[0], 10) || 0;
+        if (fields[4] === "1") continue;
+        if (fields[5] !== "REVIEW_REQUIRED") continue;
+        tasks.push(
+          buildRequiredReviewCandidate({
+            repo,
+            number,
+            title: fields[1],
+            webUrl: fields[2],
+            updatedAt: fields[3],
+          }),
+        );
+      }
+    }
+
+    const searchScopes: SearchScope[] = this.repoFilter.isEmpty()
+      ? [{ kind: "all" }]
+      : this.repoFilter.owners().map((owner) => ({ kind: "owner", owner }));
+    const searchJq =
+      '.[] | [(.repository.nameWithOwner // ""), ((.number | tostring) // "0"), (.title // ""), (.url // ""), (.updatedAt // ""), (if .isDraft then "1" else "0" end)] | @tsv';
+    for (const scope of searchScopes) {
+      const stdout = await this.runChecked(
+        "search required-review backlog",
+        withSearchScope(
+          [
+            "search",
+            "prs",
+            "--review",
+            "required",
+            "--state",
+            "open",
+            "--sort",
+            "updated",
+            "--order",
+            "desc",
+            "--limit",
+            String(limit),
+            "--json",
+            "number,title,url,updatedAt,repository,isDraft",
+            "--jq",
+            searchJq,
+          ],
+          scope,
+        ),
+        "search",
+      );
+      for (const line of stdout.split("\n")) {
+        if (line.trim().length === 0) continue;
+        const fields = parseTsvLine(line);
+        if (fields.length < 6) continue;
+        const repo = fields[0];
+        const number = Number.parseInt(fields[1], 10) || 0;
+        if (fields[5] === "1") continue;
+        tasks.push(
+          buildRequiredReviewCandidate({
+            repo,
+            number,
+            title: fields[2],
+            webUrl: fields[3],
+            updatedAt: fields[4],
+          }),
+        );
+      }
+    }
+
+    return deduplicate(tasks);
+  }
+
   /** Last comment on `api_url`'s thread (empty api_url → null). */
   async latestCommentActivity(apiUrl: string): Promise<ThreadActivity | null> {
     if (apiUrl.trim().length === 0) return null;
@@ -261,7 +366,7 @@ export class GhClient {
 
   /**
    * Top-level candidate producer used by the dispatcher. Runs the
-   * notification poll and (optionally) the two search queries,
+   * notification poll and (optionally) the three search/list queries,
    * aggregates, de-dups by thread_key, sorts.
    */
   async collectCandidates(options: {
@@ -299,6 +404,15 @@ export class GhClient {
         const message = errMessage(err);
         if (isRateLimitError(message)) poll.searchRateLimited = true;
         poll.warnings.push(`review search: ${message.trim()}`);
+      }
+
+      try {
+        const tasks = await this.requiredReviewBacklog(options.limit);
+        poll.tasks.push(...tasks);
+      } catch (err) {
+        const message = errMessage(err);
+        if (isRateLimitError(message)) poll.searchRateLimited = true;
+        poll.warnings.push(`review backlog: ${message.trim()}`);
       }
 
       try {

--- a/src/products/breeze/engine/runtime/task.ts
+++ b/src/products/breeze/engine/runtime/task.ts
@@ -29,7 +29,7 @@ import {
 } from "./task-util.js";
 
 export interface TaskCandidate {
-  /** Origin: `notifications` | `review-search` | `assigned-search` | `recovered-running`. */
+  /** Origin: `notifications` | `review-search` | `review-backlog` | `assigned-search` | `recovered-running`. */
   source: string;
   /** Source repo (`owner/repo`). */
   repo: string;
@@ -171,19 +171,49 @@ export function buildReviewRequestCandidate(args: {
   webUrl: string;
   updatedAt: string;
 }): TaskCandidate {
-  return {
+  return buildReviewCandidate({
+    ...args,
     source: "review-search",
+    reason: "review_requested",
+  });
+}
+
+export function buildRequiredReviewCandidate(args: {
+  repo: string;
+  number: number;
+  title: string;
+  webUrl: string;
+  updatedAt: string;
+}): TaskCandidate {
+  return buildReviewCandidate({
+    ...args,
+    source: "review-backlog",
+    reason: "review_required",
+  });
+}
+
+function buildReviewCandidate(args: {
+  repo: string;
+  number: number;
+  title: string;
+  webUrl: string;
+  updatedAt: string;
+  source: string;
+  reason: string;
+}): TaskCandidate {
+  return {
+    source: args.source,
     repo: args.repo,
     workspaceRepo: args.repo,
     threadKey: `/repos/${args.repo}/pulls/${args.number}`,
     kind: "review_request",
-    reason: "review_requested",
+    reason: args.reason,
     title: args.title,
     webUrl: args.webUrl,
     apiUrl: `https://api.github.com/repos/${args.repo}/pulls/${args.number}`,
     latestCommentApiUrl: "",
     updatedAt: args.updatedAt,
-    priority: priorityFor("review_request", "review_requested"),
+    priority: priorityFor("review_request", args.reason),
   };
 }
 

--- a/tests/breeze/breeze-daemon-gh-client.test.ts
+++ b/tests/breeze/breeze-daemon-gh-client.test.ts
@@ -26,6 +26,7 @@ import {
 import { RepoFilter } from "../../src/products/breeze/engine/runtime/repo-filter.js";
 import {
   buildNotificationCandidate,
+  buildRequiredReviewCandidate,
   buildReviewRequestCandidate,
 } from "../../src/products/breeze/engine/runtime/task.js";
 
@@ -185,6 +186,38 @@ describe("GhClient.reviewRequests / assignedItems", () => {
       "assigned_pull_request",
     ]);
   });
+
+  it("recovers required-review backlog from exact repo scopes", async () => {
+    const { executor, ctl } = makeStubExecutor();
+    ctl.setResponses([
+      {
+        stdout: [
+          "45\tHandle backlog\thttps://github.com/o/r/pull/45\t2026-04-15T12:00:00Z\t0\tREVIEW_REQUIRED",
+          "46\tSkip draft\thttps://github.com/o/r/pull/46\t2026-04-15T12:00:00Z\t1\tREVIEW_REQUIRED",
+          "47\tSkip changes requested\thttps://github.com/o/r/pull/47\t2026-04-15T12:00:00Z\t0\tCHANGES_REQUESTED",
+        ].join("\n"),
+      },
+    ]);
+    const client = new GhClient({
+      host: "github.com",
+      repoFilter: RepoFilter.parseCsv("o/r"),
+      executor,
+    });
+    const tasks = await client.requiredReviewBacklog(10);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]).toEqual(
+      buildRequiredReviewCandidate({
+        repo: "o/r",
+        number: 45,
+        title: "Handle backlog",
+        webUrl: "https://github.com/o/r/pull/45",
+        updatedAt: "2026-04-15T12:00:00Z",
+      }),
+    );
+    expect(ctl.calls[0].args.slice(0, 2)).toEqual(["pr", "list"]);
+    expect(ctl.calls[0].args).toContain("--repo");
+    expect(ctl.calls[0].args).toContain("o/r");
+  });
 });
 
 describe("GhClient.collectCandidates", () => {
@@ -238,6 +271,50 @@ describe("GhClient.collectCandidates", () => {
       lookbackSecs: 3600,
     });
     expect(poll.searchRateLimited).toBe(true);
+  });
+
+  it("adds required-review backlog when review-requested search is empty", async () => {
+    const { executor, ctl } = makeStubExecutor();
+    ctl.setResponder((spec) => {
+      if (spec.args[0] === "api") return { stdout: "" };
+      if (spec.args[0] === "search" && spec.args.includes("--review-requested=@me")) {
+        return { stdout: "" };
+      }
+      if (spec.args[0] === "pr" && spec.args[1] === "list") {
+        return {
+          stdout:
+            "11\tReview me later\thttps://github.com/o/r/pull/11\t2026-04-15T12:00:00Z\t0\tREVIEW_REQUIRED",
+        };
+      }
+      if (spec.args[0] === "search" && spec.args[1] === "issues") {
+        return { stdout: "" };
+      }
+      return { stdout: "" };
+    });
+    const client = new GhClient({
+      host: "github.com",
+      repoFilter: RepoFilter.parseCsv("o/r"),
+      executor,
+    });
+    const now = Date.UTC(2026, 3, 15, 12, 0, 0) / 1000;
+    const poll = await client.collectCandidates({
+      limit: 5,
+      includeSearch: true,
+      nowEpoch: now,
+      lookbackSecs: 3600,
+    });
+    expect(poll.tasks).toEqual([
+      buildRequiredReviewCandidate({
+        repo: "o/r",
+        number: 11,
+        title: "Review me later",
+        webUrl: "https://github.com/o/r/pull/11",
+        updatedAt: "2026-04-15T12:00:00Z",
+      }),
+    ]);
+    expect(
+      ctl.calls.some((call) => call.args[0] === "pr" && call.args[1] === "list"),
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- add a required-review backlog candidate source so breeze can recover recent PRs that still need review even when explicit reviewer-request signals are no longer visible
- use repo-accurate `gh pr list` for exact repo scopes and keep owner/all fallback via `gh search prs --review required`
- cover the new recovery path with breeze gh-client tests

## Testing
- pnpm -C first-tree test
- pnpm -C first-tree typecheck
- pnpm -C first-tree build