### PR TITLE
feat(breeze): dispatch gardener sync-proposal issues to draft-node (#277 gap 2, PR-B)

### DIFF
--- a/src/products/breeze/engine/daemon/runner.ts
+++ b/src/products/breeze/engine/daemon/runner.ts
@@ -197,6 +197,11 @@ export function buildPrompt(request: AgentRequest): string {
     `\n` +
     `Read the local snapshot files first. Only call \`gh\` when you need fresh data or to publish the final result.\n` +
     `\n` +
+    `Dispatch rule — gardener sync-proposal issues (REQUIRED CHECK):\n` +
+    `If the task Type is \`assigned_issue\` AND the issue body contains the marker \`<!-- gardener:sync-proposal\`, this is a Context Tree update request filed by \`first-tree gardener sync\`. Do NOT draft the tree change by hand. Instead, run:\n` +
+    `  first-tree gardener draft-node --issue <issue-number> --tree-repo <owner/repo>\n` +
+    `The CLI fetches the issue, parses the marker, copies the proposed NODE.md content onto a deterministic branch, and opens a tree PR for human review. Use \`--dry-run\` first if you want to preview the plan. After the CLI exits, its own BREEZE_RESULT line is the authoritative result — do not invent a new one; set the \`breeze:*\` label per the rule below and stop.\n` +
+    `\n` +
     `Status labeling rule (REQUIRED): label the issue / pull request with your current status using exactly one of:\n` +
     `- \`breeze:wip\` — you are actively working on it\n` +
     `- \`breeze:human\` — you need human input or judgment to proceed\n` +

--- a/tests/breeze/breeze-daemon-runner-agent.test.ts
+++ b/tests/breeze/breeze-daemon-runner-agent.test.ts
@@ -117,6 +117,14 @@ describe("buildPrompt", () => {
     );
     expect(differ).toContain("Working repository: alice/self");
   });
+
+  it("includes the gardener sync-proposal dispatch rule", () => {
+    const prompt = buildPrompt(fakeRequest());
+    expect(prompt).toContain("gardener:sync-proposal");
+    expect(prompt).toContain("first-tree gardener draft-node");
+    expect(prompt).toContain("--issue");
+    expect(prompt).toContain("--tree-repo");
+  });
 });
 
 describe("buildCommand", () => {


### PR DESCRIPTION
## Summary

PR-B of issue #277 gap 2. Depends on **PR-A (#283)** which ships the `first-tree gardener draft-node` CLI.

Adds a dispatch-rule block to the breeze runner prompt: when an `assigned_issue` task body contains the `<!-- gardener:sync-proposal` marker, the agent should invoke `first-tree gardener draft-node --issue <n> --tree-repo <slug>` rather than drafting the tree change by hand. The CLI's own BREEZE_RESULT line is treated as authoritative — the agent just sets the `breeze:*` label and stops.

## Follow-ups

- **PR-C**: onboarding skill + `skills/gardener/SKILL.md` Scenario G walking through end-to-end sync → tree issue → draft-node dispatch → tree PR

## Test plan

- [x] New test asserts the dispatch rule text is present in buildPrompt
- [x] Full breeze suite: 424/424 green
- [x] Typecheck clean
- [ ] Manual smoke: assign a tree-repo sync-proposal issue to the breeze identity once PR-A lands and verify the agent invokes draft-node instead of hand-editing

Refs #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)