### PR TITLE
fix(#296): drop unused installed_version field from gardener-config

### DIFF
--- a/src/products/gardener/engine/runtime/config.ts
+++ b/src/products/gardener/engine/runtime/config.ts
@@ -8,7 +8,6 @@
  *
  * Supported shape:
  *   tree_repo: owner/name
- *   installed_version: 0.1.0
  *   target_repos:
  *     - owner/repo-one
  *     - owner/repo-two
@@ -33,7 +32,6 @@ export interface ModuleToggle {
 
 export interface GardenerConfig {
   tree_repo?: string;
-  installed_version?: string;
   target_repos?: string[];
   modules?: {
     sync?: ModuleToggle;
@@ -209,9 +207,6 @@ function coerceModuleToggle(value: unknown): ModuleToggle | undefined {
 function coerceConfig(raw: Record<string, unknown>): GardenerConfig {
   const config: GardenerConfig = {};
   if (typeof raw.tree_repo === "string") config.tree_repo = raw.tree_repo;
-  if (typeof raw.installed_version === "string") {
-    config.installed_version = raw.installed_version;
-  }
   const targets = coerceStringArray(raw.target_repos);
   if (targets) config.target_repos = targets;
 

--- a/tests/gardener/gardener-respond.test.ts
+++ b/tests/gardener/gardener-respond.test.ts
@@ -97,7 +97,6 @@ describe("gardener config -- loadGardenerConfig / isModuleEnabled", () => {
       tmp.path,
       [
         "tree_repo: agent-team-foundation/first-tree",
-        "installed_version: 0.1.0",
         "target_repos:",
         "  - paperclipai/paperclip",
         "  - example/repo",
@@ -109,12 +108,30 @@ describe("gardener config -- loadGardenerConfig / isModuleEnabled", () => {
     );
     const config = loadGardenerConfig(tmp.path);
     expect(config?.tree_repo).toBe("agent-team-foundation/first-tree");
-    expect(config?.installed_version).toBe("0.1.0");
     expect(config?.target_repos).toEqual([
       "paperclipai/paperclip",
       "example/repo",
     ]);
     expect(isModuleEnabled(config, "respond")).toBe(true);
+  });
+
+  it("ignores a legacy installed_version field without erroring (#296)", () => {
+    const tmp = useTmpDir();
+    writeConfig(
+      tmp.path,
+      [
+        "tree_repo: agent-team-foundation/first-tree",
+        "installed_version: v2.4.1",
+        "target_repos:",
+        "  - example/repo",
+        "",
+      ].join("\n"),
+    );
+    const config = loadGardenerConfig(tmp.path);
+    expect(config).not.toBeNull();
+    expect(config?.tree_repo).toBe("agent-team-foundation/first-tree");
+    expect(config?.target_repos).toEqual(["example/repo"]);
+    expect((config as Record<string, unknown>).installed_version).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Fixes #296.

## Summary

- Drop `installed_version` from the `GardenerConfig` type, parser, and docblock example.
- No call-site reads it; the field had no consumer. Operators couldn't tell if it was stale because nothing ever rewrote it (the reported drift: config said `v2.4.1`, CLI reports `first-tree=0.2.10 gardener=0.4.0` — different scheme entirely).
- Parser still *accepts* a legacy `installed_version:` line in existing tree configs — it's just silently ignored, so nobody with that line in a checked-in config breaks.

## Why Option A

Of the three options in the issue body:
- **A. Remove the field** ← this PR. Zero drift possible. Simplest.
- B. Auto-update on every run. Rejected: mutates config on read-only commands (including `--dry-run`), creates surprising git diffs, races between concurrent gardeners.
- C. `breeze doctor` flags drift. Rejected: `breeze doctor` doesn't exist yet, and in practice the field stays stale because nobody runs doctor.

The audit-trail use case ("which CLI version installed this config?") is hypothetical. If we ever need it we can reintroduce a read-only field keyed off git history of the config file.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run tests/gardener/gardener-respond.test.ts` — 41/41 pass.
- [x] `pnpm exec vitest run` — 1188/1188 pass, no regressions.

This reply was authored by Claude Code on behalf of the account owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)