### PR TITLE
fix(test): serialize heavy CLI tests to remove vitest flake

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,19 @@
 import { readFileSync } from "node:fs";
 import { defineConfig } from "vitest/config";
 
+const sharedExclude = [
+  "**/node_modules/**",
+  "dist/**",
+  "**/cypress/**",
+  "**/.{idea,git,cache,output,temp}/**",
+  "**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,eslint,prettier}.config.*",
+];
+
+const heavyGlobs = [
+  "tests/e2e/**/*.test.ts",
+  "tests/tree/**/*.test.ts",
+];
+
 export default defineConfig({
   plugins: [
     {
@@ -14,17 +27,33 @@ export default defineConfig({
     },
   ],
   test: {
-    include: [
-      "tests/**/*.test.ts",
-      "tests/**/*.test.tsx",
-      "evals/tests/**/*.test.ts",
-    ],
-    exclude: [
-      "**/node_modules/**",
-      "dist/**",
-      "**/cypress/**",
-      "**/.{idea,git,cache,output,temp}/**",
-      "**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,eslint,prettier}.config.*",
+    // Heavy tests under tests/e2e and tests/tree spawn real `pnpm pack`/`pnpm build`
+    // and run the built CLI. Under default parallelism they fight for CPU and
+    // flake on 15s per-test timeouts. Split into two projects so the heavy set
+    // runs with fileParallelism disabled while unit tests stay fast.
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: "unit",
+          include: [
+            "tests/**/*.test.ts",
+            "tests/**/*.test.tsx",
+            "evals/tests/**/*.test.ts",
+          ],
+          exclude: [...sharedExclude, ...heavyGlobs],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "heavy",
+          include: heavyGlobs,
+          exclude: sharedExclude,
+          fileParallelism: false,
+          testTimeout: 30_000,
+        },
+      },
     ],
   },
 });


### PR DESCRIPTION
## Summary
- Split vitest suite into `unit` + `heavy` projects so `tests/e2e` and `tests/tree` run with `fileParallelism: false` and `testTimeout: 30_000`
- The heavy files spawn real `pnpm pack`/`pnpm build` and invoke the built CLI; default fork parallelism caused 15s per-test timeouts to flake under contention
- Unit tests keep normal parallelism; heavy tests serialize cleanly in ~11s

Closes #260.

## Test plan
- [x] `pnpm exec vitest run --project unit` green (passes runner test)
- [x] `pnpm exec vitest run --project heavy` green (26 files, 345 tests, 11.13s)
- [x] Full `pnpm exec vitest run` green three consecutive times (1155 passed / 51 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)