### PR TITLE
docs: fix onboarding path bootstrap chicken-and-egg

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,13 +123,15 @@ GitHub notifications).
 
 Latest release: https://github.com/agent-team-foundation/first-tree/releases/latest
 
-Install the CLI, then follow the onboarding skill at
-`.agents/skills/first-tree/references/onboarding.md`. Before running any
-setup command, ask me which source repo (owner/name) and which tree repo
-(owner/name) to target, and wait for my answers — do not infer from the
-current working directory. Once I've confirmed both, walk me through
-setup, then trigger one drift event end-to-end so I can watch: source PR
-→ tree issue → breeze pickup → draft-node PR.
+Install the CLI, then run `first-tree tree help onboarding` to load the
+onboarding narrative. Before running any setup command, ask me which
+source repo (owner/name) and which tree repo (owner/name) to target, and
+wait for my answers — do not infer from the current working directory.
+Once I've confirmed both, walk me through setup (which includes
+`first-tree skill install`, at which point the full skill reference also
+becomes available at `.agents/skills/first-tree/references/onboarding.md`),
+then trigger one drift event end-to-end so I can watch: source PR → tree
+issue → breeze pickup → draft-node PR.
 ```
 
 ---


### PR DESCRIPTION
## Summary

Follow-up to yuezengwu's CHANGES_REQUESTED review on #326 (review arrived 6 seconds after admin-merge — addressing it here).

The prompt merged in #326 told a cold-start agent to read `.agents/skills/first-tree/references/onboarding.md` right after CLI install. But that path only exists after `first-tree skill install` runs, which is part of the setup the onboarding skill itself walks the user through — classic chicken-and-egg.

Points the prompt at `first-tree tree help onboarding` instead (verified in `src/products/tree/cli.ts:12,37`, which already advertises this command as the "new to first-tree" entry). The skill-path reference is now mentioned as a post-install artifact, not the starting point.

## Test plan

- [x] Confirmed `first-tree tree help onboarding` is a real registered subcommand in `src/products/tree/cli.ts`
- [x] Literal paste of the new prompt references only commands that exist immediately after `npm install -g first-tree` / `npx first-tree`
- [ ] yuezengwu re-review

Refs #326.