### PR TITLE
fix(breeze): finalize codex runner output after exit

### DIFF
--- a/src/products/breeze/engine/daemon/runner.ts
+++ b/src/products/breeze/engine/daemon/runner.ts
@@ -13,10 +13,13 @@
  * builds a prompt, writes it to `<task-dir>/prompt.txt`, and execs the
  * agent binary. Stdout/stderr go to `runner-stdout.log` /
  * `runner-stderr.log`; `runner-output.txt` holds the agent's final
- * message (codex writes it via `--output-last-message`, claude's
- * stdout is copied there post-exit). These on-disk filenames keep the
- * "runner-" prefix to preserve the debug-artifact contract across the
- * Rust → TS port.
+ * message. Codex writes its rolling "last assistant message" into a
+ * temporary file during execution, and we only promote that file to
+ * `runner-output.txt` after the child exits so transient reconnect /
+ * auth messages do not look like the final task result mid-flight.
+ * Claude's stdout is copied there post-exit. These on-disk filenames
+ * keep the "runner-" prefix to preserve the debug-artifact contract
+ * across the Rust → TS port.
  *
  * The dispatcher iterates the pool in `executionOrder()` until one
  * agent returns successfully, mirroring Rust's fallback chain. Only
@@ -34,6 +37,7 @@ import {
   readFileSync,
   writeFileSync,
   existsSync,
+  rmSync,
   type WriteStream,
 } from "node:fs";
 import { spawn, type ChildProcess } from "node:child_process";
@@ -109,6 +113,10 @@ export async function executeAgent(
   const promptText = buildPrompt(request);
   const promptPath = join(request.taskDir, "prompt.txt");
   const outputPath = join(request.taskDir, "runner-output.txt");
+  const liveOutputPath =
+    spec.kind === "codex"
+      ? join(request.taskDir, "runner-last-message.txt")
+      : outputPath;
   const stdoutPath = join(request.taskDir, "runner-stdout.log");
   const stderrPath = join(request.taskDir, "runner-stderr.log");
 
@@ -120,10 +128,15 @@ export async function executeAgent(
     request,
     promptPath,
     promptText,
-    outputPath,
+    outputPath: liveOutputPath,
     stdoutPath,
     stderrPath,
   });
+
+  if (spec.kind === "codex" && existsSync(liveOutputPath)) {
+    writeFileSync(outputPath, readFileSync(liveOutputPath, "utf8"));
+    rmSync(liveOutputPath, { force: true });
+  }
 
   // Claude doesn't emit --output-last-message; copy stdout into
   // runner-output.txt so parse_result can find the final BREEZE_RESULT

--- a/tests/breeze/breeze-daemon-runner-agent.test.ts
+++ b/tests/breeze/breeze-daemon-runner-agent.test.ts
@@ -200,7 +200,9 @@ describe("AgentPool", () => {
 describe("executeAgent", () => {
   it("writes prompt, invokes spawner, parses result", async () => {
     const request = fakeRequest();
+    const finalOutputPath = join(request.taskDir, "runner-output.txt");
     const spawner: AgentSpawner = async ({ outputPath }) => {
+      expect(outputPath).not.toBe(finalOutputPath);
       writeFileSync(
         outputPath,
         "doing things\nBREEZE_RESULT: status=handled summary=all good",
@@ -215,6 +217,8 @@ describe("executeAgent", () => {
     expect(outcome.status).toBe("handled");
     expect(outcome.summary).toBe("all good");
     expect(existsSync(join(request.taskDir, "prompt.txt"))).toBe(true);
+    expect(readFileSync(finalOutputPath, "utf8")).toContain("all good");
+    expect(existsSync(join(request.taskDir, "runner-last-message.txt"))).toBe(false);
   });
 
   it("copies claude stdout into runner-output.txt", async () => {


### PR DESCRIPTION
## Summary
- write codex `--output-last-message` into a temporary file during execution
- promote that file to `runner-output.txt` only after the child exits so transient reconnect/auth messages do not masquerade as the final task result
- add runner-agent coverage for the finalized output behavior

## Testing
- pnpm -C first-tree test
- pnpm -C first-tree typecheck