### PR TITLE
Align first-tree docs and tests with current CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,12 @@ cross-domain relationships that humans and agents maintain together —
 │                         first-tree (umbrella CLI)                    │
 ├──────────────┬───────────────────────────┬───────────────────────────┤
 │    tree      │        gardener           │          breeze           │
-│  toolkit     │    local daemon           │     local daemon          │
+│  toolkit     │     maint. agent          │     local daemon          │
 ├──────────────┼───────────────────────────┼───────────────────────────┤
-│  init, bind, │ watches source repos →    │ watches gh notifications  │
-│  workspace,  │ opens issues on the tree  │ → labels / routes / drafts│
-│  publish,    │ repo & assigns owners;    │ replies for PRs, issues,  │
-│  verify, ... │ responds to sync-PR       │ discussions, reviews.     │
-│              │ review feedback.          │                           │
+│  init, bind, │ reviews source PRs/issues │ watches gh notifications  │
+│  workspace,  │ and sync PRs; can run as  │ → labels / routes / drafts│
+│  publish,    │ a workflow or daemon.     │ replies for PRs, issues,  │
+│  verify, ... │                           │ discussions, reviews.     │
 └──────────────┴───────────────────────────┴───────────────────────────┘
                            │
                    ┌───────┴────────┐
@@ -34,8 +33,8 @@ cross-domain relationships that humans and agents maintain together —
 
 | Tool | What it is | When to reach for it |
 |------|------------|----------------------|
-| **[tree](src/products/tree)** | CLI toolkit for `first-tree tree init/bind/workspace/publish/verify/upgrade/review/generate-codeowners/inject-context/bootstrap` | You want an agent to create, maintain, or bind a Context Tree repo. |
-| **[gardener](src/products/gardener)** | Local maintenance daemon that watches source repos, opens/assigns tree issues, and responds to sync-PR review feedback | You want the tree to stay coherent as code changes without asking a human to drive it. |
+| **[tree](src/products/tree)** | CLI toolkit for `first-tree tree inspect/status/init/bootstrap/bind/integrate/workspace/publish/verify/upgrade/...` | You want an agent to create, maintain, or bind a Context Tree repo. |
+| **[gardener](src/products/gardener)** | Maintenance agent for drift sync, source-repo verdict comments, sync-PR review responses, and optional push-mode workflow / pull-mode daemon orchestration | You want the tree to stay coherent as code changes without asking a human to drive it. |
 | **[breeze](src/products/breeze)** | Local inbox daemon that takes over your `gh` login and turns GitHub notifications into a triaged, optionally auto-handled queue | You want an agent sitting on your GitHub notifications so you don't have to. |
 
 Every product ships:
@@ -145,8 +144,8 @@ for the full guide, and run `first-tree tree help onboarding` to print it.
 
 ```text
 <source-repo-or-workspace>/
-  .agents/skills/first-tree/
-  .claude/skills/first-tree
+  .agents/skills/{first-tree,tree,breeze,gardener}/
+  .claude/skills/{first-tree,tree,breeze,gardener}
   WHITEPAPER.md
   AGENTS.md
   CLAUDE.md
@@ -155,8 +154,8 @@ for the full guide, and run `first-tree tree help onboarding` to print it.
   … your code …
 
 <tree-repo>/
-  .agents/skills/first-tree/
-  .claude/skills/first-tree
+  .agents/skills/{first-tree,tree,breeze,gardener}/
+  .claude/skills/{first-tree,tree,breeze,gardener}
   .first-tree/
     VERSION
     progress.md
@@ -185,9 +184,11 @@ continue to work cleanly for multi-repo workspaces.
 | Command | What it does |
 | --- | --- |
 | `first-tree tree inspect` | Classify the current folder and report existing bindings / child repos |
+| `first-tree tree status` | Human-friendly alias for `inspect` |
 | `first-tree tree init` | High-level onboarding wrapper for single repos, shared trees, and workspace roots |
 | `first-tree tree bootstrap` | Canonical low-level tree bootstrap for an explicit tree checkout |
 | `first-tree tree bind` | Lower-level binding primitive for cases where you need explicit `--mode` control |
+| `first-tree tree integrate` | Install local skill integration and source-integration files without mutating the tree repo |
 | `first-tree tree workspace sync` | Bind newly added child repos to the same shared tree, or rerun workspace-member binding manually |
 | `first-tree tree publish` | Publish a dedicated tree repo or shared tree repo to GitHub and refresh locally bound source/workspace repos |
 | `first-tree tree verify` | Run verification checks against a tree repo |
@@ -202,6 +203,15 @@ continue to work cleanly for multi-repo workspaces.
 | `first-tree gardener comment` | Review a source-repo PR or issue against the tree and post a structured verdict comment; scan mode sweeps every configured `target_repo` |
 | `first-tree gardener respond` | Fix a tree-repo sync PR based on reviewer feedback |
 | `first-tree gardener install-workflow` | Scaffold the push-mode GitHub Actions workflow in a codebase repo |
+| `first-tree gardener start` | Launch the pull-mode gardener daemon in the background |
+| `first-tree gardener status` | Report gardener daemon PID, schedule, and last-run state |
+| `first-tree gardener run-once` | Execute both gardener sweeps inline and exit |
+| `first-tree gardener stop` | Stop the pull-mode gardener daemon |
+| `first-tree breeze install` | Check prerequisites, create `~/.breeze/config.yaml`, and start the daemon |
+| `first-tree breeze start` | Launch the breeze daemon in the background |
+| `first-tree breeze status` | Print daemon/runtime status for the current breeze profile |
+| `first-tree breeze watch` | Open the live TUI inbox and activity feed |
+| `first-tree breeze poll` | Poll GitHub notifications once without requiring the daemon |
 | `first-tree skill install` | Install the four shipped skills under `.agents/skills/*` and `.claude/skills/*` |
 | `first-tree skill upgrade` | Wipe and reinstall the four shipped skills from the current package |
 | `first-tree skill list` | Print the four shipped skills with their installed status and version |

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -10,9 +10,9 @@ the files maintainers edit in this repo.
 
 `first-tree` is an umbrella CLI that dispatches into three products:
 
-- **`tree`** — Context Tree tooling (inspect / init / bind / verify / publish / upgrade / sync / ...)
+- **`tree`** — Context Tree tooling (inspect / status / init / bind / integrate / verify / publish / upgrade / ...)
 - **`breeze`** — Proposal / inbox daemon with a GitHub notifications statusline
-- **`gardener`** — Automated maintenance agent for tree sync PRs and source-repo review comments
+- **`gardener`** — Automated maintenance agent for drift sync, source-repo review comments, sync-PR responses, and workflow/daemon orchestration
 
 It also exposes one maintenance namespace:
 
@@ -45,9 +45,9 @@ ships.
 | `src/cli.ts` | Top-level umbrella dispatcher for `first-tree <namespace> <command>`; iterates the namespace manifest |
 | `src/products/manifest.ts` | Single source of truth for the CLI namespace set; add a new namespace by adding one entry here |
 | `src/products/tree/` | Tree product root (CLI dispatcher + `VERSION`) |
-| `src/products/tree/engine/` | Tree business logic: `commands/`, `runtime/`, `rules/`, `validators/`, plus `bind.ts`, `init.ts`, `verify.ts`, `publish.ts`, `sync.ts`, `workspace.ts`, `upgrade.ts`, `inspect.ts`, etc. |
+| `src/products/tree/engine/` | Tree business logic: `commands/`, `runtime/`, `rules/`, `validators/`, plus `bind.ts`, `init.ts`, `integrate.ts`, `verify.ts`, `publish.ts`, `workspace.ts`, `upgrade.ts`, `inspect.ts`, etc. |
 | `src/products/breeze/` | Breeze product: CLI dispatcher + `engine/` (commands, runtime, daemon, bridge, statusline) |
-| `src/products/gardener/` | Gardener product: CLI dispatcher + `engine/` (commands, runtime, comment, respond) |
+| `src/products/gardener/` | Gardener product: CLI dispatcher + `engine/` (commands, runtime, daemon, sync, comment, respond, install-workflow) |
 | `src/meta/skill-tools/` | Maintenance namespace: skill inventory, diagnosis, installation, and symlink repair |
 | `skills/first-tree/` | Entry-point skill payload that ships verbatim to user repos |
 | `skills/tree/`, `skills/breeze/`, `skills/gardener/` | Per-product operational skill payloads |

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -57,7 +57,7 @@ docs below only for source-repo implementation details.
 | `src/meta/skill-tools/cli.ts` | Skill maintenance-namespace dispatcher (lazy-loaded) |
 | `src/meta/skill-tools/README.md` | Maintainer/meta overview for the skill maintenance namespace |
 | `src/products/breeze/engine/` | Breeze business logic: `commands/`, `runtime/`, `daemon/`, `bridge.ts`, `statusline.ts` |
-| `src/products/gardener/engine/` | Gardener business logic: `commands/`, `runtime/`, `sync.ts`, `comment.ts`, `respond.ts` |
+| `src/products/gardener/engine/` | Gardener business logic: `commands/`, `runtime/`, `daemon/`, `sync.ts`, `comment.ts`, `respond.ts`, `install-workflow.ts` |
 | `src/products/gardener/engine/sync.ts` | Drift detection, proposal generation, and apply flow (moved from tree namespace) |
 | `src/products/tree/engine/init.ts` | High-level onboarding wrapper plus low-level tree bootstrap |
 | `src/products/tree/engine/inspect.ts` | Root classification before onboarding |

--- a/docs/testing/overview.md
+++ b/docs/testing/overview.md
@@ -83,7 +83,7 @@ pnpm test:e2e
 pnpm test -- tests/tree/skill-artifacts.test.ts
 pnpm test -- tests/e2e/thin-cli.test.ts
 pnpm test -- tests/tree/verify.test.ts
-pnpm test -- tests/tree/sync.test.ts
+pnpm test -- tests/gardener/sync.test.ts
 ```
 
 If a future refactor changes these paths again, keep the command semantics and
@@ -139,7 +139,7 @@ tier skips cleanly.
   dedicated-tree vs workspace contexts.
 - `tests/agent-e2e/anti-hallucination.test.ts` — three negative tests
   that assert the agent does **not** fabricate plausible-but-fake verbs
-  (`tree owner-set`, `tree status`, `breeze ack`, etc.).
+  (`tree owner-set`, `tree stats`, `breeze ack`, etc.).
 - `tests/agent-e2e/help-self-sufficiency.test.ts` — LLM judge on
   `first-tree <ns> --help` for all four namespaces (baseline in
   `baselines/help-quality.json`).

--- a/skills/breeze/SKILL.md
+++ b/skills/breeze/SKILL.md
@@ -91,8 +91,9 @@ pre-bundled minimal entry point for sub-30 ms cold starts:
 node /path/to/first-tree/dist/breeze-statusline.js
 ```
 
-The `first-tree breeze install` command wires this up into the local
-Claude Code config.
+`first-tree breeze install` does **not** wire this up into Claude Code for
+you. Configure the statusline hook manually after install if you want the
+live inbox summary in your session UI.
 
 ## Environment
 
@@ -106,8 +107,13 @@ Claude Code config.
 
 ```bash
 npx -p first-tree first-tree breeze install
-npx -p first-tree first-tree breeze start
 npx -p first-tree first-tree breeze status
+```
+
+If the daemon did not come up during install, run:
+
+```bash
+npx -p first-tree first-tree breeze start
 ```
 
 **Something looks wrong:**

--- a/skills/first-tree/references/onboarding.md
+++ b/skills/first-tree/references/onboarding.md
@@ -68,11 +68,12 @@ first-tree tree init
 
 The CLI will:
 
-- install `.agents/skills/first-tree/` and `.claude/skills/first-tree/` in the source/workspace root
+- install the four shipped skills (`first-tree`, `tree`, `breeze`, `gardener`)
+  under `.agents/skills/*` and `.claude/skills/*` in the source/workspace root
 - create `WHITEPAPER.md`
 - refresh `AGENTS.md` and `CLAUDE.md`
 - create or reuse a sibling `<repo>-tree` checkout
-- install the bundled `first-tree` skill in that tree repo if it is missing
+- install the bundled first-tree skills in that tree repo if they are missing
 - scaffold the tree repo there
 - write binding metadata in both the source repo and the tree repo
 
@@ -94,7 +95,7 @@ first-tree tree init --tree-url git@github.com:acme/org-context.git --tree-mode 
 if needed, then:
 
 - install local skill integration in the current repo
-- install the bundled `first-tree` skill in the tree repo if it is missing
+- install the bundled first-tree skills in the tree repo if they are missing
 - refresh `AGENTS.md` and `CLAUDE.md`
 - write `.first-tree/source.json` (tree repo identity + published URL when known)
 - write `.first-tree/tree.json` and `.first-tree/bindings/<source-id>.json`

--- a/skills/first-tree/references/source-workspace-installation.md
+++ b/skills/first-tree/references/source-workspace-installation.md
@@ -12,16 +12,16 @@ workspace repo, or non-git workspace folder.
 
 - The current source/workspace root is **not** the Context Tree.
 - The current source/workspace root carries only:
-  - `.agents/skills/first-tree/` and `.claude/skills/first-tree/`
+  - the four installed skills under `.agents/skills/<name>/` and
+    `.claude/skills/<name>/` (`first-tree`, `tree`, `breeze`, `gardener`)
   - `WHITEPAPER.md`
   - a managed `FIRST-TREE-SOURCE-INTEGRATION:` block in `AGENTS.md` and `CLAUDE.md`
   - `.first-tree/source.json` (includes workspace members for workspace roots)
 - `NODE.md`, `members/`, and tree-scoped `AGENTS.md` / `CLAUDE.md` belong only
   in the tree repo.
-- The tree repo keeps its own installed skill under `.agents/skills/first-tree/`
-  and `.claude/skills/first-tree`, plus tree metadata under `.first-tree/tree.json`
-  and `.first-tree/bindings/`, plus a generated `source-repos.md` index at the
-  tree root.
+- The tree repo keeps the same four installed skills, plus tree metadata under
+  `.first-tree/tree.json` and `.first-tree/bindings/`, plus a generated
+  `source-repos.md` index at the tree root.
 
 ## Binding Modes
 
@@ -36,8 +36,8 @@ workspace repo, or non-git workspace folder.
 
 ```text
 <source-or-workspace-root>/
-  .agents/skills/first-tree/
-  .claude/skills/first-tree
+  .agents/skills/{first-tree,tree,breeze,gardener}/
+  .claude/skills/{first-tree,tree,breeze,gardener}
   WHITEPAPER.md
   AGENTS.md
   CLAUDE.md
@@ -45,8 +45,8 @@ workspace repo, or non-git workspace folder.
     source.json             # includes workspace members for workspace roots
 
 <tree-repo>/
-  .agents/skills/first-tree/
-  .claude/skills/first-tree
+  .agents/skills/{first-tree,tree,breeze,gardener}/
+  .claude/skills/{first-tree,tree,breeze,gardener}
   .first-tree/
     VERSION
     progress.md

--- a/skills/first-tree/references/upgrade-contract.md
+++ b/skills/first-tree/references/upgrade-contract.md
@@ -9,10 +9,11 @@ The `first-tree` npm package ships two things:
 
 1. **CLI tools** — engine, runtime, validators, helpers, templates, and
    workflows. Users invoke them with `npx -p first-tree first-tree <command>`.
-2. **Skill payload** — `SKILL.md`, `references/`, and `VERSION`. This is copied
-   into user repos and refreshed by `first-tree tree upgrade`.
+2. **Skill payloads** — the entry-point `first-tree` skill plus the per-product
+   `tree`, `breeze`, and `gardener` handbooks. These are copied into user repos
+   and refreshed by `first-tree skill upgrade` / `first-tree tree upgrade`.
 
-The skill payload contains knowledge only. Executable behavior stays in the CLI.
+The skill payloads contain knowledge only. Executable behavior stays in the CLI.
 
 ## Versioning
 
@@ -22,15 +23,15 @@ Three-level: `major.minor.patch`.
 - `minor` — shipped skill payload changes
 - `patch` — CLI/runtime behavior changes
 
-The installed skill `VERSION` tracks `major.minor`.
+Each installed skill `VERSION` tracks `major.minor`.
 
 ## Installed Layout
 
 In a source/workspace root, `first-tree tree init` / `first-tree tree bind` produce:
 
 ```text
-.agents/skills/first-tree/
-.claude/skills/first-tree
+.agents/skills/{first-tree,tree,breeze,gardener}/
+.claude/skills/{first-tree,tree,breeze,gardener}
 WHITEPAPER.md
 AGENTS.md
 CLAUDE.md
@@ -41,8 +42,8 @@ CLAUDE.md
 In a tree repo, `first-tree tree bootstrap` produces:
 
 ```text
-.agents/skills/first-tree/
-.claude/skills/first-tree
+.agents/skills/{first-tree,tree,breeze,gardener}/
+.claude/skills/{first-tree,tree,breeze,gardener}
 .first-tree/
   VERSION
   progress.md
@@ -62,10 +63,9 @@ members/
 `first-tree skill upgrade` in any repo/workspace root:
 
 1. wipes previous installed skill locations
-2. reinstalls `.agents/skills/first-tree/`
-3. recreates the `.claude/skills/first-tree` symlink
-4. also installs the product skills under `.agents/skills/{tree,breeze,gardener}/`
-5. preserves everything outside the skill directories
+2. reinstalls `.agents/skills/{first-tree,tree,breeze,gardener}/`
+3. recreates the matching `.claude/skills/<name>` symlinks
+4. preserves everything outside the skill directories
 
 `first-tree tree upgrade` in a source/workspace root additionally refreshes
 `WHITEPAPER.md`, the managed `FIRST-TREE-SOURCE-INTEGRATION:` block, and other
@@ -109,7 +109,7 @@ metadata such as `.first-tree/VERSION` plus the installed tree-repo skill.
 
 ## Invariants
 
-- the installed skill is read-only knowledge and may be overwritten on upgrade
+- the installed skill payloads are read-only knowledge and may be overwritten on upgrade
 - tree content remains decision-focused
 - workspace child repos should share one tree, not create many parallel trees
 - shared tree bindings should live in `.first-tree/bindings/`, not in a single

--- a/src/products/breeze/README.md
+++ b/src/products/breeze/README.md
@@ -22,15 +22,27 @@ breeze/
 
 ## Commands
 
+### Primary
+
 | Command | Role |
 |---------|------|
-| `first-tree breeze install` | Set up the daemon (launchd on macOS) and Claude Code hooks |
+| `first-tree breeze install` | Check `gh` / `jq` / auth, create `~/.breeze/config.yaml`, and start the daemon. Statusline hook wiring is a separate manual step. |
 | `first-tree breeze start/stop` | Control the daemon lifecycle |
-| `first-tree breeze run-once` | One-shot poll for scripting |
-| `first-tree breeze status` | Print current inbox status |
+| `first-tree breeze status` | Print current daemon/runtime status |
+| `first-tree breeze doctor` | Diagnose daemon / gh login / runtime health |
 | `first-tree breeze watch` | Interactive TUI inbox (Ink) |
-| `first-tree breeze doctor` | Diagnose daemon / gh login / hook health |
+| `first-tree breeze poll` | One-shot inbox poll without requiring the daemon |
+
+### Advanced / internal
+
+| Command | Role |
+|---------|------|
+| `first-tree breeze run` / `first-tree breeze daemon` | Run the broker loop in the foreground |
+| `first-tree breeze run-once` | Run one poll cycle, wait for drain, then exit |
 | `first-tree breeze cleanup` | Clear stale state |
+| `first-tree breeze statusline` | CLI shim that executes the pre-bundled `dist/breeze-statusline.js` hook |
+| `first-tree breeze status-manager` | Internal helper used by breeze runners |
+| `first-tree breeze poll-inbox` | Legacy alias for `poll` |
 
 Run `first-tree breeze --help` for the authoritative list.
 

--- a/src/products/gardener/README.md
+++ b/src/products/gardener/README.md
@@ -1,16 +1,18 @@
 # `first-tree gardener`
 
-Local maintenance agent for Context Trees. Keeps the tree coherent as code and
-reviews evolve:
+Maintenance agent for Context Trees. Gardener owns three kinds of runtime:
 
-- **`respond`** — fixes sync PRs based on reviewer feedback (reactive maintenance).
-- **`comment`** — reviews source-repo PRs / issues against the bound tree and posts structured verdict comments.
+- **drift sync** — `first-tree gardener sync`
+- **source-repo verdict comments** — `first-tree gardener comment`
+- **sync-PR review responses** — `first-tree gardener respond`
 
-The intended scope extends beyond reactive maintenance: gardener should
-proactively watch source repos for changes that affect tree coverage, open
-corresponding issues on the tree repo, and assign the right owners. That
-proactive layer is the next milestone and currently ships only the `respond` +
-`comment` primitives.
+It can run in two deployment shapes:
+
+- **Push mode** — `first-tree gardener install-workflow` scaffolds the
+  `.github/workflows/first-tree-sync.yml` GitHub Actions workflow in a codebase
+  repo.
+- **Pull mode** — `first-tree gardener start` / `run-once` / `status` / `stop`
+  manage the local daemon that schedules `comment` and `sync`.
 
 ## What's In This Directory
 
@@ -20,17 +22,32 @@ gardener/
 ├── README.md              # product overview
 ├── cli.ts                 # dispatcher
 └── engine/
-    ├── commands/          # respond.ts, comment.ts
-    └── (domain modules)   # comment builder, classifier, gh helpers, …
+    ├── commands/          # sync, comment, respond, install-workflow, start, stop, status, run-once, daemon
+    ├── daemon/            # launchd config, loop orchestration, runtime state
+    ├── runtime/           # config helpers
+    └── (domain modules)   # sync, comment builder, responder, install-workflow, open-tree-pr orchestration, …
 ```
 
 ## Commands
 
+### Primary
+
 | Command | Role |
 |---------|------|
-| `first-tree gardener respond --pr <n> --repo owner/name` | Fix a sync PR based on reviewer feedback |
+| `first-tree gardener install-workflow` | Scaffold the push-mode GitHub Actions workflow in a codebase repo |
+| `first-tree gardener start/stop` | Control the pull-mode gardener daemon |
+| `first-tree gardener status` | Report daemon PID, schedule, and last-run state |
+| `first-tree gardener run-once` | Execute both sweeps inline and exit |
+
+### Agent / CI
+
+| Command | Role |
+|---------|------|
+| `first-tree gardener sync` | Detect drift between a tree repo and its bound sources; optionally propose/apply tree PRs |
 | `first-tree gardener comment --pr <n> --repo owner/name` | Review a source PR against the tree and post a verdict |
 | `first-tree gardener comment --issue <n> --repo owner/name` | Same, for an issue |
+| `first-tree gardener respond --pr <n> --repo owner/name` | Handle reviewer feedback on a sync PR |
+| `first-tree gardener daemon` | Foreground loop invoked by `start` |
 
 Run `first-tree gardener --help` for the authoritative list.
 

--- a/src/products/manifest.ts
+++ b/src/products/manifest.ts
@@ -69,7 +69,8 @@ export const PRODUCTS: readonly ProductDefinition[] = [
   {
     name: "gardener",
     kind: "product",
-    description: "Context Tree maintenance agent (respond, comment, ...)",
+    description:
+      "Context Tree maintenance agent (sync, comment, respond, install-workflow, ...)",
     load: async () => {
       const mod = await import("./gardener/cli.js");
       return { run: (args, output) => mod.runGardener(args, output) };

--- a/src/products/tree/README.md
+++ b/src/products/tree/README.md
@@ -14,7 +14,7 @@ tree/
     ├── rules/             # tree validation rules
     ├── runtime/           # asset loader, installer, upgrader, source integration
     ├── validators/        # node + member validators
-    └── (domain modules)   # bind.ts, init.ts, sync.ts, publish.ts, …
+    └── (domain modules)   # bind.ts, init.ts, integrate.ts, publish.ts, …
 ```
 
 ## Commands
@@ -22,9 +22,11 @@ tree/
 | Command | Role |
 |---------|------|
 | `first-tree tree inspect` | Classify the current folder (source / workspace / tree) |
+| `first-tree tree status` | Human-friendly alias for `inspect` |
 | `first-tree tree init` | Primary onboarding wrapper for new trees or existing shared trees |
 | `first-tree tree bootstrap` | Canonical low-level tree bootstrap for an explicit tree checkout |
 | `first-tree tree bind` | Lower-level binding primitive when you need explicit binding-mode control |
+| `first-tree tree integrate` | Install local skill integration and source-integration files without mutating the tree repo |
 | `first-tree tree workspace sync` | Bind newly added child repos to a shared tree, or rerun workspace-member binding manually |
 | `first-tree tree publish` | Push the tree to GitHub and refresh bound sources |
 | `first-tree tree verify` | Run validation checks on a tree repo |
@@ -32,7 +34,10 @@ tree/
 | `first-tree tree generate-codeowners` | Generate `.github/CODEOWNERS` from tree ownership |
 | `first-tree tree review` | PR review helper for tree repos in CI |
 | `first-tree tree inject-context` | Claude Code SessionStart payload from root `NODE.md` |
+| `first-tree tree invite` | Invite a new member to the Context Tree |
+| `first-tree tree join` | Accept an invite and join a Context Tree |
 | `first-tree tree help onboarding` | Print the full onboarding guide |
+| `first-tree gardener sync` | Drift-detection command for bound source repos (moved out of the tree namespace) |
 
 Run `first-tree tree --help` for the authoritative list.
 

--- a/tests/agent-e2e/anti-hallucination.test.ts
+++ b/tests/agent-e2e/anti-hallucination.test.ts
@@ -101,13 +101,13 @@ d("anti-hallucination (real Claude subprocess)", () => {
   );
 
   it(
-    "does not invent a `tree status` / `tree stats` command for a status request",
+    "does not invent unsupported `tree stats` / `tree state` / `tree summary` commands for a status request",
     async () => {
-      // Common hallucination: agent types `first-tree tree status` or
-      // `first-tree tree stats` even though neither exists. The nearest
-      // real commands are `tree verify` (health) and `tree inspect`
-      // (classification) — both of which this test does NOT assert for
-      // positively, because we only want the negative guarantee here.
+      // `first-tree tree status` is a real alias for `inspect`, but
+      // agents still hallucinate nearby variants such as `tree stats`,
+      // `tree state`, or `tree summary`. This test guards against those
+      // plausible-but-wrong forms without rejecting the legitimate
+      // `tree status` alias.
       const { path, cleanup } = makeSeedRepo({
         "NODE.md":
           "---\ntitle: root\nowners:\n  - Alice\n---\n\n# Root\n",
@@ -129,8 +129,8 @@ d("anti-hallucination (real Claude subprocess)", () => {
       expect(["success", "error_max_turns"]).toContain(result.exitReason);
       assertDidNotInvoke(
         result,
-        /first-tree\s+tree\s+(status|stats|state|health|summary)\b/,
-        "none of `tree status|stats|state|health|summary` exist; use `tree verify` or `tree inspect`",
+        /first-tree\s+tree\s+(stats|state|health|summary)\b/,
+        "`tree status` exists as an alias for `inspect`, but `tree stats|state|health|summary` do not",
       );
     },
     180_000,

--- a/tests/tree/skill-artifacts.test.ts
+++ b/tests/tree/skill-artifacts.test.ts
@@ -249,8 +249,13 @@ describe("skill artifacts", () => {
     expect(read("README.md")).toContain("maintenance namespace");
     expect(read("README.md")).toContain("dedicated tree repo");
     expect(read("README.md")).toContain("first-tree tree inspect");
+    expect(read("README.md")).toContain("first-tree tree status");
+    expect(read("README.md")).toContain("first-tree tree integrate");
     expect(read("README.md")).toContain("first-tree tree bind");
     expect(read("README.md")).toContain("first-tree tree workspace sync");
+    expect(read("README.md")).toContain("first-tree gardener start");
+    expect(read("README.md")).toContain("first-tree gardener run-once");
+    expect(read("README.md")).toContain("first-tree breeze install");
     expect(read("README.md")).toContain(".first-tree/source.json");
     expect(read("README.md")).toContain(".first-tree/tree.json");
     expect(read("README.md")).toContain(".first-tree/bindings/");
@@ -370,6 +375,9 @@ describe("skill artifacts", () => {
     expect(sourceWorkspaceInstall).toContain(".first-tree/tree.json");
     expect(sourceWorkspaceInstall).toContain(".first-tree/bindings/");
     expect(sourceWorkspaceInstall).toContain("source-repos.md");
+    expect(sourceWorkspaceInstall).toContain(
+      ".agents/skills/{first-tree,tree,breeze,gardener}/",
+    );
     expect(sourceWorkspaceInstall).not.toContain(".first-tree/submodules/");
     expect(sourceWorkspaceInstall).toContain("workspace-member");
     expect(sourceWorkspaceInstall).toContain("first-tree tree workspace sync");
@@ -395,6 +403,8 @@ describe("skill artifacts", () => {
     expect(maintainerArchitecture).toContain("skills/first-tree/");
     expect(maintainerArchitecture).toContain("assets/tree/");
     expect(maintainerArchitecture).toContain("src/products/tree/engine/");
+    expect(maintainerArchitecture).toContain("integrate.ts");
+    expect(maintainerArchitecture).toContain("install-workflow");
     expect(maintainerArchitecture).toContain("tests/");
     expect(maintainerArchitecture).toContain(".first-tree/bindings/");
     expect(maintainerArchitecture).toContain("source-repos.md");
@@ -402,6 +412,9 @@ describe("skill artifacts", () => {
 
     const upgradeContract = read(
       "skills/first-tree/references/upgrade-contract.md",
+    );
+    expect(upgradeContract).toContain(
+      ".agents/skills/{first-tree,tree,breeze,gardener}/",
     );
     expect(upgradeContract).not.toContain(".first-tree/submodules/");
 
@@ -417,6 +430,11 @@ describe("skill artifacts", () => {
     expect(designSync).toContain("src/products/gardener/engine/sync.ts");
     expect(designSync).toContain("tests/gardener/sync.test.ts");
     expect(designSync).toContain("first-tree gardener sync");
+
+    const testingOverview = read("docs/testing/overview.md");
+    expect(testingOverview).toContain("tests/gardener/sync.test.ts");
+    expect(testingOverview).not.toContain("tests/tree/sync.test.ts");
+    expect(testingOverview).toContain("`tree stats`");
   });
 
   it("keeps public OSS entrypoints and package metadata in place", () => {


### PR DESCRIPTION
## Summary
- align shipped references, product READMEs, top-level docs, and manifest copy with the current first-tree CLI surface
- fix the agent anti-hallucination test to allow the real `tree status` alias while still rejecting nearby fake commands
- add lightweight docs assertions so the repaired CLI contract is guarded going forward

## Tree dependency
- canonical Context Tree nodes were aligned first and merged in agent-team-foundation/first-tree-context#159

## Testing
- `pnpm validate:skill`
- `pnpm build`
- `pnpm exec vitest run tests/e2e/thin-cli.test.ts tests/meta/skill-commands.test.ts tests/gardener/gardener-install-workflow.test.ts tests/breeze/breeze-cli.test.ts tests/tree/skill-artifacts.test.ts tests/agent-e2e/anti-hallucination.test.ts --testTimeout=15000`
