### PR TITLE
fix(breeze): treat self label churn as handled activity

### DIFF
--- a/src/products/breeze/engine/daemon/gh-client.ts
+++ b/src/products/breeze/engine/daemon/gh-client.ts
@@ -353,6 +353,28 @@ export class GhClient {
     return parseThreadActivity(firstNonEmptyLine(stdout));
   }
 
+  /** Latest issue/PR event (labels, mentions, assignments, etc.). */
+  async latestIssueEventActivity(
+    repo: string,
+    issueNumber: number,
+  ): Promise<ThreadActivity | null> {
+    const jq =
+      'if length == 0 then empty else .[-1] | [(.actor.login // ""), (.actor.type // ""), (.created_at // "")] | @tsv end';
+    const stdout = await this.runChecked(
+      "inspect latest issue event activity",
+      [
+        "api",
+        `/repos/${repo}/issues/${issueNumber}/events?per_page=100`,
+        "-H",
+        "X-GitHub-Api-Version: 2022-11-28",
+        "--jq",
+        jq,
+      ],
+      "core",
+    );
+    return parseThreadActivity(firstNonEmptyLine(stdout));
+  }
+
   /** Last review on a PR. */
   async latestReviewActivity(
     repo: string,
@@ -385,11 +407,16 @@ export class GhClient {
       directComment === null && issueNumber !== undefined
         ? await this.latestIssueCommentActivity(task.repo, issueNumber)
         : null;
+    const latestEvent =
+      issueNumber !== undefined
+        ? await this.latestIssueEventActivity(task.repo, issueNumber)
+        : null;
     const comment = pickNewerActivity(directComment, fallbackComment);
+    const threadActivity = pickNewerActivity(comment, latestEvent);
     const pr = taskPrNumber(task);
     const review =
       pr !== undefined ? await this.latestReviewActivity(task.repo, pr) : null;
-    return pickNewerActivity(comment, review);
+    return pickNewerActivity(threadActivity, review);
   }
 
   /**

--- a/tests/breeze/breeze-daemon-gh-client.test.ts
+++ b/tests/breeze/breeze-daemon-gh-client.test.ts
@@ -221,6 +221,43 @@ describe("GhClient.reviewRequests / assignedItems", () => {
     });
   });
 
+  it("considers issue events when they are newer than comments/reviews", async () => {
+    const { executor, ctl } = makeStubExecutor();
+    ctl.setResponder((spec) => {
+      const path = String(spec.args[1] ?? "");
+      if (spec.args[0] !== "api") return { stdout: "" };
+      if (path.includes("/issues/45/comments")) {
+        return { stdout: "alice\tUser\t2026-04-15T12:00:00Z" };
+      }
+      if (path.includes("/issues/45/events")) {
+        return { stdout: "alice\tUser\t2026-04-15T12:05:00Z" };
+      }
+      if (path.includes("/pulls/45/reviews")) {
+        return { stdout: "" };
+      }
+      return { stdout: "" };
+    });
+    const client = new GhClient({
+      host: "github.com",
+      repoFilter: RepoFilter.empty(),
+      executor,
+    });
+    const activity = await client.latestVisibleActivity(
+      buildRequiredReviewCandidate({
+        repo: "o/r",
+        number: 45,
+        title: "Handle backlog",
+        webUrl: "https://github.com/o/r/pull/45",
+        updatedAt: "2026-04-15T12:00:00Z",
+      }),
+    );
+    expect(activity).toEqual({
+      login: "alice",
+      userType: "User",
+      updatedAt: "2026-04-15T12:05:00Z",
+    });
+  });
+
   it("recovers required-review backlog from exact repo scopes", async () => {
     const { executor, ctl } = makeStubExecutor();
     ctl.setResponses([


### PR DESCRIPTION
## Summary
- include latest issue events in `latestVisibleActivity` so self-authored label churn counts as activity for de-dupe
- cover the issue-event fallback in breeze gh-client tests

## Testing
- pnpm -C first-tree test
- pnpm -C first-tree typecheck