### PR TITLE
fix: bypass actions/checkout REST auth for tree-sync

### DIFF
--- a/.github/workflows/first-tree-sync.yml
+++ b/.github/workflows/first-tree-sync.yml
@@ -31,10 +31,28 @@ jobs:
           set -euo pipefail
           tree_repo_url="https://github.com/agent-team-foundation/first-tree-context.git"
           tree_repo_dir=".first-tree-cache/tree"
-          auth_header="$(printf 'x-access-token:%s' "$TREE_REPO_TOKEN" | base64 | tr -d '\n')"
           mkdir -p "$(dirname "$tree_repo_dir")"
-          git -c http.extraHeader="AUTHORIZATION: basic $auth_header" \
-            clone --depth 1 "$tree_repo_url" "$tree_repo_dir"
+          if git clone --depth 1 "$tree_repo_url" "$tree_repo_dir"; then
+            exit 0
+          fi
+
+          if [ -z "${TREE_REPO_TOKEN:-}" ]; then
+            echo "Anonymous tree clone failed and TREE_REPO_TOKEN is unset." >&2
+            exit 1
+          fi
+
+          rm -rf "$tree_repo_dir"
+          askpass_script="$RUNNER_TEMP/first-tree-git-askpass.sh"
+          cat >"$askpass_script" <<'EOF'
+          #!/bin/sh
+          case "$1" in
+            *Username*) printf '%s\n' 'x-access-token' ;;
+            *Password*) printf '%s\n' "$TREE_REPO_TOKEN" ;;
+          esac
+          EOF
+          chmod 700 "$askpass_script"
+          GIT_ASKPASS="$askpass_script" git clone --depth 1 "$tree_repo_url" "$tree_repo_dir"
+          rm -f "$askpass_script"
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/first-tree-sync.yml
+++ b/.github/workflows/first-tree-sync.yml
@@ -25,12 +25,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Checkout tree repo
-        uses: actions/checkout@v4
-        with:
-          repository: agent-team-foundation/first-tree-context
-          token: ${{ secrets.TREE_REPO_TOKEN }}
-          path: .first-tree-cache/tree
+      - name: Clone tree repo
+        shell: bash
+        run: |
+          set -euo pipefail
+          tree_repo_url="https://github.com/agent-team-foundation/first-tree-context.git"
+          tree_repo_dir=".first-tree-cache/tree"
+          auth_header="$(printf 'x-access-token:%s' "$TREE_REPO_TOKEN" | base64 | tr -d '\n')"
+          mkdir -p "$(dirname "$tree_repo_dir")"
+          git -c http.extraHeader="AUTHORIZATION: basic $auth_header" \
+            clone --depth 1 "$tree_repo_url" "$tree_repo_dir"
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/src/products/gardener/engine/install-workflow.ts
+++ b/src/products/gardener/engine/install-workflow.ts
@@ -192,10 +192,28 @@ jobs:
           set -euo pipefail
           tree_repo_url="https://github.com/${treeRepo}.git"
           tree_repo_dir="${treePath}"
-          auth_header="$(printf 'x-access-token:%s' "$TREE_REPO_TOKEN" | base64 | tr -d '\\n')"
           mkdir -p "$(dirname "$tree_repo_dir")"
-          git -c http.extraHeader="AUTHORIZATION: basic $auth_header" \\
-            clone --depth 1 "$tree_repo_url" "$tree_repo_dir"
+          if git clone --depth 1 "$tree_repo_url" "$tree_repo_dir"; then
+            exit 0
+          fi
+
+          if [ -z "\${TREE_REPO_TOKEN:-}" ]; then
+            echo "Anonymous tree clone failed and TREE_REPO_TOKEN is unset." >&2
+            exit 1
+          fi
+
+          rm -rf "$tree_repo_dir"
+          askpass_script="$RUNNER_TEMP/first-tree-git-askpass.sh"
+          cat >"$askpass_script" <<'EOF'
+          #!/bin/sh
+          case "$1" in
+            *Username*) printf '%s\\n' 'x-access-token' ;;
+            *Password*) printf '%s\\n' "$TREE_REPO_TOKEN" ;;
+          esac
+          EOF
+          chmod 700 "$askpass_script"
+          GIT_ASKPASS="$askpass_script" git clone --depth 1 "$tree_repo_url" "$tree_repo_dir"
+          rm -f "$askpass_script"
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/src/products/gardener/engine/install-workflow.ts
+++ b/src/products/gardener/engine/install-workflow.ts
@@ -34,7 +34,7 @@ skills/first-tree/references/workflow-mode.md).
 
 Options:
   --tree-repo <owner/name>   Tree repo slug (required). Written into the
-                             workflow's actions/checkout step.
+                             workflow's tree clone step.
   --tree-path <dir>          Path inside the runner where the tree is
                              checked out. Default: .first-tree-cache/tree
   --output <file>            Destination path for the workflow. Default:
@@ -186,12 +186,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Checkout tree repo
-        uses: actions/checkout@v4
-        with:
-          repository: ${treeRepo}
-          token: \${{ secrets.TREE_REPO_TOKEN }}
-          path: ${treePath}
+      - name: Clone tree repo
+        shell: bash
+        run: |
+          set -euo pipefail
+          tree_repo_url="https://github.com/${treeRepo}.git"
+          tree_repo_dir="${treePath}"
+          auth_header="$(printf 'x-access-token:%s' "$TREE_REPO_TOKEN" | base64 | tr -d '\\n')"
+          mkdir -p "$(dirname "$tree_repo_dir")"
+          git -c http.extraHeader="AUTHORIZATION: basic $auth_header" \\
+            clone --depth 1 "$tree_repo_url" "$tree_repo_dir"
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/tests/gardener/gardener-install-workflow.test.ts
+++ b/tests/gardener/gardener-install-workflow.test.ts
@@ -85,8 +85,9 @@ describe("gardener install-workflow — yaml builder", () => {
       nodeVersion: "22",
     });
     expect(yaml).toContain("name: First-Tree Sync");
-    expect(yaml).toContain("repository: acme/tree");
-    expect(yaml).toContain("path: .first-tree-cache/tree");
+    expect(yaml).toContain('tree_repo_url="https://github.com/acme/tree.git"');
+    expect(yaml).toContain('tree_repo_dir=".first-tree-cache/tree"');
+    expect(yaml).toContain("clone --depth 1");
     expect(yaml).toContain('node-version: "22"');
     expect(yaml).toContain("--assign-owners");
     expect(yaml).toContain(
@@ -108,7 +109,7 @@ describe("gardener install-workflow — yaml builder", () => {
       treePath: "tree-checkout",
       nodeVersion: "20",
     });
-    expect(yaml).toContain("path: tree-checkout");
+    expect(yaml).toContain('tree_repo_dir="tree-checkout"');
     expect(yaml).toContain("--tree-path tree-checkout");
     expect(yaml).toContain('node-version: "20"');
   });
@@ -126,7 +127,7 @@ describe("gardener install-workflow — runInstallWorkflow", () => {
     const target = join(tmp.path, ".github/workflows/first-tree-sync.yml");
     expect(existsSync(target)).toBe(true);
     const body = readFileSync(target, "utf-8");
-    expect(body).toContain("repository: acme/tree");
+    expect(body).toContain('tree_repo_url="https://github.com/acme/tree.git"');
     expect(lines.some((l) => l.includes("wrote"))).toBe(true);
     expect(lines.some((l) => l.includes("TREE_REPO_TOKEN"))).toBe(true);
     expect(lines.some((l) => l.includes("ANTHROPIC_API_KEY"))).toBe(true);
@@ -165,7 +166,7 @@ describe("gardener install-workflow — runInstallWorkflow", () => {
       join(tmp.path, ".github/workflows/first-tree-sync.yml"),
       "utf-8",
     );
-    expect(body).toContain("repository: other/tree");
+    expect(body).toContain('tree_repo_url="https://github.com/other/tree.git"');
   });
 
   it("prints yaml to stdout and does not write in --dry-run", async () => {
@@ -178,7 +179,8 @@ describe("gardener install-workflow — runInstallWorkflow", () => {
     expect(code).toBe(0);
     expect(existsSync(join(tmp.path, ".github/workflows/first-tree-sync.yml")))
       .toBe(false);
-    expect(lines.some((l) => l.includes("repository: acme/tree"))).toBe(true);
+    expect(lines.some((l) => l.includes("https://github.com/acme/tree.git")))
+      .toBe(true);
     expect(lines.some((l) => l.includes("dry-run"))).toBe(true);
   });
 

--- a/tests/gardener/gardener-install-workflow.test.ts
+++ b/tests/gardener/gardener-install-workflow.test.ts
@@ -88,6 +88,10 @@ describe("gardener install-workflow — yaml builder", () => {
     expect(yaml).toContain('tree_repo_url="https://github.com/acme/tree.git"');
     expect(yaml).toContain('tree_repo_dir=".first-tree-cache/tree"');
     expect(yaml).toContain("clone --depth 1");
+    expect(yaml).toContain('if git clone --depth 1 "$tree_repo_url" "$tree_repo_dir"; then');
+    expect(yaml).toContain('if [ -z "${TREE_REPO_TOKEN:-}" ]; then');
+    expect(yaml).toContain('askpass_script="$RUNNER_TEMP/first-tree-git-askpass.sh"');
+    expect(yaml).toContain("GIT_ASKPASS=\"$askpass_script\" git clone --depth 1");
     expect(yaml).toContain('node-version: "22"');
     expect(yaml).toContain("--assign-owners");
     expect(yaml).toContain(
@@ -128,6 +132,8 @@ describe("gardener install-workflow — runInstallWorkflow", () => {
     expect(existsSync(target)).toBe(true);
     const body = readFileSync(target, "utf-8");
     expect(body).toContain('tree_repo_url="https://github.com/acme/tree.git"');
+    expect(body).toContain('if git clone --depth 1 "$tree_repo_url" "$tree_repo_dir"; then');
+    expect(body).toContain('askpass_script="$RUNNER_TEMP/first-tree-git-askpass.sh"');
     expect(lines.some((l) => l.includes("wrote"))).toBe(true);
     expect(lines.some((l) => l.includes("TREE_REPO_TOKEN"))).toBe(true);
     expect(lines.some((l) => l.includes("ANTHROPIC_API_KEY"))).toBe(true);


### PR DESCRIPTION
## Summary
- replace the generated cross-repo `actions/checkout` step with a direct `git clone` that uses `TREE_REPO_TOKEN`
- keep the source repo checkout on `actions/checkout`, but avoid its default-branch REST lookup for the tree repo
- update the install-workflow tests to pin the new YAML shape

## Testing
- `pnpm exec vitest run tests/gardener/gardener-install-workflow.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test -- tests/gardener/gardener-install-workflow.test.ts` still trips an unrelated pre-existing failure in `tests/breeze/breeze-start.test.ts`

Fixes #268
