### PR TITLE
fix(breeze): suppress duplicate review backlog after self-replies

### DIFF
--- a/src/products/breeze/engine/daemon/gh-client.ts
+++ b/src/products/breeze/engine/daemon/gh-client.ts
@@ -331,6 +331,28 @@ export class GhClient {
     return parseThreadActivity(firstNonEmptyLine(stdout));
   }
 
+  /** Latest issue comment on the thread when we only have repo + number. */
+  async latestIssueCommentActivity(
+    repo: string,
+    issueNumber: number,
+  ): Promise<ThreadActivity | null> {
+    const jq =
+      'if length == 0 then empty else .[-1] | [(.user.login // ""), (.user.type // ""), (.updated_at // .created_at // "")] | @tsv end';
+    const stdout = await this.runChecked(
+      "inspect latest issue comment activity",
+      [
+        "api",
+        `/repos/${repo}/issues/${issueNumber}/comments?per_page=100`,
+        "-H",
+        "X-GitHub-Api-Version: 2022-11-28",
+        "--jq",
+        jq,
+      ],
+      "core",
+    );
+    return parseThreadActivity(firstNonEmptyLine(stdout));
+  }
+
   /** Last review on a PR. */
   async latestReviewActivity(
     repo: string,
@@ -357,7 +379,13 @@ export class GhClient {
   async latestVisibleActivity(
     task: TaskCandidate,
   ): Promise<ThreadActivity | null> {
-    const comment = await this.latestCommentActivity(task.latestCommentApiUrl);
+    const directComment = await this.latestCommentActivity(task.latestCommentApiUrl);
+    const issueNumber = taskIssueNumber(task) ?? taskPrNumber(task);
+    const fallbackComment =
+      directComment === null && issueNumber !== undefined
+        ? await this.latestIssueCommentActivity(task.repo, issueNumber)
+        : null;
+    const comment = pickNewerActivity(directComment, fallbackComment);
     const pr = taskPrNumber(task);
     const review =
       pr !== undefined ? await this.latestReviewActivity(task.repo, pr) : null;

--- a/src/products/breeze/engine/daemon/scheduler.ts
+++ b/src/products/breeze/engine/daemon/scheduler.ts
@@ -113,10 +113,11 @@ export class Scheduler {
         );
       }
       if (
+        record.lastHandledUpdatedAt.length > 0 &&
         shouldIgnoreLatestSelfActivity(
           this.identity.login,
           activity,
-          candidate.updatedAt,
+          record.lastHandledUpdatedAt,
         )
       ) {
         record.lastHandledUpdatedAt = candidate.updatedAt;

--- a/tests/breeze/breeze-daemon-gh-client.test.ts
+++ b/tests/breeze/breeze-daemon-gh-client.test.ts
@@ -187,6 +187,40 @@ describe("GhClient.reviewRequests / assignedItems", () => {
     ]);
   });
 
+  it("falls back to issue comments for search-derived PR candidates", async () => {
+    const { executor, ctl } = makeStubExecutor();
+    ctl.setResponder((spec) => {
+      if (spec.args[0] === "api" && String(spec.args[1]).includes("/issues/45/comments")) {
+        return {
+          stdout: "alice\tUser\t2026-04-15T12:00:00Z",
+        };
+      }
+      if (spec.args[0] === "api" && String(spec.args[1]).includes("/pulls/45/reviews")) {
+        return { stdout: "" };
+      }
+      return { stdout: "" };
+    });
+    const client = new GhClient({
+      host: "github.com",
+      repoFilter: RepoFilter.empty(),
+      executor,
+    });
+    const activity = await client.latestVisibleActivity(
+      buildRequiredReviewCandidate({
+        repo: "o/r",
+        number: 45,
+        title: "Handle backlog",
+        webUrl: "https://github.com/o/r/pull/45",
+        updatedAt: "2026-04-15T12:00:00Z",
+      }),
+    );
+    expect(activity).toEqual({
+      login: "alice",
+      userType: "User",
+      updatedAt: "2026-04-15T12:00:00Z",
+    });
+  });
+
   it("recovers required-review backlog from exact repo scopes", async () => {
     const { executor, ctl } = makeStubExecutor();
     ctl.setResponses([
@@ -413,7 +447,7 @@ describe("pure helpers", () => {
     expect(shouldIgnoreSelfAuthored("alice", "bob", "comment")).toBe(false);
   });
 
-  it("shouldIgnoreLatestSelfActivity compares against task updated_at", () => {
+  it("shouldIgnoreLatestSelfActivity compares against the handled watermark", () => {
     const activity = {
       login: "alice",
       userType: "User",

--- a/tests/breeze/breeze-daemon-scheduler.test.ts
+++ b/tests/breeze/breeze-daemon-scheduler.test.ts
@@ -131,8 +131,8 @@ describe("Scheduler.shouldSchedule", () => {
     expect(await sched.shouldSchedule(candidate)).toBe(false);
   });
 
-  it("short-circuits when latestVisibleActivity says we already replied", async () => {
-    const store = new ThreadStore({ runnerHome: makeHome("selfact") });
+  it("does not short-circuit self activity before the first handled pass", async () => {
+    const store = new ThreadStore({ runnerHome: makeHome("selfact-first") });
     const ghClient = {
       async latestVisibleActivity() {
         return {
@@ -155,6 +155,44 @@ describe("Scheduler.shouldSchedule", () => {
       title: "t",
       webUrl: "u",
       updatedAt: "2026-04-15T12:00:00Z",
+    });
+    expect(await sched.shouldSchedule(candidate)).toBe(true);
+  });
+
+  it("short-circuits when latestVisibleActivity says we already replied after a handled pass", async () => {
+    const store = new ThreadStore({ runnerHome: makeHome("selfact") });
+    const ghClient = {
+      async latestVisibleActivity() {
+        return {
+          login: "alice",
+          userType: "User",
+          updatedAt: "2026-04-15T12:00:01Z",
+        };
+      },
+    } as never;
+    const candidate = buildReviewRequestCandidate({
+      repo: "o/r",
+      number: 4,
+      title: "t",
+      webUrl: "u",
+      updatedAt: "2026-04-15T12:00:02Z",
+    });
+    store.saveThreadRecord({
+      threadKey: candidate.threadKey,
+      repo: candidate.repo,
+      lastSeenUpdatedAt: "",
+      lastHandledUpdatedAt: "2026-04-15T12:00:00Z",
+      lastResult: "handled",
+      failureCount: 0,
+      nextRetryEpoch: 0,
+      lastTaskId: "",
+    });
+    const sched = new Scheduler({
+      store,
+      ghClient,
+      identity: { host: "github.com", login: "alice" },
+      pollIntervalSec: 60,
+      nowSec: () => 1_000,
     });
     expect(await sched.shouldSchedule(candidate)).toBe(false);
     const record = store.loadThreadRecord(candidate.threadKey);


### PR DESCRIPTION
## Summary
- fall back to issue comments when search-derived PR candidates lack `latestCommentApiUrl`
- only suppress self-authored latest activity after a thread has already been handled once
- add regression tests for comment-aware de-dupe and first-run behavior

## Testing
- pnpm -C first-tree test
- pnpm -C first-tree typecheck