### PR TITLE
fix(breeze): use ?participating=true on notifications (drop ?all=true)

### DIFF
--- a/src/products/breeze/engine/commands/poll.ts
+++ b/src/products/breeze/engine/commands/poll.ts
@@ -74,7 +74,7 @@ function formatUtcIso(date: Date): string {
   return `${date.toISOString().slice(0, 19)}Z`;
 }
 
-/** Raw GitHub notification as returned by `/notifications?all=true`. */
+/** Raw GitHub notification as returned by `/notifications?participating=true`. */
 interface RawNotification {
   id?: string;
   reason?: string;
@@ -554,7 +554,9 @@ export async function runPoll(
   try {
     const stdout = gh.runChecked("fetch notifications", [
       "api",
-      "/notifications?all=true",
+      // See #251: `all=true` bypassed GitHub's spam filter. `participating=true`
+      // restricts to direct-participation notifications.
+      "/notifications?participating=true",
       "--paginate",
       "-H",
       "X-GitHub-Api-Version: 2022-11-28",

--- a/src/products/breeze/engine/daemon/gh-client.ts
+++ b/src/products/breeze/engine/daemon/gh-client.ts
@@ -88,7 +88,10 @@ export class GhClient {
       "read recent notifications",
       [
         "api",
-        "/notifications?all=true&participating=false&per_page=100",
+        // See #251: `all=true&participating=false` bypassed GitHub's server-side
+        // spam filter and let breeze act on mention-then-delete notifications.
+        // `participating=true` restricts to direct-participation notifications.
+        "/notifications?participating=true&per_page=100",
         "--paginate",
         "-H",
         "X-GitHub-Api-Version: 2022-11-28",

--- a/src/products/breeze/engine/daemon/poller.ts
+++ b/src/products/breeze/engine/daemon/poller.ts
@@ -174,7 +174,12 @@ export async function pollOnce(deps: PollOnceDeps): Promise<PollOutcome> {
   try {
     const stdout = gh.runChecked("fetch notifications", [
       "api",
-      "/notifications?all=true",
+      // `participating=true` restricts to notifications where the user is a
+      // direct participant (author, assignee, mention, review_requested) and
+      // respects GitHub's server-side spam filter. `?all=true` was previously
+      // used here but bypassed the filter, causing breeze to act on
+      // mention-then-delete spam surfaced to no one in the UI (#251).
+      "/notifications?participating=true",
       "--paginate",
       "-H",
       "X-GitHub-Api-Version: 2022-11-28",

--- a/tests/breeze/breeze-daemon-gh-client.test.ts
+++ b/tests/breeze/breeze-daemon-gh-client.test.ts
@@ -119,7 +119,7 @@ describe("GhClient.recentNotifications", () => {
     expect(tasks[0].kind).toBe("mention");
     // Assert the argv sent to gh contains the paginate + notifications endpoint.
     expect(ctl.calls[0].args).toContain("--paginate");
-    expect(ctl.calls[0].args).toContain("/notifications?all=true&participating=false&per_page=100");
+    expect(ctl.calls[0].args).toContain("/notifications?participating=true&per_page=100");
   });
 
   it("drops lines that predate the lookback window", async () => {

--- a/tests/breeze/breeze-daemon-poller.test.ts
+++ b/tests/breeze/breeze-daemon-poller.test.ts
@@ -37,7 +37,7 @@ interface ResponseMatcher {
   stderr?: string;
 }
 
-function makeStubGh(matchers: ResponseMatcher[]): GhClient {
+function makeStubGh(matchers: ResponseMatcher[]): GhClient & { calls: string[][] } {
   const calls: string[][] = [];
   const spawn = vi
     .fn()
@@ -64,7 +64,8 @@ function makeStubGh(matchers: ResponseMatcher[]): GhClient {
         output: [],
       };
     });
-  return new GhClient({ spawn });
+  const client = new GhClient({ spawn });
+  return Object.assign(client, { calls });
 }
 
 function mkBreezeDir(): { dir: string; inbox: string; activity: string } {
@@ -180,6 +181,14 @@ describe("pollOnce parity with Rust fetcher", () => {
     expect(outcome.newCount).toBe(1);
     expect(outcome.warnings).toEqual([]);
     expect(outcome.rateLimited).toBe(false);
+
+    // #251: must hit /notifications?participating=true (not ?all=true),
+    // which respects GitHub's server-side spam filter.
+    const notifCall = gh.calls.find(
+      (argv) => argv[0] === "api" && argv[1]?.startsWith("/notifications"),
+    );
+    expect(notifCall).toBeDefined();
+    expect(notifCall?.[1]).toBe("/notifications?participating=true");
 
     const parsed = JSON.parse(readFileSync(ctx.inbox, "utf-8")) as {
       last_poll: string;


### PR DESCRIPTION
## Summary
- Switch all three `/notifications` callers (poller.ts, gh-client.ts, poll.ts) from `?all=true` (or `?all=true&participating=false`) to `?participating=true`
- `?all=true` bypasses GitHub's server-side spam filter; `?participating=true` restricts to notifications where the user is a direct participant (author, assignee, mention, review_requested) and respects the filter
- This is Layer 1 from #251; Layers 2 (loud warning on `repos: [all]`) and 3 (trusted_actors allowlist) are left as separate follow-ups

Closes #251.

## Background

On 2026-04-21 a breeze user running with `repos: [all]` posted AI-generated reviews on ~15 unrelated public OSS repos within about an hour. The trigger notifications (`unread: false` + `last_read_at: null` + `subject_type: null`) were server-filtered — never visible to the user's GitHub inbox UI, but surfaced to breeze via `?all=true`. See issue #251 for full forensic evidence.

## Test plan
- [x] `pnpm exec vitest run tests/breeze/` — 424 passed
- [x] New regression assertion in `breeze-daemon-poller.test.ts` pins the URL to `/notifications?participating=true`
- [x] Existing `breeze-daemon-gh-client.test.ts` assertion updated to `participating=true&per_page=100`

🤖 Generated with [Claude Code](https://claude.com/claude-code)