### PR TITLE
fix(gardener/respond): accept draft-node-* branches (#307)

### DIFF
--- a/src/products/gardener/engine/respond.ts
+++ b/src/products/gardener/engine/respond.ts
@@ -1,9 +1,10 @@
 /**
  * gardener-respond — port of `gardener-respond-manual.md` runbook.
  *
- * Reads review feedback on sync PRs (branches prefixed `first-tree/sync-`
- * or label `first-tree:sync`), classifies it, applies fixes, replies to
- * reviewers, and records learnings for gardener-sync.
+ * Reads review feedback on gardener-authored tree PRs (branches prefixed
+ * `first-tree/sync-` or `first-tree/draft-node-`, or label `first-tree:sync`),
+ * classifies it, applies fixes, replies to reviewers, and records learnings
+ * for gardener-sync.
  *
  * This TypeScript port preserves the runbook's hard rules byte-for-byte
  * where the runbook is specific. Output text, labels, commit messages,
@@ -50,9 +51,10 @@ export const RESPOND_USAGE = `usage: first-tree gardener respond --pr <n> --repo
 Fix a single sync PR based on reviewer feedback. Ports the
 gardener-respond-manual.md runbook into a deterministic CLI.
 
-Only acts on PRs whose branch starts with \`first-tree/sync-\` or whose
-label set contains \`first-tree:sync\`. Never force-pushes, never creates
-new PRs, never merges (that is the reviewer agent's job).
+Only acts on PRs whose branch starts with \`first-tree/sync-\` or
+\`first-tree/draft-node-\`, or whose label set contains \`first-tree:sync\`.
+Never force-pushes, never creates new PRs, never merges (that is the
+reviewer agent's job).
 
 Invocation is single-PR only. The trigger is breeze-runner dispatching
 on a \`review_requested\`/reviewer-feedback notification, which supplies
@@ -292,9 +294,28 @@ export function hasSyncLabel(view: PrView): boolean {
   return false;
 }
 
+/**
+ * Branch prefixes gardener authors on tree repos and accepts for respond.
+ *
+ *   - `first-tree/sync-` — batched-PR sweeps from `sync --apply` /
+ *     `start --sync-apply`.
+ *   - `first-tree/draft-node-` — per-issue PRs from `draft-node`, which
+ *     is dispatched by breeze after `sync --open-issues`.
+ *
+ * Both are gardener-authored tree updates and share the same review →
+ * respond → fix → re-push loop; respond has no reason to treat them
+ * differently. Fixes #307.
+ */
+const RESPOND_BRANCH_PREFIXES = [
+  "first-tree/sync-",
+  "first-tree/draft-node-",
+] as const;
+
 export function isSyncPr(view: PrView): boolean {
-  if (view.headRefName && view.headRefName.startsWith("first-tree/sync-")) {
-    return true;
+  if (view.headRefName) {
+    for (const prefix of RESPOND_BRANCH_PREFIXES) {
+      if (view.headRefName.startsWith(prefix)) return true;
+    }
   }
   return hasSyncLabel(view);
 }

--- a/tests/gardener/gardener-respond.test.ts
+++ b/tests/gardener/gardener-respond.test.ts
@@ -763,6 +763,18 @@ describe("gardener respond -- helpers", () => {
     expect(isSyncPr({ number: 1, headRefName: "feature/x" })).toBe(false);
   });
 
+  it("also recognises draft-node PRs as respondable (#307)", () => {
+    // draft-node writes branches like `first-tree/draft-node-<proposal_id>`.
+    // respond needs to accept them so the issue → draft-node → PR → respond
+    // chain actually connects.
+    expect(
+      isSyncPr({
+        number: 1,
+        headRefName: "first-tree/draft-node-19aeb0ab73f4",
+      }),
+    ).toBe(true);
+  });
+
   it("extracts source PR metadata from the body marker", () => {
     const body =
       "<!-- gardener:sync · source_pr=3001 · source_repo=paperclipai/paperclip -->";


### PR DESCRIPTION
Fixes #307.

## Summary

- Widen `isSyncPr` to recognise both `first-tree/sync-*` (batched from `sync --apply`) and `first-tree/draft-node-*` (per-issue from `draft-node`).
- Stored both prefixes in a `RESPOND_BRANCH_PREFIXES` constant so future additions have one place to edit.
- Updated the file header and CLI usage text for consistency.

## Why option 1 (widen filter) over option 2 (rename draft-node branches)

The issue suggested renaming draft-node's output to `first-tree/sync-*` so only one prefix existed. I picked option 1 instead because:

- **Backward-compat:** renaming the branch pattern would strand any in-flight draft-node PR (including live ones on paperclip-tree). Widening the filter is non-breaking.
- **Signal value:** the prefix tells a human reviewer *which* gardener command authored the PR — `draft-node` for per-issue work, `sync` for batched sweeps. That's useful context in the PR list; collapsing them loses it.
- **Cost:** +14 lines vs. a cross-product rename affecting branch names, PR-list conventions, and at least one e2e run.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run tests/gardener/gardener-respond.test.ts` — 40/40 pass, including the new `#307` case for `first-tree/draft-node-19aeb0ab73f4`.
- [ ] E2E: leave a review comment on `serenakeyitan/paperclip-tree#336` after merge, confirm respond no longer skips with "not a sync PR" (deferred — verifies in next #291 e2e run).

This reply was authored by Claude Code on behalf of the account owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
