### PR TITLE
fix(gardener): rate-limit backoff for sync --open-issues (#304)

### DIFF
--- a/src/products/gardener/engine/sync.ts
+++ b/src/products/gardener/engine/sync.ts
@@ -1526,6 +1526,54 @@ async function existingProposalIssueUrl(
   }
 }
 
+/**
+ * Detect GitHub rate-limit errors surfaced by `gh`. Covers both the
+ * REST "rate limit exceeded" wording and the GraphQL "API rate limit
+ * already exceeded" wording reported in #304.
+ */
+export function isRateLimitError(stderr: string): boolean {
+  if (!stderr) return false;
+  const s = stderr.toLowerCase();
+  return (
+    s.includes("rate limit") ||
+    s.includes("api rate limit") ||
+    s.includes("secondary rate limit") ||
+    s.includes("abuse detection") ||
+    s.includes("429")
+  );
+}
+
+/**
+ * Fixes #304: run a single `gh issue create` invocation with
+ * exponential backoff on GitHub rate-limit errors. A 44-proposal run
+ * was losing 35 of 44 issues to back-to-back 429s with no recovery;
+ * per-call backoff keeps the run alive long enough for the existing
+ * proposal_id idempotency to handle any true failures on re-run.
+ */
+export async function runWithRateLimitBackoff(
+  shellRun: ShellRun,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  opts: { maxRetries?: number; baseDelayMs?: number; sleep?: (ms: number) => Promise<void> } = {},
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const maxRetries = opts.maxRetries ?? 4;
+  const baseDelayMs = opts.baseDelayMs ?? 30_000;
+  const sleep =
+    opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  let res = await shellRun("gh", args, { env });
+  for (let attempt = 0; attempt < maxRetries; attempt += 1) {
+    if (res.code === 0) return res;
+    if (!isRateLimitError(res.stderr || "")) return res;
+    const waitMs = baseDelayMs * Math.pow(2, attempt);
+    console.log(
+      `⚠ rate-limited by GitHub (${(res.stderr || "").split("\n")[0] || "no stderr"}). Sleeping ${Math.round(waitMs / 1000)}s before retry ${attempt + 1}/${maxRetries}.`,
+    );
+    await sleep(waitMs);
+    res = await shellRun("gh", args, { env });
+  }
+  return res;
+}
+
 export async function runOpenIssuesMode(
   input: RunOpenIssuesInput,
 ): Promise<number> {
@@ -1625,10 +1673,10 @@ export async function runOpenIssuesMode(
         return out;
       };
 
-      let res = await shellRun(
-        "gh",
+      let res = await runWithRateLimitBackoff(
+        shellRun,
         buildArgs({ withAssignees: true, withLabels: true }),
-        { env: tokenEnv },
+        tokenEnv,
       );
       if (res.code !== 0) {
         // `gh` 422 on unknown labels — retry without labels so the
@@ -1638,10 +1686,10 @@ export async function runOpenIssuesMode(
           console.log(
             `\u26A0 label rejected on ${treeSlug} (${stderr.split("\n")[0] || "422"}) \u2014 retrying without --label`,
           );
-          res = await shellRun(
-            "gh",
+          res = await runWithRateLimitBackoff(
+            shellRun,
             buildArgs({ withAssignees: true, withLabels: false }),
-            { env: tokenEnv },
+            tokenEnv,
           );
         }
       }
@@ -1656,10 +1704,10 @@ export async function runOpenIssuesMode(
           assignees = [];
           needsOwner = true;
           if (!labels.includes("needs-owner")) labels.push("needs-owner");
-          res = await shellRun(
-            "gh",
+          res = await runWithRateLimitBackoff(
+            shellRun,
             buildArgs({ withAssignees: false, withLabels: true }),
-            { env: tokenEnv },
+            tokenEnv,
           );
           if (res.code !== 0) {
             const stderr2 = res.stderr || "";
@@ -1667,10 +1715,10 @@ export async function runOpenIssuesMode(
               console.log(
                 `\u26A0 label rejected on ${treeSlug} after assignee retry \u2014 retrying without --label`,
               );
-              res = await shellRun(
-                "gh",
+              res = await runWithRateLimitBackoff(
+                shellRun,
                 buildArgs({ withAssignees: false, withLabels: false }),
-                { env: tokenEnv },
+                tokenEnv,
               );
             }
           }

--- a/tests/gardener/sync-open-issues.test.ts
+++ b/tests/gardener/sync-open-issues.test.ts
@@ -5,7 +5,9 @@ import { describe, expect, it } from "vitest";
 import {
   buildSyncProposalBody,
   computeProposalId,
+  isRateLimitError,
   runOpenIssuesMode,
+  runWithRateLimitBackoff,
   type ClassificationItem,
   type ClassifiedPrLike,
   type DriftReportLike,
@@ -751,5 +753,89 @@ describe("sync --open-issues · runOpenIssuesMode", () => {
         process.env.TREE_REPO_TOKEN = previousToken;
       }
     }
+  });
+});
+
+describe("sync --open-issues · rate-limit backoff (#304)", () => {
+  it("recognises GraphQL 'API rate limit already exceeded' as a rate-limit error", () => {
+    expect(
+      isRateLimitError(
+        "GraphQL: API rate limit already exceeded for user ID 94026305.",
+      ),
+    ).toBe(true);
+  });
+
+  it("recognises 'secondary rate limit' and 429 as rate-limit errors", () => {
+    expect(isRateLimitError("You have exceeded a secondary rate limit")).toBe(true);
+    expect(isRateLimitError("HTTP 429: Too Many Requests")).toBe(true);
+  });
+
+  it("does not misclassify non-rate-limit errors (422, network)", () => {
+    expect(isRateLimitError("422 Unprocessable: label not found")).toBe(false);
+    expect(isRateLimitError("network unreachable")).toBe(false);
+    expect(isRateLimitError("")).toBe(false);
+  });
+
+  it("runWithRateLimitBackoff retries on rate-limit then succeeds (#304)", async () => {
+    const calls: Array<{ args: string[] }> = [];
+    const sleeps: number[] = [];
+    let attempt = 0;
+    const res = await runWithRateLimitBackoff(
+      async (_cmd, args) => {
+        calls.push({ args: [...args] });
+        attempt += 1;
+        if (attempt <= 2) {
+          return {
+            code: 1,
+            stdout: "",
+            stderr: "GraphQL: API rate limit already exceeded for user ID 1.",
+          };
+        }
+        return { code: 0, stdout: "https://x/issues/1\n", stderr: "" };
+      },
+      ["issue", "create", "--repo", "org/tree", "--title", "T", "--body", "B"],
+      {},
+      {
+        baseDelayMs: 1,
+        sleep: async (ms) => {
+          sleeps.push(ms);
+        },
+      },
+    );
+    expect(res.code).toBe(0);
+    expect(calls).toHaveLength(3);
+    // Exponential: 1ms, 2ms between the 3 attempts.
+    expect(sleeps).toEqual([1, 2]);
+  });
+
+  it("runWithRateLimitBackoff returns non-rate-limit errors immediately (no retry)", async () => {
+    let attempts = 0;
+    const res = await runWithRateLimitBackoff(
+      async () => {
+        attempts += 1;
+        return { code: 1, stdout: "", stderr: "422 Unprocessable: label not found" };
+      },
+      ["issue", "create"],
+      {},
+      { baseDelayMs: 1, sleep: async () => {} },
+    );
+    expect(res.code).toBe(1);
+    expect(attempts).toBe(1);
+  });
+
+  it("runWithRateLimitBackoff gives up after maxRetries on persistent rate-limit", async () => {
+    let attempts = 0;
+    const res = await runWithRateLimitBackoff(
+      async () => {
+        attempts += 1;
+        return { code: 1, stdout: "", stderr: "API rate limit already exceeded" };
+      },
+      ["issue", "create"],
+      {},
+      { maxRetries: 2, baseDelayMs: 1, sleep: async () => {} },
+    );
+    expect(res.code).toBe(1);
+    // initial attempt + 2 retries = 3.
+    expect(attempts).toBe(3);
   });
 });


### PR DESCRIPTION
Fixes #304.

## Summary

- Add `runWithRateLimitBackoff()` + `isRateLimitError()` helpers to `sync.ts`.
- Wrap every `gh issue create` invocation in `runOpenIssuesMode` with the backoff helper.
- On a rate-limit stderr (covers GraphQL "API rate limit already exceeded", REST "rate limit exceeded", secondary-rate-limit, abuse-detection, and 429), sleep for exponentially growing intervals (30s → 60s → 120s → 240s, default 4 retries) and retry the same args.
- Non-rate-limit errors short-circuit — the existing 422 retry ladder (label-strip → assignee-strip → label-strip-again) is unchanged.

## Why within-run backoff

Reporter hit GitHub's per-user limit after ~10 of 44 creates and lost the other 35 because there was no retry. The existing `proposal_id` idempotency would have skipped them on re-run — but re-running re-classifies 54 source PRs through the `claude` CLI (expensive) and, per #305, isn't deterministic. Keeping the run alive across a single 60s limit window is the cheapest fix; within-run backoff complements the existing idempotency rather than replacing it.

Checkpoint-to-disk + classify-once-then-fire-as-resumable-phase from the issue description are separate, larger changes — this PR is the minimal bleed-stopper.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run tests/gardener/sync-open-issues.test.ts` — 26/26 pass, including 6 new cases:
  - `isRateLimitError` recognises GraphQL/secondary/429 wordings, rejects 422 + empty
  - `runWithRateLimitBackoff` retries on rate-limit and succeeds
  - returns non-rate-limit errors immediately (no retry)
  - gives up after `maxRetries` on persistent rate-limit
- [ ] E2E: re-run the #304 reporter's 44-proposal scenario after merge and confirm 0 rate-limit losses.

This reply was authored by Claude Code on behalf of the account owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
