### PR TITLE
refactor(gardener): migrate sync from tree namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,6 @@ continue to work cleanly for multi-repo workspaces.
 | `first-tree tree bind` | Bind the current repo/workspace root to an existing tree repo |
 | `first-tree tree workspace sync` | Bind discovered child repos to the same shared tree |
 | `first-tree tree publish` | Publish a dedicated tree repo or shared tree repo to GitHub and refresh locally bound source/workspace repos |
-| `first-tree tree sync` | Detect drift between a tree repo and its bound source repos; supports `--propose` and `--apply` |
 | `first-tree tree verify` | Run verification checks against a tree repo |
 | `first-tree tree upgrade` | Refresh installed source/workspace integration or tree metadata from the current package |
 | `first-tree tree generate-codeowners` | Generate `.github/CODEOWNERS` from tree ownership frontmatter |
@@ -197,6 +196,10 @@ continue to work cleanly for multi-repo workspaces.
 | `first-tree tree join` | Accept an invite and join a Context Tree |
 | `first-tree tree inject-context` | Output a Claude Code SessionStart hook payload from the root `NODE.md` |
 | `first-tree tree help onboarding` | Print the full onboarding guide |
+| `first-tree gardener sync` | Detect drift between a tree repo and its bound source repos; supports `--propose` and `--apply`. Moved from `first-tree tree sync`. |
+| `first-tree gardener comment` | Review a source-repo PR or issue against the tree and post a structured verdict comment; scan mode sweeps every configured `target_repo` |
+| `first-tree gardener respond` | Fix a tree-repo sync PR based on reviewer feedback |
+| `first-tree gardener install-workflow` | Scaffold the push-mode GitHub Actions workflow in a codebase repo |
 | `first-tree skill install` | Install the four shipped skills under `.agents/skills/*` and `.claude/skills/*` |
 | `first-tree skill upgrade` | Wipe and reinstall the four shipped skills from the current package |
 | `first-tree skill list` | Print the four shipped skills with their installed status and version |

--- a/assets/tree/claude-commands/first-tree-sync-schedule.md
+++ b/assets/tree/claude-commands/first-tree-sync-schedule.md
@@ -5,7 +5,7 @@
 ## What this does
 
 Runs two maintenance steps in sequence:
-1. `first-tree tree sync` -- detect source drift and open tree-update PRs
+1. `first-tree gardener sync` -- detect source drift and open tree-update PRs
 2. `gardener` review -- review open PRs on the tree repo for context fit
 
 ## Step 1: Run sync

--- a/assets/tree/claude-commands/first-tree-sync-start.md
+++ b/assets/tree/claude-commands/first-tree-sync-start.md
@@ -1,6 +1,6 @@
-Start first-tree sync automation for this tree repo.
+Start gardener sync automation for this tree repo.
 
-first-tree sync detects when bound source repos have drifted from the
+gardener sync detects when bound source repos have drifted from the
 tree and opens PRs to update it. It also runs repo-gardener to review
 those PRs for context fit.
 
@@ -9,7 +9,7 @@ those PRs for context fit.
 Check that `.claude/commands/first-tree-sync.md` exists locally.
 
 - If missing → output:
-  "❌ first-tree sync is not installed. Run `first-tree tree upgrade` to
+  "❌ gardener sync is not installed. Run `first-tree tree upgrade` to
   install the sync runbook, then retry."
   STOP.
 
@@ -141,7 +141,7 @@ Start: `/loop 10m /first-tree-sync-loop`
 ## 9. Confirm
 
 Output:
-"🌳 first-tree sync is running.
+"🌳 gardener sync is running.
 - Tree repo: `<this repo>`
 - Bound sources: <list of sourceId → remoteUrl>
 - Cloud schedule: <every hour | SKIPPED>

--- a/assets/tree/claude-commands/first-tree-sync-stop.md
+++ b/assets/tree/claude-commands/first-tree-sync-stop.md
@@ -1,4 +1,4 @@
-Stop all first-tree sync automation for this tree repo.
+Stop all gardener sync automation for this tree repo.
 
 ## 1. Stop local loop
 
@@ -20,7 +20,7 @@ later with `/first-tree-sync-start`.
 ## 3. Confirm
 
 Output:
-"🌳 first-tree sync stopped.
+"🌳 gardener sync stopped.
 - Local loop: stopped
 - Cloud schedule: disabled (not deleted)
 - Restart anytime: `/first-tree-sync-start`"

--- a/assets/tree/claude-commands/first-tree-sync.md
+++ b/assets/tree/claude-commands/first-tree-sync.md
@@ -40,7 +40,7 @@ Check the calling context:
 `RUN_MODE` determines which GitHub access mechanism is required:
 
 - `manual` / `loop` -> runs locally on the user's machine. Use the
-  `gh` CLI and the bundled `first-tree tree sync` command. Verify
+  `gh` CLI and the bundled `first-tree gardener sync` command. Verify
   `gh auth status` succeeds; if not, exit with:
 
   > ❌ `gh` is not authenticated. Run `gh auth login` and retry.
@@ -79,7 +79,7 @@ server naming. If the connected connector uses different names (e.g.
 `mcp__claude_ai_github__list_commits`), use the equivalent tool.
 
 **Local execution advantage**: in `manual` / `loop` mode the bundled
-`first-tree tree sync` CLI handles Steps 1-3 as a single command,
+`first-tree gardener sync` CLI handles Steps 1-3 as a single command,
 including LLM-backed classification via the local `claude` CLI. Cloud
 `schedule` mode must reimplement the same logic step-by-step using MCP
 tools because the container cannot shell out to `claude`.
@@ -146,7 +146,7 @@ stderr and surface it to the user.
 If you do not have a built `dist/`, fall back to:
 
 ```bash
-npx -p first-tree first-tree tree sync --tree-path "$PWD" --propose
+npx -p first-tree first-tree gardener sync --tree-path "$PWD" --propose
 ```
 
 ✓ If the CLI succeeded, proposals are written under
@@ -320,7 +320,7 @@ with the GitHub connector wired. A reasonable cadence:
 
 ## Recap
 
-- Local mode is a thin wrapper around `first-tree tree sync`. The CLI
+- Local mode is a thin wrapper around `first-tree gardener sync`. The CLI
   does the heavy lifting, including LLM-backed classification via the
   local `claude` CLI (required).
 - Cloud mode reimplements detection + classification using MCP

--- a/docs/design/sync.md
+++ b/docs/design/sync.md
@@ -1,4 +1,4 @@
-# `first-tree tree sync`
+# `first-tree gardener sync`
 
 Authoritative decision node: `first-tree-skill-cli/sync.md` in the bound
 Context Tree.
@@ -6,13 +6,21 @@ Context Tree.
 This repo-local file is intentionally thin. It tracks only source-repo
 implementation touchpoints that do not belong in the tree.
 
+> Moved from `first-tree tree sync` so all tree-maintenance runtime
+> commands (`sync`, `comment`, `respond`) live under one product. The
+> CLI at `first-tree tree sync` now prints a migration pointer and exits
+> non-zero; slash commands (`/first-tree-sync*`) are unchanged and call
+> the new entry point internally.
+
 ## Local Implementation Touchpoints
 
-- `src/products/tree/engine/sync.ts` — core detect/propose/apply implementation
-- `src/products/tree/engine/commands/sync.ts` — CLI adapter
-- `tests/tree/sync.test.ts` — sync behavior coverage
+- `src/products/gardener/engine/sync.ts` — core detect/propose/apply implementation
+- `src/products/gardener/engine/commands/sync.ts` — CLI adapter
+- `tests/gardener/sync.test.ts` — sync behavior coverage
+- `tests/gardener/sync-golden-snapshot.test.ts` — golden-snapshot coverage
 - `assets/tree/claude-commands/first-tree-sync*.md` — installed runbooks
-  and schedule payload
+  and schedule payload (file names unchanged; internals call
+  `first-tree gardener sync`)
 
 ## Change Checklist
 

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -13,7 +13,7 @@ docs below only for source-repo implementation details.
 | `first-tree-skill-cli/thin-cli-shell.md` | Command-surface contract for the thin CLI shell |
 | `first-tree-skill-cli/build-and-distribution.md` | Packaging and release invariants |
 | `first-tree-skill-cli/validation-surface.md` | Validation philosophy and coverage expectations |
-| `first-tree-skill-cli/sync.md` | Authoritative product/architecture context for `first-tree tree sync` |
+| `first-tree-skill-cli/sync.md` | Authoritative product/architecture context for `first-tree gardener sync` |
 | `src/products/manifest.ts` | Single source of truth for the CLI namespace set: products (`tree`, `breeze`, `gardener`) plus maintenance (`skill`) |
 | `skills/first-tree/SKILL.md` | User-facing entry-point skill: methodology + routing to product skills |
 | `skills/tree/SKILL.md` | Operational handbook for the `first-tree tree` CLI |
@@ -57,7 +57,8 @@ docs below only for source-repo implementation details.
 | `src/meta/skill-tools/cli.ts` | Skill maintenance-namespace dispatcher (lazy-loaded) |
 | `src/meta/skill-tools/README.md` | Maintainer/meta overview for the skill maintenance namespace |
 | `src/products/breeze/engine/` | Breeze business logic: `commands/`, `runtime/`, `daemon/`, `bridge.ts`, `statusline.ts` |
-| `src/products/gardener/engine/` | Gardener business logic: `commands/`, `runtime/`, `comment.ts`, `respond.ts` |
+| `src/products/gardener/engine/` | Gardener business logic: `commands/`, `runtime/`, `sync.ts`, `comment.ts`, `respond.ts` |
+| `src/products/gardener/engine/sync.ts` | Drift detection, proposal generation, and apply flow (moved from tree namespace) |
 | `src/products/tree/engine/init.ts` | High-level onboarding wrapper plus low-level tree bootstrap |
 | `src/products/tree/engine/inspect.ts` | Root classification before onboarding |
 | `src/products/tree/engine/bind.ts` | Binding a source/workspace root to an existing tree |
@@ -65,7 +66,6 @@ docs below only for source-repo implementation details.
 | `src/products/tree/engine/publish.ts` | Tree publish flow and local source refresh |
 | `src/products/tree/engine/upgrade.ts` | Installed-skill / tree upgrade behavior |
 | `src/products/tree/engine/verify.ts` | Tree verification |
-| `src/products/tree/engine/sync.ts` | Drift detection, proposal generation, and apply flow |
 | `src/products/tree/engine/runtime/binding-state.ts` | `source.json`, `tree.json`, and `bindings/` schema |
 | `src/products/tree/engine/runtime/local-tree-config.ts` | Local tree config helpers (delegates to `source.json`) |
 | `src/products/tree/engine/runtime/source-repo-index.ts` | Generated `source-repos.md` index plus root tree repo guidance |
@@ -79,7 +79,8 @@ docs below only for source-repo implementation details.
 | `tests/tree/init.test.ts` | Tree bootstrap and init wrapper behavior |
 | `tests/e2e/cli-e2e.test.ts` | End-to-end CLI smoke coverage across repo, workspace, publish, and review workflows |
 | `tests/tree/publish.test.ts` | Publish orchestration |
-| `tests/tree/sync.test.ts` | Sync behavior and apply flow |
+| `tests/gardener/sync.test.ts` | Sync behavior and apply flow |
+| `tests/gardener/sync-golden-snapshot.test.ts` | Sync golden-snapshot coverage |
 | `tests/e2e/thin-cli.test.ts` | Thin CLI smoke coverage |
 | `tests/tree/skill-artifacts.test.ts` | Skill export and doc integrity |
 | `tests/tree/upgrade.test.ts` | Upgrade behavior |

--- a/skills/first-tree/references/onboarding.md
+++ b/skills/first-tree/references/onboarding.md
@@ -242,8 +242,8 @@ examples, not a required sequence — pick what fits the task at hand.
 From the tree repo:
 
 ```bash
-first-tree tree sync                         # detect drift between source + tree
-first-tree tree sync --apply                 # open tree PRs for each drift group
+first-tree gardener sync                         # detect drift between source + tree
+first-tree gardener sync --apply                 # open tree PRs for each drift group
 ```
 
 Runs against the bound source repo, groups changes by affected tree

--- a/skills/gardener/SKILL.md
+++ b/skills/gardener/SKILL.md
@@ -47,7 +47,7 @@ idempotent and guarded against acting on its own prior comments.
 ## Core Concepts
 
 - **Sync PR** — a PR opened against a tree repo by automation (commonly
-  by `first-tree tree sync`) to propagate a decision; gardener's
+  by `first-tree gardener sync`) to propagate a decision; gardener's
   `respond` subcommand fixes these based on reviewer feedback.
 - **Source-repo PR/issue** — a PR or issue opened on an application repo
   that gardener's `comment` subcommand evaluates against the bound
@@ -70,6 +70,7 @@ idempotent and guarded against acting on its own prior comments.
 
 | Command | Purpose |
 |---|---|
+| `first-tree gardener sync` | Detect drift between the tree and its bound source repos. Writes proposals under `.first-tree/proposals/`, edits tree files, commits to a new branch in the tree repo, and opens a PR labeled `first-tree:sync`. Phases: `--propose` detects + writes proposals, `--apply` also writes new tree files and opens the PR, default is detect-only. Moved from `first-tree tree sync`. |
 | `first-tree gardener comment` | Review a source-repo PR or issue against the tree and post a structured verdict comment. Scan mode (no `--pr`/`--issue`) walks every **open** PR and issue. The merge→tree-issue branch only fires on a single MERGED PR with a prior gardener marker (single-item invocation), and requires `TREE_REPO_TOKEN`. Pass `--assign-owners` to auto-assign NODE owners on the tree issue. |
 | `first-tree gardener respond` | Acknowledge reviewer feedback on a sync PR (Phase 5: real edit orchestrator for `parent_subdomain_missing` + planner seam — see [#160](https://github.com/agent-team-foundation/first-tree/issues/160) / [#219](https://github.com/agent-team-foundation/first-tree/issues/219); unsupported patterns fall back to a placeholder reply). |
 | `first-tree gardener install-workflow` | Scaffold `.github/workflows/first-tree-sync.yml` in the caller's codebase repo so per-PR events drive the sync flow — the push-mode entry point. |

--- a/skills/tree/SKILL.md
+++ b/skills/tree/SKILL.md
@@ -57,7 +57,6 @@ During `bind` / `init`, the CLI also ensures the tree repo has the bundled
 | `first-tree tree verify` | Validate a tree repo: frontmatter, owners, soft_links, members, progress |
 | `first-tree tree upgrade` | Refresh the installed skill payloads or tree metadata from the bundled package |
 | `first-tree tree publish` | Publish a tree repo to GitHub and refresh locally bound source/workspace repos |
-| `first-tree tree sync` | Detect drift between a tree repo and its bound source repos; supports `--propose` and `--apply` |
 | `first-tree tree review` | CI helper: run Claude Code PR review against tree changes |
 | `first-tree tree generate-codeowners` | Regenerate `.github/CODEOWNERS` from tree ownership |
 | `first-tree tree invite` | Invite a new member to the Context Tree (human, personal_assistant, or autonomous_agent) |
@@ -103,5 +102,7 @@ Ownership model and node-naming rules: see the
 - `first-tree` — entry-point skill: methodology, references, and routing
   between product skills. Load this first.
 - `breeze` — load if the task involves the breeze daemon or notifications.
-- `gardener` — load if the task involves automated responses to tree sync
-  PR feedback.
+- `gardener` — load if the task involves any tree-maintenance runtime:
+  drift sync (`gardener sync`), verdict comments on source-repo PRs
+  (`gardener comment`), or responses to sync-PR review feedback
+  (`gardener respond`).

--- a/src/products/gardener/cli.ts
+++ b/src/products/gardener/cli.ts
@@ -20,12 +20,19 @@ import { readOwnVersion } from "#shared/version.js";
 
 export const GARDENER_USAGE = `usage: first-tree gardener <command>
 
-  Gardener maintains Context Tree repos by responding to review feedback
-  on sync PRs. This CLI is designed for agents, not humans.
+  Gardener maintains Context Tree repos by detecting drift between a
+  tree and the source repos it describes, posting structured verdicts
+  on source-repo PRs/issues, and responding to reviewer feedback on
+  sync PRs. This CLI is designed for agents, not humans.
 
 Commands:
-  respond               Fix sync PRs based on reviewer feedback
+  sync                  Detect drift between a tree repo and its bound
+                        sources. Opens a PR against the tree repo with
+                        proposal files and applied edits. Moved from
+                        \`first-tree tree sync\` so all tree-maintenance
+                        runtime commands live under one product.
   comment               Review source-repo PRs/issues against the tree
+  respond               Fix sync PRs based on reviewer feedback
   install-workflow      Scaffold .github/workflows/first-tree-sync.yml in
                         the caller's codebase repo (push mode: replaces
                         the gardener service with an event-driven flow)
@@ -35,6 +42,9 @@ Options:
   --version, -v         Show gardener product version
 
 Examples:
+  first-tree gardener sync --help
+  first-tree gardener sync --tree-path ../my-tree --propose
+  first-tree gardener sync --apply
   first-tree gardener respond --help
   first-tree gardener respond --dry-run
   first-tree gardener respond --pr 123 --repo owner/name
@@ -69,6 +79,12 @@ export async function runGardener(
   const command = args[0];
 
   switch (command) {
+    case "sync": {
+      const { runSync } = await import(
+        "./engine/commands/sync.js"
+      );
+      return runSync(args.slice(1));
+    }
     case "respond": {
       const { runRespond } = await import(
         "./engine/commands/respond.js"

--- a/src/products/gardener/engine/commands/sync.ts
+++ b/src/products/gardener/engine/commands/sync.ts
@@ -1,0 +1,1 @@
+export { SYNC_USAGE, runSyncCli as runSync } from "#products/gardener/engine/sync.js";

--- a/src/products/gardener/engine/sync.ts
+++ b/src/products/gardener/engine/sync.ts
@@ -29,7 +29,7 @@ import type {
 
 const execFileAsync = promisify(execFile);
 
-export const SYNC_USAGE = `usage: first-tree tree sync [--tree-path PATH] [--source ID] [--propose] [--apply] [--dry-run]
+export const SYNC_USAGE = `usage: first-tree gardener sync [--tree-path PATH] [--source ID] [--propose] [--apply] [--dry-run]
 
 Detect drift between a Context Tree and the source repo(s) it describes.
 Runs in three phases controlled by flags:
@@ -807,7 +807,7 @@ Return a JSON array only, no prose.`;
       "  npm install -g @anthropic-ai/claude-code\n\n" +
       "Then authenticate:\n" +
       "  claude login\n\n" +
-      "Once installed, re-run: first-tree tree sync --tree-path <path>",
+      "Once installed, re-run: first-tree gardener sync --tree-path <path>",
     );
     process.exit(1);
   }
@@ -1301,7 +1301,7 @@ export async function runSync(
 
   if (!repo.looksLikeTreeRepo()) {
     console.error(
-      `\u274C ${treeRoot} does not look like a Context Tree repo. Run first-tree tree sync inside a tree repo, or pass --tree-path.`,
+      `\u274C ${treeRoot} does not look like a Context Tree repo. Run first-tree gardener sync inside a tree repo, or pass --tree-path.`,
     );
     return 1;
   }
@@ -1321,7 +1321,7 @@ export async function runSync(
       "  npm install -g @anthropic-ai/claude-code\n\n" +
       "Then authenticate:\n" +
       "  claude login\n\n" +
-      "Once installed, re-run: first-tree tree sync --tree-path <path>",
+      "Once installed, re-run: first-tree gardener sync --tree-path <path>",
     );
     return 1;
   }
@@ -1350,7 +1350,7 @@ export async function runSync(
         `   Sync needs a GitHub URL to fetch commits and merged PRs.\n` +
         `   Fix: edit .first-tree/bindings/${binding.sourceId}.json and add:\n` +
         `     "remoteUrl": "https://github.com/<owner>/<repo>"\n` +
-        `   Then re-run first-tree tree sync.`,
+        `   Then re-run first-tree gardener sync.`,
       );
       hasConfigErrors = true;
       continue;

--- a/src/products/tree/cli.ts
+++ b/src/products/tree/cli.ts
@@ -22,7 +22,6 @@ Commands:
   publish               Publish a tree repo to GitHub
   verify                Run verification checks against a tree repo
   upgrade               Refresh source/workspace integration or tree metadata
-  sync                  Detect drift between a tree repo and its bound sources
   review                Run Claude Code PR review (CI helper)
   generate-codeowners   Generate .github/CODEOWNERS from tree ownership
   invite                Invite a new member to the Context Tree
@@ -122,10 +121,22 @@ export async function runTree(
       return runUpgrade(args.slice(1));
     }
     case "sync": {
-      const { runSync } = await import(
-        "#products/tree/engine/commands/sync.js"
+      write(
+        "❌ `first-tree tree sync` has moved to `first-tree gardener sync`.",
       );
-      return runSync(args.slice(1));
+      write(
+        "   The drift-detection command now lives under the gardener product",
+      );
+      write(
+        "   alongside `gardener comment` and `gardener respond`. Run",
+      );
+      write(
+        "   `first-tree gardener sync --help` for usage. Slash commands",
+      );
+      write(
+        "   (/first-tree-sync, /first-tree-sync-loop, …) are unchanged.",
+      );
+      return 1;
     }
     case "review": {
       const { runReview } = await import(

--- a/src/products/tree/engine/commands/sync.ts
+++ b/src/products/tree/engine/commands/sync.ts
@@ -1,1 +1,0 @@
-export { SYNC_USAGE, runSyncCli as runSync } from "#products/tree/engine/sync.js";

--- a/src/products/tree/engine/open-tree-pr.ts
+++ b/src/products/tree/engine/open-tree-pr.ts
@@ -57,7 +57,7 @@ export async function openTreePr(
     for (const label of labels) {
       await shellRun(
         "gh",
-        ["label", "create", label, "--color", "2ea44f", "--description", `Created by first-tree sync`, "--force"],
+        ["label", "create", label, "--color", "2ea44f", "--description", `Created by gardener sync`, "--force"],
         { cwd: treeRoot },
       );
     }

--- a/tests/fixtures/sync-golden/README.md
+++ b/tests/fixtures/sync-golden/README.md
@@ -5,9 +5,9 @@
 maintainers.**
 
 These fixtures lock down the external-effects shape of
-`first-tree sync --apply` — the commit message, PR title, PR body,
+`gardener sync --apply` — the commit message, PR title, PR body,
 labels, branch name pattern, and order of `git`/`gh` calls. Repo-gardener
-shells out to `first-tree sync --apply` on a schedule and parses these
+shells out to `gardener sync --apply` on a schedule and parses these
 surfaces. Any drift here silently changes what repo-gardener produces
 in production.
 

--- a/tests/fixtures/sync-golden/two-pr-apply.json
+++ b/tests/fixtures/sync-golden/two-pr-apply.json
@@ -269,7 +269,7 @@
         "--color",
         "2ea44f",
         "--description",
-        "Created by first-tree sync",
+        "Created by gardener sync",
         "--force"
       ],
       "cwdLabel": "<tree-root>"
@@ -283,7 +283,7 @@
         "--color",
         "2ea44f",
         "--description",
-        "Created by first-tree sync",
+        "Created by gardener sync",
         "--force"
       ],
       "cwdLabel": "<tree-root>"

--- a/tests/gardener/sync-golden-snapshot.test.ts
+++ b/tests/gardener/sync-golden-snapshot.test.ts
@@ -1,11 +1,11 @@
 /**
  * sync.ts golden snapshot — locks the external-effects shape of
- * `first-tree sync --apply` so the Phase 3 refactor (factor out an
+ * `gardener sync --apply` so the Phase 3 refactor (factor out an
  * `openTreePr` primitive for the gardener merge→issue worker path)
  * cannot silently change what repo-gardener depends on.
  *
  * Repo-gardener (`agent-team-foundation/repo-gardener`) shells out to
- * `first-tree sync --apply` on a schedule. If the CLI changes commit
+ * `gardener sync --apply` on a schedule. If the CLI changes commit
  * messages, PR titles, PR bodies, labels, branch names, or the order
  * of git/gh calls, repo-gardener's scheduled runs would produce
  * different PRs — a silent production break.
@@ -24,7 +24,7 @@ import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { runSync } from "#products/tree/engine/sync.js";
+import { runSync } from "#products/gardener/engine/sync.js";
 import type {
   ShellResult,
   ShellRun,

--- a/tests/gardener/sync.test.ts
+++ b/tests/gardener/sync.test.ts
@@ -7,7 +7,7 @@ import {
   runSync,
   runSyncCli,
   scanTreeNodes,
-} from "#products/tree/engine/sync.js";
+} from "#products/gardener/engine/sync.js";
 import type {
   ShellResult,
   ShellRun,

--- a/tests/tree/open-tree-pr.test.ts
+++ b/tests/tree/open-tree-pr.test.ts
@@ -59,7 +59,7 @@ describe("openTreePr", () => {
     expect(labelCreate.args).toEqual([
       "label", "create", "first-tree:sync",
       "--color", "2ea44f",
-      "--description", "Created by first-tree sync",
+      "--description", "Created by gardener sync",
       "--force",
     ]);
 

--- a/tests/tree/skill-artifacts.test.ts
+++ b/tests/tree/skill-artifacts.test.ts
@@ -349,12 +349,12 @@ describe("skill artifacts", () => {
     expect(sourceMap).toContain("docs/build/distribution.md");
     expect(sourceMap).toContain("docs/testing/overview.md");
     expect(sourceMap).toContain("src/products/tree/engine/publish.ts");
-    expect(sourceMap).toContain("src/products/tree/engine/sync.ts");
+    expect(sourceMap).toContain("src/products/gardener/engine/sync.ts");
     expect(sourceMap).toContain("src/products/tree/engine/inspect.ts");
     expect(sourceMap).toContain("src/products/tree/engine/bind.ts");
     expect(sourceMap).toContain("src/products/tree/engine/workspace-sync.ts");
     expect(sourceMap).toContain("tests/tree/publish.test.ts");
-    expect(sourceMap).toContain("tests/tree/sync.test.ts");
+    expect(sourceMap).toContain("tests/gardener/sync.test.ts");
     expect(sourceMap).toContain("src/products/tree/engine/runtime/binding-state.ts");
     expect(sourceMap).toContain("src/products/tree/engine/runtime/local-tree-config.ts"); // still exists, delegates to source.json
     expect(sourceMap).toContain("src/products/tree/engine/runtime/source-repo-index.ts");
@@ -413,8 +413,9 @@ describe("skill artifacts", () => {
 
     const designSync = read("docs/design/sync.md");
     expect(designSync).toContain("first-tree-skill-cli/sync.md");
-    expect(designSync).toContain("src/products/tree/engine/sync.ts");
-    expect(designSync).toContain("tests/tree/sync.test.ts");
+    expect(designSync).toContain("src/products/gardener/engine/sync.ts");
+    expect(designSync).toContain("tests/gardener/sync.test.ts");
+    expect(designSync).toContain("first-tree gardener sync");
   });
 
   it("keeps public OSS entrypoints and package metadata in place", () => {


### PR DESCRIPTION
## Summary

All tree-maintenance runtime commands (`sync`, `comment`, `respond`) now live under the gardener product. `first-tree gardener sync` is the new canonical entry point. This is a **namespace move** — the drift-detection implementation is unchanged (99% git-mv preserved).

### Why

`sync` is a tree-maintenance runtime: reads source repos, opens PRs against the tree. Same shape as `gardener comment` / `respond`. Keeping it under `tree` made the namespace split hard to explain — `tree` owns repo/workspace binding + onboarding, `gardener` owns automated tree upkeep. Grouping the three sibling commands under one product simplifies the next step (a gardener daemon that schedules both `comment` sweeps and `sync` drift detection).

### Hard migration — no alias

Pre-GA user base, so cleanest path:

- `first-tree tree sync` → prints a migration pointer and exits `1`
- `first-tree gardener sync` → the real command
- Slash commands (`/first-tree-sync`, `/first-tree-sync-loop`, …) **keep their names** (user-facing) but internals call `gardener sync`

### What changed

| Category | Change |
|---|---|
| Source moves | `src/products/tree/engine/sync.ts` → `src/products/gardener/engine/sync.ts`; same for `commands/sync.ts` |
| Test moves | `tests/tree/sync*.test.ts` → `tests/gardener/sync*.test.ts` |
| CLI | `tree/cli.ts` prints migration error; `gardener/cli.ts` registers `sync` subcommand + updated USAGE |
| Docs | `README.md`, `docs/source-map.md`, `docs/design/sync.md`, three SKILL.mds, `skills/first-tree/references/onboarding.md`, all `assets/tree/claude-commands/first-tree-sync*.md`, fixture READMEs, skill-artifacts test expectations |
| Untouched | `workspace-sync.ts` (different command — `first-tree tree workspace sync` stays in tree) |

## Test plan
- [x] `pnpm exec vitest run tests/gardener tests/tree` — 533 pass
- [x] Specifically `tests/gardener/sync.test.ts` (29) + `tests/gardener/sync-golden-snapshot.test.ts` (3) + updated `tests/tree/skill-artifacts.test.ts` (6) all green
- [x] `pnpm exec tsc --noEmit` clean (no errors in tracked files)
- [ ] Manual smoke: `npx -p first-tree first-tree gardener sync --help` on merge
- [ ] Manual smoke: `npx -p first-tree first-tree tree sync` prints the migration pointer and exits non-zero