### PR TITLE
docs: make end-to-end onboarding prompt source/tree-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,25 +112,30 @@ https://github.com/<your-org>/<your-tree-repo>.
 
 **Driving one full gardener → breeze cycle end-to-end:**
 
-Pick the source repo (the codebase you ship from) and the tree repo (where
-`NODE.md` lives) before pasting. The agent asks for both up front and won't
-assume either.
+Paste this as-is — the agent asks you for the source repo and tree repo
+before running anything, so there's nothing to fill in up front.
 
 ```text
 Use the latest first-tree CLI (https://github.com/agent-team-foundation/first-tree).
 
-Source repo: <owner/source-repo>
-Tree repo:   <owner/tree-repo>
+Before running any command, ask me two questions and wait for my answers:
 
-Run `first-tree tree inspect --json` in the source repo, install the skill, and
-bind it to the tree repo above. Then install the gardener push-mode workflow
-(`first-tree gardener install-workflow --tree-repo <owner/tree-repo>`) — the agent
-will walk you through the required `ANTHROPIC_API_KEY` and `TREE_REPO_TOKEN`
-secrets — and start breeze (`first-tree breeze install`) so notifications route
-back to me. Trigger one drift event end-to-end: source PR → tree issue →
-breeze pickup → draft-node PR.
+1. "What is the source repo you ship from?" (owner/name on GitHub)
+2. "What is the tree repo that stores NODE.md?" (owner/name on GitHub)
 
-Monitor the two repos above.
+Do not assume, guess, or infer either from the current working directory.
+If either answer is missing or ambiguous, stop and re-ask. Only after I've
+confirmed both, proceed.
+
+Then, using those two values:
+
+Run `first-tree tree inspect --json` in the source repo, install the skill,
+and bind it to the tree repo. Install the gardener push-mode workflow
+(`first-tree gardener install-workflow --tree-repo <tree-repo>`) — you will
+walk me through the required `ANTHROPIC_API_KEY` and `TREE_REPO_TOKEN`
+secrets — and start breeze (`first-tree breeze install`) so notifications
+route back to me. Trigger one drift event end-to-end: source PR → tree
+issue → breeze pickup → draft-node PR. Monitor both repos I gave you.
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -112,18 +112,25 @@ https://github.com/<your-org>/<your-tree-repo>.
 
 **Driving one full gardener → breeze cycle end-to-end:**
 
+Pick the source repo (the codebase you ship from) and the tree repo (where
+`NODE.md` lives) before pasting. The agent asks for both up front and won't
+assume either.
+
 ```text
 Use the latest first-tree CLI (https://github.com/agent-team-foundation/first-tree).
-Run `first-tree tree inspect --json`, install the skill, and bind this repo to a
-tree. Then install the gardener push-mode workflow
+
+Source repo: <owner/source-repo>
+Tree repo:   <owner/tree-repo>
+
+Run `first-tree tree inspect --json` in the source repo, install the skill, and
+bind it to the tree repo above. Then install the gardener push-mode workflow
 (`first-tree gardener install-workflow --tree-repo <owner/tree-repo>`) — the agent
 will walk you through the required `ANTHROPIC_API_KEY` and `TREE_REPO_TOKEN`
 secrets — and start breeze (`first-tree breeze install`) so notifications route
 back to me. Trigger one drift event end-to-end: source PR → tree issue →
 breeze pickup → draft-node PR.
 
-Monitor: https://github.com/paperclipai/paperclip (source) and
-https://github.com/serenakeyitan/paperclip-tree (tree).
+Monitor the two repos above.
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -127,15 +127,26 @@ Do not assume, guess, or infer either from the current working directory.
 If either answer is missing or ambiguous, stop and re-ask. Only after I've
 confirmed both, proceed.
 
+Prerequisites: `gh` CLI authed (`gh auth status`), `jq` installed,
+Node ≥ 22, and `ANTHROPIC_API_KEY` exported locally.
+
 Then, using those two values:
 
-Run `first-tree tree inspect --json` in the source repo, install the skill,
-and bind it to the tree repo. Install the gardener push-mode workflow
-(`first-tree gardener install-workflow --tree-repo <tree-repo>`) — you will
-walk me through the required `ANTHROPIC_API_KEY` and `TREE_REPO_TOKEN`
-secrets — and start breeze (`first-tree breeze install`) so notifications
-route back to me. Trigger one drift event end-to-end: source PR → tree
-issue → breeze pickup → draft-node PR. Monitor both repos I gave you.
+1. Clone both repos locally if they aren't already, and `cd` into the
+   source repo checkout before running anything else.
+2. Run `first-tree tree inspect --json` in the source repo to confirm
+   classification, then run `first-tree skill install` to install the
+   first-tree skill, and bind to the tree repo with
+   `first-tree tree bind --tree-path <path-to-tree-repo-checkout>`.
+3. From inside the source repo checkout, install the gardener push-mode
+   workflow: `first-tree gardener install-workflow --tree-repo <tree-repo>`.
+   Walk me through the required `ANTHROPIC_API_KEY` and `TREE_REPO_TOKEN`
+   secrets.
+4. Start breeze so notifications route back to me:
+   `first-tree breeze install --allow-repo <source-repo>,<tree-repo>`.
+5. Trigger one drift event end-to-end: source PR → tree issue →
+   breeze pickup → draft-node PR. Monitor both repos I gave you via
+   `gh pr list` / `gh issue list` on each.
 ```
 
 ---


### PR DESCRIPTION
## Summary

The end-to-end onboarding prompt in README.md hardcoded `paperclip` (source) and `paperclip-tree` (tree), so pasting it as-is pointed every new user at a demo repo they don't own. Restructures the prompt so the user names their **source repo** and **tree repo** as explicit fields at the top, and drops the paperclip monitor URLs.

Also removes a stray `gardener install` mention that referenced a command we don't ship (the real command is `gardener install-workflow`).

## Test plan

- [x] Re-read the onboarding section end to end — prompt is now copy-paste usable for any source+tree pair
- [x] Only command references in the block are real CLI commands (`tree inspect`, `gardener install-workflow`, `breeze install`)