### PR TITLE
docs(onboarding): gate Step 6.2 watch check on notifications token scope

### DIFF
--- a/skills/first-tree/references/onboarding.md
+++ b/skills/first-tree/references/onboarding.md
@@ -214,12 +214,15 @@ answer is missing or ambiguous, stop and re-ask.
 
 ### 6.2 Verify Watch Status
 
-First, confirm the user's `gh` token has the `notifications` scope —
-without it `/subscription` returns 404 for every repo, whether
-watching or not:
+First, confirm the user's active `github.com` `gh` token has the
+`notifications` scope — without it `/subscription` returns 404 for
+every repo, whether watching or not. Scope the check to the active
+`github.com` account; a bare `gh auth status | grep notifications`
+can false-positive on multi-host or multi-account setups where
+another stored account has the scope:
 
 ```bash
-gh auth status 2>&1 | grep -i 'notifications'
+gh auth status --active --hostname github.com 2>&1 | grep -i 'notifications'
 ```
 
 If the scope is missing, instruct the user to run:
@@ -375,12 +378,15 @@ ignore them.
   first-time setup).
 - Pull-based dispatch silently no-ops without a GitHub watch
   subscription. Verify before claiming setup is complete.
-- `gh api /repos/<repo>/subscription` returns 404 when the user's
-  token lacks the `notifications` scope — which default `gh auth
-  login` does **not** grant. Check `gh auth status` for the scope
-  first; if missing, run `gh auth refresh -h github.com -s
-  notifications`. Treat 404 as "not watching" only after the scope
-  is confirmed present.
+- `gh api /repos/<repo>/subscription` returns 404 when the active
+  `github.com` token lacks the `notifications` scope — which default
+  `gh auth login` does **not** grant. Check scope with
+  `gh auth status --active --hostname github.com 2>&1 | grep -i
+  notifications` (scope the check to the active account — a bare
+  `gh auth status` grep can false-positive on multi-host or
+  multi-account setups). If missing, run
+  `gh auth refresh -h github.com -s notifications`. Treat 404 as
+  "not watching" only after the scope is confirmed present.
 - `TREE_REPO_TOKEN` must be in the environment for every `gardener`
   invocation, not just at setup.
 

--- a/skills/first-tree/references/onboarding.md
+++ b/skills/first-tree/references/onboarding.md
@@ -214,6 +214,25 @@ answer is missing or ambiguous, stop and re-ask.
 
 ### 6.2 Verify Watch Status
 
+First, confirm the user's `gh` token has the `notifications` scope —
+without it `/subscription` returns 404 for every repo, whether
+watching or not:
+
+```bash
+gh auth status 2>&1 | grep -i 'notifications'
+```
+
+If the scope is missing, instruct the user to run:
+
+```bash
+gh auth refresh -h github.com -s notifications
+```
+
+This is interactive and opens a browser for consent. Wait for the
+user to confirm before proceeding.
+
+Once the scope is present, check the subscription:
+
 ```bash
 gh api /repos/<source-repo>/subscription
 # 200 → watching
@@ -356,6 +375,12 @@ ignore them.
   first-time setup).
 - Pull-based dispatch silently no-ops without a GitHub watch
   subscription. Verify before claiming setup is complete.
+- `gh api /repos/<repo>/subscription` returns 404 when the user's
+  token lacks the `notifications` scope — which default `gh auth
+  login` does **not** grant. Check `gh auth status` for the scope
+  first; if missing, run `gh auth refresh -h github.com -s
+  notifications`. Treat 404 as "not watching" only after the scope
+  is confirmed present.
 - `TREE_REPO_TOKEN` must be in the environment for every `gardener`
   invocation, not just at setup.
 


### PR DESCRIPTION
Fixes #332.

## Problem

`gh api /repos/<repo>/subscription` returns 404 for every repo when the user's `gh` token lacks the `notifications` OAuth scope — which default `gh auth login` does not grant (typical scopes are `admin:org, gist, repo, workflow`). An agent following Step 6.2 on a default token would:

1. Run the check → get 404.
2. Conclude "not watching," tell the user to click Watch → All Activity.
3. User already is watching, clicks again, refreshes, agent re-runs → still 404.
4. Stuck.

## Change

Step 6.2 now:

1. Runs `gh auth status | grep notifications` first.
2. If absent, tells the user to run `gh auth refresh -h github.com -s notifications` (interactive) and waits for confirmation.
3. Only then runs the `/subscription` check.

Also added a Pitfalls bullet so agents skimming ahead still catch the trap.

## Test plan

- [ ] Read Step 6.2: flow is scope check → refresh if needed → subscription check.
- [ ] Read Pitfalls bullet: explains 404-without-scope explicitly.
- [ ] No changes outside `skills/first-tree/references/onboarding.md`.

Discovered during v0.2.15 onboarding test.