### PR TITLE
fix(gardener/draft-node): strip trailing /NODE.md from marker (#306)

### DIFF
--- a/src/products/gardener/engine/draft-node.ts
+++ b/src/products/gardener/engine/draft-node.ts
@@ -153,6 +153,36 @@ const MARKER_RE =
   /<!--\s*gardener:sync-proposal\s+([^>]+?)\s*-->/;
 
 /**
+ * Normalize the `node=<path>` field from a sync-proposal marker.
+ *
+ * Earlier gardener versions wrote the marker's `node=` as the tree
+ * directory path (`product/task-system/stale-execution-lock-recovery`),
+ * but a later change started emitting the trailing `/NODE.md`
+ * (`…/stale-execution-lock-recovery/NODE.md`). draft-node always appends
+ * `NODE.md` before writing, which silently produced the doubled
+ * `…/NODE.md/NODE.md` path seen on paperclip-tree#336.
+ *
+ * Treat both forms as equivalent: the marker names a node directory,
+ * and draft-node is the single authority on where `NODE.md` lives
+ * inside it. Strips optional trailing `/NODE.md` (case-insensitive on
+ * the filename). Also trims trailing slashes so `join()` behaves.
+ *
+ * Fixes #306.
+ */
+export function normalizeMarkerNode(raw: string | undefined): string {
+  if (!raw) return "";
+  let out = raw.trim();
+  // Strip a trailing `/NODE.md` (case-insensitive on the basename).
+  const withoutNodeMd = out.replace(/\/NODE\.md\/*$/iu, "");
+  if (withoutNodeMd !== out) {
+    out = withoutNodeMd;
+  }
+  // Trim any remaining trailing slashes.
+  out = out.replace(/\/+$/u, "");
+  return out;
+}
+
+/**
  * Parse the `<!-- gardener:sync-proposal · k=v · k=v … -->` marker.
  * Returns null when no marker is present or required fields are
  * missing. Field order-insensitive; accepts the middle-dot separator
@@ -172,7 +202,7 @@ export function parseProposalMarker(body: string): ProposalMarker | null {
   }
   const proposalId = fields.proposal_id;
   const sourceSha = fields.source_sha;
-  const node = fields.node;
+  const node = normalizeMarkerNode(fields.node);
   if (!proposalId || !node) return null;
   return {
     proposalId,

--- a/tests/gardener/draft-node.test.ts
+++ b/tests/gardener/draft-node.test.ts
@@ -119,6 +119,27 @@ describe("gardener draft-node · parseProposalMarker", () => {
     const marker = parseProposalMarker(body);
     expect(marker?.sourceSha).toBe("unknown");
   });
+
+  it("strips a trailing /NODE.md from node= so draft-node does not write the doubled path (#306)", () => {
+    const body =
+      "<!-- gardener:sync-proposal · proposal_id=19aeb0ab73f4 · source_sha=unknown · node=product/task-system/stale-execution-lock-recovery/NODE.md -->";
+    const marker = parseProposalMarker(body);
+    expect(marker?.node).toBe("product/task-system/stale-execution-lock-recovery");
+  });
+
+  it("leaves node= unchanged when it does not end in /NODE.md", () => {
+    const body =
+      "<!-- gardener:sync-proposal · proposal_id=ab · source_sha=cd · node=engineering/backend/auth -->";
+    const marker = parseProposalMarker(body);
+    expect(marker?.node).toBe("engineering/backend/auth");
+  });
+
+  it("strips trailing slashes too", () => {
+    const body =
+      "<!-- gardener:sync-proposal · proposal_id=ab · source_sha=cd · node=engineering/backend/auth/ -->";
+    const marker = parseProposalMarker(body);
+    expect(marker?.node).toBe("engineering/backend/auth");
+  });
 });
 
 describe("gardener draft-node · extractProposedContent", () => {


### PR DESCRIPTION
Fixes #306.

## Summary

- Add `normalizeMarkerNode()` that strips an optional trailing `/NODE.md` (case-insensitive on the filename) plus any trailing slashes from the marker's `node=` field.
- Apply it inside `parseProposalMarker` so every consumer of `marker.node` (the path-append in `runDraftNode`, the dry-run output, the commit message, the PR title) sees the directory form.
- draft-node is the single authority for "where NODE.md lives inside a node directory" — collapsing the marker to the directory form is the right layer to fix this.

## Why parse-side (not write-side)

Per #306, the in-the-wild markers already have `node=.../NODE.md`, so any fix that only touched the write-side in `sync.ts` wouldn't repair paperclip-tree#318's existing issue and the others like it. A parse-side normalization catches both existing state and any future write-side drift (the classifier output is LLM-produced and has already shown this bug once).

The write-side in `buildSyncProposalBody` passes `proposal.path` straight through — if we want to prevent the bad form from being written at all, that's a separate follow-up that needs to touch every place `proposal.path` is used (issue title, body `Proposed tree update for …`, log lines, etc.) and decide what the canonical form is. Out of scope for this bug fix.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run tests/gardener/draft-node.test.ts` — 28/28 pass, including 3 new normalization cases.
- [ ] E2E: re-dispatch draft-node against paperclip-tree#318 after merge, confirm the new PR writes `product/task-system/stale-execution-lock-recovery/NODE.md` (single file) instead of the doubled path.

This reply was authored by Claude Code on behalf of the account owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
