### PR TITLE
fix(gardener/sync): auto-seed sync-proposal label on tree repo (#303)

### DIFF
--- a/src/products/gardener/engine/sync.ts
+++ b/src/products/gardener/engine/sync.ts
@@ -950,6 +950,77 @@ async function ghAuthOk(shellRun: ShellRun): Promise<boolean> {
   return result.code === 0;
 }
 
+/**
+ * Labels gardener applies to its sync-proposal issues. Kept in one place
+ * so `ensureTreeLabels` and the issue-create block agree.
+ */
+export const GARDENER_SYNC_LABELS: ReadonlyArray<{
+  name: string;
+  color: string;
+  description: string;
+}> = [
+  {
+    name: "first-tree:sync-proposal",
+    color: "0e8a16",
+    description: "Gardener-proposed tree update awaiting owner review",
+  },
+  {
+    name: "gardener",
+    color: "c5def5",
+    description: "Authored by the gardener automation",
+  },
+  {
+    name: "needs-owner",
+    color: "d93f0b",
+    description: "No NODE.md owner resolved — triage required",
+  },
+];
+
+/**
+ * Best-effort seed gardener's labels on the tree repo before we start
+ * opening issues. `gh label create` returns a 422 with "already exists"
+ * when the label is present — we treat that as success. Creation failures
+ * are non-fatal: the issue-create loop still has its legacy
+ * retry-without-label fallback so we degrade gracefully.
+ *
+ * Fixes #303: previously the first `gh issue create` call would fail with
+ * "label not found", we'd silently drop the label, and breeze's
+ * draft-node dispatcher (which filters on `first-tree:sync-proposal`)
+ * would skip every issue.
+ */
+export async function ensureTreeLabels(
+  shellRun: ShellRun,
+  treeSlug: string,
+  tokenEnv: NodeJS.ProcessEnv,
+): Promise<void> {
+  for (const label of GARDENER_SYNC_LABELS) {
+    const res = await shellRun(
+      "gh",
+      [
+        "label",
+        "create",
+        label.name,
+        "--repo",
+        treeSlug,
+        "--color",
+        label.color,
+        "--description",
+        label.description,
+      ],
+      { env: tokenEnv },
+    );
+    if (res.code === 0) {
+      console.log(`\u2713 seeded label on ${treeSlug}: ${label.name}`);
+      continue;
+    }
+    const stderr = res.stderr || "";
+    if (/already exists/i.test(stderr)) continue;
+    console.log(
+      `\u26A0 could not seed label ${label.name} on ${treeSlug} (${stderr.split("\n")[0] || "unknown"}) \u2014 will retry per-issue`,
+    );
+  }
+}
+
 function logDriftTable(reports: DriftReport[]): void {
   console.log("\nSync summary:");
   for (const report of reports) {
@@ -1475,6 +1546,10 @@ export async function runOpenIssuesMode(
   }
   const sourceRepo = `${drift.ownerRepo.owner}/${drift.ownerRepo.repo}`;
   const tokenEnv: NodeJS.ProcessEnv = { ...process.env, GH_TOKEN: treeRepoToken };
+
+  if (!dryRun) {
+    await ensureTreeLabels(shellRun, treeSlug, tokenEnv);
+  }
 
   let created = 0;
   let skipped = 0;

--- a/tests/gardener/sync-open-issues.test.ts
+++ b/tests/gardener/sync-open-issues.test.ts
@@ -601,4 +601,155 @@ describe("sync --open-issues · runOpenIssuesMode", () => {
     expect(exitCode).toBe(1);
     expect(calls).toHaveLength(0);
   });
+
+  it("seeds gardener labels on the tree repo before the first issue create (#303)", async () => {
+    const previousToken = process.env.TREE_REPO_TOKEN;
+    process.env.TREE_REPO_TOKEN = "tree-token";
+
+    const treeRoot = mkdtempSync(
+      join(tmpdir(), "first-tree-sync-open-issues-label-seed-"),
+    );
+    mkdirSync(join(treeRoot, baseProposal.path), { recursive: true });
+
+    const labelCreateCalls: string[][] = [];
+    const issueCreateCalls: string[][] = [];
+
+    try {
+      const exitCode = await runOpenIssuesMode({
+        drift: {
+          binding: { sourceId: "acme-web" },
+          ownerRepo: { owner: "acme", repo: "web" },
+        },
+        classifiedPrs: [{
+          pr: {
+            number: 42,
+            title: "Split auth",
+            mergeCommitSha: "deadbeefcafebabe",
+            authorLogin: "octocat",
+          },
+          filtered: [baseProposal],
+        }],
+        treeRoot,
+        shellRun: async (command, args) => {
+          if (command !== "gh") {
+            return { code: 1, stdout: "", stderr: `unexpected command: ${command}` };
+          }
+          if (args[0] === "repo" && args[1] === "view") {
+            return { code: 0, stdout: "agent-team-foundation/first-tree-context\n", stderr: "" };
+          }
+          if (args[0] === "label" && args[1] === "create") {
+            labelCreateCalls.push([...args]);
+            return { code: 0, stdout: "", stderr: "" };
+          }
+          if (args[0] === "issue" && args[1] === "list") {
+            return { code: 0, stdout: "[]", stderr: "" };
+          }
+          if (args[0] === "issue" && args[1] === "create") {
+            issueCreateCalls.push([...args]);
+            return {
+              code: 0,
+              stdout: "https://github.com/agent-team-foundation/first-tree-context/issues/999\n",
+              stderr: "",
+            };
+          }
+          return { code: 1, stdout: "", stderr: `unexpected gh args: ${args.join(" ")}` };
+        },
+        dryRun: false,
+      });
+
+      expect(exitCode).toBe(0);
+
+      const seededLabelNames = labelCreateCalls.map((args) => args[2]);
+      expect(seededLabelNames).toContain("first-tree:sync-proposal");
+      expect(seededLabelNames).toContain("gardener");
+      expect(seededLabelNames).toContain("needs-owner");
+
+      expect(issueCreateCalls).toHaveLength(1);
+      const issueArgs = issueCreateCalls[0];
+      const labelIdx = issueArgs.indexOf("--label");
+      expect(labelIdx).toBeGreaterThanOrEqual(0);
+      expect(issueArgs[labelIdx + 1]).toContain("first-tree:sync-proposal");
+    } finally {
+      rmSync(treeRoot, { recursive: true, force: true });
+      if (previousToken === undefined) {
+        delete process.env.TREE_REPO_TOKEN;
+      } else {
+        process.env.TREE_REPO_TOKEN = previousToken;
+      }
+    }
+  });
+
+  it("treats 'label already exists' on seed as success and still applies labels on issue create (#303)", async () => {
+    const previousToken = process.env.TREE_REPO_TOKEN;
+    process.env.TREE_REPO_TOKEN = "tree-token";
+
+    const treeRoot = mkdtempSync(
+      join(tmpdir(), "first-tree-sync-open-issues-label-exists-"),
+    );
+    mkdirSync(join(treeRoot, baseProposal.path), { recursive: true });
+
+    const issueCreateCalls: string[][] = [];
+
+    try {
+      const exitCode = await runOpenIssuesMode({
+        drift: {
+          binding: { sourceId: "acme-web" },
+          ownerRepo: { owner: "acme", repo: "web" },
+        },
+        classifiedPrs: [{
+          pr: {
+            number: 42,
+            title: "Split auth",
+            mergeCommitSha: "deadbeefcafebabe",
+            authorLogin: "octocat",
+          },
+          filtered: [baseProposal],
+        }],
+        treeRoot,
+        shellRun: async (command, args) => {
+          if (command !== "gh") {
+            return { code: 1, stdout: "", stderr: `unexpected command: ${command}` };
+          }
+          if (args[0] === "repo" && args[1] === "view") {
+            return { code: 0, stdout: "agent-team-foundation/first-tree-context\n", stderr: "" };
+          }
+          if (args[0] === "label" && args[1] === "create") {
+            return {
+              code: 1,
+              stdout: "",
+              stderr: "HTTP 422: Validation Failed (already exists)",
+            };
+          }
+          if (args[0] === "issue" && args[1] === "list") {
+            return { code: 0, stdout: "[]", stderr: "" };
+          }
+          if (args[0] === "issue" && args[1] === "create") {
+            issueCreateCalls.push([...args]);
+            return {
+              code: 0,
+              stdout: "https://github.com/agent-team-foundation/first-tree-context/issues/1000\n",
+              stderr: "",
+            };
+          }
+          return { code: 1, stdout: "", stderr: `unexpected gh args: ${args.join(" ")}` };
+        },
+        dryRun: false,
+      });
+
+      expect(exitCode).toBe(0);
+      expect(issueCreateCalls).toHaveLength(1);
+      const issueArgs = issueCreateCalls[0];
+      expect(issueArgs).toContain("--label");
+      // First attempt should carry the label — no retry-without-label was needed.
+      const labelIdx = issueArgs.indexOf("--label");
+      expect(issueArgs[labelIdx + 1]).toContain("first-tree:sync-proposal");
+    } finally {
+      rmSync(treeRoot, { recursive: true, force: true });
+      if (previousToken === undefined) {
+        delete process.env.TREE_REPO_TOKEN;
+      } else {
+        process.env.TREE_REPO_TOKEN = previousToken;
+      }
+    }
+  });
 });


### PR DESCRIPTION
Fixes #303.

## Summary

- Add `ensureTreeLabels()` in `sync.ts` that seeds `first-tree:sync-proposal`, `gardener`, and `needs-owner` on the tree repo once per `--open-issues` run, before any `gh issue create` call.
- "Already exists" on seed is treated as success. Other seed failures log a warning and fall through to the existing retry-without-label path — no regression on that degraded mode.
- Now issues keep their `first-tree:sync-proposal` label, so breeze's draft-node dispatcher actually sees them.

## Why this over the alternatives

The issue listed three options: (a) auto-create, (b) hard-fail, (c) keep silent-drop. Auto-create is idempotent, doesn't require operator prep, and fails gracefully — the hard-fail option would block first-time users of a fresh tree repo, and silent-drop is what caused the bug.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run tests/gardener/sync-open-issues.test.ts` (20/20 pass, including 2 new #303 tests + the 18 pre-existing tests that verify the degraded retry-without-label path still works)
- [ ] E2E: re-run `first-tree gardener sync --open-issues` against a fresh tree repo without the labels; confirm issues are created with `first-tree:sync-proposal` label (deferred — will verify after merge during the next #291 e2e run)

This reply was authored by Claude Code on behalf of the account owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
