### PR TITLE
test(gardener): orchestration tests for runOpenIssuesMode (#281)

### DIFF
--- a/src/products/gardener/engine/sync.ts
+++ b/src/products/gardener/engine/sync.ts
@@ -1312,12 +1312,12 @@ async function pushAndCreatePrsParallel(
   return { successes, failures, prUrls };
 }
 
-interface DriftReportLike {
+export interface DriftReportLike {
   binding: { sourceId: string };
   ownerRepo: OwnerRepo;
 }
 
-interface ClassifiedPrLike {
+export interface ClassifiedPrLike {
   pr: {
     number: number | null;
     title: string | null;
@@ -1327,7 +1327,7 @@ interface ClassifiedPrLike {
   filtered: ClassificationItem[];
 }
 
-interface RunOpenIssuesInput {
+export interface RunOpenIssuesInput {
   drift: DriftReportLike;
   classifiedPrs: ClassifiedPrLike[];
   treeRoot: string;

--- a/tests/gardener/sync-open-issues.test.ts
+++ b/tests/gardener/sync-open-issues.test.ts
@@ -229,4 +229,180 @@ describe("sync --open-issues · runOpenIssuesMode", () => {
       }
     }
   });
+
+  interface RunArgs {
+    shell: (
+      command: string,
+      args: string[],
+      options: { env?: NodeJS.ProcessEnv },
+    ) => Promise<{ code: number; stdout: string; stderr: string }>;
+    dryRun?: boolean;
+    token?: string | null;
+  }
+
+  async function runWithHarness({ shell, dryRun = false, token = "tree-token" }: RunArgs) {
+    const previousToken = process.env.TREE_REPO_TOKEN;
+    if (token === null) {
+      delete process.env.TREE_REPO_TOKEN;
+    } else {
+      process.env.TREE_REPO_TOKEN = token;
+    }
+    const treeRoot = mkdtempSync(join(tmpdir(), "first-tree-sync-open-issues-"));
+    mkdirSync(join(treeRoot, baseProposal.path), { recursive: true });
+    const calls: Array<{ command: string; args: string[]; envToken?: string }> = [];
+    try {
+      const exitCode = await runOpenIssuesMode({
+        drift: {
+          binding: { sourceId: "acme-web" },
+          ownerRepo: { owner: "acme", repo: "web" },
+        },
+        classifiedPrs: [
+          {
+            pr: {
+              number: 42,
+              title: "Split auth",
+              mergeCommitSha: "deadbeefcafebabe",
+              authorLogin: "octocat",
+            },
+            filtered: [baseProposal],
+          },
+        ],
+        treeRoot,
+        shellRun: async (command, args, options = {}) => {
+          calls.push({
+            command,
+            args: [...args],
+            envToken: options.env?.GH_TOKEN,
+          });
+          return shell(command, args, options);
+        },
+        dryRun,
+      });
+      return { exitCode, calls };
+    } finally {
+      rmSync(treeRoot, { recursive: true, force: true });
+      if (previousToken === undefined) {
+        delete process.env.TREE_REPO_TOKEN;
+      } else {
+        process.env.TREE_REPO_TOKEN = previousToken;
+      }
+    }
+  }
+
+  it("happy path: one `gh issue create` call with proposal_id in body and GH_TOKEN threaded", async () => {
+    const { exitCode, calls } = await runWithHarness({
+      shell: async (_cmd, args) => {
+        if (args[0] === "repo" && args[1] === "view") {
+          return { code: 0, stdout: "agent-team-foundation/tree\n", stderr: "" };
+        }
+        if (args[0] === "issue" && args[1] === "list") {
+          return { code: 0, stdout: "[]", stderr: "" };
+        }
+        if (args[0] === "issue" && args[1] === "create") {
+          return { code: 0, stdout: "https://github.com/org/tree/issues/1\n", stderr: "" };
+        }
+        return { code: 1, stdout: "", stderr: `unexpected: ${args.join(" ")}` };
+      },
+    });
+    expect(exitCode).toBe(0);
+    const createCalls = calls.filter((c) => c.args[0] === "issue" && c.args[1] === "create");
+    expect(createCalls).toHaveLength(1);
+    const createCall = createCalls[0];
+    expect(createCall.envToken).toBe("tree-token");
+    const bodyIdx = createCall.args.indexOf("--body");
+    expect(bodyIdx).toBeGreaterThan(-1);
+    expect(createCall.args[bodyIdx + 1]).toContain("proposal_id=");
+    expect(createCall.args).toContain("first-tree:sync-proposal,gardener");
+  });
+
+  it("retries without --label when gh rejects unknown labels (422)", async () => {
+    let createAttempts = 0;
+    const { exitCode, calls } = await runWithHarness({
+      shell: async (_cmd, args) => {
+        if (args[0] === "repo" && args[1] === "view") {
+          return { code: 0, stdout: "org/tree\n", stderr: "" };
+        }
+        if (args[0] === "issue" && args[1] === "list") {
+          return { code: 0, stdout: "[]", stderr: "" };
+        }
+        if (args[0] === "issue" && args[1] === "create") {
+          createAttempts += 1;
+          if (createAttempts === 1) {
+            return { code: 1, stdout: "", stderr: "422 Unprocessable: label not found" };
+          }
+          return { code: 0, stdout: "https://github.com/org/tree/issues/1\n", stderr: "" };
+        }
+        return { code: 1, stdout: "", stderr: `unexpected: ${args.join(" ")}` };
+      },
+    });
+    expect(exitCode).toBe(0);
+    const createCalls = calls.filter((c) => c.args[0] === "issue" && c.args[1] === "create");
+    expect(createCalls).toHaveLength(2);
+    expect(createCalls[0].args).toContain("--label");
+    expect(createCalls[1].args).not.toContain("--label");
+  });
+
+  it("retries without --assignee and adds needs-owner when assignee is rejected (422)", async () => {
+    // Attempt 1 (with --label + --assignee) fails 422 → code tries label-strip first.
+    // Attempt 2 (with --assignee, no --label) still fails 422 on assignee → code strips assignee.
+    // Attempt 3 (no --assignee, with --label including needs-owner) succeeds.
+    let createAttempts = 0;
+    const { exitCode, calls } = await runWithHarness({
+      shell: async (_cmd, args) => {
+        if (args[0] === "repo" && args[1] === "view") {
+          return { code: 0, stdout: "org/tree\n", stderr: "" };
+        }
+        if (args[0] === "issue" && args[1] === "list") {
+          return { code: 0, stdout: "[]", stderr: "" };
+        }
+        if (args[0] === "issue" && args[1] === "create") {
+          createAttempts += 1;
+          if (createAttempts <= 2) {
+            return {
+              code: 1,
+              stdout: "",
+              stderr: "422 Unprocessable: assignee not a collaborator",
+            };
+          }
+          return { code: 0, stdout: "https://github.com/org/tree/issues/1\n", stderr: "" };
+        }
+        return { code: 1, stdout: "", stderr: `unexpected: ${args.join(" ")}` };
+      },
+    });
+    expect(exitCode).toBe(0);
+    const createCalls = calls.filter((c) => c.args[0] === "issue" && c.args[1] === "create");
+    expect(createCalls).toHaveLength(3);
+    const retry = createCalls[2];
+    expect(retry.args).not.toContain("--assignee");
+    const labelIdx = retry.args.indexOf("--label");
+    expect(labelIdx).toBeGreaterThan(-1);
+    expect(retry.args[labelIdx + 1]).toContain("needs-owner");
+  });
+
+  it("dry-run skips `gh issue create` but still resolves the tree slug", async () => {
+    const { exitCode, calls } = await runWithHarness({
+      dryRun: true,
+      shell: async (_cmd, args) => {
+        if (args[0] === "repo" && args[1] === "view") {
+          return { code: 0, stdout: "org/tree\n", stderr: "" };
+        }
+        if (args[0] === "issue" && args[1] === "list") {
+          return { code: 0, stdout: "[]", stderr: "" };
+        }
+        return { code: 1, stdout: "", stderr: `unexpected: ${args.join(" ")}` };
+      },
+    });
+    expect(exitCode).toBe(0);
+    expect(calls.some((c) => c.args[0] === "repo" && c.args[1] === "view")).toBe(true);
+    expect(calls.some((c) => c.args[0] === "issue" && c.args[1] === "create")).toBe(false);
+  });
+
+  it("fails fast when TREE_REPO_TOKEN is unset", async () => {
+    const { exitCode, calls } = await runWithHarness({
+      token: null,
+      shell: async () => ({ code: 1, stdout: "", stderr: "should not be called" }),
+    });
+    expect(exitCode).toBe(1);
+    expect(calls).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to #278 (bingran review #3). Adds 5 orchestration tests for `runOpenIssuesMode`'s retry + idempotency + dry-run paths via a tiny harness that feeds fake \`gh\` responses through the existing \`shellRun\` injection point:

- **Happy path** — one \`gh issue create\` call with \`proposal_id=\` in the body and \`GH_TOKEN\` threaded from \`TREE_REPO_TOKEN\`
- **422 label-strip retry** — tree repo without seeded labels
- **422 assignee-strip retry** — lands \`needs-owner\` in the label list; exercises the full attempt-1 → attempt-2 → attempt-3 fall-through
- **Dry-run** — skips \`gh issue create\` but still resolves the tree slug
- **Missing token** — exit code 1 without invoking the shell

Also exports \`DriftReportLike\`, \`ClassifiedPrLike\`, \`RunOpenIssuesInput\` so the harness doesn't replicate internal shapes.

## Out of scope

The two \"Also in scope\" items from #281 are intentionally deferred so this PR stays pure tests:
- Tighten 422-detection regex
- \`.first-tree/open-issues.json\` local cache for search-index lag

Both can land as separate PRs once we've seen real-world false positives / lag incidents.

## Base branch note

Opened against **fix/280-drop-org-default-owner** so the tests reflect post-#280 semantics. I'll retarget to \`main\` (and rebase) once #286 merges.

## Test plan

- [x] New tests: 5 added
- [x] Full gardener suite: 333/333 green (was 328)
- [x] Typecheck clean

Closes #281
Refs #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)