### PR TITLE
fix(gardener/daemon): format --merged-since as minutes, not raw seconds

### DIFF
--- a/src/products/gardener/engine/daemon/loop.ts
+++ b/src/products/gardener/engine/daemon/loop.ts
@@ -132,6 +132,21 @@ async function defaultRunSweep(
   return invokeCli(args, config.treePath);
 }
 
+/**
+ * Format a lookback in seconds into a duration string that
+ * `gardener comment --merged-since` accepts. The comment parser only
+ * supports `m/h/d/w` suffixes, so bare seconds (e.g. `600s`) are
+ * rejected. Round up to the nearest minute so we never shrink the
+ * window below what the operator configured.
+ */
+export function formatMergedSince(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) return "1m";
+  if (seconds < 60) return "1m";
+  if (seconds % 86400 === 0) return `${seconds / 86400}d`;
+  if (seconds % 3600 === 0) return `${seconds / 3600}h`;
+  return `${Math.ceil(seconds / 60)}m`;
+}
+
 export function buildGardenerSweepArgs(
   config: GardenerDaemonConfig,
 ): string[] {
@@ -141,7 +156,7 @@ export function buildGardenerSweepArgs(
     "--tree-path",
     config.treePath,
     "--merged-since",
-    `${config.mergedLookbackSeconds}s`,
+    formatMergedSince(config.mergedLookbackSeconds),
   ];
   if (config.assignOwners) args.push("--assign-owners");
   return args;

--- a/tests/gardener/gardener-daemon.test.ts
+++ b/tests/gardener/gardener-daemon.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   buildGardenerSweepArgs,
   buildSyncSweepArgs,
+  formatMergedSince,
   parseBreezeResult,
   runOnce,
 } from "#products/gardener/engine/daemon/loop.js";
@@ -138,6 +139,41 @@ describe("gardener daemon -- state helpers", () => {
   });
 });
 
+describe("gardener daemon -- formatMergedSince", () => {
+  it("formats minutes when no larger unit divides cleanly", () => {
+    expect(formatMergedSince(600)).toBe("10m");
+    expect(formatMergedSince(120)).toBe("2m");
+  });
+
+  it("prefers hours when the duration is a whole number of hours", () => {
+    expect(formatMergedSince(3600)).toBe("1h");
+    expect(formatMergedSince(7200)).toBe("2h");
+  });
+
+  it("prefers days when the duration is a whole number of days", () => {
+    expect(formatMergedSince(86400)).toBe("1d");
+    expect(formatMergedSince(172800)).toBe("2d");
+  });
+
+  it("rounds sub-minute durations up to the parser's minimum (1m)", () => {
+    expect(formatMergedSince(1)).toBe("1m");
+    expect(formatMergedSince(59)).toBe("1m");
+  });
+
+  it("handles non-positive/NaN inputs safely", () => {
+    expect(formatMergedSince(0)).toBe("1m");
+    expect(formatMergedSince(-5)).toBe("1m");
+    expect(formatMergedSince(Number.NaN)).toBe("1m");
+  });
+
+  it("never emits an `s` suffix (rejected by `gardener comment --merged-since`)", () => {
+    for (const seconds of [1, 59, 60, 120, 600, 3599, 3600, 86399, 86400]) {
+      expect(formatMergedSince(seconds)).not.toMatch(/s$/);
+      expect(formatMergedSince(seconds)).toMatch(/^\d+[mhdw]$/);
+    }
+  });
+});
+
 describe("gardener daemon -- sweep arg builders", () => {
   it("gardener sweep passes --merged-since and assign-owners when enabled", () => {
     const config = buildDaemonConfig({
@@ -151,7 +187,8 @@ describe("gardener daemon -- sweep arg builders", () => {
     expect(args).toContain("comment");
     expect(args).toContain("--merged-since");
     const idx = args.indexOf("--merged-since");
-    expect(args[idx + 1]).toMatch(/^\d+s$/);
+    // Must be m/h/d/w — `gardener comment --merged-since` rejects `s`.
+    expect(args[idx + 1]).toMatch(/^\d+[mhdw]$/);
     expect(args).toContain("--assign-owners");
   });
 


### PR DESCRIPTION
## Summary

The daemon was interpolating `mergedLookbackSeconds` directly as `${n}s`, but `gardener comment --merged-since` only accepts `m/h/d/w` suffixes. Every daemon gardener-sweep tick was failing on argument parsing before doing any work.

## Fix

Added `formatMergedSince()` helper in `loop.ts` that picks the largest clean unit (d/h/m) and rounds sub-minute inputs up to `1m` (the parser's minimum).

## Tests

- Updated existing sweep-arg builder assertion from `/^\d+s$/` (which enshrined the bug) to `/^\d+[mhdw]$/`.
- Added a dedicated `formatMergedSince` test suite covering minute/hour/day preference, sub-minute rounding, and NaN/negative/zero handling.

All 33 tests in `tests/gardener/gardener-daemon.test.ts` pass.

Closes #252