### PR TITLE
fix(sync): make `gh pr merge --auto` opt-in (default off)

### DIFF
--- a/src/products/gardener/engine/runtime/config.ts
+++ b/src/products/gardener/engine/runtime/config.ts
@@ -28,6 +28,24 @@ import { join } from "node:path";
 
 export interface ModuleToggle {
   enabled: boolean;
+  /**
+   * Sync-only: queue GitHub native auto-merge on freshly-opened tree
+   * PRs. **Defaults to false.** Setting `true` is safe ONLY when the
+   * tree repo has branch protection that requires approvals/checks —
+   * `gh pr merge --auto` waits for those before merging. On a repo
+   * without branch protection, `--auto` merges immediately and bypasses
+   * review entirely.
+   *
+   * The flag is read from the same `modules.sync` block:
+   *
+   *   modules:
+   *     sync:
+   *       enabled: true
+   *       auto_merge: true   # only if your tree repo requires approvals
+   *
+   * Ignored on non-sync modules.
+   */
+  auto_merge?: boolean;
 }
 
 export interface GardenerConfig {
@@ -195,13 +213,19 @@ function coerceModuleToggle(value: unknown): ModuleToggle | undefined {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
     return undefined;
   }
-  const raw = (value as Record<string, unknown>).enabled;
-  if (typeof raw === "boolean") return { enabled: raw };
-  if (typeof raw === "string") {
-    if (raw === "true") return { enabled: true };
-    if (raw === "false") return { enabled: false };
-  }
-  return undefined;
+  const obj = value as Record<string, unknown>;
+  const raw = obj.enabled;
+  let enabled: boolean | undefined;
+  if (typeof raw === "boolean") enabled = raw;
+  else if (raw === "true") enabled = true;
+  else if (raw === "false") enabled = false;
+  if (enabled === undefined) return undefined;
+  const toggle: ModuleToggle = { enabled };
+  const am = obj.auto_merge;
+  if (typeof am === "boolean") toggle.auto_merge = am;
+  else if (am === "true") toggle.auto_merge = true;
+  else if (am === "false") toggle.auto_merge = false;
+  return toggle;
 }
 
 function coerceConfig(raw: Record<string, unknown>): GardenerConfig {

--- a/src/products/gardener/engine/sync.ts
+++ b/src/products/gardener/engine/sync.ts
@@ -23,6 +23,7 @@ import {
 } from "#products/tree/engine/runtime/binding-state.js";
 import { resolveNodeOwners } from "../../../../assets/tree/helpers/generate-codeowners.js";
 import { openTreePr } from "#products/tree/engine/open-tree-pr.js";
+import { loadGardenerConfig } from "./runtime/config.js";
 import type {
   ShellResult,
   ShellRun,
@@ -1432,12 +1433,14 @@ async function pushAndCreatePr(
   shellRun: ShellRun,
   treeRoot: string,
   prepared: PreparedProposalGroup,
+  autoMerge: boolean,
 ): Promise<{ success: boolean; prUrl?: string; error?: string }> {
   return openTreePr(shellRun, treeRoot, {
     branch: prepared.branch,
     title: prepared.prTitle,
     body: prepared.prBody,
     labels: ["first-tree:sync"],
+    autoMerge,
   });
 }
 
@@ -1449,6 +1452,7 @@ async function pushAndCreatePrsParallel(
   treeRoot: string,
   preparedGroups: PreparedProposalGroup[],
   concurrency: number,
+  autoMerge: boolean,
 ): Promise<{ successes: number; failures: number; prUrls: string[] }> {
   const results: { success: boolean; prUrl?: string; error?: string }[] = [];
   const prUrls: string[] = [];
@@ -1459,7 +1463,7 @@ async function pushAndCreatePrsParallel(
       batch.map(async (prepared) => {
         const MAX_RETRIES = 2;
         for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-          const result = await pushAndCreatePr(shellRun, treeRoot, prepared);
+          const result = await pushAndCreatePr(shellRun, treeRoot, prepared, autoMerge);
           if (result.success) return result;
 
           // Check for rate limiting
@@ -1874,6 +1878,14 @@ export async function runSync(
     return 1;
   }
 
+  // Resolve sync auto-merge opt-in. Defaults to false: opening a tree
+  // PR no longer queues `gh pr merge --auto` unless the user explicitly
+  // opts in via `modules.sync.auto_merge: true`. Even with the flag on,
+  // it is only safe when the tree repo has branch protection that
+  // requires approvals/checks. See `OpenTreePrOpts.autoMerge`.
+  const gardenerCfg = loadGardenerConfig(treeRoot);
+  const syncAutoMerge = gardenerCfg?.modules?.sync?.auto_merge === true;
+
   // Check that claude CLI is available (required for classification)
   const hasClaude = await claudeCliAvailable(shellRun);
   if (!hasClaude) {
@@ -2276,6 +2288,7 @@ export async function runSync(
             repo.root,
             preparedGroups,
             APPLY_CONCURRENCY,
+            syncAutoMerge,
           );
           console.log(`\u2713 Push/PR phase complete: ${successes} succeeded, ${failures} failed`);
           for (const prUrl of prUrls) {

--- a/src/products/tree/engine/open-tree-pr.ts
+++ b/src/products/tree/engine/open-tree-pr.ts
@@ -6,6 +6,24 @@ export interface OpenTreePrOpts {
   body: string;
   labels?: string[];
   env?: NodeJS.ProcessEnv;
+  /**
+   * Queue GitHub's native auto-merge after the PR is opened. Defaults
+   * to **false**.
+   *
+   * `gh pr merge --auto` waits for branch protection (required reviews,
+   * required checks) to be satisfied before merging. On a repo without
+   * branch protection, "auto-merge" merges immediately — the PR opens
+   * and lands in the same instant, bypassing review entirely. Several
+   * deployments have seen tree PRs merged without a single approval
+   * because of this.
+   *
+   * Default off so the unsafe path is opt-in. Callers (gardener-sync)
+   * should only set `autoMerge: true` when the tree repo has branch
+   * protection that requires approvals — typically driven by a config
+   * flag like `modules.sync.auto_merge: true` in
+   * `.claude/gardener-config.yaml`.
+   */
+  autoMerge?: boolean;
 }
 
 export interface OpenTreePrResult {
@@ -28,7 +46,7 @@ export async function openTreePr(
   treeRoot: string,
   opts: OpenTreePrOpts,
 ): Promise<OpenTreePrResult> {
-  const { branch, title, body, labels, env } = opts;
+  const { branch, title, body, labels, env, autoMerge = false } = opts;
 
   const pushResult = await shellRun("git", ["push", "origin", branch], {
     cwd: treeRoot,
@@ -66,24 +84,25 @@ export async function openTreePr(
     await shellRun("gh", ["pr", "edit", prUrl, ...labelArgs], { cwd: treeRoot, env });
   }
 
-  // Queue GitHub's native auto-merge. Treated as best-effort: repos with
-  // "Allow auto-merge" disabled (the default) emit a specific error
-  // string which we swallow so behavior is unchanged for every repo that
-  // hasn't opted in via its Settings page. Any other failure (auth,
-  // transport, unexpected gh output) is surfaced — otherwise gardener
-  // would report the PR as handled while auto-merge was never queued.
-  // See #321.
-  const autoMerge = await shellRun(
-    "gh",
-    ["pr", "merge", prUrl, "--auto", "--squash", "--delete-branch"],
-    { cwd: treeRoot, env },
-  );
-  if (autoMerge.code !== 0 && !isAutoMergeDisabledError(autoMerge.stderr)) {
-    return {
-      success: false,
-      prUrl,
-      error: `gh pr merge --auto failed: ${autoMerge.stderr.trim()}`,
-    };
+  // Queue GitHub's native auto-merge — but only when the caller
+  // explicitly opts in. `gh pr merge --auto` is safe ONLY on repos with
+  // branch protection that requires approvals/checks; on a repo without
+  // protection it merges immediately and bypasses review. Default off
+  // means a fresh deployment never silently auto-merges sync PRs. See
+  // #321 for context.
+  if (autoMerge) {
+    const autoMergeResult = await shellRun(
+      "gh",
+      ["pr", "merge", prUrl, "--auto", "--squash", "--delete-branch"],
+      { cwd: treeRoot, env },
+    );
+    if (autoMergeResult.code !== 0 && !isAutoMergeDisabledError(autoMergeResult.stderr)) {
+      return {
+        success: false,
+        prUrl,
+        error: `gh pr merge --auto failed: ${autoMergeResult.stderr.trim()}`,
+      };
+    }
   }
 
   return { success: true, prUrl };

--- a/tests/fixtures/sync-golden/two-pr-apply.json
+++ b/tests/fixtures/sync-golden/two-pr-apply.json
@@ -311,30 +311,6 @@
       "cwdLabel": "<tree-root>"
     },
     {
-      "command": "gh",
-      "args": [
-        "pr",
-        "merge",
-        "https://github.com/alice/tree/pull/501",
-        "--auto",
-        "--squash",
-        "--delete-branch"
-      ],
-      "cwdLabel": "<tree-root>"
-    },
-    {
-      "command": "gh",
-      "args": [
-        "pr",
-        "merge",
-        "https://github.com/alice/tree/pull/502",
-        "--auto",
-        "--squash",
-        "--delete-branch"
-      ],
-      "cwdLabel": "<tree-root>"
-    },
-    {
       "command": "git",
       "args": [
         "checkout",

--- a/tests/tree/open-tree-pr.test.ts
+++ b/tests/tree/open-tree-pr.test.ts
@@ -45,12 +45,14 @@ describe("openTreePr", () => {
     expect(result).toEqual({ success: true, prUrl: "https://github.com/o/r/pull/42" });
 
     const kinds = calls.map((c) => `${c.command} ${c.args.slice(0, 2).join(" ")}`);
+    // Auto-merge is opt-in (defaults to false). The happy path should
+    // NOT include `gh pr merge` — that only fires when the caller
+    // passes `autoMerge: true`. See OpenTreePrOpts.autoMerge.
     expect(kinds).toEqual([
       "git push origin",
       "gh pr create",
       "gh label create",
       "gh pr edit",
-      "gh pr merge",
     ]);
 
     const prCreate = calls.find((c) => c.command === "gh" && c.args[1] === "create")!;
@@ -125,10 +127,10 @@ describe("openTreePr", () => {
     });
 
     expect(result).toEqual({ success: true, prUrl: "https://x/pr/1" });
+    // No labels and no autoMerge → only push + create.
     expect(calls.map((c) => c.command + " " + c.args[0] + " " + c.args[1])).toEqual([
       "git push origin",
       "gh pr create",
-      "gh pr merge",
     ]);
   });
 
@@ -174,13 +176,16 @@ describe("openTreePr", () => {
     expect(gitPush.env).toBe(undefined);
 
     const ghCalls = calls.filter((c) => c.command === "gh");
-    expect(ghCalls).toHaveLength(4);
+    // pr create + label create + pr edit (no auto-merge by default)
+    expect(ghCalls).toHaveLength(3);
     for (const call of ghCalls) {
       expect(call.env?.GH_TOKEN).toBe("secret-token");
     }
   });
 
-  it("queues GitHub native auto-merge after PR create (#321)", async () => {
+  it("does NOT queue auto-merge by default", async () => {
+    // Auto-merge is opt-in. Default off avoids silently merging fresh
+    // sync PRs on tree repos without branch protection.
     const { shell, calls } = recordingShell((c) => {
       if (c.command === "git") return { stdout: "", stderr: "", code: 0 };
       if (c.args[1] === "create") return { stdout: "https://x/pr/7", stderr: "", code: 0 };
@@ -189,6 +194,18 @@ describe("openTreePr", () => {
 
     await openTreePr(shell, "/tree", { branch: "b", title: "t", body: "y" });
 
+    expect(calls.some((c) => c.command === "gh" && c.args[1] === "merge")).toBe(false);
+  });
+
+  it("queues GitHub native auto-merge when autoMerge=true (#321)", async () => {
+    const { shell, calls } = recordingShell((c) => {
+      if (c.command === "git") return { stdout: "", stderr: "", code: 0 };
+      if (c.args[1] === "create") return { stdout: "https://x/pr/7", stderr: "", code: 0 };
+      return { stdout: "", stderr: "", code: 0 };
+    });
+
+    await openTreePr(shell, "/tree", { branch: "b", title: "t", body: "y", autoMerge: true });
+
     const autoMerge = calls.find((c) => c.command === "gh" && c.args[1] === "merge")!;
     expect(autoMerge.args).toEqual([
       "pr", "merge", "https://x/pr/7",
@@ -196,7 +213,7 @@ describe("openTreePr", () => {
     ]);
   });
 
-  it("skips auto-merge queueing when the PR already exists", async () => {
+  it("skips auto-merge queueing when the PR already exists (even with autoMerge=true)", async () => {
     const { shell, calls } = recordingShell((c) => {
       if (c.command === "git") return { stdout: "", stderr: "", code: 0 };
       if (c.args[1] === "create") {
@@ -205,13 +222,13 @@ describe("openTreePr", () => {
       return { stdout: "", stderr: "", code: 0 };
     });
 
-    const result = await openTreePr(shell, "/tree", { branch: "b", title: "t", body: "y" });
+    const result = await openTreePr(shell, "/tree", { branch: "b", title: "t", body: "y", autoMerge: true });
 
     expect(result.success).toBe(true);
     expect(calls.some((c) => c.command === "gh" && c.args[1] === "merge")).toBe(false);
   });
 
-  it("treats the 'auto-merge not allowed' error as success (repo hasn't opted in)", async () => {
+  it("treats the 'auto-merge not allowed' error as success when autoMerge=true (repo hasn't opted in)", async () => {
     const { shell, calls } = recordingShell((c) => {
       if (c.command === "git") return { stdout: "", stderr: "", code: 0 };
       if (c.args[1] === "create") return { stdout: "https://x/pr/9", stderr: "", code: 0 };
@@ -221,13 +238,13 @@ describe("openTreePr", () => {
       return { stdout: "", stderr: "", code: 0 };
     });
 
-    const result = await openTreePr(shell, "/tree", { branch: "b", title: "t", body: "y" });
+    const result = await openTreePr(shell, "/tree", { branch: "b", title: "t", body: "y", autoMerge: true });
 
     expect(result).toEqual({ success: true, prUrl: "https://x/pr/9" });
     expect(calls.some((c) => c.command === "gh" && c.args[1] === "merge")).toBe(true);
   });
 
-  it("surfaces non-disabled gh pr merge failures instead of silently swallowing", async () => {
+  it("surfaces non-disabled gh pr merge failures when autoMerge=true", async () => {
     const { shell } = recordingShell((c) => {
       if (c.command === "git") return { stdout: "", stderr: "", code: 0 };
       if (c.args[1] === "create") return { stdout: "https://x/pr/11", stderr: "", code: 0 };
@@ -237,7 +254,7 @@ describe("openTreePr", () => {
       return { stdout: "", stderr: "", code: 0 };
     });
 
-    const result = await openTreePr(shell, "/tree", { branch: "b", title: "t", body: "y" });
+    const result = await openTreePr(shell, "/tree", { branch: "b", title: "t", body: "y", autoMerge: true });
 
     expect(result.success).toBe(false);
     expect(result.prUrl).toBe("https://x/pr/11");


### PR DESCRIPTION
## Summary

Sync used to call `gh pr merge --auto --squash --delete-branch` on every freshly-opened tree PR. The comment on the call assumes branch protection will gate it — but **on a repo without protection, `--auto` merges immediately**. There's no waiting, no review.

19 sync PRs on `serenakeyitan/paperclip-tree` were merged this way today — zero approvals across all of them. The reviewer (bingran-you, via breeze) had no chance to review; sync opened and merged in the same instant. Confirmed by checking the merge timestamps and `merged_by` (matches the sync run, no APPROVED reviews on file).

## Fix

Auto-merge is now **opt-in via config**, defaults off:

```yaml
modules:
  sync:
    enabled: true
    auto_merge: true   # only safe if your tree repo requires approvals
```

- New `OpenTreePrOpts.autoMerge?: boolean` (default false). Skips the `gh pr merge --auto` step entirely when false.
- New `ModuleToggle.auto_merge?: boolean`. Sync reads `modules.sync.auto_merge` and threads it through `pushAndCreatePr(s)` → `openTreePr`.
- Doc comments call out the unsafe-without-protection caveat clearly.

## Behavior change for existing users

If your deployment was relying on the default auto-merge, you now need to opt in. **Don't** opt in unless your tree repo has branch protection that requires approvals — the config flag only makes the choice explicit, it doesn't make `--auto` safe on an unprotected repo.

## Test plan

- [x] New: "does NOT queue auto-merge by default" — verifies the no-merge call sequence on fresh deployments.
- [x] Existing auto-merge tests updated to opt in with `autoMerge: true`. All 4 still pass.
- [x] Sync golden snapshot for `two-pr-apply` regenerated (no more `gh pr merge` in default call sequence).
- [x] `pnpm test` → 1204 passed, 0 failed.
- [x] `pnpm typecheck` clean.

## Discovered while

Running gardener locally on `serenakeyitan/paperclip-tree`. Audit of recently-merged sync PRs showed 19/20 had `[]` for non-gardener APPROVED reviews, all merged within seconds of being opened by the same sync run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)