### PR TITLE
fix(gardener): drop silent org-as-default-owner attempt in sync --open-issues

### DIFF
--- a/src/products/gardener/engine/sync.ts
+++ b/src/products/gardener/engine/sync.ts
@@ -283,6 +283,22 @@ function findExistingMemberDirByAuthorLogin(
   return matches[0] ?? null;
 }
 
+function dedupeOwners(owners: Iterable<string>): string[] {
+  const seen = new Set<string>();
+  const resolved: string[] = [];
+  for (const owner of owners) {
+    const cleaned = owner.replace(/^@+/, "").trim();
+    if (cleaned === "") continue;
+    const normalized = normalizeGitHubLogin(cleaned);
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    resolved.push(cleaned);
+  }
+  return resolved;
+}
+
+// Apply path (writing a new NODE.md): use node owners and fall back to the
+// PR author so the newly drafted node isn't ownerless.
 function resolveProposalOwners(
   treeRoot: string,
   targetDir: string,
@@ -292,18 +308,18 @@ function resolveProposalOwners(
   if (authorLogin) {
     combined.push(authorLogin);
   }
+  return dedupeOwners(combined);
+}
 
-  const seen = new Set<string>();
-  const resolved: string[] = [];
-  for (const owner of combined) {
-    const cleaned = owner.replace(/^@+/, "").trim();
-    if (cleaned === "") continue;
-    const normalized = normalizeGitHubLogin(cleaned);
-    if (seen.has(normalized)) continue;
-    seen.add(normalized);
-    resolved.push(cleaned);
-  }
-  return resolved;
+// --open-issues path: assignees must come from NODE.md owners only. If the
+// node has no `owners:`, we want `needs-owner` to fire — we must not silently
+// fall back to the PR author (that would mask the signal that #280 aims to
+// surface).
+function resolveIssueAssignees(
+  treeRoot: string,
+  targetDir: string,
+): string[] {
+  return dedupeOwners(resolveNodeOwners(targetDir, treeRoot, new Map()));
 }
 
 interface CommitSummary {
@@ -1481,12 +1497,7 @@ export async function runOpenIssuesMode(
         continue;
       }
       const absDir = join(treeRoot, proposal.path);
-      const owners = resolveProposalOwners(
-        treeRoot,
-        absDir,
-        classified.pr.authorLogin,
-      );
-      let assignees = owners;
+      let assignees = resolveIssueAssignees(treeRoot, absDir);
       let needsOwner = assignees.length === 0;
 
       const body = buildSyncProposalBody({

--- a/src/products/gardener/engine/sync.ts
+++ b/src/products/gardener/engine/sync.ts
@@ -1500,19 +1500,20 @@ export async function runOpenIssuesMode(
       let assignees = resolveIssueAssignees(treeRoot, absDir);
       let needsOwner = assignees.length === 0;
 
-      const body = buildSyncProposalBody({
-        proposal,
-        proposalId,
-        sourceRepo,
-        sourcePr: classified.pr.number,
-        sourcePrTitle: classified.pr.title,
-        sourceSha: classified.pr.mergeCommitSha
-          ? classified.pr.mergeCommitSha.slice(0, 7)
-          : null,
-        autoAssigned: assignees.length > 0,
-        needsOwner,
-      });
       const title = `[gardener] ${proposal.suggested_node_title || proposal.path}`;
+      const currentBody = (): string =>
+        buildSyncProposalBody({
+          proposal,
+          proposalId,
+          sourceRepo,
+          sourcePr: classified.pr.number,
+          sourcePrTitle: classified.pr.title,
+          sourceSha: classified.pr.mergeCommitSha
+            ? classified.pr.mergeCommitSha.slice(0, 7)
+            : null,
+          autoAssigned: assignees.length > 0,
+          needsOwner,
+        });
 
       if (dryRun) {
         console.log(
@@ -1526,21 +1527,20 @@ export async function runOpenIssuesMode(
 
       const labels = ["first-tree:sync-proposal", "gardener"];
       if (needsOwner) labels.push("needs-owner");
-      const baseArgs = [
-        "issue",
-        "create",
-        "--repo",
-        treeSlug,
-        "--title",
-        title,
-        "--body",
-        body,
-      ];
       const buildArgs = (opts: {
         withAssignees: boolean;
         withLabels: boolean;
       }): string[] => {
-        const out = [...baseArgs];
+        const out = [
+          "issue",
+          "create",
+          "--repo",
+          treeSlug,
+          "--title",
+          title,
+          "--body",
+          currentBody(),
+        ];
         if (opts.withAssignees && assignees.length > 0) {
           out.push("--assignee", assignees.join(","));
         }

--- a/src/products/gardener/engine/sync.ts
+++ b/src/products/gardener/engine/sync.ts
@@ -1372,7 +1372,7 @@ export function buildSyncProposalBody(params: {
     ? `**Source PR:** ${sourceRepo}#${sourcePr}${sourcePrTitle ? ` \u2014 ${sourcePrTitle}` : ""}`
     : `**Source:** ${sourceRepo} (unlinked commits)`;
   const ownerNote = needsOwner
-    ? `_No \`owners:\` on the affected node — assigned the tree-repo default as a fallback. Label \`needs-owner\` flags this for triage._\n\n`
+    ? `_No \`owners:\` on the affected node — filing unassigned. Label \`needs-owner\` flags this for manual triage; add owners to the NODE.md frontmatter and re-run sync for auto-routing._\n\n`
     : autoAssigned
       ? `_Assigned to node owners from the affected NODE.md. First assignee to pick this up drafts a tree PR and links it back in a comment._\n\n`
       : "";
@@ -1406,20 +1406,6 @@ async function resolveTreeSlug(
   if (res.code !== 0) return null;
   const slug = res.stdout.trim();
   return slug.length > 0 ? slug : null;
-}
-
-async function resolveTreeDefaultOwner(
-  shellRun: ShellRun,
-  treeSlug: string,
-): Promise<string | null> {
-  const res = await shellRun(
-    "gh",
-    ["api", `/repos/${treeSlug}`, "-q", ".owner.login"],
-    {},
-  );
-  if (res.code !== 0) return null;
-  const login = res.stdout.trim();
-  return login.length > 0 ? login : null;
 }
 
 async function existingProposalIssueUrl(
@@ -1473,12 +1459,6 @@ export async function runOpenIssuesMode(
   }
   const sourceRepo = `${drift.ownerRepo.owner}/${drift.ownerRepo.repo}`;
   const tokenEnv: NodeJS.ProcessEnv = { ...process.env, GH_TOKEN: treeRepoToken };
-  let cachedDefaultOwner: string | null | undefined;
-  const resolveDefaultOwner = async (): Promise<string | null> => {
-    if (cachedDefaultOwner !== undefined) return cachedDefaultOwner;
-    cachedDefaultOwner = await resolveTreeDefaultOwner(shellRun, treeSlug);
-    return cachedDefaultOwner;
-  };
 
   let created = 0;
   let skipped = 0;
@@ -1507,14 +1487,7 @@ export async function runOpenIssuesMode(
         classified.pr.authorLogin,
       );
       let assignees = owners;
-      let needsOwner = false;
-      if (assignees.length === 0) {
-        const defaultOwner = await resolveDefaultOwner();
-        if (defaultOwner) {
-          assignees = [defaultOwner];
-          needsOwner = true;
-        }
-      }
+      let needsOwner = assignees.length === 0;
 
       const body = buildSyncProposalBody({
         proposal,

--- a/tests/gardener/sync-open-issues.test.ts
+++ b/tests/gardener/sync-open-issues.test.ts
@@ -311,4 +311,99 @@ describe("sync --open-issues · runOpenIssuesMode", () => {
       }
     }
   });
+
+  it("rebuilds the issue body after the assignee-strip retry so needs-owner is reflected in body copy too", async () => {
+    const previousToken = process.env.TREE_REPO_TOKEN;
+    process.env.TREE_REPO_TOKEN = "tree-token";
+
+    const treeRoot = mkdtempSync(join(tmpdir(), "first-tree-sync-open-issues-body-rebuild-"));
+    const nodeDir = join(treeRoot, baseProposal.path);
+    mkdirSync(nodeDir, { recursive: true });
+    // NODE.md has a real owner — initial create will attempt --assignee.
+    writeFileSync(
+      join(nodeDir, "NODE.md"),
+      "---\ntitle: \"Auth service\"\nowners: [not-a-collaborator]\n---\n\nBody.\n",
+    );
+
+    const createCalls: string[][] = [];
+
+    try {
+      const exitCode = await runOpenIssuesMode({
+        drift: {
+          binding: { sourceId: "acme-web" },
+          ownerRepo: { owner: "acme", repo: "web" },
+        },
+        classifiedPrs: [{
+          pr: {
+            number: 42,
+            title: "Split auth",
+            mergeCommitSha: "deadbeefcafebabe",
+            authorLogin: "octocat",
+          },
+          filtered: [baseProposal],
+        }],
+        treeRoot,
+        shellRun: async (command, args) => {
+          if (command !== "gh") {
+            return { code: 1, stdout: "", stderr: `unexpected command: ${command}` };
+          }
+          if (args[0] === "repo" && args[1] === "view") {
+            return { code: 0, stdout: "agent-team-foundation/first-tree-context\n", stderr: "" };
+          }
+          if (args[0] === "issue" && args[1] === "list") {
+            return { code: 0, stdout: "[]", stderr: "" };
+          }
+          if (args[0] === "issue" && args[1] === "create") {
+            createCalls.push([...args]);
+            // First attempt: 422 because assignee isn't a collaborator.
+            if (createCalls.length === 1) {
+              return {
+                code: 1,
+                stdout: "",
+                stderr: "Validation Failed: assignee not-a-collaborator is not a collaborator",
+              };
+            }
+            // Retry without --assignee succeeds.
+            return {
+              code: 0,
+              stdout: "https://github.com/agent-team-foundation/first-tree-context/issues/888\n",
+              stderr: "",
+            };
+          }
+          return { code: 1, stdout: "", stderr: `unexpected gh args: ${args.join(" ")}` };
+        },
+        dryRun: false,
+      });
+
+      expect(exitCode).toBe(0);
+      expect(createCalls.length).toBe(2);
+
+      // Initial attempt carried --assignee and a body claiming auto-assignment.
+      const firstArgs = createCalls[0];
+      expect(firstArgs).toContain("--assignee");
+      const firstBody = firstArgs[firstArgs.indexOf("--body") + 1];
+      expect(firstBody.toLowerCase()).toContain("assigned to node owners");
+      expect(firstBody.toLowerCase()).not.toContain("no `owners:`");
+
+      // Retry: --assignee gone, --label includes needs-owner, body rebuilt to
+      // match the final (unassigned / needs-owner) state — no lingering
+      // "assigned to node owners" copy.
+      const retryArgs = createCalls[1];
+      expect(retryArgs).not.toContain("--assignee");
+      const labelIdx = retryArgs.indexOf("--label");
+      expect(labelIdx).toBeGreaterThanOrEqual(0);
+      expect(retryArgs[labelIdx + 1]).toContain("needs-owner");
+      const retryBody = retryArgs[retryArgs.indexOf("--body") + 1];
+      expect(retryBody.toLowerCase()).toContain("no `owners:`");
+      expect(retryBody.toLowerCase()).toContain("filing unassigned");
+      expect(retryBody.toLowerCase()).not.toContain("assigned to node owners");
+    } finally {
+      rmSync(treeRoot, { recursive: true, force: true });
+      if (previousToken === undefined) {
+        delete process.env.TREE_REPO_TOKEN;
+      } else {
+        process.env.TREE_REPO_TOKEN = previousToken;
+      }
+    }
+  });
 });

--- a/tests/gardener/sync-open-issues.test.ts
+++ b/tests/gardener/sync-open-issues.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -220,6 +220,88 @@ describe("sync --open-issues · runOpenIssuesMode", () => {
         call.command === "gh" && call.args[0] === "issue" && call.args[1] === "create"
       );
       expect(issueCreateCall).toBeUndefined();
+    } finally {
+      rmSync(treeRoot, { recursive: true, force: true });
+      if (previousToken === undefined) {
+        delete process.env.TREE_REPO_TOKEN;
+      } else {
+        process.env.TREE_REPO_TOKEN = previousToken;
+      }
+    }
+  });
+
+  it("files the issue unassigned with needs-owner when the node's owners: is empty, even when the PR author exists (#280)", async () => {
+    const previousToken = process.env.TREE_REPO_TOKEN;
+    process.env.TREE_REPO_TOKEN = "tree-token";
+
+    const treeRoot = mkdtempSync(join(tmpdir(), "first-tree-sync-open-issues-needs-owner-"));
+    const nodeDir = join(treeRoot, baseProposal.path);
+    mkdirSync(nodeDir, { recursive: true });
+    // NODE.md exists with an empty owners: list — this is the case #280 targets.
+    writeFileSync(
+      join(nodeDir, "NODE.md"),
+      "---\ntitle: \"Auth service\"\nowners: []\n---\n\nBody.\n",
+    );
+
+    const calls: Array<{ command: string; args: string[] }> = [];
+
+    try {
+      const exitCode = await runOpenIssuesMode({
+        drift: {
+          binding: { sourceId: "acme-web" },
+          ownerRepo: { owner: "acme", repo: "web" },
+        },
+        classifiedPrs: [{
+          pr: {
+            number: 42,
+            title: "Split auth",
+            mergeCommitSha: "deadbeefcafebabe",
+            // PR author is set — previous behaviour would have assigned them.
+            authorLogin: "octocat",
+          },
+          filtered: [baseProposal],
+        }],
+        treeRoot,
+        shellRun: async (command, args) => {
+          calls.push({ command, args: [...args] });
+          if (command !== "gh") {
+            return { code: 1, stdout: "", stderr: `unexpected command: ${command}` };
+          }
+          if (args[0] === "repo" && args[1] === "view") {
+            return { code: 0, stdout: "agent-team-foundation/first-tree-context\n", stderr: "" };
+          }
+          if (args[0] === "issue" && args[1] === "list") {
+            return { code: 0, stdout: "[]", stderr: "" };
+          }
+          if (args[0] === "issue" && args[1] === "create") {
+            return {
+              code: 0,
+              stdout: "https://github.com/agent-team-foundation/first-tree-context/issues/777\n",
+              stderr: "",
+            };
+          }
+          return { code: 1, stdout: "", stderr: `unexpected gh args: ${args.join(" ")}` };
+        },
+        dryRun: false,
+      });
+
+      expect(exitCode).toBe(0);
+
+      const createCall = calls.find(
+        (c) => c.command === "gh" && c.args[0] === "issue" && c.args[1] === "create",
+      );
+      expect(createCall).toBeDefined();
+      // No PR-author fallback: --assignee must not be set.
+      expect(createCall?.args).not.toContain("--assignee");
+      expect(createCall?.args.some((a) => a.includes("octocat"))).toBe(false);
+      // The needs-owner label must be applied instead.
+      const labelIdx = createCall?.args.indexOf("--label") ?? -1;
+      expect(labelIdx).toBeGreaterThanOrEqual(0);
+      expect(createCall?.args[labelIdx + 1]).toContain("needs-owner");
+      // And the body should surface the needs-owner copy.
+      const bodyIdx = createCall?.args.indexOf("--body") ?? -1;
+      expect(bodyIdx).toBeGreaterThanOrEqual(0);
+      expect(createCall?.args[bodyIdx + 1].toLowerCase()).toContain("needs-owner");
     } finally {
       rmSync(treeRoot, { recursive: true, force: true });
       if (previousToken === undefined) {


### PR DESCRIPTION
## Summary

Follow-up to #278 (bingran review #2).

`resolveTreeDefaultOwner` returned the tree repo's `.owner.login`, which is an organization slug for most tree repos. GitHub rejects orgs as issue assignees, so the call always failed and fell through to the 422-assignee-strip retry that already lands the issue unassigned with `needs-owner`. Net effect: silent dead code that made logs + issue body copy confusing.

This picks **Option 1** from #280 (the issue listed three): drop the call, treat empty-owners as `needs-owner` directly, update the issue-body copy to say "filing unassigned" instead of "assigned the tree-repo default".

The 422-assignee-strip retry from #278 still handles the case that actually matters (individual-user tree repos whose assignee isn't a collaborator).

Options 2 (CODEOWNERS parsing) and 3 (gardener.defaultAssignee config) can be filed as separate features if a real use case emerges — right now there's no evidence either was ever exercised.

## Test plan

- [x] Full gardener suite: 328/328 green
- [x] Typecheck clean
- [x] Existing `tests/gardener/sync-open-issues.test.ts` body-copy assertion still passes (it checks for "no \`owners:\`" and "needs-owner", which are preserved)

Closes #280
Refs #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)