### PR TITLE
perf(breeze/launchd): don't shell out inside renderLaunchdPlist tests

### DIFF
--- a/src/products/breeze/engine/daemon/launchd.ts
+++ b/src/products/breeze/engine/daemon/launchd.ts
@@ -31,6 +31,19 @@ export interface LaunchdPlistInputs {
   logPath: string;
   /** Extra env variables (HOME / PATH are added automatically). */
   env?: Record<string, string | undefined>;
+  /**
+   * How to fetch a passthrough env var that isn't already in `env`.
+   * Defaults to `resolveLaunchdEnvVar`, which shells out to
+   * `/bin/zsh -lc` — fine in production, but kills test perf on slow
+   * login shells. Pass a no-op or a stub in tests.
+   */
+  resolveEnvVar?: (variable: string) => string | undefined;
+  /**
+   * How to enumerate env vars from the user's login shell. Defaults to
+   * `readLoginShellEnvVarNames`, which shells out once. Tests pass an
+   * explicit list (or `[]`) to avoid the subshell.
+   */
+  loginShellVars?: readonly string[];
 }
 
 /** True on darwin with `launchctl` available. */
@@ -216,12 +229,16 @@ export function renderLaunchdPlist(inputs: LaunchdPlistInputs): string {
   for (const [key, value] of Object.entries(inputs.env ?? {})) {
     pushEnv(key, value);
   }
-  const passthroughVars = collectLaunchdPassthroughEnvVars({
-    ...process.env,
-    ...(inputs.env ?? {}),
-  });
+  const resolveVar = inputs.resolveEnvVar ?? resolveLaunchdEnvVar;
+  const passthroughVars = collectLaunchdPassthroughEnvVars(
+    { ...process.env, ...(inputs.env ?? {}) },
+    inputs.loginShellVars ?? readLoginShellEnvVarNames(),
+  );
   for (const variable of passthroughVars) {
-    pushEnv(variable, inputs.env?.[variable] ?? resolveLaunchdEnvVar(variable));
+    // Only fall back to the resolver for vars not already supplied;
+    // keeps tests and deterministic callers subprocess-free.
+    const supplied = inputs.env?.[variable];
+    pushEnv(variable, supplied ?? resolveVar(variable));
   }
 
   const environmentXml = envPairs

--- a/tests/breeze/breeze-daemon-launchd.test.ts
+++ b/tests/breeze/breeze-daemon-launchd.test.ts
@@ -42,6 +42,12 @@ describe("escapeXml", () => {
 });
 
 describe("renderLaunchdPlist", () => {
+  // Shared stubs so tests don't spawn /bin/zsh -lc for every passthrough
+  // var (that was timing out the suite on machines with slow login
+  // shells). See issue #258.
+  const noResolve = (): undefined => undefined;
+  const noLoginShell: readonly string[] = [];
+
   it("produces a well-formed plist with KeepAlive and RunAtLoad", () => {
     const xml = renderLaunchdPlist({
       login: "alice",
@@ -50,6 +56,8 @@ describe("renderLaunchdPlist", () => {
       arguments: ["breeze", "daemon", "--backend=ts"],
       logPath: "/tmp/breeze.log",
       env: { PATH: "/opt/bin", HOME: "/Users/alice" },
+      resolveEnvVar: noResolve,
+      loginShellVars: noLoginShell,
     });
     expect(xml).toContain("<string>com.breeze.runner.alice.default</string>");
     expect(xml).toContain("<key>KeepAlive</key>");
@@ -75,6 +83,8 @@ describe("renderLaunchdPlist", () => {
       arguments: ["--note", "hello <world> & 'friends'"],
       logPath: "/tmp/x",
       env: { PATH: "/a", HOME: "/b" },
+      resolveEnvVar: noResolve,
+      loginShellVars: noLoginShell,
     });
     expect(xml).toContain("hello &lt;world&gt; &amp; &apos;friends&apos;");
   });
@@ -92,6 +102,8 @@ describe("renderLaunchdPlist", () => {
         AZURE_OPENAI_API_KEY_TEST: "test-slot-key",
         AWS_PROFILE: "bedrock-profile",
       },
+      resolveEnvVar: noResolve,
+      loginShellVars: noLoginShell,
     });
     expect(xml).toContain("<key>AZURE_OPENAI_API_KEY_TEST</key>");
     expect(xml).toContain("<string>test-slot-key</string>");


### PR DESCRIPTION
## Summary

\`renderLaunchdPlist\` was unconditionally calling \`readLoginShellEnvVarNames()\` and \`resolveLaunchdEnvVar()\` for every passthrough env var, and each of those \`spawnSync\`'s \`/bin/zsh -lc\`. On machines with slow login shells (rc files running nvm, starship, etc.), that's ~1s per subshell — three tests in \`breeze-daemon-launchd.test.ts\` were timing out at 5s after accumulating 15–25s of subshell init time.

## Fix

Add two optional injection points on \`LaunchdPlistInputs\`:

- \`resolveEnvVar?: (variable) => string | undefined\` — defaults to the production \`resolveLaunchdEnvVar\`, overridable in tests.
- \`loginShellVars?: readonly string[]\` — defaults to the result of \`readLoginShellEnvVarNames()\`, overridable in tests.

Production callers (\`bootstrapLaunchdJob\`) are untouched and still inherit real shell-resolved env. Tests pass a no-op resolver and an empty list, dropping the 3 failing tests from 5s+ timeout to 6ms total.

## Verification

\`\`\`
$ pnpm exec vitest run tests/breeze/breeze-daemon-launchd.test.ts
 Test Files  1 passed (1)
      Tests  10 passed (10)
   Duration  726ms
\`\`\`

Previously: 3 failed | 7 passed, 57s.

Closes #258