### PR TITLE
feat(gardener): add draft-node CLI (#277 gap 2, PR-A)

### DIFF
--- a/src/products/gardener/cli.ts
+++ b/src/products/gardener/cli.ts
@@ -44,6 +44,10 @@ Agent commands (invoked by the daemon, breeze, or CI — not normally by humans)
   comment               Review source-repo PRs/issues against the tree
                         and post structured verdict comments.
   respond               Fix sync PRs based on reviewer feedback.
+  draft-node            Draft a tree-node update from a sync-proposal
+                        issue and open a tree PR. Invoked by breeze
+                        when the user is assigned on a tree-repo issue
+                        carrying the \`gardener:sync-proposal\` marker.
   daemon                Foreground loop invoked by \`start\`; not for
                         direct human use.
 
@@ -119,6 +123,12 @@ export async function runGardener(
         });
       }
       return runComment(args.slice(1), { write });
+    }
+    case "draft-node": {
+      const { runDraftNode } = await import(
+        "./engine/commands/draft-node.js"
+      );
+      return runDraftNode(args.slice(1), { write });
     }
     case "install-workflow": {
       const { runInstallWorkflow } = await import(

--- a/src/products/gardener/engine/commands/draft-node.ts
+++ b/src/products/gardener/engine/commands/draft-node.ts
@@ -1,0 +1,1 @@
+export { runDraftNode, DRAFT_NODE_USAGE } from "../draft-node.js";

--- a/src/products/gardener/engine/draft-node.ts
+++ b/src/products/gardener/engine/draft-node.ts
@@ -1,0 +1,480 @@
+/**
+ * gardener-draft-node — Phase 3 of the #277 onboarding pipeline.
+ *
+ * Consumes a tree-repo issue filed by `gardener sync --open-issues`
+ * (or by the merged-PR branch of `gardener comment` — both paths emit
+ * the same `<!-- gardener:sync-proposal · proposal_id=… · source_sha=…
+ * · node=<path> -->` dispatch marker), writes the proposed NODE.md
+ * body to disk, commits on a per-proposal branch, and opens a tree
+ * PR. Called by breeze when the user is assigned on such an issue.
+ *
+ * BREEZE_RESULT trailer: the last line of stdout is always
+ *   `BREEZE_RESULT: status=<handled|skipped|failed> summary=<...>`
+ * so breeze-runner can parse the outcome from a captured stdout
+ * buffer. Matches the shape of `comment` and `respond`.
+ *
+ * Non-goals for this module:
+ *   - Classifier involvement: the "proposed node content" is already
+ *     in the issue body. `draft-node` copies it through verbatim. If
+ *     the owner wants edits, that's a human touch on the resulting
+ *     PR, not this command's job.
+ *   - Merged-PR path routing differences: the `source=merged-pr`
+ *     marker field is not acted on here. Both paths produce a tree
+ *     PR from the same body shape.
+ */
+
+import { execFile } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { promisify } from "node:util";
+
+import type { ShellRun } from "#products/tree/engine/runtime/shell.js";
+import { openTreePr } from "#products/tree/engine/open-tree-pr.js";
+
+const execFileAsync = promisify(execFile);
+
+export const DRAFT_NODE_USAGE = `usage: first-tree gardener draft-node --issue <n> --tree-repo <owner/name> [--tree-path PATH]
+
+Draft a tree-node update from a gardener-filed proposal issue and open
+a tree PR. Reads the \`<!-- gardener:sync-proposal · proposal_id=… ·
+source_sha=… · node=<path> -->\` marker on the issue to locate the
+target NODE.md, extracts the proposed content from the issue body, and
+commits it on a per-proposal branch.
+
+Triggered by breeze when the logged-in user is assigned on a tree-repo
+issue labeled \`first-tree:sync-proposal\`. Idempotent: re-runs on the
+same issue reuse the same branch + skip the commit if the content is
+already applied.
+
+Options:
+  --issue <n>           Tree-repo issue number (required)
+  --tree-repo <slug>    Tree repo (owner/name). Default: resolved from
+                        \`gh repo view\` inside --tree-path.
+  --tree-path PATH      Tree repo directory (default: cwd)
+  --dry-run             Print planned actions; do not write, commit, or push
+  --help, -h            Show this help message
+
+Environment:
+  TREE_REPO_TOKEN       PAT with repo scope on the tree repo. Required
+                        for the \`gh issue view\` call and for
+                        \`gh pr create\`. No fallback to ambient \`gh\`
+                        auth — unset → skipped.
+  DRAFT_NODE_LOG        Optional JSONL event log path (default
+                        $HOME/.gardener/draft-node-runs.jsonl).
+
+Exit codes:
+  0 handled/skipped
+  1 unrecoverable error
+`;
+
+export interface DraftNodeDeps {
+  write?: (line: string) => void;
+  shell?: ShellRun;
+  env?: NodeJS.ProcessEnv;
+  cwd?: string;
+}
+
+export type DraftNodeStatus = "handled" | "skipped" | "failed";
+
+export interface ParsedFlags {
+  help: boolean;
+  issue: number | null;
+  treeRepo: string | null;
+  treePath: string | null;
+  dryRun: boolean;
+  unknown: string | null;
+}
+
+export function parseFlags(args: string[]): ParsedFlags {
+  const out: ParsedFlags = {
+    help: false,
+    issue: null,
+    treeRepo: null,
+    treePath: null,
+    dryRun: false,
+    unknown: null,
+  };
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--help" || arg === "-h") {
+      out.help = true;
+      continue;
+    }
+    if (arg === "--dry-run") {
+      out.dryRun = true;
+      continue;
+    }
+    if (arg === "--issue") {
+      const next = args[i + 1];
+      const parsed = Number(next);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        out.issue = parsed;
+        i += 1;
+        continue;
+      }
+      out.unknown = `--issue requires a positive integer, got: ${next ?? "(missing)"}`;
+      return out;
+    }
+    if (arg === "--tree-repo") {
+      const next = args[i + 1];
+      if (next && /^[^/\s]+\/[^/\s]+$/.test(next)) {
+        out.treeRepo = next;
+        i += 1;
+        continue;
+      }
+      out.unknown = `--tree-repo requires owner/name, got: ${next ?? "(missing)"}`;
+      return out;
+    }
+    if (arg === "--tree-path") {
+      const next = args[i + 1];
+      if (next) {
+        out.treePath = next;
+        i += 1;
+        continue;
+      }
+      out.unknown = `--tree-path requires a path`;
+      return out;
+    }
+    out.unknown = arg;
+    return out;
+  }
+  return out;
+}
+
+export interface ProposalMarker {
+  proposalId: string;
+  sourceSha: string;
+  node: string;
+  source: string | null;
+  sourcePr: string | null;
+}
+
+const MARKER_RE =
+  /<!--\s*gardener:sync-proposal\s+([^>]+?)\s*-->/;
+
+/**
+ * Parse the `<!-- gardener:sync-proposal · k=v · k=v … -->` marker.
+ * Returns null when no marker is present or required fields are
+ * missing. Field order-insensitive; accepts the middle-dot separator
+ * emitted by both sync and comment paths.
+ */
+export function parseProposalMarker(body: string): ProposalMarker | null {
+  const match = body.match(MARKER_RE);
+  if (!match) return null;
+  const fields: Record<string, string> = {};
+  const raw = match[1];
+  for (const part of raw.split(/\s*[·•]\s*|\s{2,}/)) {
+    const eq = part.indexOf("=");
+    if (eq <= 0) continue;
+    const key = part.slice(0, eq).trim();
+    const val = part.slice(eq + 1).trim();
+    if (key) fields[key] = val;
+  }
+  const proposalId = fields.proposal_id;
+  const sourceSha = fields.source_sha;
+  const node = fields.node;
+  if (!proposalId || !node) return null;
+  return {
+    proposalId,
+    sourceSha: sourceSha ?? "unknown",
+    node,
+    source: fields.source ?? null,
+    sourcePr: fields.source_pr ?? null,
+  };
+}
+
+/**
+ * Extract the proposed NODE.md body from a sync-proposal issue. The
+ * convention (sync.ts:1389) is a `### Proposed node content\n` header
+ * followed by the markdown and a trailing `\n---\n` separator.
+ *
+ * For the merged-PR path the body shape is different: no "Proposed
+ * node content" section exists (the body describes the change, not a
+ * ready-to-apply NODE update). In that case this function returns
+ * null and callers defer — a human or a later classifier pass has to
+ * draft the content.
+ */
+export function extractProposedContent(body: string): string | null {
+  const headerRe = /^###\s+Proposed\s+node\s+content\s*$/m;
+  const headerMatch = body.match(headerRe);
+  if (!headerMatch || headerMatch.index === undefined) return null;
+  const after = body.slice(headerMatch.index + headerMatch[0].length);
+  // The "Proposed node content" section often starts with a YAML
+  // frontmatter fence (`---` on its own line) and ends with a footer
+  // separator (another `---`). We want to stop at the *footer*, not
+  // the frontmatter close. Strategy: find the last `---` line in
+  // `after` and treat it as the footer terminator. If only one
+  // `---` exists, treat it as frontmatter (no terminator) and return
+  // everything through end-of-body; if zero exist, same.
+  const sepRe = /^\s*---\s*$/gm;
+  const seps: number[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = sepRe.exec(after)) !== null) {
+    seps.push(m.index);
+  }
+  let sliceEnd = after.length;
+  if (seps.length >= 3) {
+    // frontmatter open, frontmatter close, footer
+    sliceEnd = seps[seps.length - 1];
+  } else if (seps.length === 1) {
+    // single `---` is almost certainly the footer (no frontmatter)
+    sliceEnd = seps[0];
+  }
+  // seps.length === 0 or 2 → no discernible footer; keep full slice.
+  // For 2 the common case is frontmatter open+close with no footer,
+  // which means the content runs to EOF.
+  const raw = after.slice(0, sliceEnd);
+  const trimmed = raw.replace(/^\n+/, "").replace(/\s+$/, "");
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function draftBranchName(proposalId: string): string {
+  return `first-tree/draft-node-${proposalId}`;
+}
+
+export function draftCommitMessage(node: string, proposalId: string): string {
+  return `chore(tree): draft ${node} from proposal ${proposalId}`;
+}
+
+export function draftPrTitle(node: string): string {
+  return `[gardener] draft ${node}`;
+}
+
+export function draftPrBody(params: {
+  issueNumber: number;
+  treeRepo: string;
+  marker: ProposalMarker;
+}): string {
+  const { issueNumber, treeRepo, marker } = params;
+  const sourceLine = marker.sourcePr
+    ? `**Source PR:** ${marker.sourcePr}`
+    : `**Source SHA:** ${marker.sourceSha}`;
+  return [
+    `Drafted from ${treeRepo}#${issueNumber} (proposal \`${marker.proposalId}\`).`,
+    "",
+    sourceLine,
+    "",
+    `Closes ${treeRepo}#${issueNumber} on merge.`,
+    "",
+    "---",
+    "",
+    `<sub>Auto-drafted by \`first-tree gardener draft-node\` (#277). Review the node content before merging.</sub>`,
+  ].join("\n");
+}
+
+function defaultShellRun(): ShellRun {
+  return async (command, args, options) => {
+    try {
+      const res = await execFileAsync(command, args, {
+        cwd: options?.cwd,
+        timeout: options?.timeout,
+        env: options?.env ?? process.env,
+        maxBuffer: 50 * 1024 * 1024,
+      });
+      return {
+        stdout: String(res.stdout ?? ""),
+        stderr: String(res.stderr ?? ""),
+        code: 0,
+      };
+    } catch (err) {
+      const error = err as NodeJS.ErrnoException & {
+        stdout?: string | Buffer;
+        stderr?: string | Buffer;
+        code?: number | string;
+      };
+      return {
+        stdout: error.stdout ? String(error.stdout) : "",
+        stderr: error.stderr ? String(error.stderr) : String(error.message ?? ""),
+        code: typeof error.code === "number" ? error.code : 1,
+      };
+    }
+  };
+}
+
+function emitBreezeResult(
+  write: (line: string) => void,
+  status: DraftNodeStatus,
+  summary: string,
+): void {
+  const compact = summary.replace(/\s+/g, " ").trim() || "no-op";
+  write(`BREEZE_RESULT: status=${status} summary=${compact}`);
+}
+
+async function fetchIssueBody(
+  shell: ShellRun,
+  treeRepo: string,
+  issue: number,
+  env: NodeJS.ProcessEnv,
+): Promise<{ body: string; error?: string }> {
+  const res = await shell(
+    "gh",
+    ["issue", "view", String(issue), "--repo", treeRepo, "--json", "body", "-q", ".body"],
+    { env },
+  );
+  if (res.code !== 0) {
+    return { body: "", error: res.stderr.trim() || `gh issue view exited ${res.code}` };
+  }
+  return { body: res.stdout };
+}
+
+async function resolveTreeSlug(
+  shell: ShellRun,
+  treeRoot: string,
+): Promise<string | null> {
+  const res = await shell(
+    "gh",
+    ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+    { cwd: treeRoot },
+  );
+  if (res.code !== 0) return null;
+  const slug = res.stdout.trim();
+  return slug.length > 0 ? slug : null;
+}
+
+export async function runDraftNode(
+  args: string[],
+  deps: DraftNodeDeps = {},
+): Promise<number> {
+  const write = deps.write ?? ((line: string) => console.log(line));
+  const shell = deps.shell ?? defaultShellRun();
+  const env = deps.env ?? process.env;
+  const cwd = deps.cwd ?? process.cwd();
+
+  const flags = parseFlags(args);
+  if (flags.help) {
+    write(DRAFT_NODE_USAGE);
+    emitBreezeResult(write, "skipped", "help requested");
+    return 0;
+  }
+  if (flags.unknown) {
+    write(`\u274C ${flags.unknown}`);
+    write(DRAFT_NODE_USAGE);
+    emitBreezeResult(write, "failed", `bad flag: ${flags.unknown}`);
+    return 1;
+  }
+  if (!flags.issue) {
+    write(`\u274C --issue <n> is required`);
+    write(DRAFT_NODE_USAGE);
+    emitBreezeResult(write, "failed", "missing --issue");
+    return 1;
+  }
+
+  const treeRoot = flags.treePath ? resolve(cwd, flags.treePath) : cwd;
+
+  const token = env.TREE_REPO_TOKEN;
+  if (!token) {
+    write(`\u26A0 TREE_REPO_TOKEN unset — refusing to act on tree repo`);
+    emitBreezeResult(write, "skipped", "TREE_REPO_TOKEN unset");
+    return 0;
+  }
+  const tokenEnv: NodeJS.ProcessEnv = { ...env, GH_TOKEN: token };
+
+  const treeRepo = flags.treeRepo ?? (await resolveTreeSlug(shell, treeRoot));
+  if (!treeRepo) {
+    write(`\u274C could not resolve tree repo slug (pass --tree-repo)`);
+    emitBreezeResult(write, "failed", "tree-repo unresolved");
+    return 1;
+  }
+
+  write(`\u2712 draft-node: ${treeRepo}#${flags.issue}`);
+
+  const fetched = await fetchIssueBody(shell, treeRepo, flags.issue, tokenEnv);
+  if (fetched.error) {
+    write(`\u274C failed to fetch issue: ${fetched.error}`);
+    emitBreezeResult(write, "failed", `gh issue view: ${fetched.error}`);
+    return 1;
+  }
+  const marker = parseProposalMarker(fetched.body);
+  if (!marker) {
+    write(`\u26A0 no gardener:sync-proposal marker found on ${treeRepo}#${flags.issue} \u2014 skipping`);
+    emitBreezeResult(write, "skipped", "no sync-proposal marker");
+    return 0;
+  }
+  write(`  proposal_id=${marker.proposalId} node=${marker.node} source=${marker.source ?? "sync"}`);
+
+  const proposedContent = extractProposedContent(fetched.body);
+  if (!proposedContent) {
+    write(
+      `\u26A0 issue has marker but no "### Proposed node content" section ` +
+        `(likely a merged-PR issue) \u2014 deferring to human`,
+    );
+    emitBreezeResult(write, "skipped", "no proposed content in body");
+    return 0;
+  }
+
+  const nodePath = join(treeRoot, marker.node, "NODE.md");
+  const branch = draftBranchName(marker.proposalId);
+
+  if (flags.dryRun) {
+    write(`  would write: ${nodePath}`);
+    write(`  would branch: ${branch}`);
+    write(`  would commit: ${draftCommitMessage(marker.node, marker.proposalId)}`);
+    write(`  would open PR titled: ${draftPrTitle(marker.node)}`);
+    emitBreezeResult(write, "skipped", `dry-run: ${marker.node}`);
+    return 0;
+  }
+
+  const checkoutRes = await shell("git", ["checkout", "-B", branch], { cwd: treeRoot });
+  if (checkoutRes.code !== 0) {
+    write(`\u274C git checkout failed: ${checkoutRes.stderr.trim()}`);
+    emitBreezeResult(write, "failed", "git checkout");
+    return 1;
+  }
+
+  mkdirSync(dirname(nodePath), { recursive: true });
+  // Preserve existing frontmatter if the NODE.md already exists. For
+  // v1 we just overwrite with the proposed content; the classifier
+  // supplies a full body including frontmatter. If that changes,
+  // this is the place to splice.
+  const body = proposedContent.endsWith("\n") ? proposedContent : `${proposedContent}\n`;
+  writeFileSync(nodePath, body);
+
+  const addRes = await shell("git", ["add", nodePath], { cwd: treeRoot });
+  if (addRes.code !== 0) {
+    write(`\u274C git add failed: ${addRes.stderr.trim()}`);
+    emitBreezeResult(write, "failed", "git add");
+    return 1;
+  }
+  const stagedCheck = await shell("git", ["diff", "--cached", "--quiet"], {
+    cwd: treeRoot,
+  });
+  if (stagedCheck.code === 0) {
+    write(`\u2713 ${marker.node}: content already applied \u2014 nothing to commit`);
+    emitBreezeResult(write, "skipped", `already-applied: ${marker.node}`);
+    return 0;
+  }
+  const commitRes = await shell(
+    "git",
+    ["commit", "-m", draftCommitMessage(marker.node, marker.proposalId)],
+    { cwd: treeRoot },
+  );
+  if (commitRes.code !== 0) {
+    write(`\u274C git commit failed: ${commitRes.stderr.trim()}`);
+    emitBreezeResult(write, "failed", "git commit");
+    return 1;
+  }
+
+  const prResult = await openTreePr(shell, treeRoot, {
+    branch,
+    title: draftPrTitle(marker.node),
+    body: draftPrBody({
+      issueNumber: flags.issue,
+      treeRepo,
+      marker,
+    }),
+    labels: ["first-tree:draft-node"],
+  });
+  if (!prResult.success) {
+    write(`\u274C openTreePr failed: ${prResult.error ?? "unknown"}`);
+    emitBreezeResult(write, "failed", `openTreePr: ${prResult.error ?? "unknown"}`);
+    return 1;
+  }
+  write(`\u2713 opened tree PR: ${prResult.prUrl ?? "(url unknown)"}`);
+  emitBreezeResult(
+    write,
+    "handled",
+    `drafted ${marker.node} \u2192 ${prResult.prUrl ?? "(pr)"}`,
+  );
+  return 0;
+}
+

--- a/src/products/gardener/engine/draft-node.ts
+++ b/src/products/gardener/engine/draft-node.ts
@@ -320,15 +320,66 @@ async function fetchIssueBody(
 async function resolveTreeSlug(
   shell: ShellRun,
   treeRoot: string,
+  env?: NodeJS.ProcessEnv,
 ): Promise<string | null> {
   const res = await shell(
     "gh",
     ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
-    { cwd: treeRoot },
+    { cwd: treeRoot, env },
   );
   if (res.code !== 0) return null;
   const slug = res.stdout.trim();
   return slug.length > 0 ? slug : null;
+}
+
+async function checkoutDraftBranch(
+  shell: ShellRun,
+  treeRoot: string,
+  branch: string,
+): Promise<{ error?: string }> {
+  const localBranch = await shell("git", ["rev-parse", "--verify", branch], {
+    cwd: treeRoot,
+  });
+  if (localBranch.code === 0) {
+    const checkoutLocal = await shell("git", ["checkout", branch], {
+      cwd: treeRoot,
+    });
+    if (checkoutLocal.code !== 0) {
+      return { error: checkoutLocal.stderr.trim() || "git checkout failed" };
+    }
+    return {};
+  }
+
+  const fetchRemote = await shell("git", ["fetch", "origin", branch], {
+    cwd: treeRoot,
+  });
+  if (fetchRemote.code === 0) {
+    const checkoutRemote = await shell(
+      "git",
+      ["checkout", "-B", branch, "FETCH_HEAD"],
+      { cwd: treeRoot },
+    );
+    if (checkoutRemote.code !== 0) {
+      return { error: checkoutRemote.stderr.trim() || "git checkout failed" };
+    }
+    return {};
+  }
+
+  if (
+    !/couldn't find remote ref|could not find remote branch|remote ref does not exist/i.test(
+      fetchRemote.stderr,
+    )
+  ) {
+    return { error: fetchRemote.stderr.trim() || "git fetch failed" };
+  }
+
+  const checkoutNew = await shell("git", ["checkout", "-B", branch], {
+    cwd: treeRoot,
+  });
+  if (checkoutNew.code !== 0) {
+    return { error: checkoutNew.stderr.trim() || "git checkout failed" };
+  }
+  return {};
 }
 
 export async function runDraftNode(
@@ -369,7 +420,7 @@ export async function runDraftNode(
   }
   const tokenEnv: NodeJS.ProcessEnv = { ...env, GH_TOKEN: token };
 
-  const treeRepo = flags.treeRepo ?? (await resolveTreeSlug(shell, treeRoot));
+  const treeRepo = flags.treeRepo ?? (await resolveTreeSlug(shell, treeRoot, tokenEnv));
   if (!treeRepo) {
     write(`\u274C could not resolve tree repo slug (pass --tree-repo)`);
     emitBreezeResult(write, "failed", "tree-repo unresolved");
@@ -414,9 +465,9 @@ export async function runDraftNode(
     return 0;
   }
 
-  const checkoutRes = await shell("git", ["checkout", "-B", branch], { cwd: treeRoot });
-  if (checkoutRes.code !== 0) {
-    write(`\u274C git checkout failed: ${checkoutRes.stderr.trim()}`);
+  const checkoutRes = await checkoutDraftBranch(shell, treeRoot, branch);
+  if (checkoutRes.error) {
+    write(`\u274C git checkout failed: ${checkoutRes.error}`);
     emitBreezeResult(write, "failed", "git checkout");
     return 1;
   }
@@ -463,6 +514,7 @@ export async function runDraftNode(
       marker,
     }),
     labels: ["first-tree:draft-node"],
+    env: tokenEnv,
   });
   if (!prResult.success) {
     write(`\u274C openTreePr failed: ${prResult.error ?? "unknown"}`);
@@ -477,4 +529,3 @@ export async function runDraftNode(
   );
   return 0;
 }
-

--- a/src/products/tree/engine/open-tree-pr.ts
+++ b/src/products/tree/engine/open-tree-pr.ts
@@ -5,6 +5,7 @@ export interface OpenTreePrOpts {
   title: string;
   body: string;
   labels?: string[];
+  env?: NodeJS.ProcessEnv;
 }
 
 export interface OpenTreePrResult {
@@ -27,7 +28,7 @@ export async function openTreePr(
   treeRoot: string,
   opts: OpenTreePrOpts,
 ): Promise<OpenTreePrResult> {
-  const { branch, title, body, labels } = opts;
+  const { branch, title, body, labels, env } = opts;
 
   const pushResult = await shellRun("git", ["push", "origin", branch], {
     cwd: treeRoot,
@@ -39,7 +40,7 @@ export async function openTreePr(
   const prCreate = await shellRun(
     "gh",
     ["pr", "create", "--head", branch, "--title", title, "--body", body],
-    { cwd: treeRoot },
+    { cwd: treeRoot, env },
   );
   if (prCreate.code !== 0) {
     const stderr = prCreate.stderr.trim();
@@ -58,11 +59,11 @@ export async function openTreePr(
       await shellRun(
         "gh",
         ["label", "create", label, "--color", "2ea44f", "--description", `Created by gardener sync`, "--force"],
-        { cwd: treeRoot },
+        { cwd: treeRoot, env },
       );
     }
     const labelArgs = labels.flatMap((l) => ["--add-label", l]);
-    await shellRun("gh", ["pr", "edit", prUrl, ...labelArgs], { cwd: treeRoot });
+    await shellRun("gh", ["pr", "edit", prUrl, ...labelArgs], { cwd: treeRoot, env });
   }
 
   return { success: true, prUrl };

--- a/tests/gardener/draft-node.test.ts
+++ b/tests/gardener/draft-node.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  DRAFT_NODE_USAGE,
+  draftBranchName,
+  draftCommitMessage,
+  draftPrBody,
+  draftPrTitle,
+  extractProposedContent,
+  parseFlags,
+  parseProposalMarker,
+  runDraftNode,
+} from "#products/gardener/engine/draft-node.js";
+
+describe("gardener draft-node · parseFlags", () => {
+  it("parses --issue --tree-repo --tree-path --dry-run", () => {
+    const flags = parseFlags([
+      "--issue",
+      "42",
+      "--tree-repo",
+      "agent-team-foundation/first-tree-context",
+      "--tree-path",
+      "../tree",
+      "--dry-run",
+    ]);
+    expect(flags).toMatchObject({
+      issue: 42,
+      treeRepo: "agent-team-foundation/first-tree-context",
+      treePath: "../tree",
+      dryRun: true,
+      help: false,
+      unknown: null,
+    });
+  });
+
+  it("flags --help / -h", () => {
+    expect(parseFlags(["--help"]).help).toBe(true);
+    expect(parseFlags(["-h"]).help).toBe(true);
+  });
+
+  it("rejects non-integer --issue", () => {
+    const flags = parseFlags(["--issue", "abc"]);
+    expect(flags.issue).toBe(null);
+    expect(flags.unknown).toMatch(/--issue/);
+  });
+
+  it("rejects zero or negative --issue", () => {
+    expect(parseFlags(["--issue", "0"]).unknown).toMatch(/--issue/);
+    expect(parseFlags(["--issue", "-3"]).unknown).toMatch(/--issue/);
+  });
+
+  it("rejects malformed --tree-repo", () => {
+    expect(parseFlags(["--tree-repo", "no-slash"]).unknown).toMatch(/--tree-repo/);
+    expect(parseFlags(["--tree-repo", "a/b/c"]).unknown).toMatch(/--tree-repo/);
+  });
+
+  it("reports unknown flags", () => {
+    const flags = parseFlags(["--issue", "5", "--nonsense"]);
+    expect(flags.unknown).toBe("--nonsense");
+  });
+});
+
+describe("gardener draft-node · parseProposalMarker", () => {
+  it("parses the sync variant with three required fields", () => {
+    const body =
+      "<!-- gardener:sync-proposal · proposal_id=abc123def456 · source_sha=deadbeef · node=engineering/backend/auth -->\n\n" +
+      "Proposed tree update for `engineering/backend/auth`.\n";
+    const marker = parseProposalMarker(body);
+    expect(marker).toEqual({
+      proposalId: "abc123def456",
+      sourceSha: "deadbeef",
+      node: "engineering/backend/auth",
+      source: null,
+      sourcePr: null,
+    });
+  });
+
+  it("parses the merged-PR variant with source= and source_pr= fields", () => {
+    const body =
+      "<!-- gardener:sync-proposal · proposal_id=0000ffff1111 · source_sha=abcd1234 · node=pkg-a · source=merged-pr · source_pr=alice/cool#207 -->\n";
+    const marker = parseProposalMarker(body);
+    expect(marker).toMatchObject({
+      proposalId: "0000ffff1111",
+      sourceSha: "abcd1234",
+      node: "pkg-a",
+      source: "merged-pr",
+      sourcePr: "alice/cool#207",
+    });
+  });
+
+  it("returns null for bodies without a marker", () => {
+    expect(parseProposalMarker("just a body, no marker")).toBe(null);
+  });
+
+  it("returns null when required fields are missing", () => {
+    // proposal_id absent
+    expect(
+      parseProposalMarker(
+        "<!-- gardener:sync-proposal · source_sha=x · node=y -->",
+      ),
+    ).toBe(null);
+    // node absent
+    expect(
+      parseProposalMarker(
+        "<!-- gardener:sync-proposal · proposal_id=x · source_sha=y -->",
+      ),
+    ).toBe(null);
+  });
+
+  it("tolerates source_sha=unknown", () => {
+    const body =
+      "<!-- gardener:sync-proposal · proposal_id=aa · source_sha=unknown · node=p -->";
+    const marker = parseProposalMarker(body);
+    expect(marker?.sourceSha).toBe("unknown");
+  });
+});
+
+describe("gardener draft-node · extractProposedContent", () => {
+  it("extracts content between the header and the --- separator", () => {
+    const body = [
+      "<!-- marker -->",
+      "",
+      "Proposed tree update for `pkg-a`.",
+      "",
+      "### Rationale",
+      "Because reasons.",
+      "",
+      "### Proposed node content",
+      "---",
+      "owners: [alice]",
+      "---",
+      "",
+      "# Auth module",
+      "",
+      "Handles signin.",
+      "",
+      "---",
+      "Filed by sync.",
+    ].join("\n");
+    const extracted = extractProposedContent(body);
+    expect(extracted).toContain("owners: [alice]");
+    expect(extracted).toContain("# Auth module");
+    expect(extracted).toContain("Handles signin.");
+    expect(extracted).not.toContain("Filed by sync.");
+  });
+
+  it("returns null when no proposed-content section exists", () => {
+    const body = "<!-- marker -->\n\nJust a description of the change.";
+    expect(extractProposedContent(body)).toBe(null);
+  });
+
+  it("handles body where proposed content ends at EOF (no --- separator)", () => {
+    const body =
+      "### Proposed node content\n# Title\n\nBody text without a trailing separator.";
+    const extracted = extractProposedContent(body);
+    expect(extracted).toContain("# Title");
+    expect(extracted).toContain("Body text without a trailing separator.");
+  });
+});
+
+describe("gardener draft-node · derived strings", () => {
+  it("draftBranchName is deterministic from proposal id", () => {
+    expect(draftBranchName("abc123")).toBe("first-tree/draft-node-abc123");
+  });
+
+  it("draftCommitMessage includes node and proposal id", () => {
+    expect(draftCommitMessage("engineering/backend", "abc123")).toBe(
+      "chore(tree): draft engineering/backend from proposal abc123",
+    );
+  });
+
+  it("draftPrTitle includes node", () => {
+    expect(draftPrTitle("pkg-a")).toBe("[gardener] draft pkg-a");
+  });
+
+  it("draftPrBody shows source PR link when marker has source_pr", () => {
+    const body = draftPrBody({
+      issueNumber: 42,
+      treeRepo: "org/tree",
+      marker: {
+        proposalId: "abc",
+        sourceSha: "dead",
+        node: "pkg-a",
+        source: "merged-pr",
+        sourcePr: "alice/cool#207",
+      },
+    });
+    expect(body).toContain("org/tree#42");
+    expect(body).toContain("**Source PR:** alice/cool#207");
+    expect(body).toContain("Closes org/tree#42 on merge.");
+  });
+
+  it("draftPrBody falls back to source SHA when source_pr absent", () => {
+    const body = draftPrBody({
+      issueNumber: 42,
+      treeRepo: "org/tree",
+      marker: {
+        proposalId: "abc",
+        sourceSha: "dead",
+        node: "pkg-a",
+        source: null,
+        sourcePr: null,
+      },
+    });
+    expect(body).toContain("**Source SHA:** dead");
+  });
+});
+
+describe("gardener draft-node · runDraftNode integration (mocked shell)", () => {
+  it("emits BREEZE_RESULT skipped when TREE_REPO_TOKEN is unset", async () => {
+    const lines: string[] = [];
+    const code = await runDraftNode(
+      ["--issue", "1", "--tree-repo", "org/tree"],
+      {
+        write: (line) => lines.push(line),
+        env: {},
+        cwd: "/tmp",
+        shell: vi.fn(),
+      },
+    );
+    expect(code).toBe(0);
+    expect(lines.some((l) => l.includes("BREEZE_RESULT: status=skipped"))).toBe(
+      true,
+    );
+    expect(lines.some((l) => l.includes("TREE_REPO_TOKEN unset"))).toBe(true);
+  });
+
+  it("emits failed when --issue is missing", async () => {
+    const lines: string[] = [];
+    const code = await runDraftNode([], {
+      write: (line) => lines.push(line),
+      env: { TREE_REPO_TOKEN: "t" },
+      cwd: "/tmp",
+      shell: vi.fn(),
+    });
+    expect(code).toBe(1);
+    expect(lines.some((l) => l.includes("BREEZE_RESULT: status=failed"))).toBe(
+      true,
+    );
+  });
+
+  it("emits skipped when issue has no gardener:sync-proposal marker", async () => {
+    const lines: string[] = [];
+    const shell = vi.fn(async () => ({
+      stdout: "Just an issue body with no marker.\n",
+      stderr: "",
+      code: 0,
+    }));
+    const code = await runDraftNode(
+      ["--issue", "5", "--tree-repo", "org/tree"],
+      {
+        write: (line) => lines.push(line),
+        env: { TREE_REPO_TOKEN: "t" },
+        cwd: "/tmp",
+        shell,
+      },
+    );
+    expect(code).toBe(0);
+    expect(lines.some((l) => l.includes("BREEZE_RESULT: status=skipped"))).toBe(
+      true,
+    );
+    expect(lines.some((l) => l.includes("no sync-proposal marker"))).toBe(true);
+  });
+
+  it("dry-run previews the plan without invoking git/gh", async () => {
+    const lines: string[] = [];
+    const issueBody = [
+      "<!-- gardener:sync-proposal · proposal_id=aa11bb22 · source_sha=dead · node=pkg-a -->",
+      "",
+      "### Proposed node content",
+      "# Pkg A",
+      "",
+      "Body.",
+      "",
+      "---",
+      "Filed.",
+    ].join("\n");
+    const shell = vi.fn(async () => ({
+      stdout: issueBody,
+      stderr: "",
+      code: 0,
+    }));
+    const code = await runDraftNode(
+      ["--issue", "7", "--tree-repo", "org/tree", "--dry-run"],
+      {
+        write: (line) => lines.push(line),
+        env: { TREE_REPO_TOKEN: "t" },
+        cwd: "/tmp",
+        shell,
+      },
+    );
+    expect(code).toBe(0);
+    expect(shell).toHaveBeenCalledTimes(1); // only the gh issue view call
+    expect(lines.some((l) => l.includes("would branch: first-tree/draft-node-aa11bb22"))).toBe(true);
+    expect(lines.some((l) => l.includes("BREEZE_RESULT: status=skipped"))).toBe(true);
+    expect(lines.some((l) => l.includes("dry-run"))).toBe(true);
+  });
+
+  it("DRAFT_NODE_USAGE mentions --issue and TREE_REPO_TOKEN", () => {
+    expect(DRAFT_NODE_USAGE).toContain("--issue");
+    expect(DRAFT_NODE_USAGE).toContain("TREE_REPO_TOKEN");
+    expect(DRAFT_NODE_USAGE).toContain("gardener:sync-proposal");
+  });
+});

--- a/tests/gardener/draft-node.test.ts
+++ b/tests/gardener/draft-node.test.ts
@@ -12,6 +12,12 @@ import {
   runDraftNode,
 } from "#products/gardener/engine/draft-node.js";
 
+type ShellCall = {
+  command: string;
+  args: string[];
+  options?: { cwd?: string; env?: NodeJS.ProcessEnv };
+};
+
 describe("gardener draft-node · parseFlags", () => {
   it("parses --issue --tree-repo --tree-path --dry-run", () => {
     const flags = parseFlags([
@@ -294,6 +300,76 @@ describe("gardener draft-node · runDraftNode integration (mocked shell)", () =>
     expect(lines.some((l) => l.includes("would branch: first-tree/draft-node-aa11bb22"))).toBe(true);
     expect(lines.some((l) => l.includes("BREEZE_RESULT: status=skipped"))).toBe(true);
     expect(lines.some((l) => l.includes("dry-run"))).toBe(true);
+  });
+
+  it("reuses an existing remote draft branch before checking for staged changes", async () => {
+    const calls: ShellCall[] = [];
+    const lines: string[] = [];
+    const issueBody = [
+      "<!-- gardener:sync-proposal · proposal_id=aa11bb22 · source_sha=dead · node=pkg-a -->",
+      "",
+      "### Proposed node content",
+      "# Pkg A",
+      "",
+      "Body.",
+      "",
+      "---",
+      "Filed.",
+    ].join("\n");
+    const shell = vi.fn(async (command: string, args: string[], options?: ShellCall["options"]) => {
+      calls.push({ command, args, options });
+      if (command === "gh" && args[0] === "issue") {
+        return { stdout: issueBody, stderr: "", code: 0 };
+      }
+      if (command === "git" && args[0] === "rev-parse") {
+        return { stdout: "", stderr: "unknown revision", code: 1 };
+      }
+      if (command === "git" && args[0] === "fetch") {
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      if (command === "git" && args[0] === "checkout") {
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      if (command === "git" && args[0] === "add") {
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      if (command === "git" && args[0] === "diff") {
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      throw new Error(`unexpected call: ${command} ${args.join(" ")}`);
+    });
+
+    const code = await runDraftNode(
+      ["--issue", "7", "--tree-repo", "org/tree"],
+      {
+        write: (line) => lines.push(line),
+        env: { TREE_REPO_TOKEN: "secret-token" },
+        cwd: "/tmp",
+        shell,
+      },
+    );
+
+    expect(code).toBe(0);
+
+    const issueView = calls.find((call) => call.command === "gh" && call.args[0] === "issue");
+    expect(issueView?.options?.env?.GH_TOKEN).toBe("secret-token");
+
+    const fetchIndex = calls.findIndex(
+      (call) => call.command === "git" && call.args[0] === "fetch",
+    );
+    const checkoutIndex = calls.findIndex(
+      (call) => call.command === "git" && call.args[0] === "checkout",
+    );
+    expect(fetchIndex).toBeGreaterThan(-1);
+    expect(checkoutIndex).toBeGreaterThan(fetchIndex);
+    expect(calls[checkoutIndex]?.args).toEqual([
+      "checkout",
+      "-B",
+      "first-tree/draft-node-aa11bb22",
+      "FETCH_HEAD",
+    ]);
+    expect(lines.some((line) => line.includes("already applied"))).toBe(true);
+    expect(lines.some((line) => line.includes("BREEZE_RESULT: status=skipped"))).toBe(true);
   });
 
   it("DRAFT_NODE_USAGE mentions --issue and TREE_REPO_TOKEN", () => {

--- a/tests/tree/open-tree-pr.test.ts
+++ b/tests/tree/open-tree-pr.test.ts
@@ -5,15 +5,20 @@ import type {
   ShellRun,
 } from "#products/tree/engine/runtime/shell.js";
 
-type Call = { command: string; args: string[] };
+type Call = {
+  command: string;
+  args: string[];
+  env?: NodeJS.ProcessEnv;
+};
 
 function recordingShell(
   handler: (c: Call) => ShellResult,
 ): { shell: ShellRun; calls: Call[] } {
   const calls: Call[] = [];
-  const shell: ShellRun = async (command, args) => {
-    calls.push({ command, args });
-    return handler({ command, args });
+  const shell: ShellRun = async (command, args, options) => {
+    const call = { command, args, env: options?.env };
+    calls.push(call);
+    return handler(call);
   };
   return { shell, calls };
 }
@@ -146,5 +151,30 @@ describe("openTreePr", () => {
       "--add-label", "label-a",
       "--add-label", "label-b",
     ]);
+  });
+
+  it("passes env through to gh calls only", async () => {
+    const { shell, calls } = recordingShell((c) => {
+      if (c.command === "git") return { stdout: "", stderr: "", code: 0 };
+      if (c.args[1] === "create") return { stdout: "https://x/pr/1", stderr: "", code: 0 };
+      return { stdout: "", stderr: "", code: 0 };
+    });
+
+    await openTreePr(shell, "/tree", {
+      branch: "b",
+      title: "t",
+      body: "y",
+      labels: ["label-a"],
+      env: { GH_TOKEN: "secret-token" },
+    });
+
+    const gitPush = calls.find((c) => c.command === "git")!;
+    expect(gitPush.env).toBe(undefined);
+
+    const ghCalls = calls.filter((c) => c.command === "gh");
+    expect(ghCalls).toHaveLength(3);
+    for (const call of ghCalls) {
+      expect(call.env?.GH_TOKEN).toBe("secret-token");
+    }
   });
 });


### PR DESCRIPTION
## Summary

Gap #2 of issue #277 split into 3 PRs; this is **PR-A** (the CLI + tests).

Adds `first-tree gardener draft-node --issue <n> --tree-repo <slug>`, intended for breeze to invoke when a user is assigned on a tree-repo issue carrying the `gardener:sync-proposal` marker (shape landed in #282). It:

- Fetches the tree issue via `gh issue view` with `TREE_REPO_TOKEN`
- Parses the `gardener:sync-proposal` marker (`proposal_id`, `source_sha`, `node`, optional `source=merged-pr`/`source_pr=<repo>#<n>`)
- Extracts the proposed NODE.md body from the `### Proposed node content` section
- Checks out deterministic branch `first-tree/draft-node-<proposal_id>`, writes NODE.md, commits, and opens a tree PR via the shared `openTreePr` primitive
- Emits `BREEZE_RESULT: status=<handled|skipped|failed>` on every exit path

**Scope is intentionally tight:** no classifier, no content synthesis — the proposal body is copied verbatim; humans edit on the resulting PR. Merged-PR variant issues (which have no proposed-content section) are skipped with a "defer to human" result.

## Follow-ups

- **PR-B**: breeze runner prompt update teaching the dispatch rule (task kind `assigned_issue` + tree repo + marker present → invoke `draft-node`)
- **PR-C**: onboarding skill + `skills/gardener/SKILL.md` Scenario G showing end-to-end with draft-node

## Test plan

- [x] 24 unit tests (tests/gardener/draft-node.test.ts)
- [x] Full gardener suite: 327/327 green
- [x] Typecheck clean
- [ ] Manual smoke: --dry-run against a real tree-repo issue once PR-B lands

Refs #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)