### PR TITLE
fix(breeze/start): refuse and warn when a live daemon exists

### DIFF
--- a/src/products/breeze/engine/commands/start.ts
+++ b/src/products/breeze/engine/commands/start.ts
@@ -95,6 +95,10 @@ export async function runStart(
     profile,
   );
   if (existingLock && !isLockStale(existingLock)) {
+    const stopCmd = formatStopCommand({
+      home: options.runnerHome ?? parseHome(argv),
+      profile: options.profile ?? parseProfile(argv),
+    });
     write(
       `breeze: daemon already running (pid ${existingLock.pid}).`,
     );
@@ -105,7 +109,7 @@ export async function runStart(
       "  will not update if you edit ~/.breeze/config.yaml or re-run `start`.",
     );
     write(
-      "  Run `first-tree breeze stop` first, then re-run `start` with the",
+      `  Run \`${stopCmd}\` first, then re-run \`start\` with the`,
     );
     write("  full --allow-repo csv.");
     return 1;
@@ -163,6 +167,29 @@ export async function runStart(
   write(`pid: ${child.pid}`);
   write(`log: ${logPath}`);
   return 0;
+}
+
+/**
+ * Build the `breeze stop` suggestion shown when we refuse to start
+ * because a live daemon is already running. If the current invocation
+ * resolved a non-default `--home`/`--profile`, surface those flags so
+ * the user targets the same runner instead of silently stopping the
+ * default one.
+ */
+function formatStopCommand(opts: {
+  home?: string;
+  profile?: string;
+}): string {
+  const parts = ["first-tree breeze stop"];
+  if (opts.home) parts.push(`--home ${shellQuote(opts.home)}`);
+  if (opts.profile && opts.profile !== "default") {
+    parts.push(`--profile ${shellQuote(opts.profile)}`);
+  }
+  return parts.join(" ");
+}
+
+function shellQuote(v: string): string {
+  return /^[\w@%+=:,./-]+$/.test(v) ? v : `'${v.replace(/'/g, `'\\''`)}'`;
 }
 
 function parseHome(argv: readonly string[]): string | undefined {

--- a/src/products/breeze/engine/commands/start.ts
+++ b/src/products/breeze/engine/commands/start.ts
@@ -15,6 +15,7 @@ import {
   parseAllowRepoArg,
   requireExplicitRepoFilter,
 } from "../runtime/allow-repo.js";
+import { findServiceLock, isLockStale } from "../daemon/claim.js";
 import { resolveDaemonIdentity } from "../daemon/identity.js";
 import {
   bootstrapLaunchdJob,
@@ -75,6 +76,38 @@ export async function runStart(
     write(
       `breeze: start failed: ${err instanceof Error ? err.message : String(err)}`,
     );
+    return 1;
+  }
+
+  // #293: detect a live daemon and refuse to silently no-op. The bootstrap
+  // path below is idempotent at the launchd level, but it doesn't update
+  // the running process's allow-list — users kept running `breeze start`
+  // with a new --allow-repo and seeing no effect. Fail loudly so the user
+  // knows to stop first.
+  const existingLock = findServiceLock(
+    `${home}/locks`,
+    {
+      host: config.host,
+      login: identity.login,
+      scopes: [],
+      gitProtocol: "",
+    },
+    profile,
+  );
+  if (existingLock && !isLockStale(existingLock)) {
+    write(
+      `breeze: daemon already running (pid ${existingLock.pid}).`,
+    );
+    write(
+      "  The live daemon's --allow-repo list is baked in at start time and",
+    );
+    write(
+      "  will not update if you edit ~/.breeze/config.yaml or re-run `start`.",
+    );
+    write(
+      "  Run `first-tree breeze stop` first, then re-run `start` with the",
+    );
+    write("  full --allow-repo csv.");
     return 1;
   }
 

--- a/tests/breeze/breeze-start.test.ts
+++ b/tests/breeze/breeze-start.test.ts
@@ -119,4 +119,49 @@ describe("runStart", () => {
     expect(output).toContain("daemon already running (pid 97184)");
     expect(output).toContain("first-tree breeze stop");
   });
+
+  it("includes --home/--profile in the stop hint when the caller set them (#301 review)", async () => {
+    vi.doMock("../../src/products/breeze/engine/daemon/launchd.js", () => ({
+      supportsLaunchd: () => true,
+      bootstrapLaunchdJob: vi.fn(),
+    }));
+    vi.doMock("../../src/products/breeze/engine/daemon/identity.js", () => ({
+      resolveDaemonIdentity: () => ({ login: "alice", host: "github.com" }),
+    }));
+    vi.doMock("../../src/products/breeze/engine/runtime/config.js", () => ({
+      loadBreezeDaemonConfig: () => ({ host: "github.com" }),
+    }));
+    vi.doMock("../../src/products/breeze/engine/daemon/claim.js", () => ({
+      findServiceLock: () => ({
+        pid: 4242,
+        heartbeat_epoch: Math.floor(Date.now() / 1000),
+        active_tasks: 0,
+        note: "",
+      }),
+      isLockStale: () => false,
+    }));
+
+    const { runStart } = await import(
+      "../../src/products/breeze/engine/commands/start.js"
+    );
+
+    const lines: string[] = [];
+    const code = await runStart(
+      [
+        "--allow-repo",
+        "owner/repo",
+        "--home",
+        "/custom/home",
+        "--profile",
+        "work",
+      ],
+      { write: (line) => lines.push(line) },
+    );
+
+    expect(code).toBe(1);
+    const output = lines.join("\n");
+    expect(output).toContain(
+      "first-tree breeze stop --home /custom/home --profile work",
+    );
+  });
 });

--- a/tests/breeze/breeze-start.test.ts
+++ b/tests/breeze/breeze-start.test.ts
@@ -41,6 +41,10 @@ describe("runStart", () => {
     vi.doMock("../../src/products/breeze/engine/runtime/config.js", () => ({
       loadBreezeDaemonConfig: () => ({ host: "github.com" }),
     }));
+    vi.doMock("../../src/products/breeze/engine/daemon/claim.js", () => ({
+      findServiceLock: () => null,
+      isLockStale: () => false,
+    }));
 
     const { runStart } = await import(
       "../../src/products/breeze/engine/commands/start.js"
@@ -73,5 +77,46 @@ describe("runStart", () => {
       }),
     );
     expect(lines).toContain("breeze-daemon started in background via launchd");
+  });
+
+  it("refuses to start and points to `breeze stop` when a live daemon is detected (#293)", async () => {
+    const bootstrapLaunchdJob = vi.fn();
+
+    vi.doMock("../../src/products/breeze/engine/daemon/launchd.js", () => ({
+      supportsLaunchd: () => true,
+      bootstrapLaunchdJob,
+    }));
+    vi.doMock("../../src/products/breeze/engine/daemon/identity.js", () => ({
+      resolveDaemonIdentity: () => ({ login: "alice", host: "github.com" }),
+    }));
+    vi.doMock("../../src/products/breeze/engine/runtime/config.js", () => ({
+      loadBreezeDaemonConfig: () => ({ host: "github.com" }),
+    }));
+    vi.doMock("../../src/products/breeze/engine/daemon/claim.js", () => ({
+      findServiceLock: () => ({
+        pid: 97184,
+        heartbeat_epoch: Math.floor(Date.now() / 1000),
+        active_tasks: 0,
+        note: "",
+      }),
+      isLockStale: () => false,
+    }));
+
+    const { runStart } = await import(
+      "../../src/products/breeze/engine/commands/start.js"
+    );
+
+    const lines: string[] = [];
+    const code = await runStart(["--allow-repo", "owner/repo"], {
+      runnerHome: "/tmp/breeze-home/runner",
+      entrypoint: "/tmp/first-tree/dist/cli.js",
+      write: (line) => lines.push(line),
+    });
+
+    expect(code).toBe(1);
+    expect(bootstrapLaunchdJob).not.toHaveBeenCalled();
+    const output = lines.join("\n");
+    expect(output).toContain("daemon already running (pid 97184)");
+    expect(output).toContain("first-tree breeze stop");
   });
 });


### PR DESCRIPTION
## Summary

- \`breeze start\` now checks the service lock before bootstrapping launchd.
- If a non-stale lock exists (a daemon is already running), print the pid, explain that the live allow-list can't be updated from here, point at \`first-tree breeze stop\`, and exit 1.
- No behavior change when no daemon is running — launchd bootstrap path is unchanged.

## Motivation

Tester (#291 item 2) ran \`breeze start --allow-repo <new csv>\` while a daemon was already running with a different list. The command appeared to succeed but the live allow-list didn't update, because launchd's \`kickstart\` is idempotent on label and doesn't re-read args. This made it look like the allow-list edit took effect when it silently didn't.

This is the minimal fix: exit loudly when we detect a live daemon, so the user knows to \`stop\` first. The richer \"reconcile config.yaml \`repos:\` against the live allow-list automatically\" story is left to #297 (\`breeze add-repo\`).

## Refs

Closes #293
Umbrella: #291

## Test plan

- [x] \`tests/breeze/breeze-start.test.ts\` now has 3 tests: missing allow-repo, happy path (with \`findServiceLock\` mocked to null), and the new \"daemon already running\" path.
- [ ] Smoke test locally: start breeze, run \`first-tree breeze start --allow-repo ...\` again, confirm the error message appears and launchd is not re-kickstarted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)