### PR TITLE
feat: make tree bindings URL-first

### DIFF
--- a/.first-tree/source.json
+++ b/.first-tree/source.json
@@ -2,15 +2,14 @@
   "bindingMode": "shared-source",
   "rootKind": "git-repo",
   "scope": "repo",
-  "sourceId": "first-tree-b27f27a6",
+  "sourceId": "github-com-agent-team-foundation-first-tree",
   "sourceName": "first-tree",
   "tree": {
     "entrypoint": "/repos/first-tree",
-    "localPath": "../first-tree-context",
     "remoteUrl": "https://github.com/agent-team-foundation/first-tree-context",
     "treeId": "first-tree-context",
     "treeMode": "shared",
     "treeRepoName": "first-tree-context"
   },
-  "schemaVersion": 1
+  "schemaVersion": 3
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,8 +141,8 @@ FIRST-TREE-SOURCE-STATE: `.first-tree/source.json`
 
 ### Before every task
 
-- Read `.first-tree/source.json` first. If it exists, resolve its `tree.localPath` value from this repo root and treat that checkout as the canonical local tree repo.
-- If that configured checkout exists locally, update it before you read anything else.
+- Read `.first-tree/source.json` first. Use its recorded tree repo URL and tree repo name as the source of truth for which Context Tree this repo belongs to.
+- If you already have that tree repo cloned locally, update it before you read anything else.
 - If the configured checkout is missing, clone a temporary working copy from `https://github.com/agent-team-foundation/first-tree-context` into `.first-tree/tmp/first-tree-context/`, use it for the current task, and delete it before you finish.
 - Never commit anything under `.first-tree/tmp/` to this repo. It is local-only workspace state.
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -72,6 +72,7 @@ ships.
   bound Context Tree repo.
 - Treat `source-repos.md` as generated output; tree-side truth still lives in
   `.first-tree/tree.json` and `.first-tree/bindings/`. Source-side truth
-  lives in `.first-tree/source.json` and `.first-tree/local-tree.json`.
+  lives in `.first-tree/source.json`, while local temporary checkouts stay
+  under `.first-tree/tmp/`.
 - When the binding schema or install contract changes, update the tree node,
   source docs, code, and tests together.

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -70,7 +70,7 @@ docs below only for source-repo implementation details.
 | `src/products/tree/engine/runtime/local-tree-config.ts` | Local tree config helpers (delegates to `source.json`) |
 | `src/products/tree/engine/runtime/source-repo-index.ts` | Generated `source-repos.md` index plus root tree repo guidance |
 | `src/products/tree/engine/runtime/source-integration.ts` | Managed `AGENTS.md` / `CLAUDE.md` source integration block |
-| `src/products/tree/engine/workspace.ts` | Child repo / submodule discovery |
+| `src/products/tree/engine/workspace.ts` | Local child-repo discovery for workspace roots |
 
 ## Validation
 

--- a/skills/first-tree/references/onboarding.md
+++ b/skills/first-tree/references/onboarding.md
@@ -22,7 +22,7 @@ That model supports all of these cases cleanly:
 - a single repo with its own dedicated tree
 - a repo that should reuse an existing shared tree
 - a non-git workspace folder containing many repos
-- a git workspace root repo containing many child repos or submodules
+- a git workspace root repo containing many child repos
 
 ## Step 1: Inspect First
 
@@ -39,7 +39,7 @@ This tells the agent whether the current root is:
 - a `workspace-repo`
 - a `workspace-folder`
 
-It also reports discovered child repos / submodules plus any existing
+It also reports discovered local child repos plus any existing
 `.first-tree/source.json`, `.first-tree/tree.json`,
 and `.first-tree/bindings/` state.
 
@@ -93,18 +93,19 @@ If the user gives only a remote URL:
 first-tree tree bind --tree-url git@github.com:acme/org-context.git --tree-mode shared
 ```
 
-`bind` will clone a local checkout if needed, then:
+`bind` will use the tree checkout you pointed at, or clone a temporary local
+checkout under `.first-tree/tmp/` when you provide only a remote URL. Then it will:
 
 - install local skill integration in the current repo
 - install the bundled `first-tree` skill in the tree repo if it is missing
 - refresh `AGENTS.md` and `CLAUDE.md`
-- write `.first-tree/source.json` (includes tree localPath)
+- write `.first-tree/source.json` (tree repo identity + published URL when known)
 - write `.first-tree/tree.json` and `.first-tree/bindings/<source-id>.json`
 - refresh the tree repo's `source-repos.md` index plus root repo-discovery guidance
 
 ### Case C: Workspace Root + Shared Tree
 
-If the current root contains many child repos or submodules, onboard the whole
+If the current root contains many child repos, onboard the whole
 workspace with one shared tree:
 
 ```bash
@@ -217,7 +218,7 @@ first-tree tree publish
 
 - it creates or reuses the GitHub tree remote
 - it pushes the tree commits
-- it refreshes any locally bound source/workspace repos with the published tree URL
+- it refreshes any explicit or locally discoverable source/workspace repos with the published tree URL
 - if exactly one source/workspace repo is being refreshed, it can still open a PR there with `--open-pr`
 
 For shared trees bound to multiple repos, `publish` refreshes all local bindings
@@ -227,9 +228,8 @@ but does not try to open many code PRs automatically.
 
 - Start from `.first-tree/source.json` in the current source/workspace root.
 - If you are starting from the tree repo itself, use `source-repos.md` as the quick index of bound source/workspace repos and their GitHub URLs, while treating `.first-tree/bindings/` as the canonical machine-readable source of truth.
-- Resolve the recorded `localPath`.
-- If the checkout is missing but the tree has been published, create a temporary
-  clone under `.first-tree/tmp/`.
+- Use the recorded tree repo name + GitHub URL as the source of truth for which tree this repo belongs to.
+- If you already have that tree repo cloned locally, use it; otherwise, if the tree has been published, create a temporary clone under `.first-tree/tmp/`.
 - At task close-out, always ask whether the tree needs updating.
 
 ## Sample Tasks After Onboarding

--- a/skills/first-tree/references/source-workspace-installation.md
+++ b/skills/first-tree/references/source-workspace-installation.md
@@ -76,7 +76,7 @@ Do not recreate a new sibling tree repo when the user already has a shared tree
 they want to keep using.
 
 Whenever a git-backed source/workspace root is bound, keep the binding metadata
-pointing at the tree checkout and published tree URL. The tree repo may also
+pointing at the tree repo name and published tree URL. The tree repo may also
 refresh `source-repos.md` plus lightweight root guidance derived from those
 bindings, but `.first-tree/bindings/` remains the canonical machine-readable
 source of truth. Do not create hidden codebase mirrors in the tree repo by
@@ -84,13 +84,13 @@ default.
 
 ## Workspace Rule
 
-If the current root contains many child repos or submodules:
+If the current root contains many child repos:
 
 - the workspace root should get local first-tree integration
 - all child repos should bind to the same shared tree
 - child repos should not each create their own separate tree repos
 
-Only real child git repos / submodules should be synced automatically. Plain
+Only real child git repos should be synced automatically. Plain
 package folders that are not repos do not get repo-level binding metadata.
 
 ## Verification And Upgrade
@@ -108,7 +108,7 @@ package folders that are not repos do not get repo-level binding metadata.
 `first-tree tree publish` is tree-centric:
 
 - it publishes the tree repo
-- it refreshes locally bound source/workspace repos with the published tree URL
+- it refreshes any explicit or locally discoverable source/workspace repos with the published tree URL
 - it opens a code PR only when exactly one source/workspace repo is being refreshed
 
 That keeps shared trees workable for multi-repo workspaces without forcing

--- a/skills/first-tree/references/upgrade-contract.md
+++ b/skills/first-tree/references/upgrade-contract.md
@@ -79,7 +79,7 @@ metadata such as `.first-tree/VERSION` plus the installed tree-repo skill.
 - tree content: `NODE.md`, domains, members, leaf nodes
 - user-authored content outside the managed framework markers
 - source/workspace binding metadata
-- local checkout guidance in `.first-tree/source.json`
+- tree repo identity metadata in `.first-tree/source.json`
 
 ## Command Intent
 
@@ -94,10 +94,10 @@ metadata such as `.first-tree/VERSION` plus the installed tree-repo skill.
 - `first-tree tree bind`
   - connect a source/workspace root to an existing tree repo
 - `first-tree tree workspace sync`
-  - bind child repos to the same shared tree
+  - bind discovered local child repos to the same shared tree
 - `first-tree tree publish`
   - publish the tree repo
-  - refresh locally bound source/workspace repos with the published URL
+  - refresh any explicit or locally discoverable source/workspace repos with the published URL
 - `first-tree tree verify`
   - validate the tree repo
 - `first-tree tree upgrade`

--- a/skills/tree/SKILL.md
+++ b/skills/tree/SKILL.md
@@ -39,7 +39,7 @@ Most commands accept or classify one of these three shapes.
 3. If they do, use `first-tree tree bind`.
 4. If they do not, use `first-tree tree init`.
 5. If the current root is a workspace, run `first-tree tree workspace sync` so
-   all child repos bind to the same shared tree.
+   all discovered local child repos bind to the same shared tree.
 
 During `bind` / `init`, the CLI also ensures the tree repo has the bundled
 `first-tree` skill installed and refreshes binding metadata in both locations.
@@ -48,15 +48,15 @@ During `bind` / `init`, the CLI also ensures the tree repo has the bundled
 
 | Command | Purpose |
 |---|---|
-| `first-tree tree inspect` | Classify the current folder and report bindings / child repos |
+| `first-tree tree inspect` | Classify the current folder and report bindings / locally discovered child repos |
 | `first-tree tree status` | Alias for `inspect` (human-friendly name) |
 | `first-tree tree init` | High-level onboarding wrapper for single repos, shared trees, and workspace roots |
 | `first-tree tree bootstrap` | Low-level tree bootstrap for an explicit tree checkout |
 | `first-tree tree bind` | Bind the current repo/workspace root to an existing tree repo |
-| `first-tree tree workspace sync` | Bind child repos to the same shared tree |
+| `first-tree tree workspace sync` | Bind discovered local child repos to the same shared tree |
 | `first-tree tree verify` | Validate a tree repo: frontmatter, owners, soft_links, members, progress |
 | `first-tree tree upgrade` | Refresh the installed skill payloads or tree metadata from the bundled package |
-| `first-tree tree publish` | Publish a tree repo to GitHub and refresh locally bound source/workspace repos |
+| `first-tree tree publish` | Publish a tree repo to GitHub and refresh any explicit or locally discoverable source/workspace repos |
 | `first-tree tree review` | CI helper: run Claude Code PR review against tree changes |
 | `first-tree tree generate-codeowners` | Regenerate `.github/CODEOWNERS` from tree ownership |
 | `first-tree tree invite` | Invite a new member to the Context Tree (human, personal_assistant, or autonomous_agent) |

--- a/src/products/tree/README.md
+++ b/src/products/tree/README.md
@@ -25,8 +25,8 @@ tree/
 | `first-tree tree init` | High-level onboarding wrapper |
 | `first-tree tree bootstrap` | Canonical low-level tree bootstrap for an explicit tree checkout |
 | `first-tree tree bind` | Bind current repo/workspace to an existing tree |
-| `first-tree tree workspace sync` | Bind discovered child repos to a shared tree |
-| `first-tree tree publish` | Push the tree to GitHub and refresh bound sources |
+| `first-tree tree workspace sync` | Bind discovered local child repos to a shared tree |
+| `first-tree tree publish` | Push the tree to GitHub and refresh any explicit or locally discoverable bound sources |
 | `first-tree tree verify` | Run validation checks on a tree repo |
 | `first-tree tree upgrade` | Refresh installed source/tree integration from the package |
 | `first-tree tree generate-codeowners` | Generate `.github/CODEOWNERS` from tree ownership |

--- a/src/products/tree/cli.ts
+++ b/src/products/tree/cli.ts
@@ -18,7 +18,7 @@ Commands:
   bootstrap             Low-level tree-repo bootstrap for an explicit tree checkout
   bind                  Bind the current repo/workspace root to an existing tree repo
   integrate             Install the first-tree skill and source-integration block without touching the tree repo
-  workspace             Workspace helpers (currently: sync child repos to a shared tree)
+  workspace             Workspace helpers (currently: sync discovered local child repos to a shared tree)
   publish               Publish a tree repo to GitHub
   verify                Run verification checks against a tree repo
   upgrade               Refresh source/workspace integration or tree metadata

--- a/src/products/tree/engine/bind.ts
+++ b/src/products/tree/engine/bind.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import { Repo } from "#products/tree/engine/repo.js";
 import {
@@ -29,10 +29,10 @@ import {
 } from "#products/tree/engine/runtime/adapters.js";
 import { syncTreeSourceRepoIndex } from "#products/tree/engine/runtime/source-repo-index.js";
 import {
+  tempLocalTreeRoot,
   upsertLocalTreeGitIgnore,
 } from "#products/tree/engine/runtime/local-tree-config.js";
 import { upsertFirstTreeIndexFile, upsertSourceIntegrationFiles } from "#products/tree/engine/runtime/source-integration.js";
-import { relativeRepoPath } from "#products/tree/engine/dedicated-tree.js";
 
 export const BIND_USAGE = `usage: first-tree tree bind [--tree-path PATH | --tree-url URL] [--tree-mode dedicated|shared] [--mode standalone-source|shared-source|workspace-root|workspace-member] [--workspace-id ID] [--workspace-root PATH] [--entrypoint PATH]
 
@@ -45,7 +45,7 @@ What it does:
   4. Writes .first-tree/tree.json and .first-tree/bindings/<source-id>.json
      in the target tree repo, and refreshes source-repos.md plus root guidance
   5. Ensures the target tree repo also has the first-tree skill installed
-  6. Syncs the bound codebase repo into the tree repo under .first-tree/submodules/
+  6. Records only repo identity metadata (GitHub URLs + entrypoints), not local checkout paths
 
 Typical examples:
   first-tree tree bind --tree-path ../org-context --tree-mode shared
@@ -54,7 +54,7 @@ Typical examples:
 
 Options:
   --tree-path PATH      Local checkout of the tree repo to bind
-  --tree-url URL        Remote URL for the tree repo; if --tree-path is omitted, clone it to a sibling checkout
+  --tree-url URL        Remote URL for the tree repo; if --tree-path is omitted, clone it into .first-tree/tmp/
   --tree-mode MODE      dedicated or shared (default: infer)
   --mode MODE           standalone-source, shared-source, workspace-root, or workspace-member (default: infer)
   --workspace-id ID     Workspace identifier for workspace-root/member bindings
@@ -130,6 +130,7 @@ function cloneTreeCheckout(
   treeUrl: string,
   targetRoot: string,
 ): void {
+  mkdirSync(dirname(targetRoot), { recursive: true });
   runner("git", ["clone", treeUrl, targetRoot], {
     cwd: dirname(targetRoot),
   });
@@ -221,7 +222,7 @@ function ensureTreeCheckout(
 
   if (!resolvedTreeRoot && resolvedTreeUrl) {
     const inferredName = inferTreeRepoNameFromUrl(resolvedTreeUrl);
-    resolvedTreeRoot = join(dirname(sourceRepo.root), inferredName);
+    resolvedTreeRoot = tempLocalTreeRoot(cwd, inferredName);
     if (!existsSync(resolvedTreeRoot)) {
       cloneTreeCheckout(runner, resolvedTreeUrl, resolvedTreeRoot);
     }
@@ -385,14 +386,18 @@ export function runBind(repo?: Repo, options?: BindOptions): number {
     options?.workspaceRoot,
   );
   const rootKind: RootKind = sourceRepo.isGitRepo() ? "git-repo" : "folder";
-  const sourceId = buildStableSourceId(sourceRepo.root, sourceRepo.repoName());
+  const sourceRemoteUrl = sourceRepo.isGitRepo()
+    ? readGitRemoteUrl(runner, sourceRepo.root)
+    : null;
+  const sourceId = buildStableSourceId(sourceRepo.repoName(), {
+    fallbackRoot: sourceRepo.root,
+    remoteUrl: sourceRemoteUrl ?? undefined,
+  });
   const entrypoint = options?.entrypoint
     ?? deriveDefaultEntrypoint(bindingMode, sourceRepo.repoName(), workspaceId);
-  const localTreePath = relativeRepoPath(sourceRepo.root, treeResolution.treeRepo.root);
   const remoteUrl = treeResolution.treeUrl;
   const treeReference: BoundTreeReference = {
     entrypoint,
-    localPath: localTreePath,
     ...(remoteUrl ? { remoteUrl } : {}),
     treeId: buildTreeId(treeResolution.treeRepoName),
     treeMode,
@@ -434,9 +439,6 @@ export function runBind(repo?: Repo, options?: BindOptions): number {
       sourceName: sourceRepo.repoName(),
       tree: treeReference,
       workspaceId,
-      workspaceRootPath: workspaceRootPath
-        ? relativeRepoPath(sourceRepo.root, workspaceRootPath)
-        : undefined,
     });
 
     const existingTreeState = readTreeState(treeResolution.treeRepo.root);
@@ -448,9 +450,6 @@ export function runBind(repo?: Repo, options?: BindOptions): number {
       treeMode,
       treeRepoName: treeResolution.treeRepoName,
     });
-    const sourceRemoteUrl = sourceRepo.isGitRepo()
-      ? readGitRemoteUrl(runner, sourceRepo.root)
-      : null;
     writeTreeBinding(treeResolution.treeRepo.root, sourceId, {
       bindingMode,
       entrypoint,
@@ -459,13 +458,9 @@ export function runBind(repo?: Repo, options?: BindOptions): number {
       scope,
       sourceId,
       sourceName: sourceRepo.repoName(),
-      sourceRootPath: relativeRepoPath(treeResolution.treeRepo.root, sourceRepo.root),
       treeMode,
       treeRepoName: treeResolution.treeRepoName,
       workspaceId,
-      workspaceRootPath: workspaceRootPath
-        ? relativeRepoPath(treeResolution.treeRepo.root, workspaceRootPath)
-        : undefined,
     });
     const treeAgentHooks = ensureAgentContextHooks(treeResolution.treeRepo.root);
     const sourceRepoIndex = syncTreeSourceRepoIndex(treeResolution.treeRepo.root);
@@ -475,13 +470,11 @@ export function runBind(repo?: Repo, options?: BindOptions): number {
         workspaceRootPath,
         workspaceId,
         new Repo(workspaceRootPath).isGitRepo() ? "git-repo" : "folder",
-        {
-          ...treeReference,
-          localPath: relativeRepoPath(workspaceRootPath, treeResolution.treeRepo.root),
-        },
+        treeReference,
         {
           bindingMode: "workspace-member",
-          relativePath: relativeRepoPath(workspaceRootPath, sourceRepo.root),
+          entrypoint,
+          remoteUrl: sourceRemoteUrl ?? undefined,
           rootKind,
           sourceId,
           sourceName: sourceRepo.repoName(),

--- a/src/products/tree/engine/dedicated-tree.ts
+++ b/src/products/tree/engine/dedicated-tree.ts
@@ -5,7 +5,7 @@ import { readBootstrapState } from "#products/tree/engine/runtime/bootstrap.js";
 import { readSourceState } from "#products/tree/engine/runtime/binding-state.js";
 import {
   readLocalTreeConfig,
-  resolveConfiguredLocalTreePath,
+  resolveLocalTreeCheckout,
 } from "#products/tree/engine/runtime/local-tree-config.js";
 
 import {
@@ -277,9 +277,12 @@ export function resolveDedicatedTreeRepoForSource(
 
 function localCandidatePaths(sourceRepo: Repo, extraNames: string[] = []): string[] {
   const paths = new Set<string>();
-  const configuredLocalPath = resolveConfiguredLocalTreePath(sourceRepo.root);
-  if (configuredLocalPath !== null && isGitRepoPath(configuredLocalPath)) {
-    paths.add(configuredLocalPath);
+  const resolvedCheckout = resolveLocalTreeCheckout(sourceRepo.root, undefined, {
+    materialize: false,
+    refresh: false,
+  });
+  if (resolvedCheckout !== null && isGitRepoPath(resolvedCheckout.path)) {
+    paths.add(resolvedCheckout.path);
   }
   for (const treeRepoName of [
     ...extraNames,
@@ -333,10 +336,12 @@ function inspectExistingCandidate(
     const bootstrap = readBootstrapState(path);
     if (bootstrap !== null) {
       bootstrapTreeRepoName = bootstrap.treeRepoName;
-      const resolvedSourceRoot = resolve(path, bootstrap.sourceRepoPath);
-      bootstrapMatchesSource =
-        resolvedSourceRoot === sourceRepo.root
-        || bootstrap.sourceRepoName === sourceRepo.repoName();
+      bootstrapMatchesSource = bootstrap.sourceRepoName === sourceRepo.repoName();
+      if (bootstrap.sourceRepoPath) {
+        const resolvedSourceRoot = resolve(path, bootstrap.sourceRepoPath);
+        bootstrapMatchesSource = bootstrapMatchesSource
+          || resolvedSourceRoot === sourceRepo.root;
+      }
     }
   }
 

--- a/src/products/tree/engine/init.ts
+++ b/src/products/tree/engine/init.ts
@@ -8,7 +8,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { runBind } from "#products/tree/engine/bind.js";
+import { readGitRemoteUrl, runBind } from "#products/tree/engine/bind.js";
 import {
   relativeRepoPath,
   resolveDedicatedTreeRepoForSource,
@@ -98,7 +98,7 @@ Default behavior:
     repo to it.
   - Workspace root (git repo with child repos or a plain folder containing
     child repos): installs local skill integration at the workspace root,
-    creates or reuses one shared tree checkout, then binds discovered child
+    creates or reuses one shared tree checkout, then binds discovered local child
     repos to that same tree.
   - Existing tree checkout or URL: binds the current repo/workspace root to
     the provided tree instead of creating a new sibling tree repo.
@@ -120,7 +120,7 @@ Options:
                              Seed initial \`members/*/NODE.md\` files from contributor history
   --tree-name NAME           Override the default sibling repo name (\`<repo>-tree\`)
   --tree-path PATH           Use an explicit local tree repo path
-  --tree-url URL             Bind to or clone an existing remote tree repo
+  --tree-url URL             Bind to an existing remote tree repo (uses a temporary local checkout when needed)
   --tree-mode MODE           dedicated or shared
   --scope MODE               repo or workspace
   --workspace-id ID          Workspace identifier for shared workspace onboarding
@@ -145,12 +145,29 @@ const TEMPLATE_MAP: TemplateTarget[] = [
 ];
 
 interface TaskListContext {
-  sourceRepoPath?: string;
   sourceRepoName?: string;
+  sourceRepoPath?: string;
+  sourceRepoRemoteUrl?: string;
   treeRepoName?: string;
   dedicatedTreeRepo?: boolean;
   frameworkVersionPath?: string;
   progressPath?: string;
+}
+
+function runInitCommandRunner(
+  command: string,
+  args: string[],
+  options: { cwd: string },
+): string {
+  return execFileSync(command, args, {
+    cwd: options.cwd,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      GIT_TERMINAL_PROMPT: "0",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
 }
 
 function installSkill(source: string, target: string): void {
@@ -200,8 +217,8 @@ export function formatTaskList(
         " in your source repositories.",
       "",
     );
-    if (context.sourceRepoPath) {
-      lines.push(`**Bootstrap source repo:** \`${context.sourceRepoPath}\``, "");
+    if (context.sourceRepoRemoteUrl) {
+      lines.push(`**Bootstrap source repo URL:** \`${context.sourceRepoRemoteUrl}\``, "");
     }
     if (context.sourceRepoName) {
       lines.push(
@@ -210,10 +227,10 @@ export function formatTaskList(
       );
       lines.push("## Source Workspace Workflow");
       lines.push(
-        `- [ ] When this initial tree version is ready, run \`first-tree tree publish --open-pr\` from this dedicated tree repo. It will create or reuse the GitHub \`*-tree\` repo, continue supporting older \`*-context\` repos, record the published tree GitHub URL back in \`${context.sourceRepoName}\`, refresh the local tree checkout config, and open the source/workspace PR.`,
+        `- [ ] When this initial tree version is ready, run \`first-tree tree publish --open-pr\` from this dedicated tree repo. It will create or reuse the GitHub \`*-tree\` repo, continue supporting older \`*-context\` repos, record the published tree GitHub URL back in \`${context.sourceRepoName}\`, and open the source/workspace PR when a local checkout is available.`,
       );
       lines.push(
-        `- [ ] After publish succeeds, treat the checkout recorded in \`${SOURCE_STATE}\` as the canonical local working copy for this tree. The bootstrap repo can be deleted when you no longer need it.`,
+        `- [ ] After publish succeeds, treat the tree repo URL recorded in \`${SOURCE_STATE}\` as the canonical source of truth. Local checkouts can live wherever is convenient on each machine.`,
       );
       lines.push("");
     }
@@ -330,7 +347,9 @@ export function runInit(repo?: Repo, options?: InitOptions): number {
         frameworkVersionPath: r.frameworkVersionPath(),
         progressPath: r.preferredProgressPath(),
         sourceRepoName: sourceRepo.repoName(),
-        sourceRepoPath: relativeRepoPath(r.root, sourceRepo.root),
+        sourceRepoRemoteUrl: sourceRepo.isGitRepo()
+          ? readGitRemoteUrl(runInitCommandRunner, sourceRepo.root) ?? undefined
+          : undefined,
         treeRepoName: initTarget.treeRepoName,
       }
     : {
@@ -506,7 +525,9 @@ export function runInit(repo?: Repo, options?: InitOptions): number {
   if (initTarget.dedicatedTreeRepo) {
     writeBootstrapState(r.root, {
       sourceRepoName: sourceRepo.repoName(),
-      sourceRepoPath: relativeRepoPath(r.root, sourceRepo.root),
+      sourceRepoRemoteUrl: sourceRepo.isGitRepo()
+        ? readGitRemoteUrl(runInitCommandRunner, sourceRepo.root) ?? undefined
+        : undefined,
       treeRepoName: initTarget.treeRepoName,
     });
   }

--- a/src/products/tree/engine/inspect.ts
+++ b/src/products/tree/engine/inspect.ts
@@ -20,7 +20,7 @@ Inspect the current folder and report how first-tree would classify it.
 Output includes:
   - resolved root and whether it is a git repo or plain folder
   - whether the root looks like a tree repo, source repo, or workspace root
-  - discovered child repos / submodules for workspace onboarding
+  - discovered local child git repos for workspace onboarding
   - any existing first-tree binding metadata
   - managed Claude Code / Codex agent context hook health
 
@@ -100,6 +100,9 @@ export function runInspect(repo?: Repo, json = false): number {
   if (inspection.sourceState !== null) {
     console.log(`  Binding mode:   ${inspection.sourceState.bindingMode}`);
     console.log(`  Tree repo:      ${inspection.sourceState.tree.treeRepoName}`);
+    if (inspection.sourceState.tree.remoteUrl) {
+      console.log(`  Tree repo URL:  ${inspection.sourceState.tree.remoteUrl}`);
+    }
   } else if (inspection.treeState !== null) {
     console.log(`  Tree mode:      ${inspection.treeState.treeMode}`);
     console.log(`  Tree repo:      ${inspection.treeState.treeRepoName}`);

--- a/src/products/tree/engine/integrate.ts
+++ b/src/products/tree/engine/integrate.ts
@@ -8,9 +8,7 @@ import {
   inferTreeMode,
   readGitRemoteUrl,
   resolveWorkspaceId,
-  resolveWorkspaceRootPath,
 } from "#products/tree/engine/bind.js";
-import { relativeRepoPath } from "#products/tree/engine/dedicated-tree.js";
 import { Repo } from "#products/tree/engine/repo.js";
 import {
   ensureAgentContextHooks,
@@ -205,24 +203,22 @@ export function runIntegrate(options: IntegrateOptions): number {
     bindingMode,
     options.workspaceId,
   );
-  const workspaceRootPath = resolveWorkspaceRootPath(
-    cwd,
-    sourceRepo,
-    bindingMode,
-    options.workspaceRoot,
-  );
   const rootKind: RootKind = sourceRepo.isGitRepo() ? "git-repo" : "folder";
-  const sourceId = buildStableSourceId(sourceRepo.root, sourceRepo.repoName());
+  const sourceRemoteUrl = sourceRepo.isGitRepo()
+    ? readGitRemoteUrl(runner, sourceRepo.root)
+    : null;
+  const sourceId = buildStableSourceId(sourceRepo.repoName(), {
+    fallbackRoot: sourceRepo.root,
+    remoteUrl: sourceRemoteUrl ?? undefined,
+  });
   const entrypoint = options.entrypoint
     ?? deriveDefaultEntrypoint(
       bindingMode,
       sourceRepo.repoName(),
       workspaceId,
     );
-  const localTreePath = relativeRepoPath(sourceRepo.root, treeRepo.root);
   const treeReference: BoundTreeReference = {
     entrypoint,
-    localPath: localTreePath,
     ...(resolvedTreeUrl ? { remoteUrl: resolvedTreeUrl } : {}),
     treeId: buildTreeId(treeRepoName),
     treeMode,
@@ -266,9 +262,6 @@ export function runIntegrate(options: IntegrateOptions): number {
       sourceName: sourceRepo.repoName(),
       tree: treeReference,
       workspaceId,
-      workspaceRootPath: workspaceRootPath
-        ? relativeRepoPath(sourceRepo.root, workspaceRootPath)
-        : undefined,
     });
 
     if (firstTreeIndex.action === "created") {

--- a/src/products/tree/engine/publish.ts
+++ b/src/products/tree/engine/publish.ts
@@ -4,7 +4,6 @@ import { dirname, join, resolve } from "node:path";
 import {
   formatDedicatedTreePathExample,
   inferSourceRepoNameFromTreeRepoName,
-  relativeRepoPath,
 } from "#products/tree/engine/dedicated-tree.js";
 import { Repo } from "#products/tree/engine/repo.js";
 import {
@@ -38,8 +37,8 @@ import {
 
 export const PUBLISH_USAGE = `usage: first-tree tree publish [--open-pr] [--tree-path PATH] [--source-repo PATH] [--source-remote NAME]
 
-Publish a Context Tree repo to GitHub and refresh any bound source/workspace
-repos with the published tree URL. This is the networked second-stage command
+Publish a Context Tree repo to GitHub and refresh any explicit or locally
+discoverable bound source/workspace repos with the published tree URL. This is the networked second-stage command
 after \`first-tree tree init\` / \`first-tree tree bind\`, run from the tree repo (or
 pointed at one with --tree-path).
 
@@ -49,18 +48,19 @@ What it does:
   2. Creates the GitHub tree repo if it doesn't exist (reuses an existing
      remote when already bound)
   3. Pushes the local tree commits via the \`gh\` CLI
-  4. Refreshes each bound source/workspace repo's
+  4. Refreshes each explicit or locally discoverable source/workspace repo's
      \`FIRST-TREE-SOURCE-INTEGRATION:\` block and \`.first-tree/source.json\`
      when that source/workspace repo is available locally
   5. Optionally opens a PR in the source repo when exactly one source repo is
      being refreshed
 
 Requires the \`gh\` CLI installed and authenticated. Requires the source repo
-to be discoverable (bound locally, sibling directory, or --source-repo PATH).
+to be discoverable locally (for example via --source-repo PATH or a sibling
+checkout that matches the binding metadata).
 
-After publish succeeds, the canonical local working copy of the tree is the
-checkout recorded in \`.first-tree/source.json\` inside the source repo.
-The temporary sibling bootstrap checkout can be deleted.
+After publish succeeds, the canonical shared identity is the published tree URL
+recorded in each bound source repo. Local checkouts can live wherever is
+convenient on each machine.
 
 Options:
   --open-pr               Open a PR in the source/workspace repo after pushing the branch
@@ -197,6 +197,18 @@ function parseGitHubRemote(url: string): GitHubRemote | null {
   };
 }
 
+function remoteUrlsMatch(left: string | null, right: string | undefined): boolean {
+  if (!left || !right) {
+    return false;
+  }
+  const leftGitHub = parseGitHubRemote(left);
+  const rightGitHub = parseGitHubRemote(right);
+  if (leftGitHub && rightGitHub) {
+    return leftGitHub.slug.toLowerCase() === rightGitHub.slug.toLowerCase();
+  }
+  return left.trim().replace(/\.git$/u, "") === right.trim().replace(/\.git$/u, "");
+}
+
 function visibilityFlag(
   visibility: GitHubRepoMetadata["visibility"],
 ): "--internal" | "--private" | "--public" {
@@ -297,6 +309,7 @@ function commitTreeState(
 
 function resolveBoundSourceRepoRoots(
   treeRepo: Repo,
+  runner: CommandRunner,
   options?: PublishOptions,
 ): string[] {
   const cwd = options?.currentCwd ?? process.cwd();
@@ -307,24 +320,57 @@ function resolveBoundSourceRepoRoots(
 
   const bindings = listTreeBindings(treeRepo.root);
   if (bindings.length > 0) {
-    return [...new Set(bindings.map((binding) =>
-      resolve(treeRepo.root, binding.sourceRootPath)
-    ))];
+    const candidates = bindings
+      .map((binding) => {
+        const siblingRoot = join(dirname(treeRepo.root), binding.sourceName);
+        const siblingRepo = new Repo(siblingRoot);
+        if (!siblingRepo.isGitRepo()) {
+          return null;
+        }
+        if (
+          binding.remoteUrl
+          && !remoteUrlsMatch(getGitRemoteUrl(runner, siblingRoot, "origin"), binding.remoteUrl)
+        ) {
+          return null;
+        }
+        return siblingRoot;
+      })
+      .filter((candidate): candidate is string => candidate !== null);
+    return [...new Set(candidates)];
   }
 
   const bootstrap = readBootstrapState(treeRepo.root);
-  if (bootstrap !== null) {
+  if (bootstrap?.sourceRepoPath) {
     return [resolve(treeRepo.root, bootstrap.sourceRepoPath)];
+  }
+  if (bootstrap !== null) {
+    const siblingRoot = join(dirname(treeRepo.root), bootstrap.sourceRepoName);
+    const siblingRepo = new Repo(siblingRoot);
+    if (
+      siblingRepo.isGitRepo()
+      && (
+        !bootstrap.sourceRepoRemoteUrl
+        || remoteUrlsMatch(
+          getGitRemoteUrl(runner, siblingRoot, "origin"),
+          bootstrap.sourceRepoRemoteUrl,
+        )
+      )
+    ) {
+      return [siblingRoot];
+    }
   }
 
   const inferredSourceRepoName = inferSourceRepoNameFromTreeRepoName(
     treeRepo.repoName(),
   );
   if (inferredSourceRepoName !== null) {
-    return [join(
+    const siblingRoot = join(
       dirname(treeRepo.root),
       inferredSourceRepoName,
-    )];
+    );
+    if (new Repo(siblingRoot).isGitRepo()) {
+      return [siblingRoot];
+    }
   }
 
   return [];
@@ -332,9 +378,10 @@ function resolveBoundSourceRepoRoots(
 
 function resolvePrimarySourceRepoRoot(
   treeRepo: Repo,
+  runner: CommandRunner,
   options?: PublishOptions,
 ): string | null {
-  const resolvedRoots = resolveBoundSourceRepoRoots(treeRepo, options);
+  const resolvedRoots = resolveBoundSourceRepoRoots(treeRepo, runner, options);
   return resolvedRoots[0] ?? null;
 }
 
@@ -421,59 +468,10 @@ function ensureSourceBranch(
   return branch;
 }
 
-function defaultLocalTreeRoot(
-  sourceRepo: Repo,
-  treeRepoName: string,
-): string {
-  return join(dirname(sourceRepo.root), treeRepoName);
-}
-
-function ensureLocalTreeCheckout(
-  runner: CommandRunner,
-  sourceRepo: Repo,
-  treeRepo: Repo,
-  remoteUrl: string,
-): string {
-  const localTreeRoot = defaultLocalTreeRoot(sourceRepo, treeRepo.repoName());
-  if (localTreeRoot === treeRepo.root) {
-    return localTreeRoot;
-  }
-
-  if (!existsSync(localTreeRoot)) {
-    runner("git", ["clone", remoteUrl, localTreeRoot], {
-      cwd: dirname(sourceRepo.root),
-    });
-    return localTreeRoot;
-  }
-
-  const localTreeRepo = new Repo(localTreeRoot);
-  if (!localTreeRepo.isGitRepo()) {
-    throw new Error(
-      `Cannot use ${localTreeRoot} as the local tree checkout because that path already exists and is not a git repository.`,
-    );
-  }
-
-  const localOrigin = getGitRemoteUrl(runner, localTreeRoot, "origin");
-  if (localOrigin === null) {
-    throw new Error(
-      `Cannot reuse ${localTreeRoot} as the local tree checkout because it does not have an \`origin\` remote.`,
-    );
-  }
-  if (localOrigin !== remoteUrl) {
-    throw new Error(
-      `Cannot reuse ${localTreeRoot} as the local tree checkout because its \`origin\` remote does not match ${remoteUrl}.`,
-    );
-  }
-
-  runner("git", ["fetch", "origin"], { cwd: localTreeRoot });
-  return localTreeRoot;
-}
-
 function updateSourceWorkspaceIntegration(
   sourceRepo: Repo,
   treeRepo: Repo,
   treeRepoUrl: string,
-  localTreeRoot: string,
 ): {
   agentHookActions: ReturnType<typeof ensureAgentContextHooks>;
   gitIgnoreAction: "created" | "updated" | "unchanged";
@@ -484,7 +482,6 @@ function updateSourceWorkspaceIntegration(
   if (sourceState !== null) {
     const updatedTree = {
       ...sourceState.tree,
-      localPath: relativeRepoPath(sourceRepo.root, localTreeRoot),
       remoteUrl: treeRepoUrl,
       treeRepoName: treeRepo.repoName(),
     };
@@ -760,40 +757,46 @@ export function runPublish(repo?: Repo, options?: PublishOptions): number {
     return 1;
   }
 
-  const sourceRepoRoots = resolveBoundSourceRepoRoots(treeRepo, options);
-  if (sourceRepoRoots.length === 0) {
-    console.error(
-      "Error: could not determine any bound source/workspace repo for this tree. Re-run `first-tree tree bind` or `first-tree tree init` first, or pass `--source-repo PATH`.",
-    );
-    return 1;
+  const sourceRepoRoots = resolveBoundSourceRepoRoots(treeRepo, runner, options);
+  const primarySourceRepoRoot = resolvePrimarySourceRepoRoot(treeRepo, runner, options);
+  const bindings = listTreeBindings(treeRepo.root);
+  const bootstrap = readBootstrapState(treeRepo.root);
+  const primaryBoundRemoteUrl = bindings
+    .map((binding) => binding.remoteUrl)
+    .find((remoteUrl): remoteUrl is string => typeof remoteUrl === "string")
+    ?? bootstrap?.sourceRepoRemoteUrl
+    ?? undefined;
+
+  let sourceRepo: Repo | null = null;
+  if (primarySourceRepoRoot !== null) {
+    const candidate = new Repo(primarySourceRepoRoot);
+    if (!candidate.isGitRepo()) {
+      if (options?.sourceRepoPath) {
+        console.error(
+          `Error: the resolved primary source/workspace repo is not a git repository: ${primarySourceRepoRoot}`,
+        );
+        return 1;
+      }
+    } else if (candidate.root === treeRepo.root) {
+      console.error(
+        "Error: the source/workspace repo and dedicated tree repo resolved to the same path. `first-tree tree publish` expects two separate repos.",
+      );
+      return 1;
+    } else if (options?.sourceRepoPath && (
+      !candidate.hasCurrentInstalledSkill() || !candidate.hasSourceWorkspaceIntegration()
+    )) {
+      console.error(
+        "Error: the source/workspace repo does not have the first-tree source integration installed. Run `first-tree tree init` from the source/workspace repo first.",
+      );
+      return 1;
+    } else {
+      sourceRepo = candidate;
+    }
   }
 
-  const primarySourceRepoRoot = resolvePrimarySourceRepoRoot(treeRepo, options);
-  if (primarySourceRepoRoot === null) {
+  if (sourceRepoRoots.length === 0 && !primaryBoundRemoteUrl) {
     console.error(
-      "Error: could not resolve a primary source/workspace repo for publishing.",
-    );
-    return 1;
-  }
-
-  const sourceRepo = new Repo(primarySourceRepoRoot);
-  if (!sourceRepo.isGitRepo()) {
-    console.error(
-      `Error: the resolved primary source/workspace repo is not a git repository: ${primarySourceRepoRoot}`,
-    );
-    return 1;
-  }
-
-  if (sourceRepo.root === treeRepo.root) {
-    console.error(
-      "Error: the source/workspace repo and dedicated tree repo resolved to the same path. `first-tree tree publish` expects two separate repos.",
-    );
-    return 1;
-  }
-
-  if (!sourceRepo.hasCurrentInstalledSkill() || !sourceRepo.hasSourceWorkspaceIntegration()) {
-    console.error(
-      "Error: the source/workspace repo does not have the first-tree source integration installed. Run `first-tree tree init` from the source/workspace repo first.",
+      "Error: could not determine any bound source/workspace repo metadata for this tree. Re-run `first-tree tree bind` or `first-tree tree init` first, or pass `--source-repo PATH`.",
     );
     return 1;
   }
@@ -803,27 +806,31 @@ export function runPublish(repo?: Repo, options?: PublishOptions): number {
   try {
     console.log("Context Tree Publish\n");
     console.log(`  Tree repo:   ${treeRepo.root}`);
-    console.log(`  Primary source repo: ${sourceRepo.root}`);
-    console.log(`  Bound source roots:  ${sourceRepoRoots.length}\n`);
+    console.log(
+      `  Primary source repo: ${sourceRepo?.root ?? "(using binding metadata only)"}`,
+    );
+    console.log(`  Local bound source roots: ${sourceRepoRoots.length}\n`);
 
-    const sourceRemoteUrl = getGitRemoteUrl(runner, sourceRepo.root, sourceRemoteName);
+    const sourceRemoteUrl = sourceRepo
+      ? getGitRemoteUrl(runner, sourceRepo.root, sourceRemoteName)
+      : primaryBoundRemoteUrl ?? null;
     if (sourceRemoteUrl === null) {
       throw new Error(
-        `Could not read git remote \`${sourceRemoteName}\` from the source/workspace repo.`,
+        `Could not determine a GitHub remote for the source/workspace repo from either local checkout metadata or tree bindings.`,
       );
     }
 
     const sourceGitHub = parseGitHubRemote(sourceRemoteUrl);
     if (sourceGitHub === null) {
       throw new Error(
-        `The source/workspace remote \`${sourceRemoteName}\` is not a GitHub remote: ${sourceRemoteUrl}`,
+        `The source/workspace remote is not a GitHub remote: ${sourceRemoteUrl}`,
       );
     }
 
     const sourceMetadata = readGitHubRepoMetadata(
       runner,
       sourceGitHub.slug,
-      sourceRepo.root,
+      sourceRepo?.root ?? treeRepo.root,
     );
     const treeSlug = `${sourceGitHub.owner}/${treeRepo.repoName()}`;
     const treeAgentHooks = ensureAgentContextHooks(treeRepo.root);
@@ -863,39 +870,32 @@ export function runPublish(repo?: Repo, options?: PublishOptions): number {
         continue;
       }
 
-      const localTreeRoot = ensureLocalTreeCheckout(
-        runner,
-        boundSourceRepo,
-        treeRepo,
-        treeRemote.remoteUrl,
-      );
       const sourceIntegrationState = updateSourceWorkspaceIntegration(
         boundSourceRepo,
         treeRepo,
         treeRemote.remoteUrl,
-        localTreeRoot,
       );
       console.log(
         `  Recorded \`${treeRemote.remoteUrl}\` for ${boundSourceRepo.root}.`,
       );
       if (sourceIntegrationState.gitIgnoreAction === "created") {
-        console.log("    Created `.gitignore` entries for local tree checkout state.");
+        console.log("    Created `.gitignore` entries for local tree working state.");
       } else if (sourceIntegrationState.gitIgnoreAction === "updated") {
-        console.log("    Updated `.gitignore` for local tree checkout state.");
+        console.log("    Updated `.gitignore` for local tree working state.");
       }
       console.log(
         sourceIntegrationState.sourceStateAction === "created"
-          ? `    Created \`${SOURCE_STATE}\` for \`${relativeRepoPath(boundSourceRepo.root, localTreeRoot)}\`.`
+          ? `    Created \`${SOURCE_STATE}\` for \`${boundSourceRepo.root}\`.`
           : sourceIntegrationState.sourceStateAction === "updated"
-          ? `    Updated \`${SOURCE_STATE}\` for \`${relativeRepoPath(boundSourceRepo.root, localTreeRoot)}\`.`
-          : `    Reused the existing \`${SOURCE_STATE}\` entry for \`${relativeRepoPath(boundSourceRepo.root, localTreeRoot)}\`.`,
+          ? `    Updated \`${SOURCE_STATE}\` for \`${boundSourceRepo.root}\`.`
+          : `    Reused the existing \`${SOURCE_STATE}\` entry for \`${boundSourceRepo.root}\`.`,
       );
       for (const message of formatAgentContextHookMessages(sourceIntegrationState.agentHookActions)) {
         console.log(`    ${message}`);
       }
     }
 
-    if (sourceRepoRoots.length === 1) {
+    if (sourceRepoRoots.length === 1 && sourceRepo !== null) {
       const sourceBranch = ensureSourceBranch(
         runner,
         sourceRepo,
@@ -950,7 +950,9 @@ export function runPublish(repo?: Repo, options?: PublishOptions): number {
       }
     } else if (options?.openPr) {
       console.log(
-        "  Skipped `--open-pr` because this shared tree is bound to multiple source/workspace roots.",
+        sourceRepo === null
+          ? "  Skipped `--open-pr` because no local source/workspace checkout was available."
+          : "  Skipped `--open-pr` because this shared tree is bound to multiple source/workspace roots.",
       );
     }
 

--- a/src/products/tree/engine/repo.ts
+++ b/src/products/tree/engine/repo.ts
@@ -52,7 +52,6 @@ const EMPTY_REPO_ENTRY_ALLOWLIST = new Set([
   "README.txt",
 ]);
 const SOURCE_FILE_HINTS = new Set([
-  ".gitmodules",
   "Cargo.toml",
   "Dockerfile",
   "Gemfile",

--- a/src/products/tree/engine/runtime/asset-loader.ts
+++ b/src/products/tree/engine/runtime/asset-loader.ts
@@ -41,11 +41,9 @@ export const TREE_PROGRESS = join(TREE_RUNTIME_ROOT, "progress.md");
 export const TREE_BOOTSTRAP_STATE = join(TREE_RUNTIME_ROOT, "bootstrap.json");
 export const TREE_STATE = join(TREE_RUNTIME_ROOT, "tree.json");
 export const TREE_BINDINGS_DIR = join(TREE_RUNTIME_ROOT, "bindings");
-export const TREE_SUBMODULES_DIR = join(TREE_RUNTIME_ROOT, "submodules");
 export const TREE_SOURCE_REPOS_FILE = "source-repos.md";
 export const LOCAL_TREE_TEMP_ROOT = join(TREE_RUNTIME_ROOT, "tmp");
 export const SOURCE_STATE = join(TREE_RUNTIME_ROOT, "source.json");
-export const SOURCE_LOCAL_STATE = join(TREE_RUNTIME_ROOT, "source.local.json");
 
 export const SKILL_AGENTS_DIR = join(SKILL_ROOT, "agents");
 export const SKILL_REFERENCES_DIR = join(SKILL_ROOT, "references");

--- a/src/products/tree/engine/runtime/binding-state.ts
+++ b/src/products/tree/engine/runtime/binding-state.ts
@@ -6,6 +6,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { basename, dirname, join } from "node:path";
+import { parseGitHubRemoteUrl } from "#products/tree/engine/member-seeding.js";
 import {
   SOURCE_STATE,
   TREE_BINDINGS_DIR,
@@ -21,12 +22,14 @@ export type SourceBindingMode =
 export type RootKind = "git-repo" | "folder";
 export type SourceScope = "repo" | "workspace";
 
-const SCHEMA_VERSION = 2;
+const SCHEMA_VERSION = 3;
 
 export interface BoundTreeReference {
   entrypoint: string;
   lastReconciledAt?: string;
   lastReconciledSourceCommit?: string;
+  // Legacy compatibility: older installs persisted a shared local checkout path.
+  // New writes should omit this field.
   localPath?: string;
   remoteUrl?: string;
   treeId: string;
@@ -44,12 +47,16 @@ export interface SourceState {
   sourceName: string;
   tree: BoundTreeReference;
   workspaceId?: string;
+  // Legacy compatibility only. New writes should omit this field.
   workspaceRootPath?: string;
 }
 
 export interface WorkspaceMember {
   bindingMode: "workspace-member";
-  relativePath: string;
+  entrypoint: string;
+  // Legacy compatibility only. New writes should omit this field.
+  relativePath?: string;
+  remoteUrl?: string;
   rootKind: RootKind;
   sourceId: string;
   sourceName: string;
@@ -84,7 +91,8 @@ export interface TreeBindingState {
   scope: SourceScope;
   sourceId: string;
   sourceName: string;
-  sourceRootPath: string;
+  // Legacy compatibility only. New writes should omit these fields.
+  sourceRootPath?: string;
   treeMode: TreeMode;
   treeRepoName: string;
   workspaceId?: string;
@@ -120,9 +128,6 @@ function parseTreeReference(value: unknown): BoundTreeReference | null {
   ) {
     return null;
   }
-  if (value.localPath !== undefined && typeof value.localPath !== "string") {
-    return null;
-  }
   if (value.remoteUrl !== undefined && typeof value.remoteUrl !== "string") {
     return null;
   }
@@ -146,7 +151,6 @@ function parseTreeReference(value: unknown): BoundTreeReference | null {
       typeof value.lastReconciledSourceCommit === "string"
         ? value.lastReconciledSourceCommit
         : undefined,
-    localPath: value.localPath,
     remoteUrl: value.remoteUrl,
     treeId: value.treeId,
     treeMode: value.treeMode,
@@ -184,12 +188,6 @@ export function readSourceState(root: string): SourceState | null {
   if (parsed.workspaceId !== undefined && typeof parsed.workspaceId !== "string") {
     return null;
   }
-  if (
-    parsed.workspaceRootPath !== undefined
-    && typeof parsed.workspaceRootPath !== "string"
-  ) {
-    return null;
-  }
   let members: WorkspaceMember[] | undefined;
   if (Array.isArray(parsed.members)) {
     const parsedMembers: WorkspaceMember[] = [];
@@ -197,16 +195,27 @@ export function readSourceState(root: string): SourceState | null {
       if (
         !isObject(candidate)
         || candidate.bindingMode !== "workspace-member"
-        || typeof candidate.relativePath !== "string"
         || (candidate.rootKind !== "git-repo" && candidate.rootKind !== "folder")
         || typeof candidate.sourceId !== "string"
         || typeof candidate.sourceName !== "string"
       ) {
         return null;
       }
+      const entrypoint = typeof candidate.entrypoint === "string"
+        ? candidate.entrypoint
+        : deriveDefaultEntrypoint(
+          "workspace-member",
+          candidate.sourceName,
+          typeof parsed.workspaceId === "string" ? parsed.workspaceId : undefined,
+        );
+      if (candidate.remoteUrl !== undefined && typeof candidate.remoteUrl !== "string") {
+        return null;
+      }
       parsedMembers.push({
         bindingMode: "workspace-member",
-        relativePath: candidate.relativePath,
+        entrypoint,
+        remoteUrl:
+          typeof candidate.remoteUrl === "string" ? candidate.remoteUrl : undefined,
         rootKind: candidate.rootKind,
         sourceId: candidate.sourceId,
         sourceName: candidate.sourceName,
@@ -226,7 +235,6 @@ export function readSourceState(root: string): SourceState | null {
     sourceName: parsed.sourceName,
     tree,
     workspaceId: parsed.workspaceId,
-    workspaceRootPath: parsed.workspaceRootPath,
   };
 }
 
@@ -283,7 +291,12 @@ export function upsertWorkspaceMember(
       (candidate) => candidate.sourceId !== member.sourceId,
     ),
     member,
-  ].sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+  ].sort((left, right) => {
+    const nameOrder = left.sourceName.localeCompare(right.sourceName);
+    return nameOrder === 0
+      ? left.sourceId.localeCompare(right.sourceId)
+      : nameOrder;
+  });
   const existing = readSourceState(root);
   if (existing === null) {
     throw new Error("Cannot upsert workspace member without an existing source state");
@@ -354,7 +367,6 @@ export function readTreeBinding(
   if (
     typeof parsed.sourceId !== "string"
     || typeof parsed.sourceName !== "string"
-    || typeof parsed.sourceRootPath !== "string"
     || typeof parsed.entrypoint !== "string"
     || typeof parsed.treeRepoName !== "string"
     || (parsed.rootKind !== "git-repo" && parsed.rootKind !== "folder")
@@ -373,12 +385,6 @@ export function readTreeBinding(
     return null;
   }
   if (parsed.workspaceId !== undefined && typeof parsed.workspaceId !== "string") {
-    return null;
-  }
-  if (
-    parsed.workspaceRootPath !== undefined
-    && typeof parsed.workspaceRootPath !== "string"
-  ) {
     return null;
   }
   if (
@@ -409,11 +415,9 @@ export function readTreeBinding(
     scope: parsed.scope,
     sourceId: parsed.sourceId,
     sourceName: parsed.sourceName,
-    sourceRootPath: parsed.sourceRootPath,
     treeMode: parsed.treeMode,
     treeRepoName: parsed.treeRepoName,
     workspaceId: parsed.workspaceId,
-    workspaceRootPath: parsed.workspaceRootPath,
   };
 }
 
@@ -449,9 +453,41 @@ export function slugifyToken(text: string): string {
   return normalized === "" ? "workspace" : normalized;
 }
 
-export function buildStableSourceId(root: string, label?: string): string {
-  const base = slugifyToken(label ?? basename(root));
-  const digest = createHash("sha1").update(root).digest("hex").slice(0, 8);
+function normalizeRemoteForId(remoteUrl: string): string {
+  const parsed = parseGitHubRemoteUrl(remoteUrl);
+  if (parsed !== null) {
+    return [
+      parsed.host.toLowerCase(),
+      parsed.owner.toLowerCase(),
+      parsed.repo.toLowerCase(),
+    ].join("/");
+  }
+  return remoteUrl.trim().replace(/\.git$/u, "");
+}
+
+export function buildStableSourceId(
+  sourceName: string,
+  options?: {
+    fallbackRoot?: string;
+    remoteUrl?: string;
+  },
+): string {
+  if (options?.remoteUrl?.trim()) {
+    const normalizedRemote = normalizeRemoteForId(options.remoteUrl);
+    const parsed = parseGitHubRemoteUrl(options.remoteUrl);
+    if (parsed !== null) {
+      return slugifyToken(`${parsed.host}-${parsed.owner}-${parsed.repo}`);
+    }
+    const base = slugifyToken(sourceName);
+    const digest = createHash("sha1").update(normalizedRemote).digest("hex").slice(0, 8);
+    return `${base}-${digest}`;
+  }
+
+  const base = slugifyToken(sourceName || basename(options?.fallbackRoot ?? ""));
+  const digest = createHash("sha1")
+    .update(options?.fallbackRoot ?? sourceName)
+    .digest("hex")
+    .slice(0, 8);
   return `${base}-${digest}`;
 }
 

--- a/src/products/tree/engine/runtime/bootstrap.ts
+++ b/src/products/tree/engine/runtime/bootstrap.ts
@@ -7,7 +7,8 @@ import {
 
 export interface BootstrapState {
   sourceRepoName: string;
-  sourceRepoPath: string;
+  sourceRepoPath?: string;
+  sourceRepoRemoteUrl?: string;
   treeRepoName: string;
 }
 
@@ -23,14 +24,22 @@ export function readBootstrapState(root: string): BootstrapState | null {
       ) as Partial<BootstrapState>;
       if (
         typeof parsed.sourceRepoName !== "string"
-        || typeof parsed.sourceRepoPath !== "string"
         || typeof parsed.treeRepoName !== "string"
+        || (
+          parsed.sourceRepoPath !== undefined
+          && typeof parsed.sourceRepoPath !== "string"
+        )
+        || (
+          parsed.sourceRepoRemoteUrl !== undefined
+          && typeof parsed.sourceRepoRemoteUrl !== "string"
+        )
       ) {
         continue;
       }
       return {
         sourceRepoName: parsed.sourceRepoName,
         sourceRepoPath: parsed.sourceRepoPath,
+        sourceRepoRemoteUrl: parsed.sourceRepoRemoteUrl,
         treeRepoName: parsed.treeRepoName,
       };
     } catch {

--- a/src/products/tree/engine/runtime/local-tree-config.ts
+++ b/src/products/tree/engine/runtime/local-tree-config.ts
@@ -1,21 +1,19 @@
+import { execFileSync } from "node:child_process";
 import {
   existsSync,
+  mkdirSync,
   readFileSync,
   writeFileSync,
 } from "node:fs";
-import { join, resolve } from "node:path";
-import {
-  readSourceState,
-} from "#products/tree/engine/runtime/binding-state.js";
-import {
-  LOCAL_TREE_TEMP_ROOT,
-  SOURCE_LOCAL_STATE,
-} from "#products/tree/engine/runtime/asset-loader.js";
+import { dirname, join } from "node:path";
+import { Repo } from "#products/tree/engine/repo.js";
+import { parseGitHubRemoteUrl } from "#products/tree/engine/member-seeding.js";
+import { readSourceState } from "#products/tree/engine/runtime/binding-state.js";
+import { LOCAL_TREE_TEMP_ROOT } from "#products/tree/engine/runtime/asset-loader.js";
 
 export interface LocalTreeConfig {
   bindingMode?: import("#products/tree/engine/runtime/binding-state.js").SourceBindingMode;
   entrypoint?: string;
-  localPath: string;
   sourceId?: string;
   treeMode?: import("#products/tree/engine/runtime/binding-state.js").TreeMode;
   treeRepoName: string;
@@ -28,50 +26,55 @@ export interface GitIgnoreUpdate {
   file: ".gitignore";
 }
 
+export interface ResolvedLocalTreeCheckout {
+  path: string;
+  source: "sibling" | "temp";
+}
+
+export interface ResolveLocalTreeCheckoutOptions {
+  materialize?: boolean;
+  refresh?: boolean;
+}
+
+export type ExecRunner = (
+  command: string,
+  args: string[],
+  options: { cwd: string },
+) => string;
+
 const LOCAL_TREE_GITIGNORE_ENTRIES = [
   `${LOCAL_TREE_TEMP_ROOT}/`,
-  SOURCE_LOCAL_STATE,
 ] as const;
+
+export function defaultExecRunner(
+  command: string,
+  args: string[],
+  options: { cwd: string },
+): string {
+  return execFileSync(command, args, {
+    cwd: options.cwd,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      GIT_TERMINAL_PROMPT: "0",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
 
 export function tempLocalTreeRoot(root: string, treeRepoName: string): string {
   return join(root, LOCAL_TREE_TEMP_ROOT, treeRepoName);
 }
 
-/**
- * Read local overrides from `.first-tree/source.local.json`.
- * This file is gitignored and only needed when the user's local tree
- * checkout path differs from the team-shared relative path in source.json.
- * Returns only the `localPath` override, or null if the file doesn't exist.
- */
-function readSourceLocalOverride(root: string): { localPath: string } | null {
-  const fullPath = join(root, SOURCE_LOCAL_STATE);
-  try {
-    const parsed = JSON.parse(readFileSync(fullPath, "utf-8")) as Record<string, unknown>;
-    if (typeof parsed.localPath === "string" && parsed.localPath.length > 0) {
-      return { localPath: parsed.localPath };
-    }
-    return null;
-  } catch {
-    return null;
-  }
-}
-
 export function readLocalTreeConfig(root: string): LocalTreeConfig | null {
   const state = readSourceState(root);
-  if (state === null) {
+  if (state === null || typeof state.tree.treeRepoName !== "string") {
     return null;
   }
-  if (typeof state.tree.localPath !== "string" || typeof state.tree.treeRepoName !== "string") {
-    return null;
-  }
-
-  // source.local.json overrides localPath when present
-  const localOverride = readSourceLocalOverride(root);
 
   return {
     bindingMode: state.bindingMode,
     entrypoint: state.tree.entrypoint,
-    localPath: localOverride?.localPath ?? state.tree.localPath,
     sourceId: state.sourceId,
     treeMode: state.tree.treeMode,
     treeRepoName: state.tree.treeRepoName,
@@ -80,12 +83,109 @@ export function readLocalTreeConfig(root: string): LocalTreeConfig | null {
   };
 }
 
-export function resolveConfiguredLocalTreePath(root: string): string | null {
+function readGitRemoteUrl(
+  runner: ExecRunner,
+  root: string,
+  remote = "origin",
+): string | null {
+  try {
+    return runner("git", ["remote", "get-url", remote], { cwd: root });
+  } catch {
+    return null;
+  }
+}
+
+function normalizeRemoteUrl(remoteUrl: string): string {
+  const parsed = parseGitHubRemoteUrl(remoteUrl);
+  if (parsed !== null) {
+    return [
+      parsed.host.toLowerCase(),
+      parsed.owner.toLowerCase(),
+      parsed.repo.toLowerCase(),
+    ].join("/");
+  }
+  return remoteUrl.trim().replace(/\.git$/u, "");
+}
+
+function remoteMatches(
+  expectedRemoteUrl: string | undefined,
+  actualRemoteUrl: string | null,
+): boolean {
+  if (!expectedRemoteUrl) {
+    return true;
+  }
+  if (!actualRemoteUrl) {
+    return false;
+  }
+  return normalizeRemoteUrl(expectedRemoteUrl) === normalizeRemoteUrl(actualRemoteUrl);
+}
+
+function isUsableTreeCheckout(
+  candidateRoot: string,
+  expectedRemoteUrl: string | undefined,
+  runner: ExecRunner,
+): boolean {
+  const repo = new Repo(candidateRoot);
+  if (!repo.isGitRepo()) {
+    return false;
+  }
+  return remoteMatches(expectedRemoteUrl, readGitRemoteUrl(runner, candidateRoot));
+}
+
+function fetchTreeCheckout(root: string, runner: ExecRunner): void {
+  try {
+    runner("git", ["fetch", "origin"], { cwd: root });
+  } catch {
+    // Best-effort refresh: callers can still use the existing checkout.
+  }
+}
+
+export function resolveLocalTreeCheckout(
+  root: string,
+  runner: ExecRunner = defaultExecRunner,
+  options?: ResolveLocalTreeCheckoutOptions,
+): ResolvedLocalTreeCheckout | null {
   const config = readLocalTreeConfig(root);
   if (config === null) {
     return null;
   }
-  return resolve(root, config.localPath);
+  const materialize = options?.materialize ?? true;
+  const refresh = options?.refresh ?? true;
+
+  const siblingRoot = join(dirname(root), config.treeRepoName);
+  if (isUsableTreeCheckout(siblingRoot, config.treeRepoUrl, runner)) {
+    if (refresh) {
+      fetchTreeCheckout(siblingRoot, runner);
+    }
+    return { path: siblingRoot, source: "sibling" };
+  }
+
+  const tempRoot = tempLocalTreeRoot(root, config.treeRepoName);
+  if (isUsableTreeCheckout(tempRoot, config.treeRepoUrl, runner)) {
+    if (refresh) {
+      fetchTreeCheckout(tempRoot, runner);
+    }
+    return { path: tempRoot, source: "temp" };
+  }
+
+  if (!materialize || !config.treeRepoUrl) {
+    return null;
+  }
+
+  if (!existsSync(tempRoot)) {
+    mkdirSync(dirname(tempRoot), { recursive: true });
+    runner("git", ["clone", config.treeRepoUrl, tempRoot], {
+      cwd: dirname(tempRoot),
+    });
+    return { path: tempRoot, source: "temp" };
+  }
+
+  if (!isUsableTreeCheckout(tempRoot, config.treeRepoUrl, runner)) {
+    return null;
+  }
+
+  fetchTreeCheckout(tempRoot, runner);
+  return { path: tempRoot, source: "temp" };
 }
 
 export function upsertLocalTreeGitIgnore(root: string): GitIgnoreUpdate {

--- a/src/products/tree/engine/runtime/source-integration.ts
+++ b/src/products/tree/engine/runtime/source-integration.ts
@@ -77,8 +77,8 @@ export function buildSourceIntegrationBlock(
   const description = describeBinding(bindingMode, treeMode, treeRepoName);
   const scopeText = describeScope(bindingMode, treeMode, treeRepoName, workspaceId);
   const fallbackInstruction = treeRepoUrl === null
-    ? `- If the tree has not been published yet, work from the local checkout recorded in \`${sourceStatePathValue}\` or the tree path you just bound until \`first-tree tree publish\` records the GitHub repo URL.`
-    : `- If the configured checkout is missing, clone a temporary working copy from \`${treeRepoUrl}\` into \`${temporaryCheckoutPath}/\`, use it for the current task, and delete it before you finish.`;
+    ? `- If the tree has not been published yet, work from the local checkout you just bound (or pass \`--tree-path\` explicitly) until \`first-tree tree publish\` records the GitHub repo URL.`
+    : `- If you do not already have that tree repo cloned locally, clone a temporary working copy from \`${treeRepoUrl}\` into \`${temporaryCheckoutPath}/\`, use it for the current task, and delete it before you finish.`;
 
   const treeRepoUrlDisplay = treeRepoUrl === null
     ? "_pending publish_"
@@ -114,8 +114,8 @@ export function buildSourceIntegrationBlock(
     "",
     "### Before every task",
     "",
-    `- Read \`${sourceStatePathValue}\` first. If it exists, resolve its \`tree.localPath\` value from this repo root and treat that checkout as the canonical local tree repo.`,
-    "- If that configured checkout exists locally, update it before you read anything else.",
+    `- Read \`${sourceStatePathValue}\` first. Use its recorded tree repo URL and tree repo name as the source of truth for which Context Tree this repo belongs to.`,
+    "- If you already have that tree repo cloned locally, update it before you read anything else.",
     fallbackInstruction,
     `- Never commit anything under \`${LOCAL_TREE_TEMP_ROOT}/\` to this repo. It is local-only workspace state.`,
     "",

--- a/src/products/tree/engine/runtime/tree-first-context.ts
+++ b/src/products/tree/engine/runtime/tree-first-context.ts
@@ -1,11 +1,11 @@
 import { existsSync, readFileSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import { TREE_SOURCE_REPOS_FILE } from "#products/tree/engine/runtime/asset-loader.js";
 import {
   listTreeBindings,
   readTreeState,
 } from "#products/tree/engine/runtime/binding-state.js";
-import { readLocalTreeConfig } from "#products/tree/engine/runtime/local-tree-config.js";
+import { readLocalTreeConfig, resolveLocalTreeCheckout } from "#products/tree/engine/runtime/local-tree-config.js";
 import { buildSourceRepoIndexTable } from "#products/tree/engine/runtime/source-repo-index.js";
 
 const ROOT_NODE_FILE = "NODE.md";
@@ -67,15 +67,15 @@ function resolveTreeContextRoot(currentRoot: string): ResolvedTreeContextRoot | 
     return null;
   }
 
-  const treeRoot = resolve(currentRoot, localTreeConfig.localPath);
-  if (!existsSync(treeRoot)) {
+  const resolvedCheckout = resolveLocalTreeCheckout(currentRoot);
+  if (resolvedCheckout === null || !existsSync(resolvedCheckout.path)) {
     return null;
   }
 
   return {
     currentEntrypoint: localTreeConfig.entrypoint,
     entrypointLabel: "bound source/workspace root",
-    treeRoot,
+    treeRoot: resolvedCheckout.path,
   };
 }
 

--- a/src/products/tree/engine/upgrade.ts
+++ b/src/products/tree/engine/upgrade.ts
@@ -3,7 +3,6 @@ import { dirname, join, resolve } from "node:path";
 import {
   buildDefaultTreeRepoName,
   formatDedicatedTreePathExample,
-  relativeRepoPath,
   resolveDedicatedTreeRepoForSource,
 } from "#products/tree/engine/dedicated-tree.js";
 import { Repo } from "#products/tree/engine/repo.js";
@@ -124,7 +123,6 @@ function writeProgress(repo: Repo, content: string): void {
 function syncLocalSourceWorkspaceState(
   sourceRepo: Repo,
   treeRepoName: string,
-  treeRoot: string,
 ): {
   gitIgnoreAction: "created" | "updated" | "unchanged";
   sourceStateAction: "created" | "updated" | "unchanged";
@@ -137,7 +135,6 @@ function syncLocalSourceWorkspaceState(
       ...existingSourceState,
       tree: {
         ...existingSourceState.tree,
-        localPath: relativeRepoPath(sourceRepo.root, treeRoot),
         treeRepoName,
       },
     });
@@ -179,15 +176,15 @@ function logLocalSourceWorkspaceState(
   state: ReturnType<typeof syncLocalSourceWorkspaceState>,
 ): void {
   if (state.gitIgnoreAction === "created") {
-    console.log("Created `.gitignore` entries for local tree checkout state.");
+    console.log("Created `.gitignore` entries for local tree working state.");
   } else if (state.gitIgnoreAction === "updated") {
-    console.log("Updated `.gitignore` for local tree checkout state.");
+    console.log("Updated `.gitignore` for local tree working state.");
   }
 
   if (state.sourceStateAction === "created") {
-    console.log("Created `.first-tree/source.json` for the local tree checkout.");
+    console.log("Created `.first-tree/source.json` for the local tree binding.");
   } else if (state.sourceStateAction === "updated") {
-    console.log("Updated `.first-tree/source.json` for the local tree checkout.");
+    console.log("Updated `.first-tree/source.json` for the local tree binding.");
   }
 }
 
@@ -391,7 +388,6 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
       const localSourceWorkspaceState = syncLocalSourceWorkspaceState(
         workingRepo,
         treeRepoName,
-        sourceRepoTreeRoot,
       );
       const sourceIntegrationOptions = sourceIntegrationOptionsForUpgrade(
         workingRepo,
@@ -462,7 +458,6 @@ export function runUpgrade(repo?: Repo, options?: UpgradeOptions): number {
     const localSourceWorkspaceState = syncLocalSourceWorkspaceState(
       workingRepo,
       treeRepoName,
-      sourceRepoTreeRoot,
     );
     const sourceIntegrationOptions = sourceIntegrationOptionsForUpgrade(
       workingRepo,

--- a/src/products/tree/engine/workspace-sync.ts
+++ b/src/products/tree/engine/workspace-sync.ts
@@ -5,11 +5,12 @@ import {
   readSourceState,
   type SourceBindingMode,
 } from "#products/tree/engine/runtime/binding-state.js";
+import { resolveLocalTreeCheckout } from "#products/tree/engine/runtime/local-tree-config.js";
 import { discoverWorkspaceRepos } from "#products/tree/engine/workspace.js";
 
 export const WORKSPACE_SYNC_USAGE = `usage: first-tree tree workspace sync [--tree-path PATH | --tree-url URL] [--workspace-id ID] [--dry-run]
 
-Bind every discovered child repo / submodule under the current workspace root
+Bind every discovered local child git repo under the current workspace root
 to the same shared Context Tree.
 
 Options:
@@ -66,10 +67,6 @@ export function parseWorkspaceSyncArgs(
     }
   }
 
-  if (!parsed.treePath && !parsed.treeUrl) {
-    return { error: "Missing --tree-path or --tree-url" };
-  }
-
   return parsed;
 }
 
@@ -82,8 +79,11 @@ export function runWorkspaceSync(repo?: Repo, options?: WorkspaceSyncOptions): n
   const members = discoverWorkspaceRepos(workspaceRoot.root);
   const workspaceId = workspaceIdForRoot(workspaceRoot, options?.workspaceId);
   const rootSourceState = readSourceState(workspaceRoot.root);
+  const resolvedLocalTreeCheckout = !options?.treePath
+    ? resolveLocalTreeCheckout(workspaceRoot.root)
+    : null;
   const treePath = options?.treePath
-    ?? rootSourceState?.tree.localPath
+    ?? resolvedLocalTreeCheckout?.path
     ?? undefined;
   const treeUrl = options?.treeUrl
     ?? rootSourceState?.tree.remoteUrl
@@ -102,7 +102,7 @@ export function runWorkspaceSync(repo?: Repo, options?: WorkspaceSyncOptions): n
   console.log(`  Child repos:    ${members.length}\n`);
 
   if (members.length === 0) {
-    console.log("No child repos or submodules were discovered.");
+    console.log("No child git repos were discovered.");
     return 0;
   }
 

--- a/src/products/tree/engine/workspace.ts
+++ b/src/products/tree/engine/workspace.ts
@@ -1,9 +1,8 @@
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, statSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
 import { Repo } from "#products/tree/engine/repo.js";
-import { TREE_SUBMODULES_DIR } from "#products/tree/engine/runtime/asset-loader.js";
 
-export type WorkspaceRepoKind = "git-submodule" | "nested-git-repo";
+export type WorkspaceRepoKind = "nested-git-repo";
 
 export interface WorkspaceRepoCandidate {
   kind: WorkspaceRepoKind;
@@ -29,20 +28,6 @@ function isDirectory(path: string): boolean {
     return statSync(path).isDirectory();
   } catch {
     return false;
-  }
-}
-
-function parseGitmodules(root: string): string[] {
-  try {
-    const text = readFileSync(join(root, ".gitmodules"), "utf-8");
-    return [...text.matchAll(/^\s*path\s*=\s*(.+?)\s*$/gm)]
-      .map((match) => match[1]?.trim())
-      .filter(
-        (value): value is string =>
-          Boolean(value) && !value.startsWith(`${TREE_SUBMODULES_DIR}/`),
-      );
-  } catch {
-    return [];
   }
 }
 
@@ -87,20 +72,6 @@ function discoverNestedRepos(
 
 export function discoverWorkspaceRepos(root: string): WorkspaceRepoCandidate[] {
   const results = new Map<string, WorkspaceRepoCandidate>();
-
-  for (const submodulePath of parseGitmodules(root)) {
-    const submoduleRoot = resolve(root, submodulePath);
-    const repo = new Repo(submoduleRoot);
-    if (!repo.isGitRepo()) {
-      continue;
-    }
-    results.set(submodulePath, {
-      kind: "git-submodule",
-      name: repo.repoName(),
-      relativePath: submodulePath,
-      root: submoduleRoot,
-    });
-  }
 
   if (existsSync(root)) {
     discoverNestedRepos(root, root, results);

--- a/tests/e2e/cli-e2e.test.ts
+++ b/tests/e2e/cli-e2e.test.ts
@@ -722,8 +722,8 @@ describe.sequential("CLI e2e smoke", () => {
       "git@github.com:acme/ADHD-tree.git",
     );
     expect(
-      JSON.parse(readFileSync(join(sourceRoot, SOURCE_STATE), "utf-8")).tree.localPath,
-    ).toBe("../ADHD-tree");
+      JSON.parse(readFileSync(join(sourceRoot, SOURCE_STATE), "utf-8")).tree.remoteUrl,
+    ).toBe("git@github.com:acme/ADHD-tree.git");
 
     const diffPath = join(sandbox.path, "pr.diff");
     const outputPath = join(sandbox.path, "review.json");

--- a/tests/tree/init.test.ts
+++ b/tests/tree/init.test.ts
@@ -103,7 +103,7 @@ describe("formatTaskList", () => {
     });
 
     expect(output).toContain("first-tree tree publish --open-pr");
-    expect(output).toContain("canonical local working copy");
+    expect(output).toContain("canonical source of truth");
   });
 });
 
@@ -288,7 +288,6 @@ describe("runInit", () => {
       JSON.parse(readFileSync(join(treeRepo, BOOTSTRAP_STATE), "utf-8")),
     ).toEqual({
       sourceRepoName: basename(sourceRepoDir.path),
-      sourceRepoPath: `../${basename(sourceRepoDir.path)}`,
       treeRepoName: basename(treeRepo),
     });
     expect(existsSync(join(sourceRepoDir.path, "NODE.md"))).toBe(false);
@@ -528,7 +527,6 @@ describe("runInit", () => {
       JSON.parse(readFileSync(join(legacyTreeRepo, BOOTSTRAP_STATE), "utf-8")),
     ).toEqual({
       sourceRepoName: basename(sourceRepoDir.path),
-      sourceRepoPath: `../${basename(sourceRepoDir.path)}`,
       treeRepoName: basename(legacyTreeRepo),
     });
     expect(

--- a/tests/tree/inject-context.test.ts
+++ b/tests/tree/inject-context.test.ts
@@ -62,6 +62,7 @@ describe("runInjectContext", () => {
     const treeRoot = join(tmpDir, "org-context");
     mkdirSync(sourceRoot, { recursive: true });
     mkdirSync(treeRoot, { recursive: true });
+    mkdirSync(join(treeRoot, ".git"), { recursive: true });
     writeFileSync(
       join(treeRoot, "NODE.md"),
       [
@@ -89,8 +90,6 @@ describe("runInjectContext", () => {
       sourceName: "product-repo",
       tree: {
         entrypoint: "/workspaces/product-repo",
-        localPath: relative(sourceRoot, treeRoot),
-        remoteUrl: "https://github.com/acme/org-context.git",
         treeId: "org-context",
         treeMode: "shared",
         treeRepoName: "org-context",

--- a/tests/tree/publish.test.ts
+++ b/tests/tree/publish.test.ts
@@ -261,7 +261,6 @@ describe("runPublish", () => {
       readFileSync(join(sourceRoot, AGENT_INSTRUCTIONS_FILE), "utf-8"),
     ).toContain("FIRST-TREE-TREE-REPO-URL: `git@github.com:acme/ADHD-tree.git`");
     const sourceState = JSON.parse(readFileSync(join(sourceRoot, SOURCE_STATE), "utf-8"));
-    expect(sourceState.tree.localPath).toBe("../ADHD-tree");
     expect(sourceState.tree.treeRepoName).toBe("ADHD-tree");
     expect(sourceState.tree.remoteUrl).toBe("git@github.com:acme/ADHD-tree.git");
     expect(readFileSync(join(sourceRoot, ".gitignore"), "utf-8")).toContain(
@@ -269,7 +268,7 @@ describe("runPublish", () => {
     );
   });
 
-  it("creates a sibling local checkout when the published tree repo is elsewhere", () => {
+  it("records the published tree URL without forcing a sibling local checkout", () => {
     const rootDir = useTmpDir();
     const sourceRoot = join(rootDir.path, "ADHD");
     const bootstrapRoot = join(rootDir.path, "bootstrap", "ADHD-tree");
@@ -290,19 +289,17 @@ describe("runPublish", () => {
     });
 
     expect(result).toBe(0);
+    const sourceState = JSON.parse(readFileSync(join(sourceRoot, SOURCE_STATE), "utf-8"));
+    expect(sourceState.tree.treeRepoName).toBe("ADHD-tree");
+    expect(sourceState.tree.remoteUrl).toBe("git@github.com:acme/ADHD-tree.git");
     expect(
       calls.some(
         (call) =>
           call.command === "git"
           && call.args[0] === "clone"
-          && call.args[1] === "git@github.com:acme/ADHD-tree.git"
-          && call.args[2] === join(rootDir.path, "ADHD-tree"),
+          && call.args[1] === "git@github.com:acme/ADHD-tree.git",
       ),
-    ).toBe(true);
-    const sourceState = JSON.parse(readFileSync(join(sourceRoot, SOURCE_STATE), "utf-8"));
-    expect(sourceState.tree.localPath).toBe("../ADHD-tree");
-    expect(sourceState.tree.treeRepoName).toBe("ADHD-tree");
-    expect(sourceState.tree.remoteUrl).toBe("git@github.com:acme/ADHD-tree.git");
+    ).toBe(false);
   });
 
   it("skips source skill artifacts when the source repo ignores /.agents/", () => {


### PR DESCRIPTION
## Summary
- remove shared local checkout paths and submodule-specific workspace discovery from tree bindings
- make source/tree identity URL-first, including stable source ids derived from repo remotes
- refresh publish, inject-context, onboarding docs, and tests around temporary local checkouts instead of shared paths

## Testing
- pnpm release:check
