### PR TITLE
tree: queue GitHub native auto-merge after opening tree PRs

### DIFF
--- a/src/products/tree/engine/open-tree-pr.ts
+++ b/src/products/tree/engine/open-tree-pr.ts
@@ -66,15 +66,45 @@ export async function openTreePr(
     await shellRun("gh", ["pr", "edit", prUrl, ...labelArgs], { cwd: treeRoot, env });
   }
 
-  // Queue GitHub's native auto-merge. No-ops silently when the target
-  // repo has "Allow auto-merge" disabled (the default), so behavior is
-  // unchanged for every repo that hasn't opted in via its Settings page.
+  // Queue GitHub's native auto-merge. Treated as best-effort: repos with
+  // "Allow auto-merge" disabled (the default) emit a specific error
+  // string which we swallow so behavior is unchanged for every repo that
+  // hasn't opted in via its Settings page. Any other failure (auth,
+  // transport, unexpected gh output) is surfaced — otherwise gardener
+  // would report the PR as handled while auto-merge was never queued.
   // See #321.
-  await shellRun(
+  const autoMerge = await shellRun(
     "gh",
     ["pr", "merge", prUrl, "--auto", "--squash", "--delete-branch"],
     { cwd: treeRoot, env },
   );
+  if (autoMerge.code !== 0 && !isAutoMergeDisabledError(autoMerge.stderr)) {
+    return {
+      success: false,
+      prUrl,
+      error: `gh pr merge --auto failed: ${autoMerge.stderr.trim()}`,
+    };
+  }
 
   return { success: true, prUrl };
+}
+
+/**
+ * Recognize the specific gh error surface for "this repo has not
+ * enabled auto-merge." Anything else is a real failure.
+ *
+ * gh/GitHub have used a handful of phrasings across versions. We match
+ * on the narrow set known to indicate disabled-on-repo, not on any
+ * stderr mentioning "auto-merge" — an auth failure message could also
+ * contain the word.
+ */
+function isAutoMergeDisabledError(stderr: string): boolean {
+  const lower = stderr.toLowerCase();
+  return (
+    lower.includes("auto-merge is not allowed")
+    || lower.includes("auto merge is not allowed")
+    || lower.includes("does not allow auto-merge")
+    || lower.includes("pull request auto merge is not allowed")
+    || lower.includes("auto-merge is not enabled")
+  );
 }

--- a/src/products/tree/engine/open-tree-pr.ts
+++ b/src/products/tree/engine/open-tree-pr.ts
@@ -66,5 +66,15 @@ export async function openTreePr(
     await shellRun("gh", ["pr", "edit", prUrl, ...labelArgs], { cwd: treeRoot, env });
   }
 
+  // Queue GitHub's native auto-merge. No-ops silently when the target
+  // repo has "Allow auto-merge" disabled (the default), so behavior is
+  // unchanged for every repo that hasn't opted in via its Settings page.
+  // See #321.
+  await shellRun(
+    "gh",
+    ["pr", "merge", prUrl, "--auto", "--squash", "--delete-branch"],
+    { cwd: treeRoot, env },
+  );
+
   return { success: true, prUrl };
 }

--- a/tests/fixtures/sync-golden/two-pr-apply.json
+++ b/tests/fixtures/sync-golden/two-pr-apply.json
@@ -311,6 +311,30 @@
       "cwdLabel": "<tree-root>"
     },
     {
+      "command": "gh",
+      "args": [
+        "pr",
+        "merge",
+        "https://github.com/alice/tree/pull/501",
+        "--auto",
+        "--squash",
+        "--delete-branch"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
+      "command": "gh",
+      "args": [
+        "pr",
+        "merge",
+        "https://github.com/alice/tree/pull/502",
+        "--auto",
+        "--squash",
+        "--delete-branch"
+      ],
+      "cwdLabel": "<tree-root>"
+    },
+    {
       "command": "git",
       "args": [
         "checkout",

--- a/tests/gardener/sync-golden-snapshot.test.ts
+++ b/tests/gardener/sync-golden-snapshot.test.ts
@@ -221,6 +221,15 @@ function makeRecordingShell(
     if (command === "gh" && args[0] === "pr" && args[1] === "edit") {
       return { stdout: "", stderr: "", code: 0 };
     }
+    if (command === "gh" && args[0] === "pr" && args[1] === "merge") {
+      // Simulate a repo without auto-merge enabled (#321). openTreePr
+      // swallows this specific error and reports success.
+      return {
+        stdout: "",
+        stderr: "auto-merge is not allowed for this repository",
+        code: 1,
+      };
+    }
     if (command === "gh" && args[0] === "label") {
       return { stdout: "", stderr: "", code: 0 };
     }

--- a/tests/gardener/sync.test.ts
+++ b/tests/gardener/sync.test.ts
@@ -543,6 +543,11 @@ describe("sync -- PR labeling", () => {
         }
         return { stdout: "", stderr: "", code: 0 };
       }
+      if (command === "gh" && args[0] === "pr" && args[1] === "merge") {
+        // Simulate a repo without auto-merge enabled (#321). openTreePr
+        // swallows this specific error and reports success.
+        return { stdout: "", stderr: "auto-merge is not allowed for this repository", code: 1 };
+      }
       return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
     };
     const code = await runSync(
@@ -698,6 +703,11 @@ describe("sync -- PR labeling", () => {
         }
         return { stdout: "", stderr: "", code: 0 };
       }
+      if (command === "gh" && args[0] === "pr" && args[1] === "merge") {
+        // Simulate a repo without auto-merge enabled (#321). openTreePr
+        // swallows this specific error and reports success.
+        return { stdout: "", stderr: "auto-merge is not allowed for this repository", code: 1 };
+      }
       return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
     };
 
@@ -793,6 +803,11 @@ describe("sync -- PR labeling", () => {
         labelArgsCaptured = [...args];
         return { stdout: "", stderr: "", code: 0 };
       }
+      if (command === "gh" && args[0] === "pr" && args[1] === "merge") {
+        // Simulate a repo without auto-merge enabled (#321). openTreePr
+        // swallows this specific error and reports success.
+        return { stdout: "", stderr: "auto-merge is not allowed for this repository", code: 1 };
+      }
       return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
     };
     const code = await runSync(
@@ -885,6 +900,11 @@ describe("sync -- PR labeling", () => {
           return { stdout: "", stderr: "", code: 1 };
         }
         return { stdout: "", stderr: "", code: 0 };
+      }
+      if (command === "gh" && args[0] === "pr" && args[1] === "merge") {
+        // Simulate a repo without auto-merge enabled (#321). openTreePr
+        // swallows this specific error and reports success.
+        return { stdout: "", stderr: "auto-merge is not allowed for this repository", code: 1 };
       }
       return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
     };
@@ -993,6 +1013,11 @@ describe("sync -- PR labeling", () => {
         }
         return { stdout: "", stderr: "", code: 0 };
       }
+      if (command === "gh" && args[0] === "pr" && args[1] === "merge") {
+        // Simulate a repo without auto-merge enabled (#321). openTreePr
+        // swallows this specific error and reports success.
+        return { stdout: "", stderr: "auto-merge is not allowed for this repository", code: 1 };
+      }
       return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
     };
     const code = await runSync(
@@ -1093,6 +1118,11 @@ describe("sync -- PR labeling", () => {
           stderr: "",
           code: 0,
         };
+      }
+      if (command === "gh" && args[0] === "pr" && args[1] === "merge") {
+        // Simulate a repo without auto-merge enabled (#321). openTreePr
+        // swallows this specific error and reports success.
+        return { stdout: "", stderr: "auto-merge is not allowed for this repository", code: 1 };
       }
       return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
     };
@@ -1225,6 +1255,11 @@ describe("sync -- PR labeling", () => {
         }
         return { stdout: "", stderr: "", code: 0 };
       }
+      if (command === "gh" && args[0] === "pr" && args[1] === "merge") {
+        // Simulate a repo without auto-merge enabled (#321). openTreePr
+        // swallows this specific error and reports success.
+        return { stdout: "", stderr: "auto-merge is not allowed for this repository", code: 1 };
+      }
       return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
     };
     const code = await runSync(
@@ -1342,6 +1377,11 @@ describe("sync -- PR labeling", () => {
           return { stdout: "", stderr: "", code: 1 };
         }
         return { stdout: "", stderr: "", code: 0 };
+      }
+      if (command === "gh" && args[0] === "pr" && args[1] === "merge") {
+        // Simulate a repo without auto-merge enabled (#321). openTreePr
+        // swallows this specific error and reports success.
+        return { stdout: "", stderr: "auto-merge is not allowed for this repository", code: 1 };
       }
       return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
     };
@@ -1471,6 +1511,11 @@ describe("sync -- PR labeling", () => {
         }
         return { stdout: "", stderr: "", code: 0 };
       }
+      if (command === "gh" && args[0] === "pr" && args[1] === "merge") {
+        // Simulate a repo without auto-merge enabled (#321). openTreePr
+        // swallows this specific error and reports success.
+        return { stdout: "", stderr: "auto-merge is not allowed for this repository", code: 1 };
+      }
       return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
     };
     const code = await runSync(
@@ -1570,6 +1615,11 @@ describe("sync -- PR labeling", () => {
           stderr: "",
           code: 0,
         };
+      }
+      if (command === "gh" && args[0] === "pr" && args[1] === "merge") {
+        // Simulate a repo without auto-merge enabled (#321). openTreePr
+        // swallows this specific error and reports success.
+        return { stdout: "", stderr: "auto-merge is not allowed for this repository", code: 1 };
       }
       return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
     };
@@ -1686,6 +1736,11 @@ describe("sync -- PR labeling", () => {
           return { stdout: "", stderr: "", code: 1 };
         }
         return { stdout: "", stderr: "", code: 0 };
+      }
+      if (command === "gh" && args[0] === "pr" && args[1] === "merge") {
+        // Simulate a repo without auto-merge enabled (#321). openTreePr
+        // swallows this specific error and reports success.
+        return { stdout: "", stderr: "auto-merge is not allowed for this repository", code: 1 };
       }
       return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
     };
@@ -1812,6 +1867,11 @@ describe("sync -- PR labeling", () => {
         }
         return { stdout: "", stderr: "", code: 0 };
       }
+      if (command === "gh" && args[0] === "pr" && args[1] === "merge") {
+        // Simulate a repo without auto-merge enabled (#321). openTreePr
+        // swallows this specific error and reports success.
+        return { stdout: "", stderr: "auto-merge is not allowed for this repository", code: 1 };
+      }
       return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
     };
 
@@ -1919,6 +1979,11 @@ describe("sync -- PR labeling", () => {
           return { stdout: "", stderr: "", code: 1 };
         }
         return { stdout: "", stderr: "", code: 0 };
+      }
+      if (command === "gh" && args[0] === "pr" && args[1] === "merge") {
+        // Simulate a repo without auto-merge enabled (#321). openTreePr
+        // swallows this specific error and reports success.
+        return { stdout: "", stderr: "auto-merge is not allowed for this repository", code: 1 };
       }
       return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
     };
@@ -2077,6 +2142,11 @@ describe("sync -- PR labeling", () => {
         }
         return { stdout: "", stderr: "", code: 0 };
       }
+      if (command === "gh" && args[0] === "pr" && args[1] === "merge") {
+        // Simulate a repo without auto-merge enabled (#321). openTreePr
+        // swallows this specific error and reports success.
+        return { stdout: "", stderr: "auto-merge is not allowed for this repository", code: 1 };
+      }
       return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
     };
 
@@ -2228,6 +2298,11 @@ describe("sync -- PR labeling", () => {
         }
         return { stdout: "", stderr: "", code: 0 };
       }
+      if (command === "gh" && args[0] === "pr" && args[1] === "merge") {
+        // Simulate a repo without auto-merge enabled (#321). openTreePr
+        // swallows this specific error and reports success.
+        return { stdout: "", stderr: "auto-merge is not allowed for this repository", code: 1 };
+      }
       return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
     };
 
@@ -2355,6 +2430,11 @@ describe("sync -- PR labeling", () => {
         }
         return { stdout: "", stderr: "", code: 0 };
       }
+      if (command === "gh" && args[0] === "pr" && args[1] === "merge") {
+        // Simulate a repo without auto-merge enabled (#321). openTreePr
+        // swallows this specific error and reports success.
+        return { stdout: "", stderr: "auto-merge is not allowed for this repository", code: 1 };
+      }
       return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
     };
 
@@ -2437,6 +2517,11 @@ describe("sync -- PR labeling", () => {
       if (command === "git") {
         if (args[0] === "symbolic-ref") return { stdout: "main\n", stderr: "", code: 0 };
         return { stdout: "", stderr: "", code: 0 };
+      }
+      if (command === "gh" && args[0] === "pr" && args[1] === "merge") {
+        // Simulate a repo without auto-merge enabled (#321). openTreePr
+        // swallows this specific error and reports success.
+        return { stdout: "", stderr: "auto-merge is not allowed for this repository", code: 1 };
       }
       return { stdout: "", stderr: `no mock for ${command} ${args.join(" ")}`, code: 1 };
     };

--- a/tests/tree/open-tree-pr.test.ts
+++ b/tests/tree/open-tree-pr.test.ts
@@ -211,7 +211,7 @@ describe("openTreePr", () => {
     expect(calls.some((c) => c.command === "gh" && c.args[1] === "merge")).toBe(false);
   });
 
-  it("ignores non-zero exit from gh pr merge (e.g. auto-merge disabled on repo)", async () => {
+  it("treats the 'auto-merge not allowed' error as success (repo hasn't opted in)", async () => {
     const { shell, calls } = recordingShell((c) => {
       if (c.command === "git") return { stdout: "", stderr: "", code: 0 };
       if (c.args[1] === "create") return { stdout: "https://x/pr/9", stderr: "", code: 0 };
@@ -225,5 +225,23 @@ describe("openTreePr", () => {
 
     expect(result).toEqual({ success: true, prUrl: "https://x/pr/9" });
     expect(calls.some((c) => c.command === "gh" && c.args[1] === "merge")).toBe(true);
+  });
+
+  it("surfaces non-disabled gh pr merge failures instead of silently swallowing", async () => {
+    const { shell } = recordingShell((c) => {
+      if (c.command === "git") return { stdout: "", stderr: "", code: 0 };
+      if (c.args[1] === "create") return { stdout: "https://x/pr/11", stderr: "", code: 0 };
+      if (c.args[1] === "merge") {
+        return { stdout: "", stderr: "HTTP 401: Bad credentials", code: 1 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    });
+
+    const result = await openTreePr(shell, "/tree", { branch: "b", title: "t", body: "y" });
+
+    expect(result.success).toBe(false);
+    expect(result.prUrl).toBe("https://x/pr/11");
+    expect(result.error).toContain("gh pr merge --auto failed");
+    expect(result.error).toContain("Bad credentials");
   });
 });

--- a/tests/tree/open-tree-pr.test.ts
+++ b/tests/tree/open-tree-pr.test.ts
@@ -50,6 +50,7 @@ describe("openTreePr", () => {
       "gh pr create",
       "gh label create",
       "gh pr edit",
+      "gh pr merge",
     ]);
 
     const prCreate = calls.find((c) => c.command === "gh" && c.args[1] === "create")!;
@@ -127,6 +128,7 @@ describe("openTreePr", () => {
     expect(calls.map((c) => c.command + " " + c.args[0] + " " + c.args[1])).toEqual([
       "git push origin",
       "gh pr create",
+      "gh pr merge",
     ]);
   });
 
@@ -172,9 +174,56 @@ describe("openTreePr", () => {
     expect(gitPush.env).toBe(undefined);
 
     const ghCalls = calls.filter((c) => c.command === "gh");
-    expect(ghCalls).toHaveLength(3);
+    expect(ghCalls).toHaveLength(4);
     for (const call of ghCalls) {
       expect(call.env?.GH_TOKEN).toBe("secret-token");
     }
+  });
+
+  it("queues GitHub native auto-merge after PR create (#321)", async () => {
+    const { shell, calls } = recordingShell((c) => {
+      if (c.command === "git") return { stdout: "", stderr: "", code: 0 };
+      if (c.args[1] === "create") return { stdout: "https://x/pr/7", stderr: "", code: 0 };
+      return { stdout: "", stderr: "", code: 0 };
+    });
+
+    await openTreePr(shell, "/tree", { branch: "b", title: "t", body: "y" });
+
+    const autoMerge = calls.find((c) => c.command === "gh" && c.args[1] === "merge")!;
+    expect(autoMerge.args).toEqual([
+      "pr", "merge", "https://x/pr/7",
+      "--auto", "--squash", "--delete-branch",
+    ]);
+  });
+
+  it("skips auto-merge queueing when the PR already exists", async () => {
+    const { shell, calls } = recordingShell((c) => {
+      if (c.command === "git") return { stdout: "", stderr: "", code: 0 };
+      if (c.args[1] === "create") {
+        return { stdout: "", stderr: "a pull request for branch already exists", code: 1 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    });
+
+    const result = await openTreePr(shell, "/tree", { branch: "b", title: "t", body: "y" });
+
+    expect(result.success).toBe(true);
+    expect(calls.some((c) => c.command === "gh" && c.args[1] === "merge")).toBe(false);
+  });
+
+  it("ignores non-zero exit from gh pr merge (e.g. auto-merge disabled on repo)", async () => {
+    const { shell, calls } = recordingShell((c) => {
+      if (c.command === "git") return { stdout: "", stderr: "", code: 0 };
+      if (c.args[1] === "create") return { stdout: "https://x/pr/9", stderr: "", code: 0 };
+      if (c.args[1] === "merge") {
+        return { stdout: "", stderr: "auto-merge is not allowed for this repository", code: 1 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    });
+
+    const result = await openTreePr(shell, "/tree", { branch: "b", title: "t", body: "y" });
+
+    expect(result).toEqual({ success: true, prUrl: "https://x/pr/9" });
+    expect(calls.some((c) => c.command === "gh" && c.args[1] === "merge")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- \`openTreePr\` now calls \`gh pr merge <url> --auto --squash --delete-branch\` after successful PR creation, so review-approved tree PRs merge themselves. This closes the end-to-end loop promised by the onboarding (\"source PR → tree issue → breeze pickup → merged tree PR\").
- Per-tree control lives entirely on the target repo: GitHub only honors \`--auto\` when the repo has \"Allow auto-merge\" enabled in Settings → General. Every repo that hasn't opted in (the default, including this one) gets a silent non-zero exit from \`gh\` and sees no behavior change.
- Skip queueing when the PR already existed (\"a pull request for branch already exists\" path) — we don't re-touch merge state on branches we didn't create this run.

## Why not a YAML/daemon-level flag

Considered a \`auto_merge:\` key in \`.claude/gardener-config.yaml\` with per-tree gates (\`allowed_authors\`, \`max_files_changed\`, etc.). Dropped it: too much config surface for an OSS tool, and it duplicates controls GitHub already provides (required reviews, required checks, branch protection). One switch, one place, auditable in the tree repo's Settings.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` — 1191 passed / 51 skipped. \`tests/tree/open-tree-pr.test.ts\` gains three new cases: asserts the \`--auto --squash --delete-branch\` argv, skips the call on the \"already exists\" path, and tolerates non-zero exit from \`gh pr merge\` (repo with auto-merge disabled).
- [x] \`tests/fixtures/sync-golden/two-pr-apply.json\` regenerated via \`UPDATE_SYNC_GOLDEN=1\` — shell-call envelope repo-gardener parses now includes the \`gh pr merge\` lines.
- [ ] Behavior check on paperclip-tree after merge: owner enables \"Allow auto-merge\" in Settings → General → next breeze-opened PR carries the queued auto-merge and lands when bingran approves.

Closes #321.