### PR TITLE
fix(breeze): clear stale runner output before retries

### DIFF
--- a/src/products/breeze/engine/daemon/runner.ts
+++ b/src/products/breeze/engine/daemon/runner.ts
@@ -120,6 +120,8 @@ export async function executeAgent(
   const stdoutPath = join(request.taskDir, "runner-stdout.log");
   const stderrPath = join(request.taskDir, "runner-stderr.log");
 
+  rmSync(outputPath, { force: true });
+  rmSync(liveOutputPath, { force: true });
   writeFileSync(promptPath, promptText);
 
   const spawner = options.spawner ?? defaultAgentSpawner;

--- a/tests/breeze/breeze-daemon-runner-agent.test.ts
+++ b/tests/breeze/breeze-daemon-runner-agent.test.ts
@@ -201,6 +201,7 @@ describe("executeAgent", () => {
   it("writes prompt, invokes spawner, parses result", async () => {
     const request = fakeRequest();
     const finalOutputPath = join(request.taskDir, "runner-output.txt");
+    writeFileSync(finalOutputPath, "stale output");
     const spawner: AgentSpawner = async ({ outputPath }) => {
       expect(outputPath).not.toBe(finalOutputPath);
       writeFileSync(


### PR DESCRIPTION
## Summary
- clear `runner-output.txt` and `runner-last-message.txt` at the start of each agent attempt
- avoid stale failure text surviving into fallback attempts or later inspection
- add a regression assertion for stale-output cleanup

## Testing
- pnpm -C first-tree test
- pnpm -C first-tree typecheck