### PR TITLE
feat(gardener/comment): ship a built-in Anthropic classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ continue to work cleanly for multi-repo workspaces.
 | `first-tree tree inject-context` | Output a Claude Code SessionStart hook payload from the root `NODE.md` |
 | `first-tree tree help onboarding` | Print the full onboarding guide |
 | `first-tree gardener sync` | Detect drift between a tree repo and its bound source repos; supports `--propose` and `--apply`. Moved from `first-tree tree sync`. |
-| `first-tree gardener comment` | Review a source-repo PR or issue against the tree and post a structured verdict comment; scan mode sweeps every configured `target_repo` |
+| `first-tree gardener comment` | Review a source-repo PR or issue against the tree and post a structured verdict comment; scan mode sweeps every configured `target_repo`. Requires `ANTHROPIC_API_KEY` in the environment — without it the CLI skips without posting. Override the model with `GARDENER_CLASSIFIER_MODEL` (default: `claude-haiku-4-5`). |
 | `first-tree gardener respond` | Fix a tree-repo sync PR based on reviewer feedback |
 | `first-tree gardener install-workflow` | Scaffold the push-mode GitHub Actions workflow in a codebase repo |
 | `first-tree gardener start` | Launch the pull-mode gardener daemon in the background |

--- a/src/products/gardener/cli.ts
+++ b/src/products/gardener/cli.ts
@@ -108,6 +108,17 @@ export async function runGardener(
       const { runComment } = await import(
         "./engine/commands/comment.js"
       );
+      const apiKey = process.env.ANTHROPIC_API_KEY;
+      if (apiKey) {
+        const { createAnthropicClassifier } = await import(
+          "./engine/classifiers/anthropic.js"
+        );
+        const model = process.env.GARDENER_CLASSIFIER_MODEL;
+        return runComment(args.slice(1), {
+          write,
+          classifier: createAnthropicClassifier({ apiKey, model }),
+        });
+      }
       return runComment(args.slice(1), { write });
     }
     case "install-workflow": {

--- a/src/products/gardener/engine/classifiers/anthropic.ts
+++ b/src/products/gardener/engine/classifiers/anthropic.ts
@@ -1,0 +1,272 @@
+/**
+ * Anthropic-backed Classifier for the gardener comment pipeline.
+ *
+ * Gated on `ANTHROPIC_API_KEY`. When the key is present, the CLI wires
+ * this into `runComment`; when absent, runComment refuses to post (see
+ * #253). The default model is `claude-haiku-4-5` — cheap and fast
+ * enough for per-PR review cadence. Override with
+ * `GARDENER_CLASSIFIER_MODEL` if you need better judgment at more cost.
+ *
+ * The model receives:
+ *   - a role prompt explaining the verdict schema
+ *   - the NODE.md digest for this tree (see tree-digest.ts)
+ *   - the PR title/body/diff (or issue title/body)
+ * and must respond with a single JSON object matching ClassifyOutput.
+ *
+ * On any error (network, non-JSON response, bad schema) we return the
+ * INSUFFICIENT_CONTEXT sentinel with a diagnostic summary so the
+ * downstream pipeline can still skip cleanly instead of posting garbage.
+ */
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import type {
+  Classifier,
+  ClassifyInput,
+  ClassifyOutput,
+  Severity,
+  Verdict,
+} from "../comment.js";
+import { collectTreeDigest, formatDigest } from "./tree-digest.js";
+
+const DEFAULT_MODEL = "claude-haiku-4-5";
+const ANTHROPIC_URL = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_VERSION = "2023-06-01";
+const MAX_TOKENS = 1024;
+const DIFF_CAP = 20_000;
+
+const VALID_VERDICTS: ReadonlySet<Verdict> = new Set<Verdict>([
+  "ALIGNED",
+  "NEW_TERRITORY",
+  "NEEDS_REVIEW",
+  "CONFLICT",
+  "INSUFFICIENT_CONTEXT",
+]);
+const VALID_SEVERITIES: ReadonlySet<Severity> = new Set<Severity>([
+  "low",
+  "medium",
+  "high",
+  "critical",
+]);
+
+export interface AnthropicClassifierOptions {
+  apiKey: string;
+  model?: string;
+  /** Injected fetch for tests. Defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+export function createAnthropicClassifier(
+  opts: AnthropicClassifierOptions,
+): Classifier {
+  const model = opts.model ?? DEFAULT_MODEL;
+  const doFetch = opts.fetchImpl ?? fetch;
+  return async (input: ClassifyInput): Promise<ClassifyOutput> => {
+    const digest = formatDigest(collectTreeDigest(input.treeRoot));
+    const userPrompt = buildUserPrompt(input, digest);
+    try {
+      const res = await doFetch(ANTHROPIC_URL, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": opts.apiKey,
+          "anthropic-version": ANTHROPIC_VERSION,
+        },
+        body: JSON.stringify({
+          model,
+          max_tokens: MAX_TOKENS,
+          system: SYSTEM_PROMPT,
+          messages: [{ role: "user", content: userPrompt }],
+        }),
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        return fallback(
+          `anthropic API ${res.status}: ${text.slice(0, 200)}`,
+        );
+      }
+      const body = (await res.json()) as AnthropicMessagesResponse;
+      const text = extractText(body);
+      if (!text) return fallback("anthropic response had no text content");
+      const parsed = parseVerdictJson(text);
+      if (!parsed) {
+        return fallback(
+          `could not parse verdict JSON from model output: ${text.slice(0, 200)}`,
+        );
+      }
+      return validateAndGroundNodes(parsed, input.treeRoot);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return fallback(`anthropic classifier error: ${msg}`);
+    }
+  };
+}
+
+interface AnthropicMessagesResponse {
+  content?: Array<{ type: string; text?: string }>;
+}
+
+function extractText(body: AnthropicMessagesResponse): string | null {
+  if (!body.content) return null;
+  const joined = body.content
+    .filter((b) => b.type === "text" && typeof b.text === "string")
+    .map((b) => b.text)
+    .join("");
+  return joined.length > 0 ? joined : null;
+}
+
+/**
+ * Model output can be wrapped in prose or code fences. Extract the
+ * first JSON object and parse it. Returns null if no valid object.
+ */
+export function parseVerdictJson(text: string): ClassifyOutput | null {
+  const stripped = text.replace(/```(?:json)?/gi, "").trim();
+  const start = stripped.indexOf("{");
+  if (start === -1) return null;
+  // Find the matching close brace via depth counting (cheap; we only
+  // expect one object per response).
+  let depth = 0;
+  let end = -1;
+  for (let i = start; i < stripped.length; i += 1) {
+    const c = stripped[i];
+    if (c === "{") depth += 1;
+    else if (c === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  if (end === -1) return null;
+  const slice = stripped.slice(start, end + 1);
+  let obj: unknown;
+  try {
+    obj = JSON.parse(slice);
+  } catch {
+    return null;
+  }
+  return shapeToClassifyOutput(obj);
+}
+
+function shapeToClassifyOutput(obj: unknown): ClassifyOutput | null {
+  if (!obj || typeof obj !== "object") return null;
+  const o = obj as Record<string, unknown>;
+  const verdict = o.verdict;
+  const severity = o.severity;
+  const summary = o.summary;
+  if (typeof verdict !== "string" || !VALID_VERDICTS.has(verdict as Verdict)) {
+    return null;
+  }
+  if (
+    typeof severity !== "string" ||
+    !VALID_SEVERITIES.has(severity as Severity)
+  ) {
+    return null;
+  }
+  if (typeof summary !== "string") return null;
+  const nodesRaw = Array.isArray(o.treeNodes) ? o.treeNodes : [];
+  const treeNodes: Array<{ path: string; summary: string }> = [];
+  for (const n of nodesRaw) {
+    if (!n || typeof n !== "object") continue;
+    const nn = n as Record<string, unknown>;
+    if (typeof nn.path === "string" && typeof nn.summary === "string") {
+      treeNodes.push({ path: nn.path, summary: nn.summary });
+    }
+  }
+  return {
+    verdict: verdict as Verdict,
+    severity: severity as Severity,
+    summary,
+    treeNodes,
+  };
+}
+
+/**
+ * Drop cited tree nodes that don't exist on disk. Models sometimes
+ * hallucinate plausible-looking paths; letting those through would
+ * render broken links in the comment body.
+ */
+export function validateAndGroundNodes(
+  out: ClassifyOutput,
+  treeRoot: string,
+): ClassifyOutput {
+  const grounded = out.treeNodes.filter((n) =>
+    existsSync(join(treeRoot, n.path))
+  );
+  return { ...out, treeNodes: grounded };
+}
+
+function fallback(reason: string): ClassifyOutput {
+  return {
+    verdict: "INSUFFICIENT_CONTEXT",
+    severity: "low",
+    summary: reason,
+    treeNodes: [],
+  };
+}
+
+const SYSTEM_PROMPT = `You are the gardener: you review pull requests and issues on a source
+code repo against a Context Tree (the tree captures cross-domain
+decisions, constraints, and the "why" behind architectural choices).
+
+Your job is to decide how this PR/issue relates to the decisions
+recorded in the tree. You will be given a digest of every NODE.md in
+the tree and the PR/issue content.
+
+Respond with a single JSON object and nothing else:
+
+{
+  "verdict": "ALIGNED" | "NEW_TERRITORY" | "NEEDS_REVIEW" | "CONFLICT" | "INSUFFICIENT_CONTEXT",
+  "severity": "low" | "medium" | "high" | "critical",
+  "summary": "<one sentence, <= 200 chars, plain prose>",
+  "treeNodes": [
+    { "path": "<tree-root-relative path to NODE.md or leaf>", "summary": "<one line>" }
+  ]
+}
+
+Verdict guidance:
+- ALIGNED: the change clearly matches an existing tree decision. Cite the node.
+- NEW_TERRITORY: the change is in an area the tree doesn't cover yet. treeNodes may be empty.
+- NEEDS_REVIEW: touches tree-recorded decisions and deserves a human look, but isn't a direct conflict.
+- CONFLICT: contradicts an existing tree decision. Cite the node that conflicts.
+- INSUFFICIENT_CONTEXT: you cannot tell from the inputs. Use sparingly.
+
+Severity guidance: match the blast radius. CONFLICT + critical for
+decisions that would require a tree PR; ALIGNED is almost always low.
+
+Only cite tree nodes whose paths appear in the digest. Do not invent
+paths. Keep summaries terse — this comment is posted to a PR.`;
+
+function buildUserPrompt(input: ClassifyInput, digest: string): string {
+  const parts: string[] = [];
+  parts.push("## Tree digest");
+  parts.push(digest);
+  parts.push("");
+  if (input.type === "pr" && input.prView) {
+    parts.push(`## PR #${input.prView.number ?? "?"}: ${input.prView.title ?? ""}`);
+    if (input.prView.body) {
+      parts.push("");
+      parts.push(input.prView.body);
+    }
+    if (input.diff) {
+      parts.push("");
+      parts.push("## Diff");
+      parts.push("```diff");
+      parts.push(input.diff.slice(0, DIFF_CAP));
+      if (input.diff.length > DIFF_CAP) {
+        parts.push(`... (truncated, ${input.diff.length - DIFF_CAP} bytes omitted)`);
+      }
+      parts.push("```");
+    }
+  } else if (input.type === "issue" && input.issueView) {
+    parts.push(`## Issue #${input.issueView.number ?? "?"}: ${input.issueView.title ?? ""}`);
+    if (input.issueView.body) {
+      parts.push("");
+      parts.push(input.issueView.body);
+    }
+  } else {
+    parts.push("(no PR or issue view supplied)");
+  }
+  return parts.join("\n");
+}

--- a/src/products/gardener/engine/classifiers/anthropic.ts
+++ b/src/products/gardener/engine/classifiers/anthropic.ts
@@ -19,7 +19,7 @@
  */
 
 import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, relative, resolve, sep } from "node:path";
 import type {
   Classifier,
   ClassifyInput,
@@ -34,6 +34,8 @@ const ANTHROPIC_URL = "https://api.anthropic.com/v1/messages";
 const ANTHROPIC_VERSION = "2023-06-01";
 const MAX_TOKENS = 1024;
 const DIFF_CAP = 20_000;
+const FETCH_TIMEOUT_MS = 60_000;
+const MODEL_SUMMARY_CAP = 200;
 
 const VALID_VERDICTS: ReadonlySet<Verdict> = new Set<Verdict>([
   "ALIGNED",
@@ -67,6 +69,7 @@ export function createAnthropicClassifier(
     try {
       const res = await doFetch(ANTHROPIC_URL, {
         method: "POST",
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
         headers: {
           "content-type": "application/json",
           "x-api-key": opts.apiKey,
@@ -177,7 +180,7 @@ function shapeToClassifyOutput(obj: unknown): ClassifyOutput | null {
   return {
     verdict: verdict as Verdict,
     severity: severity as Severity,
-    summary,
+    summary: clampSummary(summary),
     treeNodes,
   };
 }
@@ -191,10 +194,39 @@ export function validateAndGroundNodes(
   out: ClassifyOutput,
   treeRoot: string,
 ): ClassifyOutput {
-  const grounded = out.treeNodes.filter((n) =>
-    existsSync(join(treeRoot, n.path))
-  );
+  const grounded = out.treeNodes.flatMap((n) => {
+    const normalized = normalizeGroundedPath(treeRoot, n.path);
+    if (!normalized || !existsSync(normalized.absolute)) return [];
+    return [{ ...n, path: normalized.relative }];
+  });
   return { ...out, treeNodes: grounded };
+}
+
+function clampSummary(summary: string): string {
+  if (summary.length <= MODEL_SUMMARY_CAP) return summary;
+  return summary.slice(0, MODEL_SUMMARY_CAP - 1) + "…";
+}
+
+function normalizeGroundedPath(
+  treeRoot: string,
+  citedPath: string,
+): { absolute: string; relative: string } | null {
+  if (isAbsolute(citedPath)) return null;
+  const root = resolve(treeRoot);
+  const absolute = resolve(root, citedPath);
+  const relativePath = relative(root, absolute);
+  if (
+    relativePath.length === 0 ||
+    relativePath.startsWith(`..${sep}`) ||
+    relativePath === ".." ||
+    isAbsolute(relativePath)
+  ) {
+    return null;
+  }
+  return {
+    absolute,
+    relative: relativePath.split(sep).join("/"),
+  };
 }
 
 function fallback(reason: string): ClassifyOutput {

--- a/src/products/gardener/engine/classifiers/tree-digest.ts
+++ b/src/products/gardener/engine/classifiers/tree-digest.ts
@@ -1,0 +1,122 @@
+/**
+ * Walk `treeRoot` for `NODE.md` files and build a compact digest the
+ * Anthropic classifier can use to ground its verdict. The digest is
+ * `path + description + first paragraph` per node, capped at
+ * DIGEST_BUDGET_BYTES so large trees don't blow the prompt.
+ *
+ * This is intentionally a flat listing — no tree structure, no link
+ * resolution. The model sees "here are the tree nodes that exist,
+ * here is what each one is about" and can cite paths by string. We
+ * verify cited paths against the filesystem downstream (see
+ * validateTreeNodes) so hallucinated citations get dropped before
+ * comment body construction.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+
+export interface TreeNodeEntry {
+  /** tree-root-relative path to the NODE.md file (POSIX slashes). */
+  path: string;
+  /** Frontmatter `description:` if present, else the first paragraph. */
+  summary: string;
+}
+
+const DIGEST_BUDGET_BYTES = 30_000;
+const PER_NODE_SUMMARY_CAP = 400;
+const SKIP_DIRS = new Set([
+  ".git",
+  "node_modules",
+  ".first-tree",
+  ".claude",
+  ".agents",
+  "dist",
+  "build",
+  "tmp",
+]);
+
+export function collectTreeDigest(treeRoot: string): TreeNodeEntry[] {
+  const out: TreeNodeEntry[] = [];
+  let bytes = 0;
+  const walk = (dir: string): void => {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const name of entries) {
+      if (SKIP_DIRS.has(name)) continue;
+      const full = join(dir, name);
+      let st;
+      try {
+        st = statSync(full);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) {
+        walk(full);
+        continue;
+      }
+      if (name !== "NODE.md") continue;
+      const entry = readNodeFile(full, treeRoot);
+      if (!entry) continue;
+      const cost = entry.path.length + entry.summary.length + 4;
+      if (bytes + cost > DIGEST_BUDGET_BYTES) return;
+      bytes += cost;
+      out.push(entry);
+    }
+  };
+  walk(treeRoot);
+  return out;
+}
+
+function readNodeFile(
+  full: string,
+  treeRoot: string,
+): TreeNodeEntry | null {
+  let text: string;
+  try {
+    text = readFileSync(full, "utf-8");
+  } catch {
+    return null;
+  }
+  const rel = relative(treeRoot, full).split(sep).join("/");
+  const summary = extractSummary(text);
+  return { path: rel, summary };
+}
+
+function extractSummary(text: string): string {
+  const fm = text.match(/^---\s*\n([\s\S]*?)\n---\s*\n?/);
+  if (fm) {
+    const desc = fm[1].match(/^description\s*:\s*(.+?)\s*$/m);
+    if (desc) return trimSummary(stripQuotes(desc[1]));
+  }
+  const body = fm ? text.slice(fm[0].length) : text;
+  const paragraphs = body.split(/\n\s*\n/);
+  for (const p of paragraphs) {
+    const stripped = p.replace(/^#+\s+.*$/gm, "").trim();
+    if (stripped.length > 0) return trimSummary(stripped.replace(/\s+/g, " "));
+  }
+  return "";
+}
+
+function stripQuotes(s: string): string {
+  if (
+    (s.startsWith('"') && s.endsWith('"')) ||
+    (s.startsWith("'") && s.endsWith("'"))
+  ) {
+    return s.slice(1, -1);
+  }
+  return s;
+}
+
+function trimSummary(s: string): string {
+  if (s.length <= PER_NODE_SUMMARY_CAP) return s;
+  return s.slice(0, PER_NODE_SUMMARY_CAP - 1) + "…";
+}
+
+export function formatDigest(entries: TreeNodeEntry[]): string {
+  if (entries.length === 0) return "(no NODE.md files found)";
+  return entries.map((e) => `- \`${e.path}\` — ${e.summary}`).join("\n");
+}

--- a/src/products/gardener/engine/classifiers/tree-digest.ts
+++ b/src/products/gardener/engine/classifiers/tree-digest.ts
@@ -38,7 +38,9 @@ const SKIP_DIRS = new Set([
 export function collectTreeDigest(treeRoot: string): TreeNodeEntry[] {
   const out: TreeNodeEntry[] = [];
   let bytes = 0;
+  let exhausted = false;
   const walk = (dir: string): void => {
+    if (exhausted) return;
     let entries: string[];
     try {
       entries = readdirSync(dir);
@@ -46,6 +48,7 @@ export function collectTreeDigest(treeRoot: string): TreeNodeEntry[] {
       return;
     }
     for (const name of entries) {
+      if (exhausted) return;
       if (SKIP_DIRS.has(name)) continue;
       const full = join(dir, name);
       let st;
@@ -62,7 +65,10 @@ export function collectTreeDigest(treeRoot: string): TreeNodeEntry[] {
       const entry = readNodeFile(full, treeRoot);
       if (!entry) continue;
       const cost = entry.path.length + entry.summary.length + 4;
-      if (bytes + cost > DIGEST_BUDGET_BYTES) return;
+      if (bytes + cost > DIGEST_BUDGET_BYTES) {
+        exhausted = true;
+        return;
+      }
       bytes += cost;
       out.push(entry);
     }

--- a/src/products/gardener/engine/comment.ts
+++ b/src/products/gardener/engine/comment.ts
@@ -98,6 +98,15 @@ Options:
   --help, -h            Show this help message
 
 Environment:
+  ANTHROPIC_API_KEY     When set, the CLI wires a built-in Anthropic
+                        classifier into runComment. When unset, the CLI
+                        refuses to post (it would only produce the
+                        INSUFFICIENT_CONTEXT sentinel) and exits with a
+                        skip trailer. Required for this command to do
+                        anything useful.
+  GARDENER_CLASSIFIER_MODEL
+                        Override the Claude model used by the built-in
+                        classifier (default: claude-haiku-4-5).
   BREEZE_SNAPSHOT_DIR   Directory containing pre-fetched pr-view.json,
                         pr.diff, issue-view.json, issue-comments.json,
                         and subject.json. When set, those files are

--- a/tests/gardener/gardener-anthropic-classifier.test.ts
+++ b/tests/gardener/gardener-anthropic-classifier.test.ts
@@ -1,0 +1,291 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  createAnthropicClassifier,
+  parseVerdictJson,
+  validateAndGroundNodes,
+} from "#products/gardener/engine/classifiers/anthropic.js";
+import {
+  collectTreeDigest,
+  formatDigest,
+} from "#products/gardener/engine/classifiers/tree-digest.js";
+import type { ClassifyInput } from "#products/gardener/engine/comment.js";
+import { useTmpDir } from "../helpers.js";
+
+function seedTree(root: string): void {
+  mkdirSync(join(root, "engineering"), { recursive: true });
+  mkdirSync(join(root, "product"), { recursive: true });
+  writeFileSync(
+    join(root, "NODE.md"),
+    "---\ntitle: Root\ndescription: Example tree root\n---\n",
+  );
+  writeFileSync(
+    join(root, "engineering", "NODE.md"),
+    "---\ntitle: Engineering\ndescription: Backend services and runtime.\n---\n",
+  );
+  writeFileSync(
+    join(root, "product", "NODE.md"),
+    "---\ntitle: Product\n---\n\nThin core scope for V1.\n",
+  );
+}
+
+const prInput = (treeRoot: string): ClassifyInput => ({
+  type: "pr",
+  prView: {
+    number: 42,
+    title: "Add payment module",
+    body: "Ships the new payments table and handler.",
+    headRefOid: "abc123",
+    state: "OPEN",
+  },
+  diff: "diff --git a/src/payments.ts b/src/payments.ts\n+new code\n",
+  treeRoot,
+  treeSha: "treesha",
+});
+
+function stubFetch(text: string): typeof fetch {
+  return (async () =>
+    new Response(
+      JSON.stringify({ content: [{ type: "text", text }] }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    )) as typeof fetch;
+}
+
+describe("tree-digest collectTreeDigest", () => {
+  it("finds NODE.md files with frontmatter description or first paragraph", () => {
+    const tmp = useTmpDir();
+    seedTree(tmp.path);
+    const entries = collectTreeDigest(tmp.path);
+    expect(entries.length).toBe(3);
+    const root = entries.find((e) => e.path === "NODE.md");
+    expect(root?.summary).toBe("Example tree root");
+    const eng = entries.find((e) => e.path === "engineering/NODE.md");
+    expect(eng?.summary).toContain("Backend");
+    const product = entries.find((e) => e.path === "product/NODE.md");
+    expect(product?.summary).toBe("Thin core scope for V1.");
+  });
+
+  it("skips noise directories like node_modules and .git", () => {
+    const tmp = useTmpDir();
+    seedTree(tmp.path);
+    mkdirSync(join(tmp.path, "node_modules", "x"), { recursive: true });
+    writeFileSync(
+      join(tmp.path, "node_modules", "x", "NODE.md"),
+      "---\ntitle: Leaked\n---\n",
+    );
+    const entries = collectTreeDigest(tmp.path);
+    expect(entries.every((e) => !e.path.startsWith("node_modules/"))).toBe(true);
+  });
+});
+
+describe("tree-digest formatDigest", () => {
+  it("renders a bulleted list with backticked paths", () => {
+    const out = formatDigest([
+      { path: "a/NODE.md", summary: "hello" },
+      { path: "b/NODE.md", summary: "world" },
+    ]);
+    expect(out).toContain("- `a/NODE.md` — hello");
+    expect(out).toContain("- `b/NODE.md` — world");
+  });
+
+  it("handles empty input", () => {
+    expect(formatDigest([])).toBe("(no NODE.md files found)");
+  });
+});
+
+describe("parseVerdictJson", () => {
+  it("parses a bare JSON object", () => {
+    const out = parseVerdictJson(
+      JSON.stringify({
+        verdict: "ALIGNED",
+        severity: "low",
+        summary: "fits V1",
+        treeNodes: [{ path: "product/NODE.md", summary: "scope" }],
+      }),
+    );
+    expect(out?.verdict).toBe("ALIGNED");
+    expect(out?.treeNodes).toHaveLength(1);
+  });
+
+  it("strips ```json code fences", () => {
+    const out = parseVerdictJson(
+      '```json\n{"verdict":"CONFLICT","severity":"high","summary":"contradicts","treeNodes":[]}\n```',
+    );
+    expect(out?.verdict).toBe("CONFLICT");
+    expect(out?.severity).toBe("high");
+  });
+
+  it("rejects invalid verdict", () => {
+    const out = parseVerdictJson(
+      '{"verdict":"MAYBE","severity":"low","summary":"x","treeNodes":[]}',
+    );
+    expect(out).toBeNull();
+  });
+
+  it("rejects missing summary", () => {
+    const out = parseVerdictJson(
+      '{"verdict":"ALIGNED","severity":"low","treeNodes":[]}',
+    );
+    expect(out).toBeNull();
+  });
+
+  it("returns null on non-JSON prose", () => {
+    expect(parseVerdictJson("The model chose to refuse.")).toBeNull();
+  });
+
+  it("drops malformed treeNodes entries but keeps well-formed ones", () => {
+    const out = parseVerdictJson(
+      '{"verdict":"ALIGNED","severity":"low","summary":"s","treeNodes":[{"path":"a","summary":"b"},{"nope":true},"string"]}',
+    );
+    expect(out?.treeNodes).toEqual([{ path: "a", summary: "b" }]);
+  });
+});
+
+describe("validateAndGroundNodes", () => {
+  it("drops cited paths that do not exist on disk", () => {
+    const tmp = useTmpDir();
+    seedTree(tmp.path);
+    const grounded = validateAndGroundNodes(
+      {
+        verdict: "ALIGNED",
+        severity: "low",
+        summary: "x",
+        treeNodes: [
+          { path: "product/NODE.md", summary: "real" },
+          { path: "imaginary/NODE.md", summary: "hallucinated" },
+        ],
+      },
+      tmp.path,
+    );
+    expect(grounded.treeNodes).toEqual([
+      { path: "product/NODE.md", summary: "real" },
+    ]);
+  });
+});
+
+describe("createAnthropicClassifier", () => {
+  it("returns the parsed verdict on a well-formed response", async () => {
+    const tmp = useTmpDir();
+    seedTree(tmp.path);
+    const classifier = createAnthropicClassifier({
+      apiKey: "sk-test",
+      fetchImpl: stubFetch(
+        JSON.stringify({
+          verdict: "ALIGNED",
+          severity: "low",
+          summary: "matches V1 scope",
+          treeNodes: [{ path: "product/NODE.md", summary: "V1 scope" }],
+        }),
+      ),
+    });
+    const out = await classifier(prInput(tmp.path));
+    expect(out.verdict).toBe("ALIGNED");
+    expect(out.treeNodes).toEqual([
+      { path: "product/NODE.md", summary: "V1 scope" },
+    ]);
+  });
+
+  it("falls back to INSUFFICIENT_CONTEXT on non-JSON response", async () => {
+    const tmp = useTmpDir();
+    seedTree(tmp.path);
+    const classifier = createAnthropicClassifier({
+      apiKey: "sk-test",
+      fetchImpl: stubFetch("I cannot decide this one."),
+    });
+    const out = await classifier(prInput(tmp.path));
+    expect(out.verdict).toBe("INSUFFICIENT_CONTEXT");
+    expect(out.summary).toContain("could not parse");
+  });
+
+  it("falls back on non-2xx HTTP status", async () => {
+    const tmp = useTmpDir();
+    seedTree(tmp.path);
+    const failingFetch: typeof fetch = (async () =>
+      new Response("rate limited", { status: 429 })) as typeof fetch;
+    const classifier = createAnthropicClassifier({
+      apiKey: "sk-test",
+      fetchImpl: failingFetch,
+    });
+    const out = await classifier(prInput(tmp.path));
+    expect(out.verdict).toBe("INSUFFICIENT_CONTEXT");
+    expect(out.summary).toContain("anthropic API 429");
+  });
+
+  it("falls back on network error", async () => {
+    const tmp = useTmpDir();
+    seedTree(tmp.path);
+    const throwingFetch: typeof fetch = (async () => {
+      throw new Error("ENETDOWN");
+    }) as typeof fetch;
+    const classifier = createAnthropicClassifier({
+      apiKey: "sk-test",
+      fetchImpl: throwingFetch,
+    });
+    const out = await classifier(prInput(tmp.path));
+    expect(out.verdict).toBe("INSUFFICIENT_CONTEXT");
+    expect(out.summary).toContain("ENETDOWN");
+  });
+
+  it("drops hallucinated treeNodes before returning", async () => {
+    const tmp = useTmpDir();
+    seedTree(tmp.path);
+    const classifier = createAnthropicClassifier({
+      apiKey: "sk-test",
+      fetchImpl: stubFetch(
+        JSON.stringify({
+          verdict: "CONFLICT",
+          severity: "high",
+          summary: "contradicts scope",
+          treeNodes: [
+            { path: "product/NODE.md", summary: "real" },
+            { path: "fabricated/NODE.md", summary: "not real" },
+          ],
+        }),
+      ),
+    });
+    const out = await classifier(prInput(tmp.path));
+    expect(out.treeNodes).toEqual([
+      { path: "product/NODE.md", summary: "real" },
+    ]);
+  });
+
+  it("sends the expected API headers and model", async () => {
+    const tmp = useTmpDir();
+    seedTree(tmp.path);
+    const seen: { url?: string; headers?: Record<string, string>; body?: string } = {};
+    const captureFetch: typeof fetch = (async (url: string, init: RequestInit) => {
+      seen.url = url;
+      seen.headers = init.headers as Record<string, string>;
+      seen.body = init.body as string;
+      return new Response(
+        JSON.stringify({
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                verdict: "ALIGNED",
+                severity: "low",
+                summary: "ok",
+                treeNodes: [],
+              }),
+            },
+          ],
+        }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+    const classifier = createAnthropicClassifier({
+      apiKey: "sk-live",
+      model: "claude-sonnet-4-6",
+      fetchImpl: captureFetch,
+    });
+    await classifier(prInput(tmp.path));
+    expect(seen.url).toBe("https://api.anthropic.com/v1/messages");
+    expect(seen.headers?.["x-api-key"]).toBe("sk-live");
+    expect(seen.headers?.["anthropic-version"]).toBe("2023-06-01");
+    const parsed = JSON.parse(seen.body ?? "{}");
+    expect(parsed.model).toBe("claude-sonnet-4-6");
+    expect(parsed.messages[0].content).toContain("Add payment module");
+  });
+});

--- a/tests/gardener/gardener-anthropic-classifier.test.ts
+++ b/tests/gardener/gardener-anthropic-classifier.test.ts
@@ -140,6 +140,19 @@ describe("parseVerdictJson", () => {
     );
     expect(out?.treeNodes).toEqual([{ path: "a", summary: "b" }]);
   });
+
+  it("truncates overlong summaries to the prompt cap", () => {
+    const out = parseVerdictJson(
+      JSON.stringify({
+        verdict: "ALIGNED",
+        severity: "low",
+        summary: "x".repeat(250),
+        treeNodes: [],
+      }),
+    );
+    expect(out?.summary).toHaveLength(200);
+    expect(out?.summary.endsWith("…")).toBe(true);
+  });
 });
 
 describe("validateAndGroundNodes", () => {
@@ -157,6 +170,31 @@ describe("validateAndGroundNodes", () => {
         ],
       },
       tmp.path,
+    );
+    expect(grounded.treeNodes).toEqual([
+      { path: "product/NODE.md", summary: "real" },
+    ]);
+  });
+
+  it("drops absolute and tree-escaping cited paths", () => {
+    const tmp = useTmpDir();
+    const treeRoot = join(tmp.path, "tree");
+    const outsideRoot = join(tmp.path, "outside");
+    seedTree(treeRoot);
+    mkdirSync(outsideRoot, { recursive: true });
+    writeFileSync(join(outsideRoot, "NODE.md"), "outside");
+    const grounded = validateAndGroundNodes(
+      {
+        verdict: "ALIGNED",
+        severity: "low",
+        summary: "x",
+        treeNodes: [
+          { path: "product/NODE.md", summary: "real" },
+          { path: "../outside/NODE.md", summary: "escape" },
+          { path: join(outsideRoot, "NODE.md"), summary: "absolute" },
+        ],
+      },
+      treeRoot,
     );
     expect(grounded.treeNodes).toEqual([
       { path: "product/NODE.md", summary: "real" },
@@ -253,11 +291,17 @@ describe("createAnthropicClassifier", () => {
   it("sends the expected API headers and model", async () => {
     const tmp = useTmpDir();
     seedTree(tmp.path);
-    const seen: { url?: string; headers?: Record<string, string>; body?: string } = {};
+    const seen: {
+      url?: string;
+      headers?: Record<string, string>;
+      body?: string;
+      signal?: AbortSignal | null;
+    } = {};
     const captureFetch: typeof fetch = (async (url: string, init: RequestInit) => {
       seen.url = url;
       seen.headers = init.headers as Record<string, string>;
       seen.body = init.body as string;
+      seen.signal = init.signal;
       return new Response(
         JSON.stringify({
           content: [
@@ -284,6 +328,7 @@ describe("createAnthropicClassifier", () => {
     expect(seen.url).toBe("https://api.anthropic.com/v1/messages");
     expect(seen.headers?.["x-api-key"]).toBe("sk-live");
     expect(seen.headers?.["anthropic-version"]).toBe("2023-06-01");
+    expect(seen.signal).toBeTruthy();
     const parsed = JSON.parse(seen.body ?? "{}");
     expect(parsed.model).toBe("claude-sonnet-4-6");
     expect(parsed.messages[0].content).toContain("Add payment module");

--- a/tests/gardener/gardener-comment.test.ts
+++ b/tests/gardener/gardener-comment.test.ts
@@ -148,6 +148,91 @@ describe("gardener CLI dispatch -- comment subcommand", () => {
     expect(GARDENER_USAGE).toContain("comment");
     expect(GARDENER_USAGE).toContain("respond");
   });
+
+  it("runGardener wires GARDENER_CLASSIFIER_MODEL into the built-in classifier", async () => {
+    const tmp = useTmpDir();
+    const snapshotDir = join(tmp.path, "snap");
+    mkdirSync(snapshotDir, { recursive: true });
+    writeFileSync(join(tmp.path, "NODE.md"), "---\ndescription: Root\n---\n");
+    writeFileSync(
+      join(snapshotDir, "pr-view.json"),
+      JSON.stringify({
+        number: 1,
+        title: "t",
+        headRefOid: "abcd",
+        state: "OPEN",
+        author: { login: "u" },
+        additions: 1,
+        deletions: 0,
+        updatedAt: "2026-04-16T00:00:00Z",
+      }),
+    );
+    writeFileSync(join(snapshotDir, "issue-comments.json"), JSON.stringify([]));
+    writeFileSync(
+      join(snapshotDir, "subject.json"),
+      JSON.stringify({ gardenerUser: "repo-gardener", treeSha: "tsha1234" }),
+    );
+    writeFileSync(join(snapshotDir, "pr.diff"), "");
+
+    const originalFetch = globalThis.fetch;
+    const originalApiKey = process.env.ANTHROPIC_API_KEY;
+    const originalModel = process.env.GARDENER_CLASSIFIER_MODEL;
+    const originalSnapshotDir = process.env.BREEZE_SNAPSHOT_DIR;
+    const seen: { body?: string } = {};
+
+    try {
+      globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+        seen.body = init?.body as string;
+        return new Response(
+          JSON.stringify({
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({
+                  verdict: "ALIGNED",
+                  severity: "low",
+                  summary: "ok",
+                  treeNodes: [],
+                }),
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }) as typeof fetch;
+      process.env.ANTHROPIC_API_KEY = "sk-test";
+      process.env.GARDENER_CLASSIFIER_MODEL = "claude-sonnet-4-6";
+      process.env.BREEZE_SNAPSHOT_DIR = snapshotDir;
+
+      const { write, lines } = captureWrite();
+      const code = await runGardener(
+        [
+          "comment",
+          "--pr",
+          "1",
+          "--repo",
+          "o/r",
+          "--tree-path",
+          tmp.path,
+          "--dry-run",
+        ],
+        write,
+      );
+
+      expect(code).toBe(0);
+      expect(lines[lines.length - 1]).toMatch(/^BREEZE_RESULT: /);
+      const parsed = JSON.parse(seen.body ?? "{}");
+      expect(parsed.model).toBe("claude-sonnet-4-6");
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalApiKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+      else process.env.ANTHROPIC_API_KEY = originalApiKey;
+      if (originalModel === undefined) delete process.env.GARDENER_CLASSIFIER_MODEL;
+      else process.env.GARDENER_CLASSIFIER_MODEL = originalModel;
+      if (originalSnapshotDir === undefined) delete process.env.BREEZE_SNAPSHOT_DIR;
+      else process.env.BREEZE_SNAPSHOT_DIR = originalSnapshotDir;
+    }
+  });
 });
 
 // ─────────────────── 4. state resolution ───────────────────


### PR DESCRIPTION
## Summary

After #253, the stock `first-tree gardener comment` refuses to post without an injected classifier — so out of the box the CLI is a no-op. This PR wires a default classifier that calls Anthropic's Messages API directly, gated on `ANTHROPIC_API_KEY`.

## Behavior

- `ANTHROPIC_API_KEY` set → CLI constructs `createAnthropicClassifier` and passes it to `runComment`. Default model `claude-haiku-4-5`, overridable via `GARDENER_CLASSIFIER_MODEL`.
- `ANTHROPIC_API_KEY` unset → #253 skip behavior stands: emit `status=skipped summary=no classifier injected` and exit 0.

## Design

- **`classifiers/tree-digest.ts`** — walks `NODE.md` files under `treeRoot`, extracts frontmatter `description:` or the first paragraph, capped at ~30KB. Skips `.git`, `node_modules`, `.first-tree`, `.claude`, `.agents`, `dist`, `build`, `tmp`.
- **`classifiers/anthropic.ts`** — assembles system + user messages, POSTs to `/v1/messages` with `anthropic-version: 2023-06-01`, extracts the first JSON object from the response. Any failure (non-2xx, network error, malformed JSON, bad schema) returns the `INSUFFICIENT_CONTEXT` sentinel with a diagnostic summary — the downstream pipeline then skips cleanly instead of posting garbage.
- **Tree-node grounding** — `validateAndGroundNodes` `existsSync`'s every cited path under `treeRoot` before the comment body is built. Hallucinated citations are silently dropped.
- **No SDK dep** — uses global `fetch`. Injectable via `fetchImpl` for tests.

## Tests

17 new tests, all passing. Full gardener suite: 254/254 green.

Coverage:
- `tree-digest`: NODE.md discovery with frontmatter vs. first-paragraph summary; noise-dir skip; digest formatting.
- `parseVerdictJson`: bare JSON, fenced JSON, invalid verdict, missing fields, prose-only input, malformed `treeNodes`.
- `validateAndGroundNodes`: drops nonexistent cited paths.
- `createAnthropicClassifier`: happy path, non-JSON response, non-2xx status, network error, hallucinated node filter, request shape (`x-api-key`, `anthropic-version`, model override).

## Docs

- `COMMENT_USAGE` Environment section documents both env vars.
- `README.md` gardener-comment row notes the key requirement and the model override.

## Scope (intentional)

- Single-item and scan paths both work since the classifier plugs into `runComment` generically.
- No cost cap or rate limiting — sweep cadence is low enough that it hasn't been necessary in testing. Can follow up if real-world use shows otherwise.
- No structured tool-use for tree navigation — digest-based grounding has been sufficient and keeps latency/cost low.

Closes #256