### PR TITLE
docs(breeze): align README and tests with explicit repo scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,8 +207,8 @@ continue to work cleanly for multi-repo workspaces.
 | `first-tree gardener status` | Report gardener daemon PID, schedule, and last-run state |
 | `first-tree gardener run-once` | Execute both gardener sweeps inline and exit |
 | `first-tree gardener stop` | Stop the pull-mode gardener daemon |
-| `first-tree breeze install` | Check prerequisites, create `~/.breeze/config.yaml`, and start the daemon |
-| `first-tree breeze start` | Launch the breeze daemon in the background |
+| `first-tree breeze install --allow-repo owner/repo` | Check prerequisites, create `~/.breeze/config.yaml`, and start the daemon |
+| `first-tree breeze start --allow-repo owner/repo` | Launch the breeze daemon in the background |
 | `first-tree breeze status` | Print daemon/runtime status for the current breeze profile |
 | `first-tree breeze watch` | Open the live TUI inbox and activity feed |
 | `first-tree breeze poll` | Poll GitHub notifications once without requiring the daemon |

--- a/src/products/breeze/README.md
+++ b/src/products/breeze/README.md
@@ -26,8 +26,9 @@ breeze/
 
 | Command | Role |
 |---------|------|
-| `first-tree breeze install` | Check `gh` / `jq` / auth, create `~/.breeze/config.yaml`, and start the daemon. Statusline hook wiring is a separate manual step. |
-| `first-tree breeze start/stop` | Control the daemon lifecycle |
+| `first-tree breeze install --allow-repo owner/repo` | Check `gh` / `jq` / auth, create `~/.breeze/config.yaml`, and start the daemon. Statusline hook wiring is a separate manual step. |
+| `first-tree breeze start --allow-repo owner/repo` | Launch the daemon in the background |
+| `first-tree breeze stop` | Stop the daemon and remove its lock |
 | `first-tree breeze status` | Print current daemon/runtime status |
 | `first-tree breeze doctor` | Diagnose daemon / gh login / runtime health |
 | `first-tree breeze watch` | Interactive TUI inbox (Ink) |
@@ -37,8 +38,8 @@ breeze/
 
 | Command | Role |
 |---------|------|
-| `first-tree breeze run` / `first-tree breeze daemon` | Run the broker loop in the foreground |
-| `first-tree breeze run-once` | Run one poll cycle, wait for drain, then exit |
+| `first-tree breeze run --allow-repo owner/repo` / `first-tree breeze daemon --allow-repo owner/repo` | Run the broker loop in the foreground |
+| `first-tree breeze run-once --allow-repo owner/repo` | Run one poll cycle, wait for drain, then exit |
 | `first-tree breeze cleanup` | Clear stale state |
 | `first-tree breeze statusline` | CLI shim that executes the pre-bundled `dist/breeze-statusline.js` hook |
 | `first-tree breeze status-manager` | Internal helper used by breeze runners |

--- a/tests/breeze/breeze-cli.test.ts
+++ b/tests/breeze/breeze-cli.test.ts
@@ -124,12 +124,18 @@ describe("runBreeze dispatcher", () => {
     const runCode = await freshRun(["run", "--help"], runOutput.write);
     expect(runCode).toBe(0);
     expect(runOutput.lines.join("\n")).toContain("usage: first-tree breeze run");
+    expect(runOutput.lines.join("\n")).toContain(
+      "Required: restrict work to owner/repo or owner/* patterns",
+    );
     expect(runDaemonSpy).not.toHaveBeenCalled();
 
     const startOutput = captureOutput();
     const startCode = await freshRun(["start", "--help"], startOutput.write);
     expect(startCode).toBe(0);
     expect(startOutput.lines.join("\n")).toContain("usage: first-tree breeze start");
+    expect(startOutput.lines.join("\n")).toContain(
+      "Required: restrict work to owner/repo or owner/* patterns",
+    );
     expect(runStartSpy).not.toHaveBeenCalled();
   });
 

--- a/tests/tree/skill-artifacts.test.ts
+++ b/tests/tree/skill-artifacts.test.ts
@@ -255,7 +255,12 @@ describe("skill artifacts", () => {
     expect(read("README.md")).toContain("first-tree tree workspace sync");
     expect(read("README.md")).toContain("first-tree gardener start");
     expect(read("README.md")).toContain("first-tree gardener run-once");
-    expect(read("README.md")).toContain("first-tree breeze install");
+    expect(read("README.md")).toContain(
+      "first-tree breeze install --allow-repo owner/repo",
+    );
+    expect(read("README.md")).toContain(
+      "first-tree breeze start --allow-repo owner/repo",
+    );
     expect(read("README.md")).toContain(".first-tree/source.json");
     expect(read("README.md")).toContain(".first-tree/tree.json");
     expect(read("README.md")).toContain(".first-tree/bindings/");
@@ -276,6 +281,19 @@ describe("skill artifacts", () => {
     expect(read("AGENTS.md")).not.toContain("### Running evals");
     expect(read("AGENTS.md")).not.toContain("EVALS_TREE_REPO");
     expect(read("src/cli.ts")).not.toContain("from upstream");
+
+    const breezeReadme = read("src/products/breeze/README.md");
+    expect(breezeReadme).toContain(
+      "first-tree breeze install --allow-repo owner/repo",
+    );
+    expect(breezeReadme).toContain(
+      "first-tree breeze run --allow-repo owner/repo",
+    );
+
+    const breezeSkill = read("skills/breeze/SKILL.md");
+    expect(breezeSkill).toContain(
+      "Any command that starts the daemon now requires an explicit `--allow-repo`",
+    );
     // Note: #evals/* import alias is in package.json but evals/ is excluded from "files" so it won't ship to npm
 
     const onboarding = read("skills/first-tree/references/onboarding.md");


### PR DESCRIPTION
## Summary
- update the root README and breeze product README to show `--allow-repo` on daemon-starting examples
- extend doc/skill alignment tests so README, product README, and the breeze skill stay in sync on the explicit repo-scope contract
- tighten breeze CLI help assertions around the required `--allow-repo` wording

## Why
The startup behavior was already changed in #248, but the top-level README still showed `breeze install` / `breeze start` without the required repo scope. This follow-up closes that documentation + test parity gap before publish.

## Validation
- `pnpm exec vitest run tests/breeze/breeze-cli.test.ts tests/tree/skill-artifacts.test.ts`