### PR TITLE
fix(gardener): cache classifier results by prompt hash (#305)

### DIFF
--- a/src/products/gardener/engine/sync.ts
+++ b/src/products/gardener/engine/sync.ts
@@ -721,12 +721,61 @@ function formatPrDiffForPrompt(
   return parts.join("\n");
 }
 
+/**
+ * Fixes #305. Classification results are cached on disk keyed by
+ * sha256(prompt) so re-runs (including `--dry-run` → real run) produce
+ * the same proposal set. The prompt already encodes source commits,
+ * tree-node state, changed files, and the prompt template itself, so
+ * hashing the prompt captures every input that should invalidate the
+ * cache. Set FIRST_TREE_NO_CLASSIFIER_CACHE=1 to bypass.
+ */
+export const CLASSIFIER_CACHE_DIR = ".first-tree/classification-cache";
+
+export function classifierCachePath(treeRoot: string, promptHash: string): string {
+  return join(treeRoot, CLASSIFIER_CACHE_DIR, `${promptHash}.json`);
+}
+
+export function readClassifierCache(
+  treeRoot: string,
+  promptHash: string,
+): ClassificationItem[] | null {
+  const path = classifierCachePath(treeRoot, promptHash);
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    const entry = parsed as { proposals?: unknown };
+    if (!Array.isArray(entry.proposals)) return null;
+    return entry.proposals as ClassificationItem[];
+  } catch {
+    return null;
+  }
+}
+
+export function writeClassifierCache(
+  treeRoot: string,
+  promptHash: string,
+  proposals: ClassificationItem[],
+): void {
+  const path = classifierCachePath(treeRoot, promptHash);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(
+    path,
+    JSON.stringify(
+      { version: 1, promptHash, createdAt: new Date().toISOString(), proposals },
+      null,
+      2,
+    ),
+  );
+}
+
 async function classifyDriftViaClaude(
   shellRun: ShellRun,
   drift: DriftReport,
   treeNodes: TreeNodeSummary[],
-  changedFiles?: string[],
-  diffSummary?: string,
+  changedFiles: string[] | undefined,
+  diffSummary: string | undefined,
+  treeRoot: string,
 ): Promise<ClassificationItem[]> {
   // Build keywords from the PR for relevance matching
   const driftText = [
@@ -814,6 +863,19 @@ IMPORTANT:
 - \`suggested_soft_links\` must list every tree path the body cross-references (other domains, governance, backend, etc.) so the new node shows up in the tree graph. Use paths from the "Current tree nodes" list above. Omit or use [] when the body does not reference other domains.
 
 Return a JSON array only, no prose.`;
+
+  const promptHash = createHash("sha256").update(prompt).digest("hex");
+  const cacheBypass = process.env.FIRST_TREE_NO_CLASSIFIER_CACHE === "1";
+  if (!cacheBypass) {
+    const cached = readClassifierCache(treeRoot, promptHash);
+    if (cached) {
+      if (process.env.FIRST_TREE_DEBUG) {
+        console.error(`[DEBUG] classifier cache hit: ${promptHash.slice(0, 12)}`);
+      }
+      return cached;
+    }
+  }
+
   const CLAUDE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes per classification
   const MAX_RETRIES = 2;
   let result: ShellResult | null = null;
@@ -903,15 +965,30 @@ Return a JSON array only, no prose.`;
     }
     return null;
   };
+  const persist = (proposals: ClassificationItem[]): ClassificationItem[] => {
+    if (!cacheBypass && proposals.length > 0) {
+      try {
+        writeClassifierCache(treeRoot, promptHash, proposals);
+      } catch (err) {
+        // Cache writes are best-effort — don't fail the sync on disk
+        // errors (read-only fs, permissions, etc.).
+        if (process.env.FIRST_TREE_DEBUG) {
+          console.error(`[DEBUG] classifier cache write failed: ${String(err)}`);
+        }
+      }
+    }
+    return proposals;
+  };
+
   const direct = tryParseArray(raw);
-  if (direct) return direct;
+  if (direct) return persist(direct);
   // Last resort: extract first [...] block from the text
   const match = raw.match(/\[[\s\S]*\]/);
   if (match) {
     const extracted = tryParseArray(match[0]);
-    if (extracted) return extracted;
+    if (extracted) return persist(extracted);
   }
-  return [];
+  return persist([]);
 }
 
 function slugifyProposalPath(value: string): string {
@@ -1928,6 +2005,7 @@ export async function runSync(
             treeNodes,
             prFiles,
             diffSummary,
+            treeRoot,
           );
 
           if (proposals.length === 0) {

--- a/tests/gardener/classifier-cache.test.ts
+++ b/tests/gardener/classifier-cache.test.ts
@@ -1,0 +1,90 @@
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  CLASSIFIER_CACHE_DIR,
+  classifierCachePath,
+  readClassifierCache,
+  writeClassifierCache,
+  type ClassificationItem,
+} from "#products/gardener/engine/sync.js";
+
+const sample: ClassificationItem[] = [
+  {
+    path: "engineering/auth",
+    type: "TREE_MISS",
+    rationale: "new auth service",
+    suggested_node_title: "Auth",
+    suggested_node_body_markdown: "Body.",
+  },
+];
+
+describe("classifier cache (#305)", () => {
+  it("classifierCachePath lands under .first-tree/classification-cache/<hash>.json", () => {
+    const root = "/tmp/some-tree";
+    const p = classifierCachePath(root, "abc123");
+    expect(p).toBe(join(root, CLASSIFIER_CACHE_DIR, "abc123.json"));
+  });
+
+  it("readClassifierCache returns null when the file does not exist", () => {
+    const root = mkdtempSync(join(tmpdir(), "first-tree-cache-"));
+    try {
+      expect(readClassifierCache(root, "deadbeef")).toBeNull();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("writeClassifierCache → readClassifierCache round-trips proposals", () => {
+    const root = mkdtempSync(join(tmpdir(), "first-tree-cache-"));
+    try {
+      writeClassifierCache(root, "abc123", sample);
+      const out = readClassifierCache(root, "abc123");
+      expect(out).toEqual(sample);
+      expect(existsSync(classifierCachePath(root, "abc123"))).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("readClassifierCache returns null on malformed JSON (not a crash)", () => {
+    const root = mkdtempSync(join(tmpdir(), "first-tree-cache-"));
+    try {
+      const p = classifierCachePath(root, "badhash");
+      mkdirSync(join(root, CLASSIFIER_CACHE_DIR), { recursive: true });
+      writeFileSync(p, "{ not valid json");
+      expect(readClassifierCache(root, "badhash")).toBeNull();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("readClassifierCache returns null when payload has no proposals array", () => {
+    const root = mkdtempSync(join(tmpdir(), "first-tree-cache-"));
+    try {
+      const p = classifierCachePath(root, "nop");
+      mkdirSync(join(root, CLASSIFIER_CACHE_DIR), { recursive: true });
+      writeFileSync(p, JSON.stringify({ version: 1, createdAt: "x" }));
+      expect(readClassifierCache(root, "nop")).toBeNull();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("writes a versioned payload with createdAt + proposals (inspectable on disk)", () => {
+    const root = mkdtempSync(join(tmpdir(), "first-tree-cache-"));
+    try {
+      writeClassifierCache(root, "v1hash", sample);
+      const raw = JSON.parse(
+        require("node:fs").readFileSync(classifierCachePath(root, "v1hash"), "utf8"),
+      );
+      expect(raw.version).toBe(1);
+      expect(raw.promptHash).toBe("v1hash");
+      expect(typeof raw.createdAt).toBe("string");
+      expect(raw.proposals).toEqual(sample);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Fixes #305.

## Summary

- Add a content-addressed on-disk cache at `.first-tree/classification-cache/<sha256(prompt)>.json`.
- Before each `claude` classifier call, hash the assembled prompt and check the cache. Hit → return cached proposals, skip the CLI entirely. Miss → run the classifier as before, persist on success, return.
- `FIRST_TREE_NO_CLASSIFIER_CACHE=1` opts out.
- `.first-tree/*` is already gitignored.

## Why hash the prompt (vs. the tuple)

The reporter recommended option 1: key by `(source_sha, tree_sha, prompt_version)`. The prompt we pass to `claude` already encodes all three:
- source commits + changed files + diff summary (per-PR content → source_sha in practice)
- tree-node paths/titles/owners + bodies for related nodes (tree_sha equivalent)
- the prompt template itself (prompt_version)

So sha256-of-prompt is one invalidation surface that captures all three, and the cache key is derivable without plumbing the dimensions separately. If any input changes — commits, diff, tree body, prompt template — the hash changes and we re-classify.

## What's NOT cached

- **Timeouts.** A 5-minute timeout is transient and should retry, not lock in the empty result.
- **Empty results.** Same rationale — an empty classification is a signal the CLI misbehaved, not a stable answer.
- **Cache write failures.** Best-effort; a read-only `.first-tree/` shouldn't break sync.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run tests/gardener/classifier-cache.test.ts` — 6/6 pass (path layout, round-trip, malformed JSON, missing proposals array, versioned payload, miss returns null).
- [x] `pnpm exec vitest run tests/gardener/sync.test.ts tests/gardener/sync-open-issues.test.ts` — 49/49 pass (no regression from the added `treeRoot` parameter).
- [ ] E2E: re-run the reporter's 58-vs-44 scenario after merge — first run populates the cache, second run's proposal count matches exactly.

This reply was authored by Claude Code on behalf of the account owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
