### PR TITLE
feat(gardener): pull-mode daemon (start/stop/status/run-once)

### DIFF
--- a/skills/gardener/SKILL.md
+++ b/skills/gardener/SKILL.md
@@ -18,7 +18,7 @@ issue-filing logic:
 | Mode | How it runs | When to use |
 |---|---|---|
 | **Push (workflow)** | `.github/workflows/first-tree-sync.yml` in the codebase repo fires per-PR; no daemon. | You (or your agent) can land a workflow file in the codebase. Lowest latency, zero infra. |
-| **Pull (service)** | A `first-tree gardener` process polls target repos from outside. | The codebase repo is third-party or you otherwise can't push workflow files. |
+| **Pull (daemon)** | `first-tree gardener start` launches a long-running daemon that polls every configured source repo on a timer. | The codebase repo is third-party or you otherwise can't push workflow files. Also the right choice when you want drift detection (`gardener sync`) on a schedule. |
 
 Both modes open the same tree-repo issue on merge and post the same
 verdict comment shape on open/updated PRs. The only difference is the
@@ -75,6 +75,16 @@ idempotent and guarded against acting on its own prior comments.
 | `first-tree gardener respond` | Acknowledge reviewer feedback on a sync PR (Phase 5: real edit orchestrator for `parent_subdomain_missing` + planner seam — see [#160](https://github.com/agent-team-foundation/first-tree/issues/160) / [#219](https://github.com/agent-team-foundation/first-tree/issues/219); unsupported patterns fall back to a placeholder reply). |
 | `first-tree gardener install-workflow` | Scaffold `.github/workflows/first-tree-sync.yml` in the caller's codebase repo so per-PR events drive the sync flow — the push-mode entry point. |
 
+**Daemon lifecycle (pull mode):**
+
+| Command | Purpose |
+|---|---|
+| `first-tree gardener start` | Writes `~/.gardener/config.json` from `--tree-path` + repeated `--code-repo` args, then boots a launchd job (macOS) or detached process that runs `first-tree gardener daemon`. Schedules: `--gardener-interval` (default 5m), `--sync-interval` (default 1h). `--assign-owners` and `--sync-apply` wire their downstream flags. |
+| `first-tree gardener stop` | Tears down the launchd job (macOS) or sends SIGTERM to the PID recorded in `~/.gardener/state.json`. Idempotent. |
+| `first-tree gardener status` | Prints the recorded PID + uptime, configured schedule, and last outcome + next-due time per sweep. Read-only. |
+| `first-tree gardener run-once` | Runs both sweeps inline (no daemon). Useful for cron-style deployments or for exercising the pipeline before leaving a daemon running. |
+| `first-tree gardener daemon` | Foreground loop invoked by `start`. Not intended for direct human use. |
+
 For full options on any command, run `first-tree gardener <command> --help`.
 
 ## Typical Flows
@@ -117,6 +127,45 @@ The single-item form is what breeze-runner calls when dispatching on a
 notification. Skips the scan; reviews exactly the one item. Also takes
 the merge→tree-issue branch when pointed at a single MERGED PR with a
 prior gardener marker and `TREE_REPO_TOKEN` set.
+
+### Pull-mode daemon — monitor many code repos on a schedule
+
+Use this when push-mode workflows aren't an option or when you want
+drift detection (`gardener sync`) to run on a timer in addition to
+per-PR verdict comments.
+
+```bash
+# 1. Bind the tree checkout first (if not already): `first-tree tree bind`
+# 2. Start the daemon pointed at the tree + the code repos to watch.
+npx -p first-tree first-tree gardener start \
+  --tree-path ../my-org-tree \
+  --code-repo my-org/web --code-repo my-org/api \
+  --gardener-interval 5m \
+  --sync-interval 1h \
+  --assign-owners
+```
+
+What happens:
+- `~/.gardener/config.json` is written with the supplied schedule.
+- On macOS, a launchd plist `com.first-tree.gardener.<user>.plist`
+  lives at `~/.gardener/launchd/` and is bootstrapped into the user
+  domain. On other platforms, a detached child process is spawned.
+- The daemon ticks every ~30 s. Each tick checks whether
+  `gardener-sweep` or `sync-sweep` is due and runs it as a subprocess
+  (`gardener comment --merged-since 2×interval` and `gardener sync`
+  respectively). Outcomes get written to `~/.gardener/state.json`.
+
+Inspect and tear down:
+
+```bash
+npx -p first-tree first-tree gardener status     # last runs + next due
+npx -p first-tree first-tree gardener run-once   # fire both sweeps inline
+npx -p first-tree first-tree gardener stop       # launchctl bootout + SIGTERM
+```
+
+Set `--sync-apply` on `start` to have `sync-sweep` open tree PRs
+automatically (`gardener sync --apply`); without it, the sweep stays in
+detect-only mode.
 
 ### Install the push-mode workflow in a codebase repo
 

--- a/src/products/gardener/cli.ts
+++ b/src/products/gardener/cli.ts
@@ -28,14 +28,22 @@ export const GARDENER_USAGE = `usage: first-tree gardener <command>
 Commands:
   sync                  Detect drift between a tree repo and its bound
                         sources. Opens a PR against the tree repo with
-                        proposal files and applied edits. Moved from
-                        \`first-tree tree sync\` so all tree-maintenance
-                        runtime commands live under one product.
+                        proposal files and applied edits.
   comment               Review source-repo PRs/issues against the tree
   respond               Fix sync PRs based on reviewer feedback
   install-workflow      Scaffold .github/workflows/first-tree-sync.yml in
                         the caller's codebase repo (push mode: replaces
                         the gardener service with an event-driven flow)
+
+Daemon lifecycle (pull mode):
+  start                 Bring up the gardener daemon in the background;
+                        writes ~/.gardener/config.json, boots launchd
+                        (macOS) or detached spawn
+  stop                  Tear down the gardener daemon
+  status                Report daemon PID, schedule, and last-run state
+  run-once              Execute both sweeps inline and exit (no daemon)
+  daemon                Foreground loop (invoked by start; not for
+                        direct human use)
 
 Options:
   --help, -h            Show this help message
@@ -45,13 +53,15 @@ Examples:
   first-tree gardener sync --help
   first-tree gardener sync --tree-path ../my-tree --propose
   first-tree gardener sync --apply
-  first-tree gardener respond --help
-  first-tree gardener respond --dry-run
-  first-tree gardener respond --pr 123 --repo owner/name
   first-tree gardener comment --help
   first-tree gardener comment --pr 42 --repo owner/name
-  first-tree gardener comment --issue 7 --repo owner/name
-  first-tree gardener install-workflow --tree-repo owner/tree-repo
+  first-tree gardener respond --pr 123 --repo owner/name
+  first-tree gardener start --tree-path ../my-tree \\
+      --code-repo acme/web --code-repo acme/api \\
+      --gardener-interval 5m --sync-interval 1h --assign-owners
+  first-tree gardener status
+  first-tree gardener run-once
+  first-tree gardener stop
 `;
 
 type Output = (text: string) => void;
@@ -102,6 +112,26 @@ export async function runGardener(
         "./engine/commands/install-workflow.js"
       );
       return runInstallWorkflow(args.slice(1), { write });
+    }
+    case "start": {
+      const { runStart } = await import("./engine/commands/start.js");
+      return runStart(args.slice(1), { write });
+    }
+    case "stop": {
+      const { runStop } = await import("./engine/commands/stop.js");
+      return runStop(args.slice(1), { write });
+    }
+    case "status": {
+      const { runStatus } = await import("./engine/commands/status.js");
+      return runStatus(args.slice(1), { write });
+    }
+    case "run-once": {
+      const { runRunOnce } = await import("./engine/commands/run-once.js");
+      return runRunOnce(args.slice(1), { write });
+    }
+    case "daemon": {
+      const { runDaemon } = await import("./engine/commands/daemon.js");
+      return runDaemon(args.slice(1), { write });
     }
     default:
       write(`Unknown gardener command: ${command}`);

--- a/src/products/gardener/engine/commands/daemon.ts
+++ b/src/products/gardener/engine/commands/daemon.ts
@@ -1,0 +1,33 @@
+/**
+ * `first-tree gardener daemon` — foreground loop. Invoked by
+ * `gardener start` under launchd (or a detached spawn) and intended
+ * to run forever. Humans normally don't call this directly.
+ */
+
+import { runDaemonLoop } from "../daemon/loop.js";
+
+export const DAEMON_USAGE = `usage: first-tree gardener daemon
+
+Run the gardener daemon loop in the foreground. Invoked by
+\`gardener start\` under launchd (or a detached spawn); not intended
+for direct human use. Runs forever unless interrupted. Reads config
+from ~/.gardener/config.json on every tick.
+`;
+
+export interface RunDaemonOptions {
+  write?: (line: string) => void;
+  env?: NodeJS.ProcessEnv;
+}
+
+export async function runDaemon(
+  argv: readonly string[] = [],
+  options: RunDaemonOptions = {},
+): Promise<number> {
+  const write = options.write ?? ((line) => process.stdout.write(line + "\n"));
+  if (argv.includes("--help") || argv.includes("-h")) {
+    write(DAEMON_USAGE);
+    return 0;
+  }
+  await runDaemonLoop({ env: options.env, write });
+  return 0;
+}

--- a/src/products/gardener/engine/commands/run-once.ts
+++ b/src/products/gardener/engine/commands/run-once.ts
@@ -1,0 +1,34 @@
+/**
+ * `first-tree gardener run-once` — execute both sweeps inline and
+ * exit. Handy for exercising the daemon pipeline without starting a
+ * background process, and for cron-style deployments that prefer
+ * external scheduling.
+ */
+
+import { runOnce } from "../daemon/loop.js";
+
+export const RUN_ONCE_USAGE = `usage: first-tree gardener run-once
+
+Run both gardener sweeps exactly once (gardener-sweep, sync-sweep) and
+exit. Reads the same ~/.gardener/config.json the daemon would. Updates
+state.json with the outcome so \`gardener status\` reflects the run.
+`;
+
+export interface RunRunOnceOptions {
+  write?: (line: string) => void;
+  env?: NodeJS.ProcessEnv;
+}
+
+export async function runRunOnce(
+  argv: readonly string[] = [],
+  options: RunRunOnceOptions = {},
+): Promise<number> {
+  const write = options.write ?? ((line) => process.stdout.write(line + "\n"));
+  if (argv.includes("--help") || argv.includes("-h")) {
+    write(RUN_ONCE_USAGE);
+    return 0;
+  }
+  const results = await runOnce({ env: options.env, write });
+  const failed = Object.values(results).some((r) => r?.outcome === "failed");
+  return failed ? 1 : 0;
+}

--- a/src/products/gardener/engine/commands/start.ts
+++ b/src/products/gardener/engine/commands/start.ts
@@ -1,0 +1,231 @@
+/**
+ * `first-tree gardener start` — spawn the gardener daemon in the
+ * background. Writes `~/.gardener/config.json` from the supplied args,
+ * then boots a launchd job on macOS (or a detached `spawn` elsewhere)
+ * that runs `first-tree gardener daemon`.
+ */
+
+import { spawn } from "node:child_process";
+import { openSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir, userInfo } from "node:os";
+import {
+  buildDaemonConfig,
+  parseDurationMs,
+  resolveGardenerDir,
+  writeDaemonConfig,
+} from "../daemon/config.js";
+import {
+  bootstrapLaunchdJob,
+  gardenerLaunchdLabel,
+  gardenerLaunchdPlistPath,
+  supportsLaunchd,
+} from "../daemon/launchd.js";
+
+export const START_USAGE = `usage: first-tree gardener start --tree-path <path> --code-repo <owner/repo> [--code-repo …] [--gardener-interval 5m] [--sync-interval 1h] [--assign-owners] [--sync-apply]
+
+Bring up the gardener daemon in the background.
+
+The daemon runs two schedules:
+  gardener-sweep  invokes \`gardener comment --merged-since 2×interval\`
+                  against the tree path; handles open PR verdicts and
+                  merge→tree-issue creation across all configured code
+                  repos.
+  sync-sweep      invokes \`gardener sync\` (or \`gardener sync --apply\`
+                  when --sync-apply is set) against the tree path;
+                  detects drift and optionally opens tree PRs.
+
+Options:
+  --tree-path <path>          Required. Local checkout of the bound tree repo.
+  --code-repo <owner/name>    Required (repeatable). Source repos to monitor.
+                              These are written to target_repos in the
+                              tree repo's .claude/gardener-config.yaml so
+                              scan mode picks them up.
+  --gardener-interval <dur>   Default 5m. Accepts s/m/h/d suffixes.
+  --sync-interval <dur>       Default 1h.
+  --assign-owners             Pass --assign-owners to gardener comment
+                              so merge→tree-issue creations auto-assign
+                              NODE owners.
+  --sync-apply                Run the sync sweep in --apply mode
+                              (opens tree PRs). Default: detect only.
+  --help, -h                  Show this help.
+
+Environment:
+  GARDENER_DIR   Override ~/.gardener for state/logs/plist (test hook).
+`;
+
+export interface RunStartOptions {
+  write?: (line: string) => void;
+  env?: NodeJS.ProcessEnv;
+  /** Set to true to skip actually booting — print plan only. */
+  dryRun?: boolean;
+}
+
+interface ParsedStartFlags {
+  help: boolean;
+  treePath?: string;
+  codeRepos: string[];
+  gardenerInterval?: string;
+  syncInterval?: string;
+  assignOwners: boolean;
+  syncApply: boolean;
+  dryRun: boolean;
+  unknown?: string;
+}
+
+function parseStartFlags(args: readonly string[]): ParsedStartFlags {
+  const out: ParsedStartFlags = {
+    help: false,
+    codeRepos: [],
+    assignOwners: false,
+    syncApply: false,
+    dryRun: false,
+  };
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === "--help" || a === "-h") { out.help = true; continue; }
+    if (a === "--dry-run") { out.dryRun = true; continue; }
+    if (a === "--assign-owners") { out.assignOwners = true; continue; }
+    if (a === "--sync-apply") { out.syncApply = true; continue; }
+    if (a === "--tree-path") { out.treePath = args[++i]; continue; }
+    if (a === "--code-repo") {
+      const val = args[++i];
+      if (typeof val !== "string" || val.length === 0) {
+        out.unknown = "--code-repo requires owner/name";
+        return out;
+      }
+      out.codeRepos.push(val);
+      continue;
+    }
+    if (a === "--gardener-interval") { out.gardenerInterval = args[++i]; continue; }
+    if (a === "--sync-interval") { out.syncInterval = args[++i]; continue; }
+    out.unknown = a ?? "";
+    return out;
+  }
+  return out;
+}
+
+export async function runStart(
+  argv: readonly string[] = [],
+  options: RunStartOptions = {},
+): Promise<number> {
+  const write = options.write ?? ((line) => process.stdout.write(line + "\n"));
+  const env = options.env ?? process.env;
+
+  const flags = parseStartFlags(argv);
+  if (flags.help) {
+    write(START_USAGE);
+    return 0;
+  }
+  if (flags.unknown) {
+    write(`Unknown start option: ${flags.unknown}`);
+    write(START_USAGE);
+    return 1;
+  }
+  if (!flags.treePath) {
+    write("--tree-path is required");
+    return 1;
+  }
+  if (flags.codeRepos.length === 0) {
+    write("--code-repo is required (repeat for multiple repos)");
+    return 1;
+  }
+
+  const gardenerIntervalMs = flags.gardenerInterval
+    ? parseDurationMs(flags.gardenerInterval)
+    : undefined;
+  if (flags.gardenerInterval !== undefined && gardenerIntervalMs === null) {
+    write(`--gardener-interval: could not parse "${flags.gardenerInterval}" (expected e.g. 5m, 300s, 1h)`);
+    return 1;
+  }
+  const syncIntervalMs = flags.syncInterval
+    ? parseDurationMs(flags.syncInterval)
+    : undefined;
+  if (flags.syncInterval !== undefined && syncIntervalMs === null) {
+    write(`--sync-interval: could not parse "${flags.syncInterval}"`);
+    return 1;
+  }
+
+  const config = buildDaemonConfig({
+    treePath: flags.treePath,
+    codeRepos: flags.codeRepos,
+    gardenerIntervalMs: gardenerIntervalMs ?? undefined,
+    syncIntervalMs: syncIntervalMs ?? undefined,
+    assignOwners: flags.assignOwners,
+    syncApply: flags.syncApply,
+  });
+
+  const configFilePath = writeDaemonConfig(config, env);
+  write(`gardener daemon config written: ${configFilePath}`);
+  write(`  tree-path:          ${config.treePath}`);
+  write(`  code-repos:         ${config.codeRepos.join(", ")}`);
+  write(`  gardener-interval:  ${config.gardenerIntervalMs / 1000}s`);
+  write(`  sync-interval:      ${config.syncIntervalMs / 1000}s`);
+  write(`  merged-lookback:    ${config.mergedLookbackSeconds}s`);
+  write(`  assign-owners:      ${config.assignOwners}`);
+  write(`  sync-apply:         ${config.syncApply}`);
+
+  if (flags.dryRun) {
+    write("--dry-run: not booting daemon");
+    return 0;
+  }
+
+  const gardenerDir = resolveGardenerDir(env);
+  mkdirSync(gardenerDir, { recursive: true });
+  const logsDir = join(gardenerDir, "logs");
+  mkdirSync(logsDir, { recursive: true });
+  const nowSec = Math.floor(Date.now() / 1_000);
+  const logPath = join(logsDir, `gardener-daemon-${nowSec}.log`);
+
+  const entrypoint = process.argv[1];
+  const programArgs = entrypoint
+    ? [entrypoint, "gardener", "daemon"]
+    : ["gardener", "daemon"];
+
+  if (supportsLaunchd()) {
+    const login = userInfo().username || env.USER || "user";
+    const label = gardenerLaunchdLabel(login);
+    const plistPath = gardenerLaunchdPlistPath(gardenerDir, label);
+    try {
+      bootstrapLaunchdJob({
+        label,
+        executable: process.execPath,
+        arguments: programArgs,
+        logPath,
+        env: {
+          HOME: homedir(),
+          PATH: env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
+          GARDENER_DIR: gardenerDir,
+        },
+        workingDirectory: config.treePath,
+        plistPath,
+      });
+      write("gardener daemon started via launchd");
+      write(`  plist:  ${plistPath}`);
+      write(`  log:    ${logPath}`);
+      write(`  label:  ${label}`);
+      return 0;
+    } catch (err) {
+      write(
+        `launchd bootstrap failed (${err instanceof Error ? err.message : String(err)}), falling back to detached spawn`,
+      );
+    }
+  }
+
+  const logFd = openSync(logPath, "a");
+  const child = spawn(process.execPath, programArgs, {
+    detached: true,
+    stdio: ["ignore", logFd, logFd],
+    cwd: config.treePath,
+    env: { ...env, GARDENER_DIR: gardenerDir },
+  });
+  child.unref();
+  if (!child.pid) {
+    write("failed to spawn detached gardener daemon");
+    return 1;
+  }
+  write("gardener daemon started via detached spawn");
+  write(`  pid:  ${child.pid}`);
+  write(`  log:  ${logPath}`);
+  return 0;
+}

--- a/src/products/gardener/engine/commands/status.ts
+++ b/src/products/gardener/engine/commands/status.ts
@@ -1,0 +1,97 @@
+/**
+ * `first-tree gardener status` — print the last-run summary and the
+ * currently-configured schedule. Pure read operation; never mutates.
+ */
+
+import { loadDaemonConfig } from "../daemon/config.js";
+import { loadDaemonState } from "../daemon/state.js";
+
+export const STATUS_USAGE = `usage: first-tree gardener status
+
+Print gardener daemon state:
+  - whether a daemon process is recorded as running (pid + uptime)
+  - the current sweep schedule (from ~/.gardener/config.json)
+  - the last run time, outcome, and summary for each sweep
+  - the projected next run time per sweep
+`;
+
+export interface RunStatusOptions {
+  write?: (line: string) => void;
+  env?: NodeJS.ProcessEnv;
+  now?: () => number;
+}
+
+export async function runStatus(
+  argv: readonly string[] = [],
+  options: RunStatusOptions = {},
+): Promise<number> {
+  const write = options.write ?? ((line) => process.stdout.write(line + "\n"));
+  const env = options.env ?? process.env;
+  const now = options.now ?? (() => Date.now());
+
+  if (argv.includes("--help") || argv.includes("-h")) {
+    write(STATUS_USAGE);
+    return 0;
+  }
+
+  const config = loadDaemonConfig(env);
+  const state = loadDaemonState(env);
+
+  write("gardener daemon status");
+  if (state.pid !== undefined) {
+    const uptimeSec = state.startedAt
+      ? Math.max(0, Math.round((now() - state.startedAt) / 1000))
+      : undefined;
+    write(`  pid:       ${state.pid}${uptimeSec !== undefined ? ` (uptime ${uptimeSec}s)` : ""}`);
+  } else {
+    write("  pid:       <not running>");
+  }
+
+  if (!config) {
+    write("  config:    <missing — run `gardener start` to create>");
+    return 0;
+  }
+
+  write(`  tree-path: ${config.treePath}`);
+  write(`  code-repos: ${config.codeRepos.join(", ") || "<none>"}`);
+  write(
+    `  gardener-interval: ${config.gardenerIntervalMs / 1000}s   sync-interval: ${config.syncIntervalMs / 1000}s`,
+  );
+
+  const sweeps: Array<[keyof typeof state.sweeps, number]> = [
+    ["gardener", config.gardenerIntervalMs],
+    ["sync", config.syncIntervalMs],
+  ];
+  for (const [name, interval] of sweeps) {
+    const record = state.sweeps[name];
+    if (!record) {
+      write(`  ${name}-sweep: <never run> (next: as soon as daemon picks it up)`);
+      continue;
+    }
+    const ago = Math.max(0, now() - record.lastRunAt);
+    const nextInMs = Math.max(0, interval - ago);
+    write(
+      `  ${name}-sweep: last ${record.outcome} ${formatAgo(ago)} — ${record.summary || "(no summary)"}; next in ${formatRemaining(nextInMs)}`,
+    );
+  }
+  return 0;
+}
+
+function formatAgo(ms: number): string {
+  const sec = Math.floor(ms / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  return `${hr}h ago`;
+}
+
+function formatRemaining(ms: number): string {
+  if (ms <= 0) return "now";
+  const sec = Math.ceil(ms / 1000);
+  if (sec < 60) return `${sec}s`;
+  const min = Math.ceil(sec / 60);
+  if (min < 60) return `${min}m`;
+  const hr = Math.ceil(min / 60);
+  return `${hr}h`;
+}

--- a/src/products/gardener/engine/commands/stop.ts
+++ b/src/products/gardener/engine/commands/stop.ts
@@ -1,0 +1,78 @@
+/**
+ * `first-tree gardener stop` — tear down the gardener daemon. On
+ * macOS this `launchctl bootout`s the plist and removes it. Elsewhere
+ * we kill the PID recorded in `state.json`.
+ */
+
+import { existsSync } from "node:fs";
+import { userInfo } from "node:os";
+import { loadDaemonState, writeDaemonState } from "../daemon/state.js";
+import { resolveGardenerDir } from "../daemon/config.js";
+import {
+  booteLaunchdJob,
+  gardenerLaunchdLabel,
+  gardenerLaunchdPlistPath,
+  supportsLaunchd,
+} from "../daemon/launchd.js";
+
+export const STOP_USAGE = `usage: first-tree gardener stop
+
+Tear down the gardener daemon.
+
+- On macOS: \`launchctl bootout\`s the gardener plist + removes it.
+- Elsewhere: kills the PID recorded in ~/.gardener/state.json.
+
+Always idempotent: running \`stop\` when nothing is running is a no-op
+that exits 0.
+`;
+
+export interface RunStopOptions {
+  write?: (line: string) => void;
+  env?: NodeJS.ProcessEnv;
+}
+
+export async function runStop(
+  argv: readonly string[] = [],
+  options: RunStopOptions = {},
+): Promise<number> {
+  const write = options.write ?? ((line) => process.stdout.write(line + "\n"));
+  const env = options.env ?? process.env;
+
+  if (argv.includes("--help") || argv.includes("-h")) {
+    write(STOP_USAGE);
+    return 0;
+  }
+
+  const gardenerDir = resolveGardenerDir(env);
+  let actedOnLaunchd = false;
+
+  if (supportsLaunchd()) {
+    const login = userInfo().username || env.USER || "user";
+    const label = gardenerLaunchdLabel(login);
+    const plistPath = gardenerLaunchdPlistPath(gardenerDir, label);
+    if (existsSync(plistPath)) {
+      booteLaunchdJob(label, plistPath);
+      write(`gardener daemon stopped via launchd (${label})`);
+      actedOnLaunchd = true;
+    }
+  }
+
+  const state = loadDaemonState(env);
+  if (state.pid !== undefined) {
+    try {
+      process.kill(state.pid, "SIGTERM");
+      write(`sent SIGTERM to gardener daemon pid=${state.pid}`);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "ESRCH") {
+        write(
+          `failed to signal pid=${state.pid}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+    writeDaemonState({ ...state, pid: undefined, startedAt: undefined }, env);
+  } else if (!actedOnLaunchd) {
+    write("gardener daemon: nothing to stop");
+  }
+  return 0;
+}

--- a/src/products/gardener/engine/daemon/config.ts
+++ b/src/products/gardener/engine/daemon/config.ts
@@ -1,0 +1,154 @@
+/**
+ * Gardener daemon persisted configuration.
+ *
+ * Written by `first-tree gardener start` into `~/.gardener/config.json`
+ * (overridable via `$GARDENER_DIR`). The daemon loop reads it on each
+ * tick so a restart inherits the exact schedule + repo set the user
+ * originally passed.
+ *
+ * Intentionally minimal: this is not a general scheduler, it's a
+ * two-sweep state file (`gardener-sweep`, `sync-sweep`). Anything more
+ * complex belongs in a proper scheduler, not here.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+export interface GardenerDaemonConfig {
+  /** Absolute path to the bound tree repo checkout. */
+  treePath: string;
+  /** Source repos to sweep on each gardener-sweep tick (`owner/name`). */
+  codeRepos: string[];
+  /** Milliseconds between gardener-sweep ticks. */
+  gardenerIntervalMs: number;
+  /** Milliseconds between sync-sweep ticks. */
+  syncIntervalMs: number;
+  /**
+   * Lookback window (seconds) passed as `--merged-since` to gardener
+   * comment on each sweep. Defaults to 2× `gardenerIntervalMs` so we
+   * don't miss merges that happen between ticks.
+   */
+  mergedLookbackSeconds: number;
+  /**
+   * When true, pass `--assign-owners` to the gardener-sweep subprocess
+   * so merge→tree-issue assigns NODE owners from CODEOWNERS.
+   */
+  assignOwners: boolean;
+  /**
+   * When true, `sync-sweep` invokes `gardener sync --apply` (open tree
+   * PRs). When false, it stays in detect-only mode.
+   */
+  syncApply: boolean;
+}
+
+export function resolveGardenerDir(env: NodeJS.ProcessEnv = process.env): string {
+  return env.GARDENER_DIR ?? join(homedir(), ".gardener");
+}
+
+export function configPath(env?: NodeJS.ProcessEnv): string {
+  return join(resolveGardenerDir(env), "config.json");
+}
+
+const DEFAULT_GARDENER_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+const DEFAULT_SYNC_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+
+export function loadDaemonConfig(
+  env?: NodeJS.ProcessEnv,
+): GardenerDaemonConfig | null {
+  const path = configPath(env);
+  if (!existsSync(path)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+    return coerceDaemonConfig(raw);
+  } catch {
+    return null;
+  }
+}
+
+export function writeDaemonConfig(
+  config: GardenerDaemonConfig,
+  env?: NodeJS.ProcessEnv,
+): string {
+  const path = configPath(env);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(config, null, 2) + "\n");
+  return path;
+}
+
+function coerceDaemonConfig(raw: Record<string, unknown>): GardenerDaemonConfig {
+  const treePath = typeof raw.treePath === "string" ? raw.treePath : "";
+  const codeRepos = Array.isArray(raw.codeRepos)
+    ? raw.codeRepos.filter((x): x is string => typeof x === "string")
+    : [];
+  const gardenerIntervalMs =
+    typeof raw.gardenerIntervalMs === "number" && raw.gardenerIntervalMs > 0
+      ? raw.gardenerIntervalMs
+      : DEFAULT_GARDENER_INTERVAL_MS;
+  const syncIntervalMs =
+    typeof raw.syncIntervalMs === "number" && raw.syncIntervalMs > 0
+      ? raw.syncIntervalMs
+      : DEFAULT_SYNC_INTERVAL_MS;
+  const mergedLookbackSeconds =
+    typeof raw.mergedLookbackSeconds === "number" &&
+    raw.mergedLookbackSeconds > 0
+      ? raw.mergedLookbackSeconds
+      : Math.max(60, Math.round((gardenerIntervalMs * 2) / 1000));
+  const assignOwners = raw.assignOwners === true;
+  const syncApply = raw.syncApply === true;
+  return {
+    treePath,
+    codeRepos,
+    gardenerIntervalMs,
+    syncIntervalMs,
+    mergedLookbackSeconds,
+    assignOwners,
+    syncApply,
+  };
+}
+
+/**
+ * Parse a `<n><unit>` duration string into milliseconds. Accepts
+ * `m`/`h`/`d`, plus bare integers interpreted as seconds for shell
+ * ergonomics (the daemon never encodes sub-second timing). Returns
+ * null on unparseable input so callers can render a clear error.
+ */
+export function parseDurationMs(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  const match = trimmed.match(/^(\d+)\s*([smhd]?)$/i);
+  if (!match) return null;
+  const amount = Number(match[1]);
+  if (!Number.isFinite(amount) || amount <= 0) return null;
+  const unit = match[2].toLowerCase();
+  if (unit === "s" || unit === "") return amount * 1000;
+  if (unit === "m") return amount * 60 * 1000;
+  if (unit === "h") return amount * 60 * 60 * 1000;
+  if (unit === "d") return amount * 24 * 60 * 60 * 1000;
+  return null;
+}
+
+export function buildDaemonConfig(opts: {
+  treePath: string;
+  codeRepos: readonly string[];
+  gardenerIntervalMs?: number;
+  syncIntervalMs?: number;
+  mergedLookbackSeconds?: number;
+  assignOwners?: boolean;
+  syncApply?: boolean;
+}): GardenerDaemonConfig {
+  const gardenerIntervalMs = opts.gardenerIntervalMs ?? DEFAULT_GARDENER_INTERVAL_MS;
+  const syncIntervalMs = opts.syncIntervalMs ?? DEFAULT_SYNC_INTERVAL_MS;
+  const resolvedTree = resolve(opts.treePath);
+  return {
+    treePath: resolvedTree,
+    codeRepos: [...opts.codeRepos],
+    gardenerIntervalMs,
+    syncIntervalMs,
+    mergedLookbackSeconds:
+      opts.mergedLookbackSeconds ??
+      Math.max(60, Math.round((gardenerIntervalMs * 2) / 1000)),
+    assignOwners: opts.assignOwners ?? false,
+    syncApply: opts.syncApply ?? false,
+  };
+}

--- a/src/products/gardener/engine/daemon/launchd.ts
+++ b/src/products/gardener/engine/daemon/launchd.ts
@@ -1,0 +1,154 @@
+/**
+ * macOS launchd integration for the gardener daemon.
+ *
+ * Separate from breeze's launchd module (same pattern, different
+ * label/plist path) so the two products can be started, stopped, and
+ * diagnosed independently. On non-darwin callers fall back to a
+ * detached `spawn(...)` — see `commands/start.ts`.
+ */
+
+import { execSync, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export interface LaunchdPlistInputs {
+  label: string;
+  executable: string;
+  arguments: readonly string[];
+  logPath: string;
+  env?: Record<string, string | undefined>;
+  workingDirectory?: string;
+}
+
+export function supportsLaunchd(): boolean {
+  if (process.platform !== "darwin") return false;
+  try {
+    execSync("command -v launchctl", { stdio: ["ignore", "pipe", "ignore"] });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function sanitizeLabelSegment(raw: string): string {
+  return raw.replace(/[^A-Za-z0-9._-]/g, "_");
+}
+
+export function gardenerLaunchdLabel(login: string): string {
+  return `com.first-tree.gardener.${sanitizeLabelSegment(login)}`;
+}
+
+export function gardenerLaunchdPlistPath(
+  gardenerDir: string,
+  label: string,
+): string {
+  return join(gardenerDir, "launchd", `${label}.plist`);
+}
+
+export function launchdUserDomain(): string {
+  const result = spawnSync("id", ["-u"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `resolve user id for launchd failed: ${result.stderr?.trim() ?? ""}`,
+    );
+  }
+  const uid = (result.stdout ?? "").split("\n")[0]?.trim();
+  if (!uid) throw new Error("could not resolve numeric user id for launchd");
+  return `gui/${uid}`;
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+export function renderLaunchdPlist(
+  inputs: LaunchdPlistInputs,
+): string {
+  const argv = [inputs.executable, ...inputs.arguments];
+  const programArguments = argv
+    .map((a) => `    <string>${escapeXml(a)}</string>`)
+    .join("\n");
+  const envEntries = Object.entries(inputs.env ?? {})
+    .filter((entry): entry is [string, string] => typeof entry[1] === "string")
+    .map(
+      ([k, v]) =>
+        `    <key>${escapeXml(k)}</key>\n    <string>${escapeXml(v)}</string>`,
+    )
+    .join("\n");
+  const envBlock =
+    envEntries.length > 0
+      ? `  <key>EnvironmentVariables</key>\n  <dict>\n${envEntries}\n  </dict>\n`
+      : "";
+  const workingDir = inputs.workingDirectory
+    ? `  <key>WorkingDirectory</key>\n  <string>${escapeXml(inputs.workingDirectory)}</string>\n`
+    : "";
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${escapeXml(inputs.label)}</string>
+  <key>ProgramArguments</key>
+  <array>
+${programArguments}
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>${escapeXml(inputs.logPath)}</string>
+  <key>StandardErrorPath</key>
+  <string>${escapeXml(inputs.logPath)}</string>
+${workingDir}${envBlock}</dict>
+</plist>
+`;
+}
+
+export interface BootstrapInputs extends LaunchdPlistInputs {
+  plistPath: string;
+}
+
+export function bootstrapLaunchdJob(inputs: BootstrapInputs): {
+  plistPath: string;
+  label: string;
+} {
+  mkdirSync(dirname(inputs.plistPath), { recursive: true });
+  mkdirSync(dirname(inputs.logPath), { recursive: true });
+  writeFileSync(inputs.plistPath, renderLaunchdPlist(inputs));
+  const domain = launchdUserDomain();
+  // Boot out any prior instance first (idempotent). Ignore errors.
+  spawnSync("launchctl", ["bootout", `${domain}/${inputs.label}`], {
+    stdio: "ignore",
+  });
+  const bootstrap = spawnSync("launchctl", ["bootstrap", domain, inputs.plistPath], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (bootstrap.status !== 0) {
+    throw new Error(
+      `launchctl bootstrap failed: ${bootstrap.stderr?.trim() ?? "exit " + bootstrap.status}`,
+    );
+  }
+  return { plistPath: inputs.plistPath, label: inputs.label };
+}
+
+export function booteLaunchdJob(label: string, plistPath: string): void {
+  const domain = launchdUserDomain();
+  spawnSync("launchctl", ["bootout", `${domain}/${label}`], { stdio: "ignore" });
+  if (existsSync(plistPath)) {
+    try {
+      unlinkSync(plistPath);
+    } catch {
+      // best-effort; ignore
+    }
+  }
+}

--- a/src/products/gardener/engine/daemon/loop.ts
+++ b/src/products/gardener/engine/daemon/loop.ts
@@ -1,0 +1,274 @@
+/**
+ * Gardener daemon main loop.
+ *
+ * Tick every ~30 s. On each tick:
+ *   1. Load config + state from `~/.gardener/`.
+ *   2. For each sweep (`gardener-sweep`, `sync-sweep`), check if
+ *      `now - lastRun >= interval`. If so, run it.
+ *   3. Persist the outcome back to `state.json`.
+ *
+ * Sweeps are run **serially** — we never overlap two long-running
+ * subprocess invocations from the same daemon. Gardener sweep runs
+ * `first-tree gardener comment --merged-since <lookback> --assign-owners?`
+ * pointed at the configured tree path and target_repos list. Sync
+ * sweep runs `first-tree gardener sync [--apply]` pointed at the same
+ * tree path.
+ *
+ * Subprocess dispatch is deliberately thin: we spawn with inherited
+ * stderr/stdout to the daemon log file (caller's responsibility), and
+ * parse the last line for the `BREEZE_RESULT: status=…` trailer to
+ * populate state.
+ */
+
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import {
+  buildDaemonConfig,
+  loadDaemonConfig,
+  resolveGardenerDir,
+  writeDaemonConfig,
+  type GardenerDaemonConfig,
+} from "./config.js";
+import {
+  isSweepDue,
+  loadDaemonState,
+  updateSweepState,
+  writeDaemonState,
+  type SweepName,
+  type SweepOutcome,
+} from "./state.js";
+
+export interface LoopDeps {
+  /** Wall clock, injected for tests. */
+  now?: () => number;
+  /** Sleep between ticks. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Runs a gardener subprocess. */
+  runSweep?: (sweep: SweepName, config: GardenerDaemonConfig) => Promise<{
+    outcome: SweepOutcome;
+    summary: string;
+  }>;
+  /** If set, loop exits after this many ticks (for tests). */
+  maxTicks?: number;
+  /** Override for ~/.gardener root. */
+  env?: NodeJS.ProcessEnv;
+  write?: (line: string) => void;
+}
+
+export const DEFAULT_TICK_MS = 30 * 1000;
+
+export async function runDaemonLoop(
+  deps: LoopDeps = {},
+): Promise<void> {
+  const now = deps.now ?? (() => Date.now());
+  const sleep =
+    deps.sleep ??
+    ((ms: number) =>
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, ms);
+      }));
+  const env = deps.env ?? process.env;
+  const write = deps.write ?? ((line) => process.stdout.write(line + "\n"));
+  const runSweep = deps.runSweep ?? defaultRunSweep;
+
+  writeLogLine(env, `gardener daemon started pid=${process.pid}`);
+
+  // Stamp PID + start time into state so `gardener status` can report.
+  const initial = loadDaemonState(env);
+  writeDaemonState(
+    { ...initial, pid: process.pid, startedAt: now() },
+    env,
+  );
+
+  let tick = 0;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    tick += 1;
+    if (deps.maxTicks !== undefined && tick > deps.maxTicks) break;
+
+    const config = loadDaemonConfig(env);
+    if (!config) {
+      writeLogLine(env, `tick ${tick}: no config at ~/.gardener/config.json, idling`);
+      await sleep(DEFAULT_TICK_MS);
+      continue;
+    }
+
+    const state = loadDaemonState(env);
+    const current = now();
+
+    const schedule: Array<{ name: SweepName; intervalMs: number }> = [
+      { name: "gardener", intervalMs: config.gardenerIntervalMs },
+      { name: "sync", intervalMs: config.syncIntervalMs },
+    ];
+
+    for (const entry of schedule) {
+      if (!isSweepDue(state, entry.name, entry.intervalMs, current)) continue;
+      writeLogLine(env, `tick ${tick}: ${entry.name}-sweep due, running`);
+      write(`gardener daemon: running ${entry.name}-sweep`);
+      const result = await runSweep(entry.name, config);
+      updateSweepState(env, entry.name, {
+        lastRunAt: now(),
+        outcome: result.outcome,
+        summary: result.summary,
+      });
+      writeLogLine(
+        env,
+        `tick ${tick}: ${entry.name}-sweep ${result.outcome} — ${result.summary}`,
+      );
+    }
+
+    await sleep(DEFAULT_TICK_MS);
+  }
+}
+
+async function defaultRunSweep(
+  sweep: SweepName,
+  config: GardenerDaemonConfig,
+): Promise<{ outcome: SweepOutcome; summary: string }> {
+  const args = sweep === "gardener"
+    ? buildGardenerSweepArgs(config)
+    : buildSyncSweepArgs(config);
+  return invokeCli(args, config.treePath);
+}
+
+export function buildGardenerSweepArgs(
+  config: GardenerDaemonConfig,
+): string[] {
+  const args = [
+    "gardener",
+    "comment",
+    "--tree-path",
+    config.treePath,
+    "--merged-since",
+    `${config.mergedLookbackSeconds}s`,
+  ];
+  if (config.assignOwners) args.push("--assign-owners");
+  return args;
+}
+
+export function buildSyncSweepArgs(
+  config: GardenerDaemonConfig,
+): string[] {
+  const args = ["gardener", "sync", "--tree-path", config.treePath];
+  if (config.syncApply) args.push("--apply");
+  return args;
+}
+
+async function invokeCli(
+  args: string[],
+  cwd: string,
+): Promise<{ outcome: SweepOutcome; summary: string }> {
+  return new Promise((resolveFn) => {
+    const entrypoint = process.argv[1];
+    const argv = entrypoint ? [entrypoint, ...args] : args;
+    const child = spawn(process.execPath, argv, {
+      cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("close", (code) => {
+      const trailer = parseBreezeResult(stdout);
+      const outcome: SweepOutcome = trailer?.status ??
+        (code === 0 ? "handled" : "failed");
+      const summary = trailer?.summary ??
+        (code === 0
+          ? `exit=0 no BREEZE_RESULT trailer`
+          : `exit=${code} ${stderr.slice(0, 200)}`);
+      resolveFn({ outcome, summary });
+    });
+    child.on("error", (err) => {
+      resolveFn({
+        outcome: "failed",
+        summary: `spawn error: ${err.message}`,
+      });
+    });
+  });
+}
+
+export function parseBreezeResult(
+  stdout: string,
+): { status: SweepOutcome; summary: string } | null {
+  const lines = stdout.split(/\r?\n/);
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const match = lines[i].match(
+      /^BREEZE_RESULT:\s+status=(handled|skipped|failed)\s+summary=(.*?)(?:\s+[a-z_]+=.*)?$/,
+    );
+    if (match) {
+      return { status: match[1] as SweepOutcome, summary: match[2].trim() };
+    }
+  }
+  return null;
+}
+
+function logPath(env: NodeJS.ProcessEnv): string {
+  return join(resolveGardenerDir(env), "daemon.log");
+}
+
+function writeLogLine(env: NodeJS.ProcessEnv, line: string): void {
+  const path = logPath(env);
+  mkdirSync(dirname(path), { recursive: true });
+  const stamp = new Date().toISOString();
+  const text = `${stamp} ${line}\n`;
+  try {
+    writeFileSync(path, text, { flag: "a" });
+  } catch {
+    // Best-effort logging — don't blow up the loop on I/O issues.
+  }
+}
+
+/**
+ * One-shot: run both sweeps exactly once, return outcome per sweep.
+ * Used by `gardener run-once` to exercise the daemon pipeline without
+ * starting a background process.
+ */
+export async function runOnce(
+  deps: {
+    env?: NodeJS.ProcessEnv;
+    now?: () => number;
+    write?: (line: string) => void;
+    runSweep?: LoopDeps["runSweep"];
+  } = {},
+): Promise<{ gardener?: { outcome: SweepOutcome; summary: string }; sync?: { outcome: SweepOutcome; summary: string } }> {
+  const env = deps.env ?? process.env;
+  const now = deps.now ?? (() => Date.now());
+  const write = deps.write ?? ((line) => process.stdout.write(line + "\n"));
+  const runSweep = deps.runSweep ?? defaultRunSweep;
+  const config = loadDaemonConfig(env);
+  if (!config) {
+    write(
+      "gardener run-once: no config at ~/.gardener/config.json — run `gardener start` first, or set $GARDENER_DIR",
+    );
+    return {};
+  }
+  const results: {
+    gardener?: { outcome: SweepOutcome; summary: string };
+    sync?: { outcome: SweepOutcome; summary: string };
+  } = {};
+  for (const sweep of ["gardener", "sync"] as const) {
+    write(`gardener run-once: running ${sweep}-sweep`);
+    const result = await runSweep(sweep, config);
+    updateSweepState(env, sweep, {
+      lastRunAt: now(),
+      outcome: result.outcome,
+      summary: result.summary,
+    });
+    results[sweep] = result;
+    write(`gardener run-once: ${sweep}-sweep ${result.outcome} — ${result.summary}`);
+  }
+  return results;
+}
+
+/**
+ * Builders re-exported for tests and start-command previews — the
+ * caller's CLI asks "what would the daemon actually invoke?" and shows
+ * that in the start summary.
+ */
+export { buildDaemonConfig, writeDaemonConfig, resolve };

--- a/src/products/gardener/engine/daemon/state.ts
+++ b/src/products/gardener/engine/daemon/state.ts
@@ -1,0 +1,117 @@
+/**
+ * Gardener daemon persisted runtime state.
+ *
+ * `~/.gardener/state.json` records the last-run timestamp of each
+ * sweep, the current daemon PID (when one is running), and the exit
+ * status of the most recent sweep invocations. Read by `gardener
+ * status` for diagnostics and by the loop itself to decide when a
+ * sweep is due.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { resolveGardenerDir } from "./config.js";
+
+export type SweepName = "gardener" | "sync";
+export type SweepOutcome = "handled" | "skipped" | "failed";
+
+export interface SweepRecord {
+  /** Unix epoch ms of the last completed run. */
+  lastRunAt: number;
+  /** Outcome of the last completed run. */
+  outcome: SweepOutcome;
+  /** Short human-readable summary from the subprocess. */
+  summary: string;
+}
+
+export interface DaemonState {
+  /** OS PID of the running daemon; undefined when stopped. */
+  pid?: number;
+  /** Unix epoch ms when the current daemon process started. */
+  startedAt?: number;
+  /** Most recent outcome per sweep. */
+  sweeps: Partial<Record<SweepName, SweepRecord>>;
+}
+
+export function statePath(env?: NodeJS.ProcessEnv): string {
+  return join(resolveGardenerDir(env), "state.json");
+}
+
+export function loadDaemonState(env?: NodeJS.ProcessEnv): DaemonState {
+  const path = statePath(env);
+  if (!existsSync(path)) return { sweeps: {} };
+  try {
+    const raw = JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+    const sweepsRaw =
+      raw.sweeps && typeof raw.sweeps === "object" && !Array.isArray(raw.sweeps)
+        ? (raw.sweeps as Record<string, unknown>)
+        : {};
+    const sweeps: DaemonState["sweeps"] = {};
+    for (const key of ["gardener", "sync"] as const) {
+      const entry = sweepsRaw[key];
+      if (!entry || typeof entry !== "object") continue;
+      const record = entry as Record<string, unknown>;
+      if (typeof record.lastRunAt !== "number") continue;
+      const outcome =
+        record.outcome === "handled" ||
+        record.outcome === "skipped" ||
+        record.outcome === "failed"
+          ? record.outcome
+          : "skipped";
+      const summary = typeof record.summary === "string" ? record.summary : "";
+      sweeps[key] = {
+        lastRunAt: record.lastRunAt,
+        outcome,
+        summary,
+      };
+    }
+    return {
+      pid: typeof raw.pid === "number" ? raw.pid : undefined,
+      startedAt: typeof raw.startedAt === "number" ? raw.startedAt : undefined,
+      sweeps,
+    };
+  } catch {
+    return { sweeps: {} };
+  }
+}
+
+export function writeDaemonState(
+  state: DaemonState,
+  env?: NodeJS.ProcessEnv,
+): string {
+  const path = statePath(env);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(state, null, 2) + "\n");
+  return path;
+}
+
+export function updateSweepState(
+  env: NodeJS.ProcessEnv | undefined,
+  sweep: SweepName,
+  record: SweepRecord,
+): DaemonState {
+  const current = loadDaemonState(env);
+  const next: DaemonState = {
+    ...current,
+    sweeps: { ...current.sweeps, [sweep]: record },
+  };
+  writeDaemonState(next, env);
+  return next;
+}
+
+/**
+ * Compute whether a sweep is due. A sweep is due when it has never
+ * run, or when `now - lastRunAt >= intervalMs`. Used both by the loop
+ * (to decide what to execute next) and by `status` (to project next
+ * run times).
+ */
+export function isSweepDue(
+  state: DaemonState,
+  sweep: SweepName,
+  intervalMs: number,
+  now: number,
+): boolean {
+  const last = state.sweeps[sweep]?.lastRunAt;
+  if (last === undefined) return true;
+  return now - last >= intervalMs;
+}

--- a/tests/gardener/gardener-daemon.test.ts
+++ b/tests/gardener/gardener-daemon.test.ts
@@ -1,0 +1,390 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  buildDaemonConfig,
+  loadDaemonConfig,
+  parseDurationMs,
+  resolveGardenerDir,
+  writeDaemonConfig,
+} from "#products/gardener/engine/daemon/config.js";
+import {
+  buildGardenerSweepArgs,
+  buildSyncSweepArgs,
+  parseBreezeResult,
+  runOnce,
+} from "#products/gardener/engine/daemon/loop.js";
+import {
+  isSweepDue,
+  loadDaemonState,
+  updateSweepState,
+  writeDaemonState,
+} from "#products/gardener/engine/daemon/state.js";
+import {
+  gardenerLaunchdLabel,
+  renderLaunchdPlist,
+  sanitizeLabelSegment,
+} from "#products/gardener/engine/daemon/launchd.js";
+import { runStatus } from "#products/gardener/engine/commands/status.js";
+import { runStart } from "#products/gardener/engine/commands/start.js";
+import { runStop } from "#products/gardener/engine/commands/stop.js";
+import { useTmpDir } from "../helpers.js";
+
+function makeEnv(dir: string): NodeJS.ProcessEnv {
+  return { ...process.env, GARDENER_DIR: dir };
+}
+
+function capture(): { write: (line: string) => void; lines: string[] } {
+  const lines: string[] = [];
+  return {
+    write: (line: string) => {
+      for (const split of line.split("\n")) lines.push(split);
+    },
+    lines,
+  };
+}
+
+describe("gardener daemon -- parseDurationMs", () => {
+  it("parses seconds, minutes, hours, days", () => {
+    expect(parseDurationMs("30s")).toBe(30_000);
+    expect(parseDurationMs("5m")).toBe(300_000);
+    expect(parseDurationMs("2h")).toBe(7_200_000);
+    expect(parseDurationMs("1d")).toBe(86_400_000);
+  });
+  it("treats bare integers as seconds", () => {
+    expect(parseDurationMs("120")).toBe(120_000);
+  });
+  it("returns null on junk", () => {
+    expect(parseDurationMs("0m")).toBeNull();
+    expect(parseDurationMs("-1s")).toBeNull();
+    expect(parseDurationMs("abc")).toBeNull();
+    expect(parseDurationMs("")).toBeNull();
+  });
+});
+
+describe("gardener daemon -- config I/O", () => {
+  it("resolves GARDENER_DIR env override", () => {
+    const tmp = useTmpDir();
+    expect(resolveGardenerDir(makeEnv(tmp.path))).toBe(tmp.path);
+  });
+
+  it("writes and reads round-trip", () => {
+    const tmp = useTmpDir();
+    const env = makeEnv(tmp.path);
+    const config = buildDaemonConfig({
+      treePath: "/tmp/example-tree",
+      codeRepos: ["a/b", "c/d"],
+      gardenerIntervalMs: 60_000,
+      syncIntervalMs: 3_600_000,
+      assignOwners: true,
+      syncApply: false,
+    });
+    writeDaemonConfig(config, env);
+    const loaded = loadDaemonConfig(env);
+    expect(loaded).not.toBeNull();
+    expect(loaded?.codeRepos).toEqual(["a/b", "c/d"]);
+    expect(loaded?.assignOwners).toBe(true);
+    expect(loaded?.mergedLookbackSeconds).toBe(120); // 2× 60_000 ms → 120 s
+  });
+
+  it("returns null when no config file exists", () => {
+    const tmp = useTmpDir();
+    expect(loadDaemonConfig(makeEnv(tmp.path))).toBeNull();
+  });
+
+  it("resolves relative tree-path to absolute", () => {
+    const config = buildDaemonConfig({
+      treePath: "./some/relative/path",
+      codeRepos: ["a/b"],
+    });
+    expect(config.treePath.startsWith("/")).toBe(true);
+  });
+});
+
+describe("gardener daemon -- state helpers", () => {
+  it("isSweepDue returns true when never run", () => {
+    expect(isSweepDue({ sweeps: {} }, "gardener", 60_000, 1_000_000)).toBe(true);
+  });
+
+  it("isSweepDue returns false before interval elapses", () => {
+    const state = {
+      sweeps: {
+        gardener: { lastRunAt: 1_000_000, outcome: "handled" as const, summary: "" },
+      },
+    };
+    expect(isSweepDue(state, "gardener", 60_000, 1_030_000)).toBe(false);
+  });
+
+  it("isSweepDue returns true after interval elapses", () => {
+    const state = {
+      sweeps: {
+        gardener: { lastRunAt: 1_000_000, outcome: "handled" as const, summary: "" },
+      },
+    };
+    expect(isSweepDue(state, "gardener", 60_000, 1_061_000)).toBe(true);
+  });
+
+  it("updateSweepState round-trips to disk", () => {
+    const tmp = useTmpDir();
+    const env = makeEnv(tmp.path);
+    updateSweepState(env, "gardener", {
+      lastRunAt: 123_456,
+      outcome: "handled",
+      summary: "did stuff",
+    });
+    const loaded = loadDaemonState(env);
+    expect(loaded.sweeps.gardener?.outcome).toBe("handled");
+    expect(loaded.sweeps.gardener?.summary).toBe("did stuff");
+  });
+});
+
+describe("gardener daemon -- sweep arg builders", () => {
+  it("gardener sweep passes --merged-since and assign-owners when enabled", () => {
+    const config = buildDaemonConfig({
+      treePath: "/x",
+      codeRepos: ["a/b"],
+      gardenerIntervalMs: 300_000,
+      assignOwners: true,
+    });
+    const args = buildGardenerSweepArgs(config);
+    expect(args).toContain("gardener");
+    expect(args).toContain("comment");
+    expect(args).toContain("--merged-since");
+    const idx = args.indexOf("--merged-since");
+    expect(args[idx + 1]).toMatch(/^\d+s$/);
+    expect(args).toContain("--assign-owners");
+  });
+
+  it("sync sweep passes --apply only when syncApply=true", () => {
+    const base = buildDaemonConfig({ treePath: "/x", codeRepos: ["a/b"] });
+    expect(buildSyncSweepArgs(base)).not.toContain("--apply");
+    const applied = buildDaemonConfig({
+      treePath: "/x",
+      codeRepos: ["a/b"],
+      syncApply: true,
+    });
+    expect(buildSyncSweepArgs(applied)).toContain("--apply");
+  });
+});
+
+describe("gardener daemon -- parseBreezeResult", () => {
+  it("extracts status and summary", () => {
+    const stdout = [
+      "some noise",
+      "gardener-comment run complete",
+      "BREEZE_RESULT: status=handled summary=repos=2 handled=1 skipped=1 failed=0 tree_repo_token=absent",
+    ].join("\n");
+    const parsed = parseBreezeResult(stdout);
+    expect(parsed?.status).toBe("handled");
+    expect(parsed?.summary).toContain("repos=2");
+  });
+
+  it("returns null when no trailer present", () => {
+    expect(parseBreezeResult("no trailer here")).toBeNull();
+  });
+});
+
+describe("gardener daemon -- runOnce dispatch", () => {
+  it("invokes both sweeps and records outcomes", async () => {
+    const tmp = useTmpDir();
+    const env = makeEnv(tmp.path);
+    writeDaemonConfig(
+      buildDaemonConfig({
+        treePath: "/tmp/whatever",
+        codeRepos: ["a/b"],
+      }),
+      env,
+    );
+    const { write, lines } = capture();
+    const calls: string[] = [];
+    const results = await runOnce({
+      env,
+      now: () => 1_000_000,
+      write,
+      runSweep: async (sweep) => {
+        calls.push(sweep);
+        return {
+          outcome: "handled",
+          summary: `${sweep} did things`,
+        };
+      },
+    });
+    expect(calls).toEqual(["gardener", "sync"]);
+    expect(results.gardener?.outcome).toBe("handled");
+    expect(results.sync?.outcome).toBe("handled");
+    const state = loadDaemonState(env);
+    expect(state.sweeps.gardener?.lastRunAt).toBe(1_000_000);
+    expect(state.sweeps.sync?.lastRunAt).toBe(1_000_000);
+    expect(lines.some((l) => l.includes("gardener-sweep handled"))).toBe(true);
+  });
+
+  it("fails gracefully when no config exists", async () => {
+    const tmp = useTmpDir();
+    const env = makeEnv(tmp.path);
+    const { write, lines } = capture();
+    const results = await runOnce({ env, write, runSweep: async () => ({
+      outcome: "handled",
+      summary: "",
+    }) });
+    expect(results.gardener).toBeUndefined();
+    expect(results.sync).toBeUndefined();
+    expect(lines.some((l) => l.includes("no config"))).toBe(true);
+  });
+});
+
+describe("gardener daemon -- status", () => {
+  it("reports <not running> + <missing> when nothing configured", async () => {
+    const tmp = useTmpDir();
+    const env = makeEnv(tmp.path);
+    const { write, lines } = capture();
+    const code = await runStatus([], { env, write, now: () => 1_000_000 });
+    expect(code).toBe(0);
+    expect(lines.join("\n")).toContain("<not running>");
+    expect(lines.join("\n")).toContain("<missing");
+  });
+
+  it("reports last-run + next-in when state present", async () => {
+    const tmp = useTmpDir();
+    const env = makeEnv(tmp.path);
+    writeDaemonConfig(
+      buildDaemonConfig({
+        treePath: "/x",
+        codeRepos: ["a/b"],
+        gardenerIntervalMs: 300_000,
+        syncIntervalMs: 3_600_000,
+      }),
+      env,
+    );
+    updateSweepState(env, "gardener", {
+      lastRunAt: 900_000,
+      outcome: "handled",
+      summary: "repos=1 handled=1",
+    });
+    const { write, lines } = capture();
+    await runStatus([], { env, write, now: () => 1_000_000 });
+    const body = lines.join("\n");
+    expect(body).toContain("gardener-sweep: last handled");
+    expect(body).toContain("repos=1 handled=1");
+    expect(body).toContain("next in");
+  });
+});
+
+describe("gardener daemon -- start --dry-run", () => {
+  it("writes config without booting daemon", async () => {
+    const tmp = useTmpDir();
+    const env = makeEnv(tmp.path);
+    const { write, lines } = capture();
+    const code = await runStart(
+      [
+        "--tree-path",
+        tmp.path,
+        "--code-repo",
+        "a/b",
+        "--code-repo",
+        "c/d",
+        "--gardener-interval",
+        "10m",
+        "--sync-interval",
+        "2h",
+        "--assign-owners",
+        "--dry-run",
+      ],
+      { env, write },
+    );
+    expect(code).toBe(0);
+    const config = loadDaemonConfig(env);
+    expect(config?.codeRepos).toEqual(["a/b", "c/d"]);
+    expect(config?.gardenerIntervalMs).toBe(600_000);
+    expect(config?.syncIntervalMs).toBe(7_200_000);
+    expect(config?.assignOwners).toBe(true);
+    expect(lines.some((l) => l.includes("not booting"))).toBe(true);
+  });
+
+  it("rejects missing --tree-path", async () => {
+    const tmp = useTmpDir();
+    const env = makeEnv(tmp.path);
+    const { write, lines } = capture();
+    const code = await runStart(["--code-repo", "a/b", "--dry-run"], {
+      env,
+      write,
+    });
+    expect(code).toBe(1);
+    expect(lines.some((l) => l.includes("--tree-path is required"))).toBe(true);
+  });
+
+  it("rejects bad --gardener-interval", async () => {
+    const tmp = useTmpDir();
+    const env = makeEnv(tmp.path);
+    const { write, lines } = capture();
+    const code = await runStart(
+      [
+        "--tree-path",
+        tmp.path,
+        "--code-repo",
+        "a/b",
+        "--gardener-interval",
+        "zzz",
+        "--dry-run",
+      ],
+      { env, write },
+    );
+    expect(code).toBe(1);
+    expect(lines.some((l) => l.includes("--gardener-interval"))).toBe(true);
+  });
+});
+
+describe("gardener daemon -- stop idempotency", () => {
+  it("reports nothing to stop on a clean state", async () => {
+    const tmp = useTmpDir();
+    const env = makeEnv(tmp.path);
+    const { write, lines } = capture();
+    const code = await runStop([], { env, write });
+    expect(code).toBe(0);
+    if (process.platform !== "darwin") {
+      expect(lines.some((l) => l.includes("nothing to stop"))).toBe(true);
+    }
+  });
+
+  it("clears the pid from state", async () => {
+    const tmp = useTmpDir();
+    const env = makeEnv(tmp.path);
+    // Use a PID that definitely doesn't exist to avoid signaling real processes.
+    writeDaemonState({ pid: 2_147_483_646, startedAt: 1, sweeps: {} }, env);
+    const { write } = capture();
+    await runStop([], { env, write });
+    const state = loadDaemonState(env);
+    expect(state.pid).toBeUndefined();
+  });
+});
+
+describe("gardener daemon -- launchd helpers", () => {
+  it("sanitizes label segments", () => {
+    expect(sanitizeLabelSegment("alice")).toBe("alice");
+    expect(sanitizeLabelSegment("alice/bob")).toBe("alice_bob");
+    expect(sanitizeLabelSegment("alice@example.com")).toBe("alice_example.com");
+  });
+
+  it("builds a namespaced label", () => {
+    expect(gardenerLaunchdLabel("alice")).toBe("com.first-tree.gardener.alice");
+  });
+
+  it("renders a plist with escaped args + env", () => {
+    const plist = renderLaunchdPlist({
+      label: "com.first-tree.gardener.alice",
+      executable: "/usr/bin/node",
+      arguments: ["/cli.js", "gardener", "daemon"],
+      logPath: "/tmp/log.log",
+      env: { HOME: "/Users/alice", PATH: "/usr/bin" },
+      workingDirectory: "/Users/alice/tree",
+    });
+    expect(plist).toContain("<string>com.first-tree.gardener.alice</string>");
+    expect(plist).toContain("<string>/usr/bin/node</string>");
+    expect(plist).toContain("<string>gardener</string>");
+    expect(plist).toContain("<string>daemon</string>");
+    expect(plist).toContain("<key>HOME</key>");
+    expect(plist).toContain("<string>/Users/alice</string>");
+    expect(plist).toContain("<key>WorkingDirectory</key>");
+    expect(plist).toContain("<key>RunAtLoad</key>");
+    expect(plist).toContain("<key>KeepAlive</key>");
+  });
+});


### PR DESCRIPTION
## Summary

The long-missing gardener daemon — a CLI-launched background process that monitors several code repos at once and runs both the verdict-comment and drift-detection sweeps on a schedule.

Independent of breeze: own state directory (`~/.gardener/`), own launchd plist namespace (`com.first-tree.gardener.<user>`), own config + state files. Composes with the multi `target_repos` work in #241 and the sync namespace move in #242.

## Subcommands added to `first-tree gardener`

| Command | Purpose |
|---|---|
| `start --tree-path … --code-repo … [--code-repo …] [--gardener-interval 5m] [--sync-interval 1h] [--assign-owners] [--sync-apply]` | Writes `~/.gardener/config.json`, then `launchctl bootstrap` (macOS) or detached spawn. `--dry-run` writes the config without booting. |
| `stop` | `launchctl bootout` + remove plist on macOS, SIGTERM otherwise. Idempotent. |
| `status` | Pid/uptime + configured schedule + last outcome / next-due per sweep. Read-only. |
| `run-once` | Fires both sweeps inline. Useful for cron-style deployments and pipeline smoke. |
| `daemon` | Foreground tick loop invoked by `start`. ~30s tick. For each due sweep spawns `first-tree gardener comment --merged-since 2×interval [--assign-owners]` or `first-tree gardener sync [--apply]` against the configured tree path; parses the `BREEZE_RESULT` trailer; persists outcome. |

## On-disk layout (overridable via `$GARDENER_DIR` for tests)

```
~/.gardener/
├── config.json                # persisted schedule + repos
├── state.json                 # pid, last sweep outcomes
├── daemon.log                 # tick log
├── logs/
│   └── gardener-daemon-<ts>.log   # stdout/stderr from launchd
└── launchd/
    └── com.first-tree.gardener.<user>.plist
```

## Dependencies

- `--merged-since` flag and multi `target_repos` scan dispatch from #241.
- `gardener sync` subcommand from #242. (If #242 hasn't merged when this lands, the sync sweep would call `first-tree gardener sync` and that subcommand needs to exist.)

So the suggested merge order is: **#241 → #242 → #243 (this PR)**.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm exec vitest run` — 1040 pass / 51 skipped
- [x] 27 new tests in `tests/gardener/gardener-daemon.test.ts`:
  - parseDurationMs (3): s/m/h/d, bare ints, junk
  - config I/O (4): GARDENER_DIR override, round-trip, missing-file null, relative tree-path absolutized
  - state helpers (4): isSweepDue (never run, before, after), updateSweepState round-trip
  - sweep arg builders (2): --assign-owners + --apply gating
  - parseBreezeResult (2): extract trailer, null on no trailer
  - runOnce dispatch (2): both sweeps + state update; no-config friendly fail
  - status (2): empty + populated cases
  - start (3): --dry-run writes config; missing --tree-path; bad --gardener-interval
  - stop (2): idempotency on clean state; pid cleared
  - launchd helpers (3): sanitize, label, plist render with escapes
- [ ] Manual: `gardener start --dry-run …` then `gardener status` then `gardener stop` on a real laptop
- [ ] Manual on a real macOS box: `gardener start … && tail -f ~/.gardener/daemon.log` to see one tick complete