### PR TITLE
feat(tree): add `integrate` command for source-only binding

### DIFF
--- a/src/products/tree/cli.ts
+++ b/src/products/tree/cli.ts
@@ -17,6 +17,7 @@ Commands:
   init                  High-level onboarding wrapper for repo/workspace roots
   bootstrap             Low-level tree-repo bootstrap for an explicit tree checkout
   bind                  Bind the current repo/workspace root to an existing tree repo
+  integrate             Install the first-tree skill and source-integration block without touching the tree repo
   workspace             Workspace helpers (currently: sync child repos to a shared tree)
   publish               Publish a tree repo to GitHub
   verify                Run verification checks against a tree repo
@@ -89,6 +90,12 @@ export async function runTree(
         "#products/tree/engine/commands/bind.js"
       );
       return runBind(args.slice(1));
+    }
+    case "integrate": {
+      const { runIntegrate } = await import(
+        "#products/tree/engine/commands/integrate.js"
+      );
+      return runIntegrate(args.slice(1));
     }
     case "workspace": {
       const { runWorkspace } = await import(

--- a/src/products/tree/engine/bind.ts
+++ b/src/products/tree/engine/bind.ts
@@ -63,17 +63,17 @@ Options:
   --help                Show this help message
 `;
 
-interface CommandRunOptions {
+export interface CommandRunOptions {
   cwd: string;
 }
 
-type CommandRunner = (
+export type CommandRunner = (
   command: string,
   args: string[],
   options: CommandRunOptions,
 ) => string;
 
-function defaultCommandRunner(
+export function defaultCommandRunner(
   command: string,
   args: string[],
   options: CommandRunOptions,
@@ -117,7 +117,7 @@ function commandOutput(
   }
 }
 
-function readGitRemoteUrl(
+export function readGitRemoteUrl(
   runner: CommandRunner,
   root: string,
   remote = "origin",
@@ -140,7 +140,7 @@ function inferTreeRepoNameFromUrl(treeUrl: string): string {
   return scpMatch?.[1] ?? basename(treeUrl).replace(/\.git$/, "");
 }
 
-function inferTreeMode(
+export function inferTreeMode(
   repo: Repo,
   treeRepoName: string,
   explicit?: TreeMode,
@@ -155,7 +155,7 @@ function inferTreeMode(
   return defaultDedicatedNames.has(treeRepoName) ? "dedicated" : "shared";
 }
 
-function inferBindingMode(
+export function inferBindingMode(
   scope: SourceScope,
   treeMode: TreeMode,
   explicit?: SourceBindingMode,
@@ -169,13 +169,13 @@ function inferBindingMode(
   return treeMode === "shared" ? "shared-source" : "standalone-source";
 }
 
-function determineScope(bindingMode: SourceBindingMode): SourceScope {
+export function determineScope(bindingMode: SourceBindingMode): SourceScope {
   return bindingMode === "workspace-root" || bindingMode === "workspace-member"
     ? "workspace"
     : "repo";
 }
 
-function resolveWorkspaceId(
+export function resolveWorkspaceId(
   repo: Repo,
   bindingMode: SourceBindingMode,
   explicit?: string,
@@ -188,7 +188,7 @@ function resolveWorkspaceId(
   return explicit?.trim() || repo.repoName();
 }
 
-function resolveWorkspaceRootPath(
+export function resolveWorkspaceRootPath(
   cwd: string,
   repo: Repo,
   bindingMode: SourceBindingMode,

--- a/src/products/tree/engine/commands/integrate.ts
+++ b/src/products/tree/engine/commands/integrate.ts
@@ -1,0 +1,5 @@
+export {
+  INTEGRATE_USAGE,
+  parseIntegrateArgs,
+  runIntegrateCli as runIntegrate,
+} from "#products/tree/engine/integrate.js";

--- a/src/products/tree/engine/integrate.ts
+++ b/src/products/tree/engine/integrate.ts
@@ -1,0 +1,321 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  type CommandRunner,
+  defaultCommandRunner,
+  determineScope,
+  inferBindingMode,
+  inferTreeMode,
+  readGitRemoteUrl,
+  resolveWorkspaceId,
+  resolveWorkspaceRootPath,
+} from "#products/tree/engine/bind.js";
+import { relativeRepoPath } from "#products/tree/engine/dedicated-tree.js";
+import { Repo } from "#products/tree/engine/repo.js";
+import {
+  ensureAgentContextHooks,
+  formatAgentContextHookMessages,
+} from "#products/tree/engine/runtime/adapters.js";
+import {
+  type BoundTreeReference,
+  buildStableSourceId,
+  buildTreeId,
+  deriveDefaultEntrypoint,
+  type RootKind,
+  type SourceBindingMode,
+  type SourceScope,
+  type TreeMode,
+  writeSourceState,
+} from "#products/tree/engine/runtime/binding-state.js";
+import {
+  copyCanonicalSkill,
+  resolveBundledPackageRoot,
+} from "#products/tree/engine/runtime/installer.js";
+import { upsertLocalTreeGitIgnore } from "#products/tree/engine/runtime/local-tree-config.js";
+import {
+  upsertFirstTreeIndexFile,
+  upsertSourceIntegrationFiles,
+} from "#products/tree/engine/runtime/source-integration.js";
+
+export const INTEGRATE_USAGE = `usage: first-tree tree integrate --tree-path PATH [--tree-url URL] [--tree-mode dedicated|shared] [--mode standalone-source|shared-source|workspace-root|workspace-member] [--workspace-id ID] [--workspace-root PATH] [--entrypoint PATH] [--source-path PATH]
+
+Install the first-tree skill and the FIRST-TREE-SOURCE-INTEGRATION block into the current folder, without touching the tree repo.
+
+What it does:
+  1. Installs or refreshes the lightweight first-tree skill locally
+  2. Updates WHITEPAPER.md plus the managed FIRST-TREE-SOURCE-INTEGRATION block in AGENTS.md and CLAUDE.md
+  3. Writes .first-tree/source.json
+
+Unlike \`first-tree tree bind\`, this command does NOT:
+  - Clone the tree repo
+  - Write .first-tree/tree.json, bindings/, or source-repos.md into the tree repo
+  - Install the skill into the tree repo
+
+Use this when the tree repo is managed externally — for example, when an agent runtime
+owns its own long-lived tree checkout and wants ephemeral workspaces to reference it
+without polluting the shared tree repo.
+
+Options:
+  --tree-path PATH      Local checkout of the tree repo (required)
+  --tree-url URL        Tree repo URL recorded in source.json (default: read from tree checkout's git remote)
+  --tree-mode MODE      dedicated or shared (default: infer)
+  --mode MODE           standalone-source, shared-source, workspace-root, or workspace-member (default: infer)
+  --workspace-id ID     Workspace identifier for workspace-root/member bindings
+  --workspace-root PATH Workspace root path when binding a workspace member repo
+  --entrypoint PATH     Override the default tree entrypoint for this binding
+  --source-path PATH    Source/workspace root to integrate into (default: current directory)
+  --help                Show this help message
+`;
+
+export interface ParsedIntegrateArgs {
+  entrypoint?: string;
+  mode?: SourceBindingMode;
+  sourcePath?: string;
+  treeMode?: TreeMode;
+  treePath?: string;
+  treeUrl?: string;
+  workspaceId?: string;
+  workspaceRoot?: string;
+}
+
+export interface IntegrateOptions extends ParsedIntegrateArgs {
+  commandRunner?: CommandRunner;
+  currentCwd?: string;
+  sourceRoot?: string;
+}
+
+export function parseIntegrateArgs(
+  args: string[],
+): ParsedIntegrateArgs | { error: string } {
+  const parsed: ParsedIntegrateArgs = {};
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--tree-path":
+        parsed.treePath = args[index + 1];
+        index += 1;
+        break;
+      case "--tree-url":
+        parsed.treeUrl = args[index + 1];
+        index += 1;
+        break;
+      case "--tree-mode":
+        parsed.treeMode = args[index + 1] as TreeMode;
+        index += 1;
+        break;
+      case "--mode":
+        parsed.mode = args[index + 1] as SourceBindingMode;
+        index += 1;
+        break;
+      case "--workspace-id":
+        parsed.workspaceId = args[index + 1];
+        index += 1;
+        break;
+      case "--workspace-root":
+        parsed.workspaceRoot = args[index + 1];
+        index += 1;
+        break;
+      case "--entrypoint":
+        parsed.entrypoint = args[index + 1];
+        index += 1;
+        break;
+      case "--source-path":
+        parsed.sourcePath = args[index + 1];
+        index += 1;
+        break;
+      default:
+        return { error: `Unknown integrate option: ${arg}` };
+    }
+
+    if (args[index] === undefined || args[index]?.startsWith("--")) {
+      return { error: `Missing value for ${arg}` };
+    }
+  }
+
+  if (!parsed.treePath) {
+    return { error: "Missing --tree-path" };
+  }
+
+  if (
+    parsed.treeMode !== undefined
+    && parsed.treeMode !== "dedicated"
+    && parsed.treeMode !== "shared"
+  ) {
+    return { error: `Unsupported value for --tree-mode: ${parsed.treeMode}` };
+  }
+
+  if (
+    parsed.mode !== undefined
+    && parsed.mode !== "standalone-source"
+    && parsed.mode !== "shared-source"
+    && parsed.mode !== "workspace-root"
+    && parsed.mode !== "workspace-member"
+  ) {
+    return { error: `Unsupported value for --mode: ${parsed.mode}` };
+  }
+
+  return parsed;
+}
+
+export function runIntegrate(options: IntegrateOptions): number {
+  const cwd = options.currentCwd ?? process.cwd();
+  const runner = options.commandRunner ?? defaultCommandRunner;
+
+  if (!options.treePath) {
+    console.error("Missing --tree-path.");
+    return 1;
+  }
+
+  const sourceRootPath = options.sourcePath
+    ? resolve(cwd, options.sourcePath)
+    : cwd;
+  const sourceRepo = new Repo(sourceRootPath);
+
+  const resolvedTreeRoot = resolve(cwd, options.treePath);
+  if (!existsSync(resolvedTreeRoot)) {
+    console.error(`Tree checkout does not exist: ${resolvedTreeRoot}`);
+    return 1;
+  }
+  const treeRepo = new Repo(resolvedTreeRoot);
+  if (treeRepo.root === sourceRepo.root) {
+    console.error(
+      "The source/workspace root and tree repo resolved to the same path.",
+    );
+    return 1;
+  }
+
+  const treeRepoName = treeRepo.repoName();
+  const resolvedTreeUrl = options.treeUrl?.trim()
+    || (treeRepo.isGitRepo()
+      ? readGitRemoteUrl(runner, treeRepo.root) ?? undefined
+      : undefined)
+    || undefined;
+
+  const bundledPackageRoot = options.sourceRoot ?? resolveBundledPackageRoot();
+  const treeMode = inferTreeMode(sourceRepo, treeRepoName, options.treeMode);
+  const scopeHint: SourceScope = options.mode === "workspace-root"
+      || options.mode === "workspace-member"
+    ? "workspace"
+    : "repo";
+  const bindingMode = inferBindingMode(scopeHint, treeMode, options.mode);
+  const scope = determineScope(bindingMode);
+  const workspaceId = resolveWorkspaceId(
+    sourceRepo,
+    bindingMode,
+    options.workspaceId,
+  );
+  const workspaceRootPath = resolveWorkspaceRootPath(
+    cwd,
+    sourceRepo,
+    bindingMode,
+    options.workspaceRoot,
+  );
+  const rootKind: RootKind = sourceRepo.isGitRepo() ? "git-repo" : "folder";
+  const sourceId = buildStableSourceId(sourceRepo.root, sourceRepo.repoName());
+  const entrypoint = options.entrypoint
+    ?? deriveDefaultEntrypoint(
+      bindingMode,
+      sourceRepo.repoName(),
+      workspaceId,
+    );
+  const localTreePath = relativeRepoPath(sourceRepo.root, treeRepo.root);
+  const treeReference: BoundTreeReference = {
+    entrypoint,
+    localPath: localTreePath,
+    ...(resolvedTreeUrl ? { remoteUrl: resolvedTreeUrl } : {}),
+    treeId: buildTreeId(treeRepoName),
+    treeMode,
+    treeRepoName,
+  };
+
+  try {
+    console.log("Context Tree Integrate\n");
+    console.log(`  Source/workspace root: ${sourceRepo.root}`);
+    console.log(`  Tree repo:             ${treeRepo.root}`);
+    console.log(`  Binding mode:          ${bindingMode}`);
+    console.log(`  Tree mode:             ${treeMode}\n`);
+
+    let sourceSkillAction: "installed" | "reused";
+    if (sourceRepo.hasCurrentInstalledSkill()) {
+      sourceSkillAction = "reused";
+    } else {
+      copyCanonicalSkill(bundledPackageRoot, sourceRepo.root);
+      sourceSkillAction = "installed";
+    }
+
+    const firstTreeIndex = upsertFirstTreeIndexFile(sourceRepo.root);
+    const gitIgnore = upsertLocalTreeGitIgnore(sourceRepo.root);
+    const integrationUpdates = upsertSourceIntegrationFiles(
+      sourceRepo.root,
+      treeRepoName,
+      {
+        bindingMode,
+        entrypoint,
+        treeMode,
+        treeRepoUrl: resolvedTreeUrl,
+        workspaceId,
+      },
+    );
+    const sourceAgentHooks = ensureAgentContextHooks(sourceRepo.root);
+    writeSourceState(sourceRepo.root, {
+      bindingMode,
+      rootKind,
+      scope,
+      sourceId,
+      sourceName: sourceRepo.repoName(),
+      tree: treeReference,
+      workspaceId,
+      workspaceRootPath: workspaceRootPath
+        ? relativeRepoPath(sourceRepo.root, workspaceRootPath)
+        : undefined,
+    });
+
+    if (firstTreeIndex.action === "created") {
+      console.log("  Created WHITEPAPER.md.");
+    } else if (firstTreeIndex.action === "updated") {
+      console.log("  Updated WHITEPAPER.md.");
+    }
+    if (sourceSkillAction === "installed") {
+      console.log("  Installed the bundled first-tree skill locally.");
+    } else {
+      console.log("  Reused the existing installed first-tree skill locally.");
+    }
+    if (gitIgnore.action === "created") {
+      console.log("  Created .gitignore entries for first-tree local state.");
+    } else if (gitIgnore.action === "updated") {
+      console.log("  Updated .gitignore entries for first-tree local state.");
+    }
+    const changedFiles = integrationUpdates
+      .filter((update) => update.action !== "unchanged")
+      .map((update) => update.file);
+    if (changedFiles.length > 0) {
+      console.log(`  Updated ${changedFiles.join(" and ")}.`);
+    } else {
+      console.log("  Source integration instructions were already current.");
+    }
+    for (const message of formatAgentContextHookMessages(sourceAgentHooks)) {
+      console.log(`  ${message}`);
+    }
+    console.log("  Wrote source binding metadata.");
+    return 0;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error(`Error: ${message}`);
+    return 1;
+  }
+}
+
+export function runIntegrateCli(args: string[] = []): number {
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log(INTEGRATE_USAGE);
+    return 0;
+  }
+  const parsed = parseIntegrateArgs(args);
+  if ("error" in parsed) {
+    console.error(parsed.error);
+    console.log(INTEGRATE_USAGE);
+    return 1;
+  }
+  return runIntegrate(parsed);
+}

--- a/tests/tree/integrate.test.ts
+++ b/tests/tree/integrate.test.ts
@@ -1,0 +1,188 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+import { runIntegrate } from "#products/tree/engine/integrate.js";
+import { Repo } from "#products/tree/engine/repo.js";
+import { readSourceState } from "#products/tree/engine/runtime/binding-state.js";
+import {
+  makeGitRepo,
+  makeSourceRepo,
+  makeSourceSkill,
+  makeTreeMetadata,
+  useTmpDir,
+} from "../helpers.js";
+
+describe("runIntegrate", () => {
+  it("installs skill and writes source.json without touching the tree repo", () => {
+    const sandbox = useTmpDir();
+    const sourceBundle = useTmpDir();
+    const sourceRoot = join(sandbox.path, "product-repo");
+    const treeRoot = join(sandbox.path, "org-context");
+
+    makeSourceRepo(sourceRoot);
+    execFileSync(
+      "git",
+      ["remote", "add", "origin", "git@github.com:acme/product-repo.git"],
+      { cwd: sourceRoot, stdio: "ignore" },
+    );
+    makeGitRepo(treeRoot);
+    makeTreeMetadata(treeRoot, "0.1.0");
+    makeSourceSkill(sourceBundle.path, "0.2.0");
+
+    const result = runIntegrate({
+      currentCwd: sourceRoot,
+      sourceRoot: sourceBundle.path,
+      treeMode: "shared",
+      treePath: relative(sourceRoot, treeRoot),
+    });
+
+    expect(result).toBe(0);
+
+    // Source side: skill installed, block written, source.json written.
+    expect(
+      existsSync(join(sourceRoot, ".claude", "skills", "first-tree", "SKILL.md")),
+    ).toBe(true);
+    expect(
+      existsSync(join(sourceRoot, ".agents", "skills", "first-tree", "SKILL.md")),
+    ).toBe(true);
+    const claudeMd = readFileSync(join(sourceRoot, "CLAUDE.md"), "utf-8");
+    expect(claudeMd).toContain("<!-- BEGIN FIRST-TREE-SOURCE-INTEGRATION -->");
+    expect(claudeMd).toContain("<!-- END FIRST-TREE-SOURCE-INTEGRATION -->");
+
+    const sourceState = readSourceState(sourceRoot);
+    expect(sourceState).not.toBeNull();
+    expect(sourceState?.tree.treeRepoName).toBe("org-context");
+
+    // Tree side: untouched — no .first-tree/tree.json, bindings/, skill install, or submodule work.
+    expect(existsSync(join(treeRoot, ".first-tree", "tree.json"))).toBe(false);
+    expect(existsSync(join(treeRoot, ".first-tree", "bindings"))).toBe(false);
+    expect(
+      existsSync(join(treeRoot, ".claude", "skills", "first-tree", "SKILL.md")),
+    ).toBe(false);
+    expect(
+      existsSync(join(treeRoot, ".agents", "skills", "first-tree", "SKILL.md")),
+    ).toBe(false);
+    expect(existsSync(join(treeRoot, "source-repos.md"))).toBe(false);
+    expect(existsSync(join(treeRoot, ".gitmodules"))).toBe(false);
+  });
+
+  it("works on a non-git source folder (ephemeral workspace use case)", () => {
+    const sandbox = useTmpDir();
+    const sourceBundle = useTmpDir();
+    const sourceRoot = join(sandbox.path, "workspace-abc123");
+    const treeRoot = join(sandbox.path, "org-context");
+
+    // Plain folder — no git init.
+    execFileSync("mkdir", ["-p", sourceRoot]);
+    makeGitRepo(treeRoot);
+    makeTreeMetadata(treeRoot, "0.1.0");
+    makeSourceSkill(sourceBundle.path, "0.2.0");
+
+    const result = runIntegrate({
+      currentCwd: sourceRoot,
+      sourceRoot: sourceBundle.path,
+      treeMode: "shared",
+      treePath: relative(sourceRoot, treeRoot),
+      mode: "workspace-root",
+      workspaceId: "abc123",
+    });
+
+    expect(result).toBe(0);
+    const sourceState = readSourceState(sourceRoot);
+    expect(sourceState?.rootKind).toBe("folder");
+    expect(sourceState?.bindingMode).toBe("workspace-root");
+    expect(sourceState?.workspaceId).toBe("abc123");
+    expect(new Repo(sourceRoot).isGitRepo()).toBe(false);
+  });
+
+  it("is idempotent — running twice keeps the source integration block current", () => {
+    const sandbox = useTmpDir();
+    const sourceBundle = useTmpDir();
+    const sourceRoot = join(sandbox.path, "product-repo");
+    const treeRoot = join(sandbox.path, "org-context");
+
+    makeSourceRepo(sourceRoot);
+    makeGitRepo(treeRoot);
+    makeTreeMetadata(treeRoot, "0.1.0");
+    makeSourceSkill(sourceBundle.path, "0.2.0");
+
+    const first = runIntegrate({
+      currentCwd: sourceRoot,
+      sourceRoot: sourceBundle.path,
+      treeMode: "shared",
+      treePath: relative(sourceRoot, treeRoot),
+    });
+    expect(first).toBe(0);
+
+    const firstClaudeMd = readFileSync(join(sourceRoot, "CLAUDE.md"), "utf-8");
+
+    const second = runIntegrate({
+      currentCwd: sourceRoot,
+      sourceRoot: sourceBundle.path,
+      treeMode: "shared",
+      treePath: relative(sourceRoot, treeRoot),
+    });
+    expect(second).toBe(0);
+
+    const secondClaudeMd = readFileSync(join(sourceRoot, "CLAUDE.md"), "utf-8");
+    expect(secondClaudeMd).toBe(firstClaudeMd);
+  });
+
+  it("accepts --source-path to target a different directory than cwd", () => {
+    const sandbox = useTmpDir();
+    const sourceBundle = useTmpDir();
+    const runCwd = sandbox.path;
+    const sourceRoot = join(sandbox.path, "workspace-xyz");
+    const treeRoot = join(sandbox.path, "org-context");
+
+    execFileSync("mkdir", ["-p", sourceRoot]);
+    makeGitRepo(treeRoot);
+    makeTreeMetadata(treeRoot, "0.1.0");
+    makeSourceSkill(sourceBundle.path, "0.2.0");
+
+    const result = runIntegrate({
+      currentCwd: runCwd,
+      sourcePath: "workspace-xyz",
+      sourceRoot: sourceBundle.path,
+      treePath: "org-context",
+      mode: "workspace-root",
+      workspaceId: "xyz",
+    });
+
+    expect(result).toBe(0);
+    expect(existsSync(join(sourceRoot, ".first-tree", "source.json"))).toBe(true);
+    // runCwd itself should not have been integrated.
+    expect(existsSync(join(runCwd, ".first-tree", "source.json"))).toBe(false);
+  });
+
+  it("records the tree repo URL when provided via --tree-url", () => {
+    const sandbox = useTmpDir();
+    const sourceBundle = useTmpDir();
+    const sourceRoot = join(sandbox.path, "product-repo");
+    const treeRoot = join(sandbox.path, "org-context");
+
+    makeSourceRepo(sourceRoot);
+    makeGitRepo(treeRoot);
+    makeTreeMetadata(treeRoot, "0.1.0");
+    makeSourceSkill(sourceBundle.path, "0.2.0");
+
+    const result = runIntegrate({
+      currentCwd: sourceRoot,
+      sourceRoot: sourceBundle.path,
+      treeMode: "shared",
+      treePath: relative(sourceRoot, treeRoot),
+      treeUrl: "https://github.com/agent-team-foundation/first-tree-context",
+    });
+
+    expect(result).toBe(0);
+    const sourceState = readSourceState(sourceRoot);
+    expect(sourceState?.tree.remoteUrl).toBe(
+      "https://github.com/agent-team-foundation/first-tree-context",
+    );
+    const claudeMd = readFileSync(join(sourceRoot, "CLAUDE.md"), "utf-8");
+    expect(claudeMd).toContain(
+      "https://github.com/agent-team-foundation/first-tree-context",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- New `first-tree tree integrate` command — the source-only subset of `bind`. Installs the first-tree skill, upserts the FIRST-TREE-SOURCE-INTEGRATION block in CLAUDE.md/AGENTS.md, and writes `.first-tree/source.json`. Does **not** write to the tree repo.
- Exports several helpers from `bind.ts` (`CommandRunner`, `defaultCommandRunner`, `readGitRemoteUrl`, `inferTreeMode`, `inferBindingMode`, `determineScope`, `resolveWorkspaceId`, `resolveWorkspaceRootPath`) so `integrate` can reuse them without duplication.

## Motivation

Agent runtimes like `first-tree-hub` manage their own long-lived tree checkout and spin up ephemeral per-session workspaces. `first-tree tree bind` writes binding metadata, submodule entries, and `source-repos.md` updates into the tree repo — every session would pollute the shared tree.

`integrate` does only the source-side work, so each ephemeral workspace can self-install the skill and reference the external tree without touching it.

## Test plan

- [x] New `tests/tree/integrate.test.ts` covers:
  - Source-side writes happen; tree-side paths are untouched
  - Works on a non-git source folder (Hub workspace case)
  - Idempotent across two runs
  - `--source-path` targets a different directory than cwd
  - `--tree-url` overrides the recorded remote URL
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 986 passed, 51 skipped, 0 failures
- [x] `pnpm build` succeeds
- [x] `node dist/cli.js tree integrate --help` renders usage correctly